### PR TITLE
patch(v2.1): backport GB200 provisioning fixes

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -80,6 +80,7 @@ const DPF_DERIVED_NAME_HASH_BYTES: usize = 16;
 const DPF_FLAVOR_HASH_SUFFIX_LENGTH: usize = 17;
 const KUBERNETES_DNS_LABEL_MAX_LENGTH: usize = 63;
 const KUBERNETES_LABEL_NAME_MAX_LENGTH: usize = 63;
+const DPU_ENABLED_NODE_LABEL: &str = "feature.node.kubernetes.io/dpu-enabled";
 const GB200_RESOURCE_SUFFIX: &str = "-gb200";
 // The DPUDeployment CRD allows only 20 characters. The default BF3 name already
 // uses 18, so `-g` is the longest suffix that preserves it without truncation.
@@ -1901,6 +1902,8 @@ impl DpfDeploymentsConfig {
     }
 
     /// Validates the final Kubernetes identifiers and their uniqueness.
+    /// `DPU_ENABLED_NODE_LABEL` is reserved for the shared DPF node marker and
+    /// cannot be used as the `node_label_key` for an individual deployment.
     /// Returns every error so the operator can fix them all in one pass.
     pub fn validate_unique_identifiers(&self) -> eyre::Result<()> {
         let bf3_gb200 = self.bf3.bf3_gb200();
@@ -1962,6 +1965,11 @@ impl DpfDeploymentsConfig {
             if !is_valid_kubernetes_label_key(label_key) {
                 errors.push(format!(
                     "node_label_key {label_key:?} for deployment {deployment:?} is not a valid Kubernetes label key"
+                ));
+            }
+            if *label_key == DPU_ENABLED_NODE_LABEL {
+                errors.push(format!(
+                    "node_label_key {label_key:?} for deployment {deployment:?} is reserved for the shared DPF node marker"
                 ));
             }
         }
@@ -6779,6 +6787,36 @@ node_label_key = "carbide.nvidia.com/astra"
             services: None,
             extra_services: BTreeMap::new(),
         }
+    }
+
+    #[test]
+    fn validate_dpf_deployment_node_label_keys() {
+        check_values(
+            [
+                Check {
+                    scenario: "deployment-specific label",
+                    input: "carbide.nvidia.com/bf3",
+                    expect: true,
+                },
+                Check {
+                    scenario: "shared DPF node marker",
+                    input: DPU_ENABLED_NODE_LABEL,
+                    expect: false,
+                },
+            ],
+            |node_label_key| {
+                DpfDeploymentsConfig {
+                    bf3: DpfDeploymentConfig {
+                        node_label_key: node_label_key.to_string(),
+                        ..Default::default()
+                    },
+                    bf4_generic: None,
+                    bf4_astra: None,
+                }
+                .validate_unique_identifiers()
+                .is_ok()
+            },
+        );
     }
 
     #[test]

--- a/crates/api-core/src/handlers/client_resolution.rs
+++ b/crates/api-core/src/handlers/client_resolution.rs
@@ -22,8 +22,8 @@ use ::rpc::forge as rpc;
 use db::{self, ObjectColumnFilter};
 use model::instance::snapshot::InstanceSnapshot;
 use model::machine::machine_search_config::MachineSearchConfig;
-use model::machine::{InstanceState, MachineInterfaceSnapshot, ManagedHostState};
-use model::rack_type::select_dpu_nvconfig_profile;
+use model::machine::{InstanceState, Machine, MachineInterfaceSnapshot, ManagedHostState};
+use model::rack_type::{RackProductFamily, select_dpu_nvconfig_profile};
 use sqlx::PgConnection;
 
 use crate::CarbideError;
@@ -139,9 +139,49 @@ pub(crate) async fn resolve_machine_interface(
     }
 }
 
-/// Selects a DPU profile from the attached host's rack and the DPU's hardware
-/// identity. Missing relationships mean no platform profile applies; database
-/// failures still propagate to the caller.
+/// Returns the product family reported by Site Explorer, or falls back to the
+/// configured rack profile when that report does not name a known family.
+pub(crate) async fn resolve_host_product_family(
+    api: &Api,
+    conn: &mut PgConnection,
+    host: &Machine,
+) -> Result<Option<RackProductFamily>, CarbideError> {
+    if let Some(host_bmc_ip) = host.status.bmc_info.ip {
+        let endpoints = db::explored_endpoints::find_by_ips(&mut *conn, vec![host_bmc_ip]).await?;
+        if let Some(product_family) = endpoints
+            .first()
+            .and_then(|endpoint| endpoint.report.model())
+            .as_deref()
+            .and_then(RackProductFamily::from_hardware_model)
+        {
+            return Ok(Some(product_family));
+        }
+    }
+
+    let Some(rack_id) = host.rack_id.as_ref() else {
+        return Ok(None);
+    };
+    let Some(rack) = db::rack::find_by(
+        &mut *conn,
+        ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
+    )
+    .await?
+    .pop() else {
+        return Ok(None);
+    };
+    let Some(rack_profile_id) = rack.rack_profile_id.as_ref() else {
+        return Ok(None);
+    };
+    Ok(api
+        .runtime_config
+        .rack_profiles
+        .get(rack_profile_id.as_str())
+        .and_then(|profile| profile.product_family.clone()))
+}
+
+/// Selects a DPU profile from the attached host's observed or configured
+/// product family and the DPU's hardware identity. Missing relationships mean
+/// no platform profile applies; database failures still propagate.
 async fn resolve_dpu_nvconfig_profile(
     api: &Api,
     conn: &mut PgConnection,
@@ -158,27 +198,7 @@ async fn resolve_dpu_nvconfig_profile(
     else {
         return Ok(None);
     };
-    let Some(rack_id) = host.rack_id.as_ref() else {
-        return Ok(None);
-    };
-    let Some(rack) = db::rack::find_by(
-        &mut *conn,
-        ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
-    )
-    .await?
-    .pop() else {
-        return Ok(None);
-    };
-    let Some(rack_profile_id) = rack.rack_profile_id.as_ref() else {
-        return Ok(None);
-    };
-    let Some(rack_profile) = api
-        .runtime_config
-        .rack_profiles
-        .get(rack_profile_id.as_str())
-    else {
-        return Ok(None);
-    };
+    let product_family = resolve_host_product_family(api, conn, &host).await?;
 
     let Some(dpu) =
         db::machine::find_one(&mut *conn, dpu_machine_id, MachineSearchConfig::default()).await?
@@ -186,11 +206,10 @@ async fn resolve_dpu_nvconfig_profile(
         return Ok(None);
     };
 
-    Ok(select_dpu_nvconfig_profile(
-        rack_profile.product_family.as_ref(),
-        dpu.status.hardware_info.as_ref(),
+    Ok(
+        select_dpu_nvconfig_profile(product_family.as_ref(), dpu.status.hardware_info.as_ref())
+            .map(rpc::DpuNvConfigProfile::from),
     )
-    .map(rpc::DpuNvConfigProfile::from))
 }
 
 /// Resolve a client IP to its `CloudInitInstructions` response. The

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -18,11 +18,12 @@
 use std::collections::HashMap;
 use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
+use std::time::Duration;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::model::{RpcInto, RpcTryFrom};
 use ::rpc::{common as rpc_common, forge as rpc};
-use carbide_dpf::dpu_cr_name;
+use carbide_dpf::{DpuDeploymentType, dpu_cr_name, dpu_node_cr_name};
 use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use carbide_utils::arch::CpuArchitecture;
@@ -41,14 +42,18 @@ use model::instance::config::extension_services::InstanceExtensionServiceConfig;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::network::MachineNetworkStatusObservation;
 use model::machine::upgrade_policy::{AgentUpgradePolicy, BuildVersion};
-use model::machine::{InstanceState, LoadSnapshotOptions, ManagedHostState};
+use model::machine::{
+    InstanceState, LoadSnapshotOptions, ManagedHostState, ManagedHostStateSnapshot,
+};
 use model::machine_update_module::HOST_UPDATE_HEALTH_PROBE_ID;
 use model::network_segment::NetworkSegmentSearchConfig;
+use model::rack_type::select_dpu_nvconfig_profile;
 use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_machine_id, log_request_data};
 use crate::cfg::file::VpcIsolationBehaviorType;
 use crate::handlers::astra::{get_astra_config, process_astra_config_status};
+use crate::handlers::client_resolution::resolve_host_product_family;
 use crate::handlers::extension_service;
 use crate::handlers::utils::{StateHandlerWakeupFailed, WakeupTrigger, convert_and_log_machine_id};
 use crate::{CarbideError, cfg, ethernet_virtualization};
@@ -56,6 +61,9 @@ use crate::{CarbideError, cfg, ethernet_virtualization};
 /// vxlan48 is special HBN single vxlan device. It handles networking between machines on the
 /// same subnet. It handles the encapsulation into VXLAN and VNI for cross-host comms.
 const HBN_SINGLE_VLAN_DEVICE: &str = "vxlan48";
+
+/// Bounds Kubernetes label reads while Site Explorer attachment locks are held.
+const DPF_DEPLOYMENT_LABEL_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Consolidates host-level and DPU-level `ManagedHostNetworkConfig` into
 /// the single proto sent to `carbide-dpu-agent`. The host layer
@@ -1296,9 +1304,199 @@ pub(crate) async fn dpu_agent_upgrade_policy_action(
     Ok(tonic::Response::new(response))
 }
 
-/// Trigger DPU reprovisioning
-/// In case user passes a DPU ID, trigger_dpu_reprovisioning only for that particular DPU.
-/// In case user passes a host id, trigger_dpu_reprovisioning
+/// Returns the DPUNode when this request may need the exact BF3 to GB200
+/// deployment migration.
+async fn dpf_deployment_migration_node(
+    api: &Api,
+    conn: &mut sqlx::PgConnection,
+    snapshot: &ManagedHostStateSnapshot,
+) -> Result<Option<String>, CarbideError> {
+    if !api.runtime_config.dpf.enabled
+        || !snapshot.host_snapshot.config.dpf.used_for_ingestion
+        || snapshot.dpu_snapshots.is_empty()
+    {
+        return Ok(None);
+    }
+
+    let product_family = resolve_host_product_family(api, conn, &snapshot.host_snapshot).await?;
+    let every_dpu_uses_gb200_profile = snapshot.dpu_snapshots.iter().all(|dpu| {
+        select_dpu_nvconfig_profile(product_family.as_ref(), dpu.status.hardware_info.as_ref())
+            .is_some()
+    });
+    if !every_dpu_uses_gb200_profile {
+        return Ok(None);
+    }
+
+    Ok(snapshot
+        .host_snapshot
+        .dpf_id()
+        .map(|dpf_id| dpu_node_cr_name(&dpf_id)))
+}
+
+/// Returns whether the live DPUNode still belongs to the generic BF3
+/// deployment and therefore needs a migration of the complete DPU set.
+async fn dpf_deployment_migration_source_is_active(
+    api: &Api,
+    node_name: &str,
+) -> Result<bool, CarbideError> {
+    let dpf_sdk = api.dpf_sdk.as_deref().ok_or_else(|| {
+        CarbideError::internal(
+            "DPF SDK is unavailable while checking a DPF deployment migration".to_string(),
+        )
+    })?;
+    if dpf_sdk
+        .verify_node_labels(node_name, DpuDeploymentType::Bf3Gb200)
+        .await
+        .map_err(CarbideError::DpfError)?
+    {
+        return Ok(false);
+    }
+
+    dpf_sdk
+        .verify_node_labels(node_name, DpuDeploymentType::Bf3)
+        .await
+        .map_err(CarbideError::DpfError)
+}
+
+/// Refuses a request change that would leave only part of the attached DPU set
+/// selected while the shared DPUNode still needs deployment migration.
+fn reject_partial_dpf_deployment_migration_request_set(
+    snapshot: &ManagedHostStateSnapshot,
+    machine_id: &MachineId,
+    mode: rpc::dpu_reprovisioning_request::Mode,
+    migration_source_is_active: bool,
+) -> Result<(), CarbideError> {
+    if !migration_source_is_active {
+        return Ok(());
+    }
+
+    let requested_count = snapshot
+        .dpu_snapshots
+        .iter()
+        .filter(|dpu| {
+            let request_targets_dpu = machine_id.machine_type().is_host() || dpu.id == *machine_id;
+            if request_targets_dpu {
+                mode == rpc::dpu_reprovisioning_request::Mode::Set
+            } else {
+                dpu.reprovision_requested.is_some()
+            }
+        })
+        .count();
+    if requested_count == 0 || requested_count == snapshot.dpu_snapshots.len() {
+        return Ok(());
+    }
+
+    let operation = match mode {
+        rpc::dpu_reprovisioning_request::Mode::Set => "Set",
+        rpc::dpu_reprovisioning_request::Mode::Clear => "Clear",
+        rpc::dpu_reprovisioning_request::Mode::Restart => "Restart",
+    };
+    Err(CarbideError::FailedPrecondition(format!(
+        "{operation} for DPU {machine_id} would leave only part of the attached DPU set selected \
+         while the shared DPUNode still needs the GB200 deployment; submit {operation} with host \
+         machine ID {} so every attached DPU changes together",
+        snapshot.host_snapshot.id,
+    )))
+}
+
+/// Validates request conditions that do not require a Kubernetes read.
+fn validate_dpu_reprovisioning_request(
+    snapshot: &ManagedHostStateSnapshot,
+    machine_id: &MachineId,
+    mode: rpc::dpu_reprovisioning_request::Mode,
+) -> Result<(), CarbideError> {
+    let update_alert = snapshot
+        .aggregate_health
+        .alerts
+        .iter()
+        .find(|alert| alert.id == *HOST_UPDATE_HEALTH_PROBE_ID);
+    if !update_alert.is_some_and(|alert| {
+        alert
+            .classifications
+            .contains(&health_report::HealthAlertClassification::prevent_allocations())
+    }) {
+        return Err(CarbideError::InvalidArgument(format!(
+            "machine {machine_id} must have a 'HostUpdateInProgress' health alert with the \
+             'PreventAllocations' classification before reprovisioning. set this precondition \
+             with: `machine health-override add --template host-update <id>`",
+        )));
+    }
+
+    let reprovisioning_started = snapshot.dpu_snapshots.iter().any(|dpu| {
+        dpu.reprovision_requested
+            .as_ref()
+            .is_some_and(|request| request.started_at.is_some())
+    });
+    if reprovisioning_started && mode != rpc::dpu_reprovisioning_request::Mode::Restart {
+        return Err(CarbideError::internal(
+            "reprovisioning is already started".to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
+/// Locks every attached DPU row in stable order before revalidating and
+/// updating a reprovisioning request set.
+async fn lock_attached_dpus(
+    conn: &mut sqlx::PgConnection,
+    snapshot: &ManagedHostStateSnapshot,
+) -> Result<(), CarbideError> {
+    let dpu_ids = snapshot
+        .dpu_snapshots
+        .iter()
+        .map(|dpu| dpu.id)
+        .collect::<Vec<_>>();
+    let locked_dpus = db::machine::find(
+        conn,
+        db::ObjectFilter::List(&dpu_ids),
+        MachineSearchConfig {
+            for_update: true,
+            ..MachineSearchConfig::default()
+        },
+    )
+    .await?;
+    if locked_dpus.len() != dpu_ids.len() {
+        return Err(CarbideError::internal(format!(
+            "expected to lock {} attached DPUs but found {}",
+            dpu_ids.len(),
+            locked_dpus.len(),
+        )));
+    }
+
+    Ok(())
+}
+
+/// Loads the host snapshot used to validate and update DPU reprovisioning
+/// requests.
+async fn load_dpu_reprovisioning_snapshot(
+    api: &Api,
+    conn: &mut sqlx::PgConnection,
+    machine_id: &MachineId,
+) -> Result<ManagedHostStateSnapshot, CarbideError> {
+    db::managed_host::load_snapshot(
+        conn,
+        machine_id,
+        LoadSnapshotOptions {
+            include_history: false,
+            include_instance_data: false,
+            host_health_config: api.runtime_config.host_health,
+        },
+    )
+    .await?
+    .ok_or(CarbideError::NotFoundError {
+        kind: "machine",
+        id: machine_id.to_string(),
+    })
+}
+
+/// Triggers DPU reprovisioning for one DPU or every DPU attached to a host.
+///
+/// `Set` and `Clear` intentionally keep the transaction that owns the admin
+/// segment locks open across the DPF Kubernetes read. This prevents Site
+/// Explorer from changing attachments between the authorizing snapshot and
+/// the request writes.
+#[allow(txn_held_across_await)]
 pub(crate) async fn trigger_dpu_reprovisioning(
     api: &Api,
     request: tonic::Request<rpc::DpuReprovisioningRequest>,
@@ -1310,57 +1508,68 @@ pub(crate) async fn trigger_dpu_reprovisioning(
     let machine_id = req.machine_id.as_ref().or(req.dpu_id.as_ref());
     let machine_id = convert_and_log_machine_id(machine_id)?;
 
+    let mode = req.mode();
+    // Set and Clear must choose their complete DPU set from the same attachment
+    // state that authorizes the request writes. Take the Site Explorer lock
+    // order before loading that snapshot so attachment changes cannot make a
+    // previously ineligible host require migration after this check.
+    let admin_lock_admission = if matches!(mode, Mode::Set | Mode::Clear) {
+        Some(db::machine_interface::admin_lock_admission().await)
+    } else {
+        None
+    };
     let mut txn = api.txn_begin().await?;
-
-    let snapshot = db::managed_host::load_snapshot(
-        &mut txn,
-        &machine_id,
-        LoadSnapshotOptions {
-            include_history: false,
-            include_instance_data: false,
-            host_health_config: api.runtime_config.host_health,
-        },
-    )
-    .await?
-    .ok_or(CarbideError::NotFoundError {
-        kind: "machine",
-        id: machine_id.to_string(),
-    })?;
-
-    // Start reprovisioning only if the host has an HostUpdateInProgress health alert
-    let update_alert = snapshot
-        .aggregate_health
-        .alerts
-        .iter()
-        .find(|a| a.id == *HOST_UPDATE_HEALTH_PROBE_ID);
-    if !update_alert.is_some_and(|alert| {
-        alert
-            .classifications
-            .contains(&health_report::HealthAlertClassification::prevent_allocations())
-    }) {
-        return Err(CarbideError::InvalidArgument(format!(
-            "machine {machine_id} must have a 'HostUpdateInProgress' health alert with the 'PreventAllocations' classification before reprovisioning. set this precondition with: `machine health-override add --template host-update <id>`",
-        )).into());
+    if admin_lock_admission.is_some() {
+        db::machine_interface::lock_all_admin_segments(txn.as_mut()).await?;
     }
 
-    if snapshot.dpu_snapshots.iter().any(|ms| {
-        ms.reprovision_requested
-            .as_ref()
-            .is_some_and(|x| x.started_at.is_some())
-    }) {
-        match req.mode() {
-            Mode::Restart => {}
-            _ => {
-                return Err(CarbideError::internal(
-                    "reprovisioning is already started".to_string(),
-                )
-                .into());
-            }
-        }
+    let mut snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
+    validate_dpu_reprovisioning_request(&snapshot, &machine_id, mode)?;
+
+    let migration_node = if matches!(mode, Mode::Set | Mode::Clear) {
+        dpf_deployment_migration_node(api, txn.as_mut(), &snapshot).await?
+    } else {
+        None
+    };
+    let migration_source_is_active = if let Some(node_name) = migration_node.as_deref() {
+        // Keep the attachment locks through this Kubernetes read and the
+        // request writes. Releasing them here would allow migration eligibility
+        // to change between the two operations.
+        tokio::time::timeout(
+            DPF_DEPLOYMENT_LABEL_CHECK_TIMEOUT,
+            dpf_deployment_migration_source_is_active(api, node_name),
+        )
+        .await
+        .map_err(|_| {
+            CarbideError::DpfError(carbide_dpf::DpfError::timeout(
+                "DPUNode deployment label validation",
+                format!(
+                    "label checks for DPUNode '{node_name}' did not complete within {} seconds",
+                    DPF_DEPLOYMENT_LABEL_CHECK_TIMEOUT.as_secs()
+                ),
+            ))
+        })??
+    } else {
+        false
+    };
+
+    if mode == Mode::Set || migration_node.is_some() {
+        // Set replaces the request JSON, and migration validation depends on
+        // the complete request set. Lock and reload before either can write.
+        lock_attached_dpus(txn.as_mut(), &snapshot).await?;
+        snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
+        validate_dpu_reprovisioning_request(&snapshot, &machine_id, mode)?;
     }
 
-    match req.mode() {
+    match mode {
         Mode::Set => {
+            reject_partial_dpf_deployment_migration_request_set(
+                &snapshot,
+                &machine_id,
+                mode,
+                migration_source_is_active,
+            )?;
+
             let initiator = req.initiator().as_str_name();
             if machine_id.machine_type().is_dpu() {
                 db::machine::trigger_dpu_reprovisioning_request(
@@ -1383,6 +1592,12 @@ pub(crate) async fn trigger_dpu_reprovisioning(
             }
         }
         Mode::Clear => {
+            reject_partial_dpf_deployment_migration_request_set(
+                &snapshot,
+                &machine_id,
+                mode,
+                migration_source_is_active,
+            )?;
             if machine_id.machine_type().is_dpu() {
                 db::machine::clear_dpu_reprovisioning_request(&mut txn, &machine_id, true).await?;
             } else {
@@ -1430,6 +1645,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
     }
 
     txn.commit().await?;
+    drop(admin_lock_admission);
 
     Ok(Response::new(()))
 }

--- a/crates/api-core/src/tests/client_resolution.rs
+++ b/crates/api-core/src/tests/client_resolution.rs
@@ -16,7 +16,7 @@
  */
 
 use common::api_fixtures::{
-    TEST_RMS_RACK_PROFILE_ID, TestEnvOverrides, create_managed_host,
+    TEST_RMS_RACK_PROFILE_ID, TestEnv, TestEnvOverrides, create_managed_host,
     create_managed_host_with_config, create_test_env, create_test_env_with_overrides,
     get_config_with_rack_profiles,
 };
@@ -40,6 +40,23 @@ use crate::tests::common::api_fixtures::network_segment::{
     create_host_inband_network_segment,
 };
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
+
+/// Returns the NVConfig profile selected for a DPU cloud-init request.
+async fn resolved_dpu_nvconfig_profile(env: &TestEnv, dpu_ip: &str) -> i32 {
+    env.api
+        .get_cloud_init_instructions(
+            rpc::forge::CloudInitInstructionsRequest {
+                ip: dpu_ip.to_string(),
+            }
+            .into_request(),
+        )
+        .await
+        .expect("get_cloud_init_instructions returned an error")
+        .into_inner()
+        .discovery_instructions
+        .expect("DPU should receive discovery instructions")
+        .dpu_nvconfig_profile
+}
 
 // A client_ip that matches a row in machine_interface_addresses (the
 // common admin/host case) should resolve directly to that interface.
@@ -293,7 +310,7 @@ async fn test_zero_dpu_cloud_init_prefers_instance_when_ip_matches_host_interfac
     }
 }
 #[crate::sqlx_test]
-async fn dpu_nvconfig_profile_resolution_follows_host_rack_and_dpu_identity(pool: sqlx::PgPool) {
+async fn dpu_nvconfig_profile_resolution_uses_report_or_rack_and_dpu_identity(pool: sqlx::PgPool) {
     let env = create_test_env_with_overrides(
         pool,
         TestEnvOverrides::with_config(get_config_with_rack_profiles()),
@@ -354,21 +371,55 @@ async fn dpu_nvconfig_profile_resolution_follows_host_rack_and_dpu_identity(pool
         .to_string();
     txn.rollback().await.unwrap();
 
-    let cloud_init = env
-        .api
-        .get_cloud_init_instructions(
-            rpc::forge::CloudInitInstructionsRequest {
-                ip: dpu_interface_ip,
-            }
-            .into_request(),
-        )
-        .await
-        .expect("get_cloud_init_instructions returned an error")
-        .into_inner();
-    let profile = cloud_init
-        .discovery_instructions
-        .expect("DPU should receive discovery instructions")
-        .dpu_nvconfig_profile;
+    assert_eq!(
+        resolved_dpu_nvconfig_profile(&env, &dpu_interface_ip).await,
+        rpc::forge::DpuNvConfigProfile::Gb200B3240V1 as i32,
+    );
 
-    assert_eq!(profile, rpc::forge::DpuNvConfigProfile::Gb200B3240V1 as i32,);
+    // Non-DPF provisioning sees the same early ingestion window as DPF: the
+    // Redfish report is present, but the host does not have a rack yet.
+    let mut txn = env.pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = NULL WHERE id = $1")
+        .bind(managed_host.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    managed_host
+        .host()
+        .set_exploration_model(&mut txn, "DGX GB200 Compute Tray")
+        .await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .rack_id
+            .is_none()
+    );
+    txn.commit().await.unwrap();
+
+    assert_eq!(
+        resolved_dpu_nvconfig_profile(&env, &dpu_interface_ip).await,
+        rpc::forge::DpuNvConfigProfile::Gb200B3240V1 as i32,
+    );
+
+    // A recognized report is more specific than the rack fallback. A GB300
+    // report must not inherit the GB200 profile from stale rack metadata.
+    let mut txn = env.pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(managed_host.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    managed_host
+        .host()
+        .set_exploration_model(&mut txn, "DGX GB300 Compute Tray")
+        .await;
+    txn.commit().await.unwrap();
+
+    assert_eq!(
+        resolved_dpu_nvconfig_profile(&env, &dpu_interface_ip).await,
+        rpc::forge::DpuNvConfigProfile::Unspecified as i32,
+    );
 }

--- a/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
@@ -150,6 +150,39 @@ impl TestMachine {
         machine.bmc_addr().map(|addr| addr.ip())
     }
 
+    /// Replaces the model in this machine's persisted Site Explorer report.
+    pub(in crate::tests) async fn set_exploration_model(&self, txn: &mut Txn<'_>, model: &str) {
+        let bmc_ip = self
+            .bmc_ip(txn)
+            .await
+            .expect("fixture machine should have a BMC IP");
+        let endpoint = db::explored_endpoints::find_by_ips(txn.as_mut(), vec![bmc_ip])
+            .await
+            .unwrap()
+            .pop()
+            .expect("fixture machine should have a Site Explorer report");
+        let old_version = endpoint.report_version;
+        let waiting_for_explorer_refresh = endpoint.waiting_for_explorer_refresh;
+        let mut report = endpoint.report;
+        report
+            .systems
+            .first_mut()
+            .expect("fixture report should contain a Redfish system")
+            .model = Some(model.to_string());
+        report.model = report.model();
+
+        let updated = db::explored_endpoints::try_update(
+            bmc_ip,
+            old_version,
+            &report,
+            waiting_for_explorer_refresh,
+            txn.as_mut(),
+        )
+        .await
+        .unwrap();
+        assert!(updated, "fixture Site Explorer report should be updated");
+    }
+
     pub async fn json_history(&self, limit: Option<usize>) -> Vec<serde_json::Value> {
         let machine = self.rpc_machine().await;
         let mut states: Vec<serde_json::Value> = machine

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -20,29 +20,68 @@
 //! Verifies that DPF states (`Reprovisioning` -> `Provisioning` -> `WaitingForReady`)
 //! transition correctly when the outer state is `DPUReprovision`.
 
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
-use carbide_dpf::{DpuDeploymentType, DpuPhase};
+use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
+use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     DpfState, DpuReprovisionStates, FailureCause, InstanceState, ManagedHostState, ReprovisionState,
 };
+use rpc::forge::dpu_reprovisioning_request::Mode;
+use rpc::forge::forge_server::Forge;
 use tokio::time::timeout;
 
 use super::{dpf_config, get_host_state};
+use crate::test_support::builder::TestApiBuilder;
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
-    TEST_RMS_RACK_PROFILE_ID, TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
-    create_managed_host_with_dpf_multi, create_test_env_with_overrides, get_config,
-    get_config_with_rack_profiles,
+    TEST_RMS_RACK_PROFILE_ID, TestEnv, TestEnvOverrides, TestManagedHost,
+    create_managed_host_with_dpf, create_managed_host_with_dpf_multi,
+    create_test_env_with_overrides, get_config, get_config_with_rack_profiles,
 };
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Waits for a machine query to block behind the controller transaction used
+/// by the request update race tests.
+async fn wait_for_blocked_machine_query(pool: &sqlx::PgPool, blocker_pid: i32) {
+    for _ in 0..300 {
+        let blocked_pid: Option<i32> = sqlx::query_scalar(
+            r#"
+                SELECT activity.pid
+                FROM pg_stat_activity AS activity
+                WHERE activity.datname = current_database()
+                  AND activity.wait_event_type = 'Lock'
+                  AND $1 = ANY(pg_blocking_pids(activity.pid))
+                  AND (
+                      strpos(lower(activity.query), 'select row_to_json') > 0
+                      OR strpos(
+                          lower(activity.query),
+                          'update machines set reprovisioning_requested'
+                      ) > 0
+                  )
+                ORDER BY activity.pid
+                LIMIT 1
+            "#,
+        )
+        .bind(blocker_pid)
+        .fetch_optional(pool)
+        .await
+        .expect("database lock state should be readable");
+        if blocked_pid.is_some() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+
+    panic!("machine query never waited for database lock");
+}
 
 fn snapshot_with_crs_present(dpu_count: usize) -> HostDpfSnapshot {
     HostDpfSnapshot {
@@ -94,6 +133,222 @@ fn provisioning_mock_with_dpu_count(
         }
     });
     mock
+}
+
+/// Builds a DPF mock whose existing DPUNode still belongs to the generic BF3
+/// deployment while inventory now selects the GB200 deployment.
+fn source_deployment_mock(dpu_count: usize) -> MockDpfOperations {
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_| Ok(()));
+    mock.expect_register_dpu_node().returning(|_| Ok(()));
+    mock.expect_release_maintenance_hold().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
+    mock.expect_verify_node_labels()
+        .returning(|_, deployment| Ok(deployment == DpuDeploymentType::Bf3));
+    mock.expect_snapshot_host()
+        .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+    mock
+}
+
+/// A request rechecks migration eligibility after Site Explorer changes the
+/// host while holding its attachment locks.
+#[crate::sqlx_test]
+async fn test_gb200_deployment_migration_rechecks_after_attachment_updates(pool: sqlx::PgPool) {
+    let mock = source_deployment_mock(2);
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    mh.mark_machine_for_updates().await;
+
+    // Stand in for Site Explorer changing the machine from a generic BF3 host
+    // to a GB200 host while the request still sees the earlier data.
+    let admin_lock_admission = db::machine_interface::admin_lock_admission().await;
+    let mut attachment_txn = pool.begin().await.unwrap();
+    db::machine_interface::lock_all_admin_segments(attachment_txn.as_mut())
+        .await
+        .unwrap();
+    configure_gb200_b3240_host_in_txn(attachment_txn.as_mut(), &mh).await;
+
+    let api = env.api.clone();
+    let requested_dpu_id = mh.dpu_ids[0];
+    let mut request_task = tokio::spawn(async move {
+        api.trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: requested_dpu_id.into(),
+                machine_id: None,
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+    });
+
+    assert!(
+        timeout(Duration::from_millis(250), &mut request_task)
+            .await
+            .is_err(),
+        "the request must wait for attachment updates before checking migration"
+    );
+
+    attachment_txn.commit().await.unwrap();
+    drop(admin_lock_admission);
+    let error = timeout(TEST_TIMEOUT, request_task)
+        .await
+        .expect("timed out after releasing the attachment locks")
+        .expect("the reprovisioning request task panicked")
+        .expect_err("an individual DPU request must be rejected after GB200 becomes visible");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+
+    let mut txn = pool.begin().await.unwrap();
+    let dpu_machines = mh.dpu_db_machines(&mut txn).await;
+    assert_eq!(dpu_machines.len(), mh.dpu_ids.len());
+    assert!(
+        dpu_machines
+            .iter()
+            .all(|dpu| dpu.reprovision_requested.is_none()),
+        "a rejected partial request must not update any attached DPU"
+    );
+    txn.commit().await.unwrap();
+}
+
+/// Verifies that a `Set` request preserves controller progress made after its
+/// initial validation.
+async fn assert_dpu_reprovision_set_rechecks_request_updates(
+    pool: &sqlx::PgPool,
+    env: &TestEnv,
+    mh: &TestManagedHost,
+) {
+    let requested_dpu_id = mh.dpu_ids[0];
+    let mut request_txn = pool.begin().await.unwrap();
+    db::machine::trigger_dpu_reprovisioning_request(
+        &requested_dpu_id,
+        request_txn.as_mut(),
+        "test",
+        true,
+    )
+    .await
+    .unwrap();
+    request_txn.commit().await.unwrap();
+
+    // Stand in for the controller owning the DPU row while the API validates
+    // the current request.
+    let mut controller_txn = pool.begin().await.unwrap();
+    let blocker_pid = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(controller_txn.as_mut())
+        .await
+        .unwrap();
+    let locked_dpu = db::machine::find_one(
+        controller_txn.as_mut(),
+        &requested_dpu_id,
+        MachineSearchConfig {
+            for_update: true,
+            ..MachineSearchConfig::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        locked_dpu.is_some(),
+        "the controller must lock the test DPU"
+    );
+
+    let api = env.api.clone();
+    let request_task = tokio::spawn(async move {
+        api.trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: requested_dpu_id.into(),
+                machine_id: None,
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+    });
+
+    // Both the protected implementation and the stale write it replaces must
+    // reach the DPU row after initial validation before the controller moves it.
+    wait_for_blocked_machine_query(pool, blocker_pid).await;
+    db::machine::update_dpu_reprovision_start_time(&requested_dpu_id, controller_txn.as_mut())
+        .await
+        .unwrap();
+    controller_txn.commit().await.unwrap();
+
+    let error = timeout(TEST_TIMEOUT, request_task)
+        .await
+        .expect("timed out after the controller released the DPU row")
+        .expect("the reprovisioning request task panicked")
+        .expect_err("the request must reject controller state advanced after validation");
+    assert_eq!(error.code(), tonic::Code::Internal);
+    assert_eq!(
+        error.message(),
+        "internal error: reprovisioning is already started"
+    );
+
+    let mut txn = pool.begin().await.unwrap();
+    let dpu = db::machine::find_one(txn.as_mut(), &requested_dpu_id, Default::default())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        dpu.reprovision_requested
+            .is_some_and(|request| request.started_at.is_some()),
+        "the rejected API request must preserve the controller's start time"
+    );
+    txn.commit().await.unwrap();
+}
+
+/// An ordinary DPF reprovision request rechecks controller progress before
+/// replacing the request JSON.
+#[crate::sqlx_test]
+async fn test_dpu_reprovision_set_rechecks_after_request_updates(pool: sqlx::PgPool) {
+    let mock = provisioning_mock(Arc::new(AtomicBool::new(true)));
+    let mut config = get_config();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+    mh.mark_machine_for_updates().await;
+
+    assert_dpu_reprovision_set_rechecks_request_updates(&pool, &env, &mh).await;
+}
+
+/// A GB200 request rechecks controller progress after reading deployment
+/// labels, even when the target deployment is already active.
+#[crate::sqlx_test]
+async fn test_gb200_deployment_migration_rechecks_after_dpu_request_updates(pool: sqlx::PgPool) {
+    let mock = provisioning_mock(Arc::new(AtomicBool::new(true)));
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    mh.mark_machine_for_updates().await;
+
+    assert_dpu_reprovision_set_rechecks_request_updates(&pool, &env, &mh).await;
 }
 
 /// Build the DPU reprovision states map for the given DPF sub-state.
@@ -175,6 +430,137 @@ async fn dpu_device_names(pool: &sqlx::PgPool, mh: &TestManagedHost) -> HashSet<
         names.insert(dpu.dpf_id().unwrap());
     }
     names
+}
+
+/// Gives a DPF test host the rack and DPU inventory that select the GB200
+/// deployment.
+async fn configure_gb200_b3240_host(pool: &sqlx::PgPool, mh: &TestManagedHost) {
+    let mut txn = pool.begin().await.unwrap();
+    configure_gb200_b3240_host_in_txn(txn.as_mut(), mh).await;
+    txn.commit().await.unwrap();
+}
+
+/// Gives a DPF test host the GB200 rack and DPU inventory in an existing
+/// transaction.
+async fn configure_gb200_b3240_host_in_txn(conn: &mut sqlx::PgConnection, mh: &TestManagedHost) {
+    let rack_id = TestRackDbBuilder::new()
+        .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
+        .persist(&mut *conn)
+        .await
+        .unwrap();
+    let rack_assignment = sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(mh.id)
+        .execute(&mut *conn)
+        .await
+        .unwrap();
+    assert_eq!(
+        rack_assignment.rows_affected(),
+        1,
+        "the test host must be attached to the GB200 rack profile"
+    );
+    for dpu_id in &mh.dpu_ids {
+        let dpu = db::machine::find_one(&mut *conn, dpu_id, Default::default())
+            .await
+            .unwrap()
+            .unwrap();
+        let mut hardware_info = dpu
+            .status
+            .hardware_info
+            .expect("fixture DPU should have hardware information");
+        hardware_info
+            .dpu_info
+            .as_mut()
+            .expect("fixture DPU should have DPU information")
+            .part_number = "900-9D3B6-00CN-PA0".to_string();
+        db::machine_topology::set_topology_update_needed(&mut *conn, dpu_id, true)
+            .await
+            .unwrap();
+        db::machine_topology::create_or_update(&mut *conn, dpu_id, &hardware_info)
+            .await
+            .unwrap();
+    }
+}
+
+/// Recreates the partial DPF reprovision state that a controller without
+/// deployment migration admission could persist during a rolling update.
+async fn set_started_partial_dpf_reprovision(
+    pool: &sqlx::PgPool,
+    mh: &TestManagedHost,
+    requested_dpu_index: usize,
+) {
+    let requested_dpu_id = mh.dpu_ids[requested_dpu_index];
+    let mut txn = pool.begin().await.unwrap();
+    db::machine::trigger_dpu_reprovisioning_request(&requested_dpu_id, txn.as_mut(), "test", true)
+        .await
+        .unwrap();
+    db::machine::update_dpu_reprovision_start_time(&requested_dpu_id, txn.as_mut())
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let states = mh
+        .dpu_ids
+        .iter()
+        .map(|dpu_id| {
+            let state = if *dpu_id == requested_dpu_id {
+                ReprovisionState::DpfStates {
+                    substate: DpfState::Reprovisioning,
+                }
+            } else {
+                ReprovisionState::NotUnderReprovision
+            };
+            (*dpu_id, state)
+        })
+        .collect();
+    write_host_state(
+        pool,
+        &mh.id,
+        &ManagedHostState::DPUReprovision {
+            dpu_states: DpuReprovisionStates { states },
+        },
+    )
+    .await;
+}
+
+/// Recreates a complete request set that an older controller has already
+/// advanced unevenly during a rolling update.
+async fn set_started_complete_dpf_reprovision_with_progress(
+    pool: &sqlx::PgPool,
+    mh: &TestManagedHost,
+) {
+    let mut txn = pool.begin().await.unwrap();
+    for dpu_id in &mh.dpu_ids {
+        db::machine::trigger_dpu_reprovisioning_request(dpu_id, txn.as_mut(), "test", true)
+            .await
+            .unwrap();
+        db::machine::update_dpu_reprovision_start_time(dpu_id, txn.as_mut())
+            .await
+            .unwrap();
+    }
+    txn.commit().await.unwrap();
+
+    let states = mh
+        .dpu_ids
+        .iter()
+        .enumerate()
+        .map(|(index, dpu_id)| {
+            let substate = if index == 0 {
+                DpfState::WaitingForReady { phase_detail: None }
+            } else {
+                DpfState::Reprovisioning
+            };
+            (*dpu_id, ReprovisionState::DpfStates { substate })
+        })
+        .collect();
+    write_host_state(
+        pool,
+        &mh.id,
+        &ManagedHostState::DPUReprovision {
+            dpu_states: DpuReprovisionStates { states },
+        },
+    )
+    .await;
 }
 
 /// Reprovisioning handler: `DpfState::Reprovisioning` transitions the DPU
@@ -453,9 +839,9 @@ async fn test_multi_dpu_provisioning_registers_all_devices(pool: sqlx::PgPool) {
     );
 }
 
-/// GB200 rack identity and every attached B3240 DPU must select one shared deployment.
+/// GB200 host identity and every attached B3240 DPU must select one shared deployment.
 #[crate::sqlx_test]
-async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
+async fn test_gb200_b3240_pair_uses_specialized_deployment_from_report_or_rack(pool: sqlx::PgPool) {
     let classified_dpus = Arc::new(Mutex::new(Vec::new()));
     let verified_deployments = Arc::new(Mutex::new(Vec::new()));
     let registered_deployments = Arc::new(Mutex::new(Vec::new()));
@@ -499,48 +885,12 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
     )
     .await;
 
-    let mut txn = pool.begin().await.unwrap();
-    let rack_id = TestRackDbBuilder::new()
-        .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
-        .persist(txn.as_mut())
-        .await
-        .unwrap();
-    txn.commit().await.unwrap();
-
     let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
         .await
         .expect("timed out during initial provisioning");
 
     // Give the host a GB200 rack and both DPUs the supported B3240 identity.
-    let mut txn = pool.begin().await.unwrap();
-    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
-        .bind(rack_id.as_str())
-        .bind(mh.id)
-        .execute(txn.as_mut())
-        .await
-        .unwrap();
-    for dpu_id in &mh.dpu_ids {
-        let dpu = db::machine::find_one(txn.as_mut(), dpu_id, Default::default())
-            .await
-            .unwrap()
-            .unwrap();
-        let mut hardware_info = dpu
-            .status
-            .hardware_info
-            .expect("fixture DPU should have hardware information");
-        hardware_info
-            .dpu_info
-            .as_mut()
-            .expect("fixture DPU should have DPU information")
-            .part_number = "900-9D3B6-00CN-PA0".to_string();
-        db::machine_topology::set_topology_update_needed(txn.as_mut(), dpu_id, true)
-            .await
-            .unwrap();
-        db::machine_topology::create_or_update(txn.as_mut(), dpu_id, &hardware_info)
-            .await
-            .unwrap();
-    }
-    txn.commit().await.unwrap();
+    configure_gb200_b3240_host(&pool, &mh).await;
 
     // Ignore initial ingestion and observe one complete host deployment selection pass.
     classified_dpus.lock().unwrap().clear();
@@ -565,6 +915,629 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment(pool: sqlx::PgPool) {
     assert_eq!(
         *registered_deployments.lock().unwrap(),
         vec![DpuDeploymentType::Bf3Gb200]
+    );
+
+    // Site Explorer can identify a GB200 before discovery assigns its rack.
+    // Repeat the same selection with only the persisted Redfish model present.
+    let mut txn = pool.begin().await.unwrap();
+    let rack_id = mh.host().db_machine(&mut txn).await.rack_id.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = NULL WHERE id = $1")
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    mh.host().set_exploration_model(&mut txn, "GB200 NVL").await;
+    assert!(mh.host().db_machine(&mut txn).await.rack_id.is_none());
+    txn.commit().await.unwrap();
+
+    verified_deployments.lock().unwrap().clear();
+    registered_deployments.lock().unwrap().clear();
+    set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, DpfState::Provisioning).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        *verified_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+    assert_eq!(
+        *registered_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3Gb200]
+    );
+
+    // A recognized report takes precedence over the rack fallback. Restore
+    // the GB200 rack and report GB300 so this pass selects generic BF3.
+    let mut txn = pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
+        .bind(rack_id.as_str())
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    mh.host()
+        .set_exploration_model(&mut txn, "DGX GB300 Compute Tray")
+        .await;
+    txn.commit().await.unwrap();
+
+    verified_deployments.lock().unwrap().clear();
+    registered_deployments.lock().unwrap().clear();
+    set_reprovision_dpf_state(&pool, &mh.id, &mh.dpu_ids, DpfState::Provisioning).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    assert_eq!(
+        *verified_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3]
+    );
+    assert_eq!(
+        *registered_deployments.lock().unwrap(),
+        vec![DpuDeploymentType::Bf3]
+    );
+}
+
+/// A DPF-ingested GB200 host remains reprovisionable when runtime DPF support
+/// is disabled and no SDK is installed.
+#[crate::sqlx_test]
+async fn test_runtime_dpf_disable_skips_deployment_migration_probe(pool: sqlx::PgPool) {
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(source_deployment_mock(1))),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    mh.mark_machine_for_updates().await;
+
+    let mut disabled_config = get_config_with_rack_profiles();
+    disabled_config.dpf.enabled = false;
+    let disabled_api = TestApiBuilder::new(
+        env.pool.clone(),
+        env.api.common_pools.clone(),
+        env.api.work_lock_manager_handle.clone(),
+    )
+    .with_runtime_config(Arc::new(disabled_config))
+    .build();
+    assert!(disabled_api.dpf_sdk.is_none());
+
+    disabled_api
+        .trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: None,
+                machine_id: mh.id.into(),
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+        .expect("runtime DPF disable must skip the deployment migration probe");
+
+    let mut txn = pool.begin().await.unwrap();
+    assert!(
+        mh.dpu_n(0)
+            .db_machine(&mut txn)
+            .await
+            .reprovision_requested
+            .is_some(),
+        "the request must persist without a DPF SDK"
+    );
+    txn.commit().await.unwrap();
+}
+
+/// A GB200 deployment migration rejects a request for one DPU, then proceeds
+/// when a host request includes every attached DPU.
+#[crate::sqlx_test]
+async fn test_gb200_deployment_migration_requires_every_dpu(pool: sqlx::PgPool) {
+    let node_uses_target_labels = Arc::new(AtomicBool::new(false));
+    let target_dpu_phase = Arc::new(AtomicUsize::new(0));
+    let released_holds = Arc::new(AtomicUsize::new(0));
+    let transferred_deployments = Arc::new(Mutex::new(Vec::new()));
+    let deleted_source_devices = Arc::new(Mutex::new(Vec::new()));
+
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_| Ok(()));
+    mock.expect_register_dpu_node().returning(|_| Ok(()));
+    let released_holds_for_mock = released_holds.clone();
+    mock.expect_release_maintenance_hold().returning(move |_| {
+        released_holds_for_mock.fetch_add(1, Ordering::SeqCst);
+        Ok(())
+    });
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_| Ok(DpuDeploymentType::Bf3));
+    let node_uses_target_labels_for_verify = node_uses_target_labels.clone();
+    mock.expect_verify_node_labels()
+        .returning(move |_, deployment| {
+            let expected = if node_uses_target_labels_for_verify.load(Ordering::SeqCst) {
+                DpuDeploymentType::Bf3Gb200
+            } else {
+                DpuDeploymentType::Bf3
+            };
+            Ok(deployment == expected)
+        });
+    mock.expect_snapshot_host()
+        .returning(|_| Ok(snapshot_with_crs_present(2)));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+    let target_dpu_phase_for_mock = target_dpu_phase.clone();
+    mock.expect_get_dpu_phases_for_deployment_type().returning(
+        move |device_names, _, deployment_type| {
+            assert_eq!(deployment_type, DpuDeploymentType::Bf3Gb200);
+            match target_dpu_phase_for_mock.load(Ordering::SeqCst) {
+                0 => Ok(None),
+                1 => Ok(Some(
+                    device_names
+                        .iter()
+                        .map(|name| {
+                            (
+                                name.clone(),
+                                DpuPhase::Provisioning("OsInstalling".to_string()),
+                            )
+                        })
+                        .collect::<BTreeMap<_, _>>(),
+                )),
+                2 => Ok(Some(
+                    device_names
+                        .iter()
+                        .map(|name| (name.clone(), DpuPhase::Ready))
+                        .collect::<BTreeMap<_, _>>(),
+                )),
+                _ => Err(DpfError::InvalidState(
+                    "target DPU has the wrong flavor".to_string(),
+                )),
+            }
+        },
+    );
+    let transferred_deployments_for_mock = transferred_deployments.clone();
+    mock.expect_transfer_dpu_node_deployment_labels()
+        .returning(move |_, source, target| {
+            let mut transfers = transferred_deployments_for_mock.lock().unwrap();
+            transfers.push((source, target));
+            node_uses_target_labels.store(true, Ordering::SeqCst);
+            Ok(())
+        });
+    let deleted_source_devices_for_mock = deleted_source_devices.clone();
+    mock.expect_delete_source_dpus_for_deployment_migration()
+        .returning(move |device_names, _, source, target| {
+            assert_eq!(source, DpuDeploymentType::Bf3);
+            assert_eq!(target, DpuDeploymentType::Bf3Gb200);
+            *deleted_source_devices_for_mock.lock().unwrap() = device_names.to_vec();
+            Ok(())
+        });
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+
+    // Exercise migration admission before Site Explorer assigns a rack. The
+    // persisted Redfish model must protect the complete DPU set on its own.
+    let mut txn = pool.begin().await.unwrap();
+    sqlx::query("UPDATE machines SET rack_id = NULL WHERE id = $1")
+        .bind(mh.id)
+        .execute(txn.as_mut())
+        .await
+        .unwrap();
+    mh.host().set_exploration_model(&mut txn, "GB200 NVL").await;
+    txn.commit().await.unwrap();
+
+    let released_holds_before_migration = released_holds.load(Ordering::SeqCst);
+
+    mh.mark_machine_for_updates().await;
+    let partial_request_error = env
+        .api
+        .trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: None,
+                machine_id: mh.dpu_ids[0].into(),
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await;
+    let partial_request_error =
+        partial_request_error.expect_err("a request for one DPU must be rejected");
+    assert_eq!(
+        partial_request_error.code(),
+        tonic::Code::FailedPrecondition
+    );
+    assert!(
+        partial_request_error.message().contains(&mh.id.to_string()),
+        "the rejection must identify the request using the host ID that can migrate the full DPU set"
+    );
+
+    assert!(
+        matches!(get_host_state(&env, &mh).await, ManagedHostState::Ready),
+        "a rejected partial request must not change the host state"
+    );
+    assert!(transferred_deployments.lock().unwrap().is_empty());
+    assert!(deleted_source_devices.lock().unwrap().is_empty());
+
+    let mut txn = pool.begin().await.unwrap();
+    let first_request = mh.dpu_n(0).db_machine(&mut txn).await.reprovision_requested;
+    assert!(first_request.is_none());
+    assert!(
+        mh.dpu_n(1)
+            .db_machine(&mut txn)
+            .await
+            .reprovision_requested
+            .is_none()
+    );
+    txn.commit().await.unwrap();
+
+    mh.host().trigger_dpu_reprovisioning(Mode::Set, true).await;
+
+    let partial_clear_error = env
+        .api
+        .trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: None,
+                machine_id: mh.dpu_ids[0].into(),
+                mode: Mode::Clear as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+        .expect_err("clearing one DPU from a complete migration request must be rejected");
+    assert_eq!(partial_clear_error.code(), tonic::Code::FailedPrecondition);
+
+    let mut txn = pool.begin().await.unwrap();
+    for dpu_index in 0..mh.dpu_ids.len() {
+        assert!(
+            mh.dpu_n(dpu_index)
+                .db_machine(&mut txn)
+                .await
+                .reprovision_requested
+                .is_some(),
+            "a rejected partial clear must preserve every migration request"
+        );
+    }
+    txn.commit().await.unwrap();
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while starting the complete DPU set");
+
+    let started_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            started_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::Reprovisioning
+                        }
+                    )
+                })
+        ),
+        "the host request must start every DPU in the source deployment: {started_state:?}"
+    );
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while parking deployment migration");
+
+    let parked_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            &parked_state,
+            ManagedHostState::DPUReprovision { dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(state, ReprovisionState::NotUnderReprovision)
+                })
+        ),
+        "the complete DPU set must be parked before changing selectors: {parked_state:?}"
+    );
+    assert!(transferred_deployments.lock().unwrap().is_empty());
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during deployment migration");
+
+    let migrated_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            migrated_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(state, ReprovisionState::NotUnderReprovision)
+                })
+        ),
+        "the migration must remain parked until every target DPU is observed: {migrated_state:?}"
+    );
+    assert_eq!(
+        *transferred_deployments.lock().unwrap(),
+        vec![(DpuDeploymentType::Bf3, DpuDeploymentType::Bf3Gb200)]
+    );
+    let expected_devices = dpu_device_names(&pool, &mh).await;
+    assert_eq!(
+        deleted_source_devices
+            .lock()
+            .unwrap()
+            .iter()
+            .cloned()
+            .collect::<HashSet<_>>(),
+        expected_devices
+    );
+
+    // A source DPU can briefly retain the deterministic name after the
+    // selector changes. Keep the complete set parked until target ownership
+    // is observed for every DPU in one snapshot.
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking a stale source DPU");
+
+    let stale_source_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            stale_source_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(state, ReprovisionState::NotUnderReprovision)
+                })
+        ),
+        "source ownership must keep every DPU parked: {stale_source_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration,
+        "a DPU owned by the source must not release the target deployment's hold"
+    );
+
+    target_dpu_phase.store(3, Ordering::SeqCst);
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking target deployment configuration drift");
+
+    let mismatched_target_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            &mismatched_target_state,
+            ManagedHostState::Failed { details, .. }
+                if matches!(
+                    &details.cause,
+                    FailureCause::DpfProvisioning { err }
+                        if err.contains("target DPU has the wrong flavor")
+                )
+        ),
+        "a Ready target DPU with configuration drift must fail visibly: {mismatched_target_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration,
+        "a mismatched target DPU must not release the maintenance hold"
+    );
+
+    // Restore the parked checkpoint to continue exercising the successful path.
+    write_host_state(&pool, &mh.id, &parked_state).await;
+
+    target_dpu_phase.store(1, Ordering::SeqCst);
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking target deployment provisioning");
+
+    let target_provisioning_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            target_provisioning_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::WaitingForReady { .. }
+                        }
+                    )
+                })
+        ),
+        "observing the complete target set must move every DPU to WaitingForReady: {target_provisioning_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration,
+        "changing the durable migration marker must not release the maintenance hold"
+    );
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while processing target deployment provisioning");
+
+    let target_provisioning_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            target_provisioning_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().all(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::WaitingForReady { .. }
+                        }
+                    )
+                })
+        ),
+        "target provisioning must remain in WaitingForReady: {target_provisioning_state:?}"
+    );
+    assert_eq!(
+        released_holds.load(Ordering::SeqCst),
+        released_holds_before_migration + 1,
+        "a target DPU may release the shared maintenance hold while provisioning"
+    );
+
+    target_dpu_phase.store(2, Ordering::SeqCst);
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while checking the target deployment");
+
+    let progressing_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            progressing_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if dpu_states.states.values().any(|state| {
+                    matches!(
+                        state,
+                        ReprovisionState::DpfStates {
+                            substate: DpfState::DeviceReady
+                        }
+                    )
+                })
+        ),
+        "the target deployment labels must let reprovisioning continue: {progressing_state:?}"
+    );
+}
+
+/// A partial request started before the migration gate was rolled
+/// out continues under its current deployment instead of entering a terminal
+/// migration failure.
+#[crate::sqlx_test]
+async fn test_started_partial_migration_continues_under_source_deployment(pool: sqlx::PgPool) {
+    let reprovisioned_devices = Arc::new(Mutex::new(Vec::new()));
+    let mut mock = source_deployment_mock(2);
+    let reprovisioned_devices_for_mock = reprovisioned_devices.clone();
+    mock.expect_reprovision_dpu()
+        .times(1)
+        .returning(move |device_name, _| {
+            reprovisioned_devices_for_mock
+                .lock()
+                .unwrap()
+                .push(device_name.to_string());
+            Ok(())
+        });
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    set_started_partial_dpf_reprovision(&pool, &mh, 0).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while continuing the source deployment");
+
+    let waiting_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            waiting_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if matches!(
+                    dpu_states.states.get(&mh.dpu_ids[0]),
+                    Some(ReprovisionState::DpfStates {
+                        substate: DpfState::WaitingForReady { .. }
+                    })
+                ) && matches!(
+                    dpu_states.states.get(&mh.dpu_ids[1]),
+                    Some(ReprovisionState::NotUnderReprovision)
+                )
+        ),
+        "the DPU already being reprovisioned must continue without moving the shared selector: {waiting_state:?}"
+    );
+    assert_eq!(reprovisioned_devices.lock().unwrap().len(), 1);
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while accepting source deployment readiness");
+
+    let ready_state = get_host_state(&env, &mh).await;
+    assert!(
+        matches!(
+            ready_state,
+            ManagedHostState::DPUReprovision { ref dpu_states }
+                if matches!(
+                    dpu_states.states.get(&mh.dpu_ids[0]),
+                    Some(ReprovisionState::DpfStates {
+                        substate: DpfState::DeviceReady
+                    })
+                ) && matches!(
+                    dpu_states.states.get(&mh.dpu_ids[1]),
+                    Some(ReprovisionState::NotUnderReprovision)
+                )
+        ),
+        "source labels must remain valid until the existing request finishes: {ready_state:?}"
+    );
+}
+
+/// A complete request already advanced by an older controller finishes under
+/// BF3 instead of failing when its DPU states are no longer synchronized at the
+/// migration handoff.
+#[crate::sqlx_test]
+async fn test_started_complete_migration_with_progress_continues_under_source_deployment(
+    pool: sqlx::PgPool,
+) {
+    let mut mock = source_deployment_mock(2);
+    mock.expect_reprovision_dpu().returning(|_, _| Ok(()));
+
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    set_started_complete_dpf_reprovision_with_progress(&pool, &mh).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out while continuing the progressed request under BF3");
+
+    let state = get_host_state(&env, &mh).await;
+    let ManagedHostState::DPUReprovision { ref dpu_states } = state else {
+        panic!("an existing request must remain in DPUReprovision under BF3: {state:?}");
+    };
+    let stayed_in_dpf = dpu_states
+        .states
+        .values()
+        .all(|dpu_state| matches!(dpu_state, ReprovisionState::DpfStates { .. }));
+    let reached_device_ready = dpu_states.states.values().any(|dpu_state| {
+        matches!(
+            dpu_state,
+            ReprovisionState::DpfStates {
+                substate: DpfState::DeviceReady
+            }
+        )
+    });
+    let still_reprovisioning = dpu_states.states.values().any(|dpu_state| {
+        matches!(
+            dpu_state,
+            ReprovisionState::DpfStates {
+                substate: DpfState::Reprovisioning
+            }
+        )
+    });
+
+    assert!(
+        stayed_in_dpf && (reached_device_ready || !still_reprovisioning),
+        "an existing request must make progress under BF3 without entering the migration handoff: {state:?}"
     );
 }
 

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1524,14 +1524,19 @@ impl ManagedHostState {
         Self::Maintenance { operation }
     }
 
-    pub fn as_reprovision_state(&self, dpu_id: &MachineId) -> Option<&ReprovisionState> {
+    /// Returns the DPU reprovision states embedded in either host allocation mode.
+    pub fn dpu_reprovision_states(&self) -> Option<&DpuReprovisionStates> {
         match self {
-            ManagedHostState::DPUReprovision { dpu_states } => dpu_states.states.get(dpu_id),
-            ManagedHostState::Assigned {
+            ManagedHostState::DPUReprovision { dpu_states }
+            | ManagedHostState::Assigned {
                 instance_state: InstanceState::DPUReprovision { dpu_states },
-            } => dpu_states.states.get(dpu_id),
+            } => Some(dpu_states),
             _ => None,
         }
+    }
+
+    pub fn as_reprovision_state(&self, dpu_id: &MachineId) -> Option<&ReprovisionState> {
+        self.dpu_reprovision_states()?.states.get(dpu_id)
     }
 
     pub fn suppress_dpu_alerts(&self) -> bool {

--- a/crates/api-model/src/rack_type.rs
+++ b/crates/api-model/src/rack_type.rs
@@ -93,10 +93,11 @@ pub enum RackProductFamily {
     Other(String),
 }
 
-/// Selects the fixed DPU NVConfig profile supported by a rack and DPU identity.
+/// Selects the fixed DPU NVConfig profile supported by a product family and DPU
+/// identity.
 ///
-/// A profile is selected only for a GB200 rack and an exact supported DPU part
-/// number. Missing identity does not select a profile.
+/// A profile is selected only for the GB200 product family and an exact
+/// supported DPU part number. Missing identity does not select a profile.
 pub fn select_dpu_nvconfig_profile(
     product_family: Option<&RackProductFamily>,
     hardware_info: Option<&HardwareInfo>,
@@ -110,6 +111,28 @@ pub fn select_dpu_nvconfig_profile(
 }
 
 impl RackProductFamily {
+    /// Returns `GB200` or `GB300` when a hardware model reported by Redfish
+    /// contains exactly one of those product family tokens.
+    ///
+    /// Matching ignores ASCII case and requires whole tokens separated by ASCII
+    /// whitespace. Unknown models, concatenated names, and models naming both
+    /// families return `None`.
+    pub fn from_hardware_model(model: &str) -> Option<Self> {
+        let mut has_gb200 = false;
+        let mut has_gb300 = false;
+
+        for token in model.split_ascii_whitespace() {
+            has_gb200 |= token.eq_ignore_ascii_case("gb200");
+            has_gb300 |= token.eq_ignore_ascii_case("gb300");
+        }
+
+        match (has_gb200, has_gb300) {
+            (true, false) => Some(Self::Gb200),
+            (false, true) => Some(Self::Gb300),
+            (false, false) | (true, true) => None,
+        }
+    }
+
     /// Returns the product-family identifier sent to descriptor-based backends.
     ///
     /// Named variants use their canonical lowercase value. Values stored in
@@ -500,11 +523,65 @@ mod tests {
     }
 
     #[test]
-    fn dpu_nvconfig_profile_requires_matching_rack_and_dpu_identity() {
+    fn hardware_model_requires_one_known_product_family_token() {
         check_values(
             [
                 Check {
-                    scenario: "GB200 rack with supported B3240",
+                    scenario: "DGX GB200 compute tray",
+                    input: "DGX GB200 Compute Tray",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB200 board",
+                    input: "GB200 1CPU:2GPU Board PC",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB200 NVL",
+                    input: "GB200 NVL",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "lowercase GB200 token",
+                    input: "dgx gb200 compute tray",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB200 token separated by ASCII whitespace",
+                    input: "DGX\tGB200\nCompute Tray",
+                    expect: Some(RackProductFamily::Gb200),
+                },
+                Check {
+                    scenario: "GB300 compute tray",
+                    input: "DGX GB300 Compute Tray",
+                    expect: Some(RackProductFamily::Gb300),
+                },
+                Check {
+                    scenario: "concatenated GB200 name",
+                    input: "GB200Nvl Compute Tray",
+                    expect: None,
+                },
+                Check {
+                    scenario: "model names multiple product families",
+                    input: "GB200 GB300 Compute Tray",
+                    expect: None,
+                },
+                Check {
+                    scenario: "unknown model",
+                    input: "PowerEdge R750",
+                    expect: None,
+                },
+            ],
+            RackProductFamily::from_hardware_model,
+        );
+    }
+
+    #[test]
+    fn dpu_nvconfig_profile_requires_matching_product_family_and_dpu_identity() {
+        check_values(
+            [
+                Check {
+                    scenario: "GB200 family with supported B3240",
                     input: (
                         Some(RackProductFamily::Gb200),
                         Some(dpu_hardware_info("900-9D3B6-00CN-PA0")),
@@ -512,7 +589,7 @@ mod tests {
                     expect: Some(DpuNvConfigProfile::Gb200B3240V1),
                 },
                 Check {
-                    scenario: "other rack family with supported B3240",
+                    scenario: "other product family with supported B3240",
                     input: (
                         Some(RackProductFamily::Gb300),
                         Some(dpu_hardware_info("900-9D3B6-00CN-PA0")),
@@ -520,7 +597,7 @@ mod tests {
                     expect: None,
                 },
                 Check {
-                    scenario: "GB200 rack with another BlueField 3 product",
+                    scenario: "GB200 family with another BlueField 3 product",
                     input: (
                         Some(RackProductFamily::Gb200),
                         Some(dpu_hardware_info("900-9D3B6-00CV-AA0")),
@@ -528,12 +605,12 @@ mod tests {
                     expect: None,
                 },
                 Check {
-                    scenario: "GB200 rack without DPU hardware information",
+                    scenario: "GB200 family without DPU hardware information",
                     input: (Some(RackProductFamily::Gb200), None),
                     expect: None,
                 },
                 Check {
-                    scenario: "GB200 rack without DPU identity",
+                    scenario: "GB200 family without DPU identity",
                     input: (
                         Some(RackProductFamily::Gb200),
                         Some(HardwareInfo::default()),
@@ -541,7 +618,7 @@ mod tests {
                     expect: None,
                 },
                 Check {
-                    scenario: "missing rack family with supported B3240",
+                    scenario: "missing product family with supported B3240",
                     input: (None, Some(dpu_hardware_info("900-9D3B6-00CN-PA0"))),
                     expect: None,
                 },

--- a/crates/dpf/src/error.rs
+++ b/crates/dpf/src/error.rs
@@ -48,6 +48,12 @@ pub enum DpfError {
 }
 
 impl DpfError {
+    /// Returns whether this error represents a missing DPF resource.
+    pub fn is_not_found(&self) -> bool {
+        matches!(self, Self::NotFound { .. })
+            || matches!(self, Self::KubeError(kube::Error::Api(status)) if status.is_not_found())
+    }
+
     pub fn not_found(kind: &'static str, name: impl Into<String>) -> Self {
         Self::NotFound {
             kind,

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -17,7 +17,9 @@
 
 //! DPUFlavor configuration for HBN.
 
-use carbide_libmlx_model::nvconfig::DpuNvConfigProfile;
+use std::collections::BTreeSet;
+
+use carbide_libmlx_model::nvconfig::{DpuNvConfigProfile, GB200_B3240_V1_PF_TOTAL_SF};
 use kube::core::ObjectMeta;
 use sha2::{Digest, Sha256};
 
@@ -1194,10 +1196,15 @@ fn get_bf4_astra_config_files(
 }
 
 fn get_default_nvconfig(deployment_type: DpuDeploymentType) -> DpuFlavorNvconfig {
+    let pf_total_sf = if deployment_type == DpuDeploymentType::Bf3Gb200 {
+        GB200_B3240_V1_PF_TOTAL_SF
+    } else {
+        30
+    };
     let mut parameters = vec![
         "PF_BAR2_ENABLE=0".to_string(),
         "PER_PF_NUM_SF=1".to_string(),
-        "PF_TOTAL_SF=30".to_string(),
+        format!("PF_TOTAL_SF={pf_total_sf}"),
         "PF_SF_BAR_SIZE=10".to_string(),
         "NUM_PF_MSIX_VALID=0".to_string(),
         "PF_NUM_PF_MSIX_VALID=1".to_string(),
@@ -1214,9 +1221,15 @@ fn get_default_nvconfig(deployment_type: DpuDeploymentType) -> DpuFlavorNvconfig
     ];
 
     if deployment_type == DpuDeploymentType::Bf3Gb200 {
+        let configured_parameter_names = parameters
+            .iter()
+            .map(|parameter| nvconfig_parameter_name(parameter).to_string())
+            .collect::<BTreeSet<_>>();
+
         // DPF v26.4 accepts at most 32 parameters. These two assignments set
         // values that DPF already restores to their firmware default of 0, so
-        // omitting them preserves the required platform state.
+        // omitting them preserves the required platform state. Values already
+        // present in the BF3 base stay in their native DPF representation.
         // TODO(chet): Add PCI_SWITCH0_UPSTREAM_PORT_BUS=0 and
         // PCI_SWITCH0_UPSTREAM_PORT_PEX=0 after DPF accepts more than 32
         // NVConfig parameters.
@@ -1225,10 +1238,11 @@ fn get_default_nvconfig(deployment_type: DpuDeploymentType) -> DpuFlavorNvconfig
                 .parameters()
                 .iter()
                 .filter(|parameter| {
-                    !matches!(
-                        **parameter,
-                        "PCI_SWITCH0_UPSTREAM_PORT_BUS=0" | "PCI_SWITCH0_UPSTREAM_PORT_PEX=0"
-                    )
+                    !configured_parameter_names.contains(nvconfig_parameter_name(parameter))
+                        && !matches!(
+                            **parameter,
+                            "PCI_SWITCH0_UPSTREAM_PORT_BUS=0" | "PCI_SWITCH0_UPSTREAM_PORT_PEX=0"
+                        )
                 })
                 .map(|parameter| (*parameter).to_string()),
         );
@@ -1239,6 +1253,12 @@ fn get_default_nvconfig(deployment_type: DpuDeploymentType) -> DpuFlavorNvconfig
         device: Some(DpuFlavorNvconfigDevice::KopiumVariant0), //"*"
         parameters: Some(parameters),
     }
+}
+
+fn nvconfig_parameter_name(parameter: &str) -> &str {
+    parameter
+        .split_once('=')
+        .map_or(parameter, |(name, _)| name)
 }
 
 fn get_bf4_astra_nvconfig() -> DpuFlavorNvconfig {
@@ -2117,10 +2137,17 @@ mod tests {
             |deployment_type| get_default_nvconfig(deployment_type).parameters.unwrap();
         let bf3 = parameters(DpuDeploymentType::Bf3);
         let gb200 = parameters(DpuDeploymentType::Bf3Gb200);
+        let expected_gb200_base = bf3
+            .iter()
+            .map(|parameter| match parameter.as_str() {
+                "PF_TOTAL_SF=30" => "PF_TOTAL_SF=128".to_string(),
+                _ => parameter.clone(),
+            })
+            .collect::<Vec<_>>();
 
         assert_eq!(bf3.len(), 16);
         assert_eq!(gb200.len(), 32);
-        assert_eq!(&gb200[..bf3.len()], bf3.as_slice());
+        assert_eq!(&gb200[..bf3.len()], expected_gb200_base.as_slice());
         assert_eq!(
             &gb200[bf3.len()..],
             [

--- a/crates/dpf/src/repository/kube.rs
+++ b/crates/dpf/src/repository/kube.rs
@@ -25,7 +25,7 @@ use std::time::Duration;
 use async_trait::async_trait;
 use futures::StreamExt;
 use k8s_openapi::api::core::v1::{ConfigMap, Secret};
-use kube::api::{ListParams, Patch, PatchParams, PostParams};
+use kube::api::{DeleteParams, ListParams, Patch, PatchParams, PostParams, Preconditions};
 use kube::runtime::controller::Action;
 use kube::runtime::{Controller, watcher};
 use kube::{Api, Client, Resource};
@@ -181,6 +181,19 @@ impl DpuRepository for KubeRepository {
     async fn delete(&self, name: &str, namespace: &str) -> Result<(), DpfError> {
         let api: Api<DPU> = self.api(namespace);
         api.delete(name, &Default::default()).await?;
+        Ok(())
+    }
+
+    async fn delete_if_uid(&self, name: &str, namespace: &str, uid: &str) -> Result<(), DpfError> {
+        let api: Api<DPU> = self.api(namespace);
+        let params = DeleteParams {
+            preconditions: Some(Preconditions {
+                uid: Some(uid.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        api.delete(name, &params).await?;
         Ok(())
     }
 

--- a/crates/dpf/src/repository/traits.rs
+++ b/crates/dpf/src/repository/traits.rs
@@ -81,6 +81,12 @@ pub trait DpuRepository: Send + Sync {
     ) -> Result<(), DpfError>;
     async fn delete(&self, name: &str, namespace: &str) -> Result<(), DpfError>;
 
+    /// Delete a DPU only when its Kubernetes UID matches `uid`.
+    ///
+    /// The UID check must be part of the delete operation so a DPU recreated
+    /// under the same name cannot be deleted using an earlier observation.
+    async fn delete_if_uid(&self, name: &str, namespace: &str, uid: &str) -> Result<(), DpfError>;
+
     /// Watch for DPU changes and invoke the handler for each object.
     ///
     /// The returned future runs until the watch is cancelled. The handler's

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -102,6 +102,11 @@ const SERVICE_CR_NAME_HASH_BYTES: usize = 16;
 /// DPUDeployment. Value format: `<namespace>_<deployment_name>`.
 const DPU_OWNED_BY_DEPLOYMENT_LABEL: &str = "svc.dpu.nvidia.com/owned-by-dpudeployment";
 
+/// Returns DPF's canonical ownership label value for one DPUDeployment.
+fn dpu_deployment_owner_label_value(namespace: &str, deployment_name: &str) -> String {
+    format!("{namespace}_{deployment_name}")
+}
+
 pub(crate) const RESTART_ANNOTATION: &str =
     "provisioning.dpu.nvidia.com/dpunode-external-reboot-required";
 pub(crate) const HOLD_ANNOTATION: &str = "provisioning.dpu.nvidia.com/wait-for-external-nodeeffect";
@@ -1707,6 +1712,90 @@ impl<R: DpuNodeRepository, L: ResourceLabeler> DpfSdk<R, L> {
         }))
     }
 
+    /// Moves one DPUNode from its source DPUDeployment selector to its target
+    /// selector.
+    ///
+    /// Labels shared by both deployments and labels outside either selector
+    /// are preserved. The transfer uses the DPUNode's `resourceVersion`, so a
+    /// concurrent update returns a Kubernetes conflict instead of being
+    /// overwritten. Repeating a completed transfer does nothing. A DPUNode that
+    /// matches neither selector is rejected rather than assigned to the target
+    /// deployment.
+    pub async fn transfer_dpu_node_deployment_labels(
+        &self,
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace)
+            .await?
+            .ok_or_else(|| DpfError::not_found("DPUNode", node_name))?;
+        let source_labels = self
+            .labeler
+            .node_labels_for_deployment_type(source_deployment_type)?;
+        let target_labels = self
+            .labeler
+            .node_labels_for_deployment_type(target_deployment_type)?;
+        if source_labels.is_empty() || target_labels.is_empty() || source_labels == target_labels {
+            return Err(DpfError::ConfigError(format!(
+                "deployment label transfer requires distinct, nonempty selectors for \
+                 {source_deployment_type:?} and {target_deployment_type:?}"
+            )));
+        }
+        let current_labels = node.metadata.labels.unwrap_or_default();
+        let matches_selector = |selector: &BTreeMap<String, String>| {
+            selector
+                .iter()
+                .all(|(key, value)| current_labels.get(key) == Some(value))
+        };
+        let matches_source = matches_selector(&source_labels);
+        let matches_target = matches_selector(&target_labels);
+        if !matches_source && !matches_target {
+            return Err(DpfError::InvalidState(format!(
+                "DPUNode {node_name} labels match neither the {source_deployment_type:?} nor the \
+                 {target_deployment_type:?} deployment selector"
+            )));
+        }
+
+        let has_source_only_label = source_labels
+            .keys()
+            .any(|key| !target_labels.contains_key(key) && current_labels.contains_key(key));
+        let target_selector_differs = target_labels
+            .iter()
+            .any(|(key, value)| current_labels.get(key) != Some(value));
+        if !has_source_only_label && !target_selector_differs {
+            return Ok(());
+        }
+
+        let resource_version = node.metadata.resource_version.ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "DPUNode {node_name} has no resourceVersion for deployment label transfer"
+            ))
+        })?;
+        let mut label_changes: serde_json::Map<String, serde_json::Value> = source_labels
+            .keys()
+            .filter(|key| !target_labels.contains_key(*key))
+            .map(|key| (key.clone(), serde_json::Value::Null))
+            .collect();
+        label_changes.extend(
+            target_labels
+                .into_iter()
+                .map(|(key, value)| (key, serde_json::Value::String(value))),
+        );
+
+        // The transfer must not leave the DPUNode matching both deployment
+        // selectors. One merge patch makes the removal and addition atomic,
+        // while `resourceVersion` prevents this read from overwriting a
+        // concurrent DPUNode update.
+        let patch = json!({
+            "metadata": {
+                "resourceVersion": resource_version,
+                "labels": label_changes,
+            }
+        });
+        DpuNodeRepository::patch(&*self.repo, node_name, &self.namespace, patch).await
+    }
+
     /// Check if reboot is required for a DPU node.
     pub async fn is_reboot_required(&self, node_name: &str) -> Result<bool, DpfError> {
         let node = DpuNodeRepository::get(&*self.repo, node_name, &self.namespace).await?;
@@ -1782,7 +1871,9 @@ impl<R: DpuRepository, L> DpfSdk<R, L> {
     ///
     /// In the DPUDeployment (M4) model the operator creates DPU from DPUDevice; deleting the DPU
     /// CR causes the operator to remove it and create a new DPU (same name) that waits on node
-    /// effect. The DPUDevice CR is left in place.
+    /// effect. The DPUDevice CR is left in place. A missing DPU CR means deletion is already
+    /// complete. Treating that as success keeps retries safe when an earlier attempt deleted the
+    /// DPU but did not persist its next state, and when a DPUSet deletes it during label transfer.
     pub async fn reprovision_dpu(
         &self,
         dpu_device_name: &str,
@@ -1790,7 +1881,193 @@ impl<R: DpuRepository, L> DpfSdk<R, L> {
     ) -> Result<(), DpfError> {
         let dpf_id = node_id_from_dpu_node_cr_name(node_name);
         let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
-        DpuRepository::delete(&*self.repo, &cr_name, &self.namespace).await
+        match DpuRepository::delete(&*self.repo, &cr_name, &self.namespace).await {
+            Ok(()) => Ok(()),
+            Err(error) if error.is_not_found() => Ok(()),
+            Err(error) => Err(error),
+        }
+    }
+}
+
+impl<R: DpuRepository + DpuDeploymentRepository, L: ResourceLabeler> DpfSdk<R, L> {
+    /// Read every requested DPU phase only when one deployment owns the full set.
+    ///
+    /// A DPU that is not Ready may not report its installed BFB yet, so ownership
+    /// is sufficient until that phase. A Ready DPU must also match the flavor and
+    /// BFB declared by the deployment. `None` means at least one requested DPU is
+    /// missing, is being deleted, belongs to another deployment, or has no status.
+    pub async fn get_dpu_phases_for_deployment_type(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<Option<BTreeMap<String, DpuPhase>>, DpfError> {
+        let (deployment_name, deployment) = self.deployment_for_type(deployment_type).await?;
+        if !dpu_deployment_is_ready(&deployment) {
+            return Ok(None);
+        }
+        let expected_flavor = deployment.spec.dpus.flavor.as_deref().ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "DPUDeployment {deployment_name} has no comparable DPUFlavor"
+            ))
+        })?;
+        let expected_bfb_cr_name = deployment.spec.dpus.bfb.as_deref().ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "DPUDeployment {deployment_name} has no comparable BFB"
+            ))
+        })?;
+        let expected_bfb_filename = format!("{}-{expected_bfb_cr_name}.bfb", self.namespace);
+
+        let expected_owner = dpu_deployment_owner_label_value(&self.namespace, &deployment_name);
+        let owner_selector = format!("{DPU_OWNED_BY_DEPLOYMENT_LABEL}={expected_owner}");
+        let dpf_id = node_id_from_dpu_node_cr_name(node_name);
+        let mut dpus_by_name =
+            DpuRepository::list(&*self.repo, &self.namespace, Some(&owner_selector))
+                .await?
+                .into_iter()
+                .filter_map(|dpu| Some((dpu.metadata.name.clone()?, dpu)))
+                .collect::<HashMap<_, _>>();
+        let mut phases = BTreeMap::new();
+
+        for dpu_device_name in dpu_device_names {
+            let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
+            let Some(dpu) = dpus_by_name.remove(&cr_name) else {
+                return Ok(None);
+            };
+            let has_expected_owner = dpu
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(DPU_OWNED_BY_DEPLOYMENT_LABEL))
+                == Some(&expected_owner);
+            if !has_expected_owner || dpu.metadata.deletion_timestamp.is_some() {
+                return Ok(None);
+            }
+
+            let Some(status) = dpu.status.as_ref() else {
+                return Ok(None);
+            };
+            let phase = DpuPhase::from(status.phase.clone());
+            if phase == DpuPhase::Ready {
+                let installed_bfb = status
+                    .bfb_file
+                    .as_deref()
+                    .map(bfb_file_basename)
+                    .ok_or_else(|| {
+                        DpfError::InvalidState(format!(
+                            "Ready DPU {cr_name} does not report an installed BFB"
+                        ))
+                    })?;
+                if dpu.spec.dpu_flavor != expected_flavor || installed_bfb != expected_bfb_filename
+                {
+                    return Err(DpfError::InvalidState(format!(
+                        "Ready DPU {cr_name} does not match DPUDeployment {deployment_name}; \
+                         expected flavor {expected_flavor} and BFB {expected_bfb_filename}"
+                    )));
+                }
+            }
+            phases.insert(dpu_device_name.clone(), phase);
+        }
+
+        Ok(Some(phases))
+    }
+
+    /// Delete source deployment DPU CRs without deleting target replacements.
+    ///
+    /// Each delete carries the observed DPU UID as a Kubernetes precondition.
+    /// If a source DPU disappears and a target DPU reuses its deterministic name,
+    /// a retry preserves the replacement. A DPU owned by any deployment other
+    /// than the declared source or target is rejected.
+    pub async fn delete_source_dpus_for_deployment_migration(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        let (source_deployment_name, _) = self.deployment_for_type(source_deployment_type).await?;
+        let (target_deployment_name, _) = self.deployment_for_type(target_deployment_type).await?;
+        let source_owner =
+            dpu_deployment_owner_label_value(&self.namespace, &source_deployment_name);
+        let target_owner =
+            dpu_deployment_owner_label_value(&self.namespace, &target_deployment_name);
+        let dpf_id = node_id_from_dpu_node_cr_name(node_name);
+        let mut dpus_by_name = DpuRepository::list(&*self.repo, &self.namespace, None)
+            .await?
+            .into_iter()
+            .filter_map(|dpu| Some((dpu.metadata.name.clone()?, dpu)))
+            .collect::<HashMap<_, _>>();
+
+        for dpu_device_name in dpu_device_names {
+            let cr_name = dpu_cr_name(dpu_device_name, dpf_id);
+            let Some(dpu) = dpus_by_name.remove(&cr_name) else {
+                continue;
+            };
+            let owner = dpu
+                .metadata
+                .labels
+                .as_ref()
+                .and_then(|labels| labels.get(DPU_OWNED_BY_DEPLOYMENT_LABEL));
+            if owner == Some(&target_owner) {
+                continue;
+            }
+            if owner != Some(&source_owner) {
+                return Err(DpfError::InvalidState(format!(
+                    "DPU {cr_name} is owned by neither DPUDeployment \
+                     {source_deployment_name} nor {target_deployment_name}"
+                )));
+            }
+            let uid = dpu.metadata.uid.as_deref().ok_or_else(|| {
+                DpfError::InvalidState(format!(
+                    "DPU {cr_name} has no UID for deployment migration deletion"
+                ))
+            })?;
+            match DpuRepository::delete_if_uid(&*self.repo, &cr_name, &self.namespace, uid).await {
+                Ok(()) => {}
+                Err(error) if error.is_not_found() => {}
+                Err(error) => return Err(error),
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Find the one live DPUDeployment whose DPUSet selects a deployment type.
+    async fn deployment_for_type(
+        &self,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<(String, DPUDeployment), DpfError> {
+        let required_labels = self
+            .labeler
+            .node_labels_for_deployment_type(deployment_type)?;
+        if required_labels.is_empty() {
+            return Err(DpfError::ConfigError(format!(
+                "DPUDeployment selector for {deployment_type:?} is empty"
+            )));
+        }
+
+        let deployments = DpuDeploymentRepository::list(&*self.repo, &self.namespace).await?;
+        let mut matching_deployments = deployments.into_iter().filter(|deployment| {
+            deployment.metadata.deletion_timestamp.is_none()
+                && dpu_deployment_selects_labels(deployment, &required_labels)
+        });
+        let deployment = matching_deployments.next().ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "no DPUDeployment selects {deployment_type:?} DPU nodes"
+            ))
+        })?;
+        if matching_deployments.next().is_some() {
+            return Err(DpfError::InvalidState(format!(
+                "multiple DPUDeployments select {deployment_type:?} DPU nodes"
+            )));
+        }
+        let deployment_name = deployment.metadata.name.clone().ok_or_else(|| {
+            DpfError::InvalidState(format!(
+                "DPUDeployment selecting {deployment_type:?} DPU nodes has no name"
+            ))
+        })?;
+
+        Ok((deployment_name, deployment))
     }
 }
 
@@ -1938,6 +2215,32 @@ fn dpu_deployment_is_ready(d: &DPUDeployment) -> bool {
         return false;
     };
     cond.status == "True" && cond.observed_generation == Some(generation)
+}
+
+/// Returns true when one DPUSet in a deployment contains every required
+/// DPUNode selector label.
+fn dpu_deployment_selects_labels(
+    deployment: &DPUDeployment,
+    required_labels: &BTreeMap<String, String>,
+) -> bool {
+    deployment
+        .spec
+        .dpus
+        .dpu_sets
+        .as_ref()
+        .is_some_and(|dpu_sets| {
+            dpu_sets.iter().any(|dpu_set| {
+                dpu_set
+                    .dpu_node_selector
+                    .as_ref()
+                    .and_then(|selector| selector.match_labels.as_ref())
+                    .is_some_and(|labels| {
+                        required_labels
+                            .iter()
+                            .all(|(key, value)| labels.get(key) == Some(value))
+                    })
+            })
+        })
 }
 
 impl<R: DpuNodeMaintenanceRepository, L> DpfSdk<R, L> {
@@ -2901,6 +3204,21 @@ mod tests {
         async fn delete(&self, name: &str, ns: &str) -> Result<(), DpfError> {
             self.dpus.write().unwrap().remove(&Self::ns_key(ns, name));
             Ok(())
+        }
+        async fn delete_if_uid(&self, name: &str, ns: &str, uid: &str) -> Result<(), DpfError> {
+            let current_uid = self
+                .dpus
+                .read()
+                .unwrap()
+                .get(&Self::ns_key(ns, name))
+                .and_then(|dpu| dpu.metadata.uid.as_deref().map(str::to_owned))
+                .ok_or_else(|| DpfError::not_found("DPU", name))?;
+            if current_uid != uid {
+                return Err(DpfError::InvalidState(format!(
+                    "DPU {name} UID changed before deletion"
+                )));
+            }
+            DpuRepository::delete(self, name, ns).await
         }
         fn watch<F, Fut>(
             &self,

--- a/crates/dpf/src/test/helpers.rs
+++ b/crates/dpf/src/test/helpers.rs
@@ -159,6 +159,9 @@ impl DpuRepository for WatcherMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/maintenance_flow.rs
+++ b/crates/dpf/src/test/maintenance_flow.rs
@@ -121,6 +121,9 @@ impl DpuRepository for MaintenanceFlowMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_device_registration.rs
+++ b/crates/dpf/src/test/sdk_device_registration.rs
@@ -128,6 +128,9 @@ impl DpuRepository for DeviceRegistrationMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -19,16 +19,20 @@
 
 use std::collections::BTreeMap;
 use std::future::Future;
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use async_trait::async_trait;
 use dashmap::DashMap;
 use kube::Resource;
+use kube::core::ObjectMeta;
 
 use crate::crds::bfbs_generated::BFB;
 use crate::crds::bluefieldsoftwares_generated::BlueFieldSoftware;
-use crate::crds::dpudeployments_generated::DPUDeployment;
+use crate::crds::dpudeployments_generated::{
+    DPUDeployment, DpuDeploymentDpusDpuSets, DpuDeploymentDpusDpuSetsDpuNodeSelector,
+};
 use crate::crds::dpuflavors_generated::DPUFlavor;
+use crate::crds::dpunodes_generated::{DPUNode, DpuNodeSpec};
 use crate::crds::dpus_generated::{DPU, DpuStatusPhase};
 use crate::crds::dpuserviceconfigurations_generated::DPUServiceConfiguration;
 use crate::crds::dpuserviceinterfaces_generated::DPUServiceInterface;
@@ -37,14 +41,21 @@ use crate::crds::dpuservicetemplates_generated::DPUServiceTemplate;
 use crate::error::DpfError;
 use crate::repository::{
     BfbRepository, BlueFieldSoftwareRepository, DpfOperatorConfigRepository,
-    DpuDeploymentRepository, DpuFlavorRepository, DpuRepository, DpuServiceConfigurationRepository,
-    DpuServiceInterfaceRepository, DpuServiceNADRepository, DpuServiceTemplateRepository,
-    K8sConfigRepository,
+    DpuDeploymentRepository, DpuFlavorRepository, DpuNodeRepository, DpuRepository,
+    DpuServiceConfigurationRepository, DpuServiceInterfaceRepository, DpuServiceNADRepository,
+    DpuServiceTemplateRepository, K8sConfigRepository,
 };
-use crate::sdk::ResourceLabeler;
+use crate::sdk::{DpfSdkBuilder, ResourceLabeler};
 use crate::types::*;
 
 const TEST_NS: &str = "sdk-init-ns";
+const TEST_NODE_NAME: &str = "node-host-001";
+const TEST_DPU_NAME: &str = "node-host-001-device-001";
+const SOURCE_DEPLOYMENT: &str = "bf3-deployment";
+const TARGET_DEPLOYMENT: &str = "gb200-deployment";
+const TEST_FLAVOR: &str = "test-flavor";
+const TEST_BFB: &str = "bf-bundle-abc";
+const OWNED_BY_DEPLOYMENT_LABEL: &str = "svc.dpu.nvidia.com/owned-by-dpudeployment";
 
 fn ns_key(ns: &str, name: &str) -> String {
     format!("{}/{}", ns, name)
@@ -63,6 +74,7 @@ struct InitializationMock {
     bfbs: Arc<DashMap<String, BFB>>,
     bluefield_softwares: Arc<DashMap<String, BlueFieldSoftware>>,
     flavors: Arc<DashMap<String, DPUFlavor>>,
+    nodes: Arc<DashMap<String, DPUNode>>,
     dpus: Arc<DashMap<String, DPU>>,
     deployments: Arc<DashMap<String, DPUDeployment>>,
     service_templates: Arc<DashMap<String, DPUServiceTemplate>>,
@@ -71,6 +83,9 @@ struct InitializationMock {
     service_interfaces: Arc<DashMap<String, DPUServiceInterface>>,
     configs: Arc<DashMap<String, BTreeMap<String, String>>>,
     secrets: Arc<DashMap<String, BTreeMap<String, Vec<u8>>>>,
+    node_patches: Arc<Mutex<Vec<serde_json::Value>>>,
+    dpu_list_selectors: Arc<Mutex<Vec<Option<String>>>>,
+    dpu_uid_deletes: Arc<Mutex<Vec<(String, String)>>>,
 }
 
 #[derive(Clone, Copy)]
@@ -91,6 +106,36 @@ impl ResourceLabeler for InitializationLabeler {
             "test.nvidia.com/deployment-type".to_string(),
             deployment_type.to_string(),
         )]))
+    }
+}
+
+/// Provides selectors with one shared label and one label unique to each BF3
+/// deployment so migration tests can distinguish selector ownership.
+#[derive(Clone, Copy)]
+struct MigrationLabeler;
+
+impl ResourceLabeler for MigrationLabeler {
+    fn node_labels_for_deployment_type(
+        &self,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<BTreeMap<String, String>, DpfError> {
+        let deployment_label = match deployment_type {
+            DpuDeploymentType::Bf3 => "test.nvidia.com/bf3",
+            DpuDeploymentType::Bf3Gb200 => "test.nvidia.com/bf3gb200",
+            other => {
+                return Err(DpfError::ConfigError(format!(
+                    "no migration test selector for {other:?}"
+                )));
+            }
+        };
+
+        Ok(BTreeMap::from([
+            (
+                "test.nvidia.com/dpu-enabled".to_string(),
+                "true".to_string(),
+            ),
+            (deployment_label.to_string(), "true".to_string()),
+        ]))
     }
 }
 
@@ -173,7 +218,11 @@ impl DpuRepository for InitializationMock {
         Ok(self.dpus.get(&ns_key(ns, name)).map(|dpu| dpu.clone()))
     }
 
-    async fn list(&self, ns: &str, _label_selector: Option<&str>) -> Result<Vec<DPU>, DpfError> {
+    async fn list(&self, ns: &str, label_selector: Option<&str>) -> Result<Vec<DPU>, DpfError> {
+        self.dpu_list_selectors
+            .lock()
+            .unwrap()
+            .push(label_selector.map(str::to_string));
         let prefix = format!("{ns}/");
         Ok(self
             .dpus
@@ -197,6 +246,24 @@ impl DpuRepository for InitializationMock {
         Ok(())
     }
 
+    async fn delete_if_uid(&self, name: &str, ns: &str, uid: &str) -> Result<(), DpfError> {
+        self.dpu_uid_deletes
+            .lock()
+            .unwrap()
+            .push((name.to_string(), uid.to_string()));
+        let current_uid = self
+            .dpus
+            .get(&ns_key(ns, name))
+            .map(|dpu| dpu.metadata.uid.clone())
+            .ok_or_else(|| DpfError::not_found("DPU", name))?;
+        if current_uid.as_deref() != Some(uid) {
+            return Err(DpfError::InvalidState(format!(
+                "DPU {name} no longer has UID {uid}"
+            )));
+        }
+        DpuRepository::delete(self, name, ns).await
+    }
+
     fn watch<F, Fut>(
         &self,
         _ns: &str,
@@ -208,6 +275,54 @@ impl DpuRepository for InitializationMock {
         Fut: Future<Output = Result<(), DpfError>> + Send + 'static,
     {
         futures::future::pending()
+    }
+}
+
+#[async_trait]
+impl DpuNodeRepository for InitializationMock {
+    async fn get(&self, name: &str, ns: &str) -> Result<Option<DPUNode>, DpfError> {
+        Ok(self.nodes.get(&ns_key(ns, name)).map(|node| node.clone()))
+    }
+
+    async fn list(&self, ns: &str) -> Result<Vec<DPUNode>, DpfError> {
+        let prefix = format!("{ns}/");
+        Ok(self
+            .nodes
+            .iter()
+            .filter(|entry| entry.key().starts_with(&prefix))
+            .map(|entry| entry.value().clone())
+            .collect())
+    }
+
+    async fn create(&self, node: &DPUNode) -> Result<DPUNode, DpfError> {
+        self.nodes.insert(resource_key(node), node.clone());
+        Ok(node.clone())
+    }
+
+    async fn patch(&self, name: &str, ns: &str, patch: serde_json::Value) -> Result<(), DpfError> {
+        self.node_patches.lock().unwrap().push(patch.clone());
+
+        if let Some(mut node) = self.nodes.get_mut(&ns_key(ns, name))
+            && let Some(labels) = patch
+                .pointer("/metadata/labels")
+                .and_then(serde_json::Value::as_object)
+        {
+            let node_labels = node.metadata.labels.get_or_insert_with(BTreeMap::new);
+            for (key, value) in labels {
+                if value.is_null() {
+                    node_labels.remove(key);
+                } else if let Some(value) = value.as_str() {
+                    node_labels.insert(key.clone(), value.to_string());
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn delete(&self, name: &str, ns: &str) -> Result<(), DpfError> {
+        self.nodes.remove(&ns_key(ns, name));
+        Ok(())
     }
 }
 
@@ -379,6 +494,491 @@ impl DpfOperatorConfigRepository for InitializationMock {
     }
 }
 
+/// Builds a DPUNode with source deployment labels and one unrelated label that
+/// a migration must preserve.
+fn migration_dpu_node() -> DPUNode {
+    DPUNode {
+        metadata: ObjectMeta {
+            name: Some(TEST_NODE_NAME.to_string()),
+            namespace: Some(TEST_NS.to_string()),
+            resource_version: Some("7".to_string()),
+            labels: Some(BTreeMap::from([
+                (
+                    "test.nvidia.com/dpu-enabled".to_string(),
+                    "true".to_string(),
+                ),
+                ("test.nvidia.com/bf3".to_string(), "true".to_string()),
+                (
+                    "external.nvidia.com/label".to_string(),
+                    "preserved".to_string(),
+                ),
+            ])),
+            ..Default::default()
+        },
+        spec: DpuNodeSpec {
+            dpus: Some(vec![]),
+            node_dms_address: None,
+            node_reboot_method: None,
+        },
+        status: None,
+    }
+}
+
+/// Builds one ready or settling deployment with the selector for its requested
+/// BF3 deployment type.
+fn migration_deployment(
+    name: &str,
+    deployment_type: DpuDeploymentType,
+    ready: bool,
+) -> DPUDeployment {
+    let spec = serde_json::json!({
+        "dpus": {
+            "bfb": TEST_BFB,
+            "flavor": TEST_FLAVOR,
+            "dpuSetStrategy": { "type": "OnDelete" },
+            "nodeEffect": {},
+        },
+        "services": {},
+        "serviceChains": {
+            "switches": [],
+            "upgradePolicy": { "applyNodeEffect": true },
+        },
+    });
+    let status = serde_json::json!({
+        "conditions": [{
+            "type": "DPUSetsReconciled",
+            "status": if ready { "True" } else { "False" },
+            "observedGeneration": 1,
+            "lastTransitionTime": "2026-01-01T00:00:00Z",
+            "reason": "Test",
+        }],
+    });
+    let selector_labels = MigrationLabeler
+        .node_labels_for_deployment_type(deployment_type)
+        .expect("migration test selector");
+    let mut deployment = DPUDeployment {
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(TEST_NS.to_string()),
+            generation: Some(1),
+            ..Default::default()
+        },
+        spec: serde_json::from_value(spec).expect("valid DPUDeployment spec"),
+        status: Some(serde_json::from_value(status).expect("valid DPUDeployment status")),
+    };
+    deployment.spec.dpus.dpu_sets = Some(vec![DpuDeploymentDpusDpuSets {
+        dpu_annotations: None,
+        dpu_selector: None,
+        name_suffix: "default".to_string(),
+        dpu_node_selector: Some(DpuDeploymentDpusDpuSetsDpuNodeSelector {
+            match_expressions: None,
+            match_labels: Some(selector_labels),
+        }),
+        dpu_cluster_selector: None,
+        dpu_device_selector: None,
+        node_selector: None,
+    }]);
+    deployment
+}
+
+/// Builds one DPU owned by a selected deployment with the configuration fields
+/// that are authoritative after it reaches Ready.
+fn migration_dpu(
+    owner: &str,
+    phase: DpuStatusPhase,
+    flavor: &str,
+    installed_bfb_file: Option<&str>,
+    uid: &str,
+) -> DPU {
+    let mut dpu = super::helpers::make_dpu(TEST_NS, TEST_DPU_NAME, "001", TEST_NODE_NAME, phase);
+    dpu.metadata.labels = Some(BTreeMap::from([(
+        OWNED_BY_DEPLOYMENT_LABEL.to_string(),
+        format!("{TEST_NS}_{owner}"),
+    )]));
+    dpu.metadata.uid = Some(uid.to_string());
+    dpu.spec.dpu_flavor = flavor.to_string();
+    dpu.status.as_mut().expect("DPU status").bfb_file = installed_bfb_file.map(str::to_string);
+    dpu
+}
+
+/// Builds the SDK with migration selectors and returns the target deployment's
+/// phase for the single test DPU.
+async fn target_dpu_phase(mock: InitializationMock) -> Result<Option<DpuPhase>, DpfError> {
+    let phases = DpfSdkBuilder::new(mock, TEST_NS, String::new())
+        .with_labeler(MigrationLabeler)
+        .build_without_resources()
+        .await
+        .expect("migration SDK")
+        .get_dpu_phases_for_deployment_type(
+            &["001".to_string()],
+            TEST_NODE_NAME,
+            DpuDeploymentType::Bf3Gb200,
+        )
+        .await?;
+
+    Ok(phases.and_then(|mut phases| phases.remove("001")))
+}
+
+/// A selector transfer removes and adds the deployment-specific labels in one
+/// version-guarded patch, is idempotent, and repairs a node matching both.
+#[tokio::test]
+async fn deployment_label_transfer_is_atomic_idempotent_and_repairs_partial_state() {
+    let mock = InitializationMock::default();
+    let node = migration_dpu_node();
+    mock.nodes.insert(resource_key(&node), node);
+    let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NS, String::new())
+        .with_labeler(MigrationLabeler)
+        .build_without_resources()
+        .await
+        .expect("migration SDK");
+
+    sdk.transfer_dpu_node_deployment_labels(
+        TEST_NODE_NAME,
+        DpuDeploymentType::Bf3,
+        DpuDeploymentType::Bf3Gb200,
+    )
+    .await
+    .expect("source-to-target selector transfer");
+
+    {
+        let patches = mock.node_patches.lock().unwrap();
+        assert_eq!(patches.len(), 1);
+        assert_eq!(
+            patches[0]
+                .pointer("/metadata/resourceVersion")
+                .and_then(serde_json::Value::as_str),
+            Some("7")
+        );
+        assert!(patches[0]["metadata"]["labels"]["test.nvidia.com/bf3"].is_null());
+        assert_eq!(
+            patches[0]["metadata"]["labels"]["test.nvidia.com/bf3gb200"],
+            "true"
+        );
+    }
+
+    let node = DpuNodeRepository::get(&mock, TEST_NODE_NAME, TEST_NS)
+        .await
+        .unwrap()
+        .expect("transferred DPUNode");
+    assert_eq!(
+        node.metadata.labels,
+        Some(BTreeMap::from([
+            (
+                "test.nvidia.com/dpu-enabled".to_string(),
+                "true".to_string()
+            ),
+            ("test.nvidia.com/bf3gb200".to_string(), "true".to_string()),
+            (
+                "external.nvidia.com/label".to_string(),
+                "preserved".to_string()
+            ),
+        ]))
+    );
+
+    sdk.transfer_dpu_node_deployment_labels(
+        TEST_NODE_NAME,
+        DpuDeploymentType::Bf3,
+        DpuDeploymentType::Bf3Gb200,
+    )
+    .await
+    .expect("idempotent selector transfer");
+    assert_eq!(mock.node_patches.lock().unwrap().len(), 1);
+
+    mock.nodes
+        .get_mut(&ns_key(TEST_NS, TEST_NODE_NAME))
+        .expect("DPUNode to repair")
+        .metadata
+        .labels
+        .as_mut()
+        .expect("DPUNode labels")
+        .insert("test.nvidia.com/bf3".to_string(), "true".to_string());
+    sdk.transfer_dpu_node_deployment_labels(
+        TEST_NODE_NAME,
+        DpuDeploymentType::Bf3,
+        DpuDeploymentType::Bf3Gb200,
+    )
+    .await
+    .expect("repair selector overlap");
+
+    let node = DpuNodeRepository::get(&mock, TEST_NODE_NAME, TEST_NS)
+        .await
+        .unwrap()
+        .expect("repaired DPUNode");
+    assert!(
+        !node
+            .metadata
+            .labels
+            .expect("DPUNode labels")
+            .contains_key("test.nvidia.com/bf3")
+    );
+    assert_eq!(mock.node_patches.lock().unwrap().len(), 2);
+}
+
+/// A node outside both deployment selectors cannot be claimed by the target
+/// deployment as a side effect of migration.
+#[tokio::test]
+async fn deployment_label_transfer_rejects_unrelated_node() {
+    let mock = InitializationMock::default();
+    let mut node = migration_dpu_node();
+    node.metadata.labels = Some(BTreeMap::from([
+        (
+            "test.nvidia.com/dpu-enabled".to_string(),
+            "true".to_string(),
+        ),
+        (
+            "external.nvidia.com/label".to_string(),
+            "preserved".to_string(),
+        ),
+    ]));
+    mock.nodes.insert(resource_key(&node), node);
+    let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NS, String::new())
+        .with_labeler(MigrationLabeler)
+        .build_without_resources()
+        .await
+        .expect("migration SDK");
+
+    let error = sdk
+        .transfer_dpu_node_deployment_labels(
+            TEST_NODE_NAME,
+            DpuDeploymentType::Bf3,
+            DpuDeploymentType::Bf3Gb200,
+        )
+        .await
+        .expect_err("unrelated DPUNode must be rejected");
+
+    assert!(matches!(error, DpfError::InvalidState(_)));
+    assert!(mock.node_patches.lock().unwrap().is_empty());
+}
+
+/// Deployment-scoped reads require one unambiguous live deployment selector.
+#[tokio::test]
+async fn deployment_phase_requires_exactly_one_target_deployment() {
+    for (name, deployment_count, expected_message) in [
+        ("no matching deployment", 0, "no DPUDeployment selects"),
+        (
+            "multiple matching deployments",
+            2,
+            "multiple DPUDeployments select",
+        ),
+    ] {
+        let mock = InitializationMock::default();
+        for index in 0..deployment_count {
+            let deployment = migration_deployment(
+                &format!("target-deployment-{index}"),
+                DpuDeploymentType::Bf3Gb200,
+                true,
+            );
+            mock.deployments
+                .insert(resource_key(&deployment), deployment);
+        }
+
+        let error = target_dpu_phase(mock).await.expect_err(name);
+        assert!(
+            matches!(&error, DpfError::InvalidState(message) if message.contains(expected_message)),
+            "{name}: {error}"
+        );
+    }
+}
+
+/// Target phase reads are owner-scoped; work in progress can be reported by
+/// ownership alone, while Ready requires matching flavor and installed BFB.
+#[tokio::test]
+async fn target_deployment_phase_checks_ownership_and_ready_configuration() {
+    struct Case {
+        name: &'static str,
+        owner: &'static str,
+        phase: DpuStatusPhase,
+        flavor: &'static str,
+        installed_bfb_file: Option<&'static str>,
+        expected_phase: Option<DpuPhase>,
+        expects_error: bool,
+    }
+
+    let cases = [
+        Case {
+            name: "source still owns the DPU",
+            owner: SOURCE_DEPLOYMENT,
+            phase: DpuStatusPhase::Ready,
+            flavor: TEST_FLAVOR,
+            installed_bfb_file: Some("/bfb/sdk-init-ns-bf-bundle-abc.bfb"),
+            expected_phase: None,
+            expects_error: false,
+        },
+        Case {
+            name: "target owns a DPU still installing",
+            owner: TARGET_DEPLOYMENT,
+            phase: DpuStatusPhase::OsInstalling,
+            flavor: "old-flavor",
+            installed_bfb_file: None,
+            expected_phase: Some(DpuPhase::Provisioning("OsInstalling".to_string())),
+            expects_error: false,
+        },
+        Case {
+            name: "target owns a matching Ready DPU",
+            owner: TARGET_DEPLOYMENT,
+            phase: DpuStatusPhase::Ready,
+            flavor: TEST_FLAVOR,
+            installed_bfb_file: Some("/bfb/sdk-init-ns-bf-bundle-abc.bfb"),
+            expected_phase: Some(DpuPhase::Ready),
+            expects_error: false,
+        },
+        Case {
+            name: "Ready flavor drift",
+            owner: TARGET_DEPLOYMENT,
+            phase: DpuStatusPhase::Ready,
+            flavor: "old-flavor",
+            installed_bfb_file: Some("/bfb/sdk-init-ns-bf-bundle-abc.bfb"),
+            expected_phase: None,
+            expects_error: true,
+        },
+        Case {
+            name: "Ready BFB drift",
+            owner: TARGET_DEPLOYMENT,
+            phase: DpuStatusPhase::Ready,
+            flavor: TEST_FLAVOR,
+            installed_bfb_file: Some("/bfb/sdk-init-ns-bf-bundle-old.bfb"),
+            expected_phase: None,
+            expects_error: true,
+        },
+    ];
+
+    for case in cases {
+        let mock = InitializationMock::default();
+        let deployment = migration_deployment(TARGET_DEPLOYMENT, DpuDeploymentType::Bf3Gb200, true);
+        mock.deployments
+            .insert(resource_key(&deployment), deployment);
+        let dpu = migration_dpu(
+            case.owner,
+            case.phase,
+            case.flavor,
+            case.installed_bfb_file,
+            "dpu-uid",
+        );
+        mock.dpus.insert(resource_key(&dpu), dpu);
+
+        let result = target_dpu_phase(mock.clone()).await;
+        if case.expects_error {
+            assert!(
+                matches!(result, Err(DpfError::InvalidState(_))),
+                "{}: {result:?}",
+                case.name
+            );
+        } else {
+            assert_eq!(result.unwrap(), case.expected_phase, "{}", case.name);
+        }
+        assert_eq!(
+            *mock.dpu_list_selectors.lock().unwrap(),
+            vec![Some(format!(
+                "{OWNED_BY_DEPLOYMENT_LABEL}={TEST_NS}_{TARGET_DEPLOYMENT}"
+            ))],
+            "{}",
+            case.name
+        );
+    }
+}
+
+/// Source deletion uses the observed UID and a retry preserves a replacement
+/// already owned by the target deployment.
+#[tokio::test]
+async fn deployment_migration_deletion_is_uid_guarded_and_preserves_target_replacement() {
+    let mock = InitializationMock::default();
+    for (name, deployment_type) in [
+        (SOURCE_DEPLOYMENT, DpuDeploymentType::Bf3),
+        (TARGET_DEPLOYMENT, DpuDeploymentType::Bf3Gb200),
+    ] {
+        let deployment = migration_deployment(name, deployment_type, true);
+        mock.deployments
+            .insert(resource_key(&deployment), deployment);
+    }
+    let source_dpu = migration_dpu(
+        SOURCE_DEPLOYMENT,
+        DpuStatusPhase::Ready,
+        TEST_FLAVOR,
+        Some("/bfb/sdk-init-ns-bf-bundle-abc.bfb"),
+        "source-uid",
+    );
+    mock.dpus.insert(resource_key(&source_dpu), source_dpu);
+    let sdk = DpfSdkBuilder::new(mock.clone(), TEST_NS, String::new())
+        .with_labeler(MigrationLabeler)
+        .build_without_resources()
+        .await
+        .expect("migration SDK");
+
+    sdk.delete_source_dpus_for_deployment_migration(
+        &["001".to_string()],
+        TEST_NODE_NAME,
+        DpuDeploymentType::Bf3,
+        DpuDeploymentType::Bf3Gb200,
+    )
+    .await
+    .expect("source DPU deletion");
+    assert!(
+        DpuRepository::get(&mock, TEST_DPU_NAME, TEST_NS)
+            .await
+            .unwrap()
+            .is_none()
+    );
+    assert_eq!(
+        *mock.dpu_uid_deletes.lock().unwrap(),
+        vec![(TEST_DPU_NAME.to_string(), "source-uid".to_string())]
+    );
+
+    let target_replacement = migration_dpu(
+        TARGET_DEPLOYMENT,
+        DpuStatusPhase::OsInstalling,
+        TEST_FLAVOR,
+        None,
+        "target-uid",
+    );
+    mock.dpus
+        .insert(resource_key(&target_replacement), target_replacement);
+    sdk.delete_source_dpus_for_deployment_migration(
+        &["001".to_string()],
+        TEST_NODE_NAME,
+        DpuDeploymentType::Bf3,
+        DpuDeploymentType::Bf3Gb200,
+    )
+    .await
+    .expect("migration retry");
+
+    let replacement = DpuRepository::get(&mock, TEST_DPU_NAME, TEST_NS)
+        .await
+        .unwrap()
+        .expect("target replacement must remain");
+    assert_eq!(replacement.metadata.uid.as_deref(), Some("target-uid"));
+    assert_eq!(mock.dpu_uid_deletes.lock().unwrap().len(), 1);
+}
+
+/// A conditional delete must preserve a replacement DPU whose UID differs
+/// from the stale object observed by the migration reconciler.
+#[tokio::test]
+async fn conditional_dpu_delete_rejects_uid_mismatch() {
+    let mock = InitializationMock::default();
+    let dpu_name = "node-host-device-dpu";
+    let mut replacement = super::helpers::make_dpu(
+        TEST_NS,
+        dpu_name,
+        "device-dpu",
+        "node-host",
+        DpuStatusPhase::Ready,
+    );
+    replacement.metadata.uid = Some("replacement-uid".to_string());
+    mock.dpus.insert(resource_key(&replacement), replacement);
+
+    let error = DpuRepository::delete_if_uid(&mock, dpu_name, TEST_NS, "stale-uid")
+        .await
+        .expect_err("a stale UID must not delete the replacement DPU");
+
+    assert!(matches!(error, DpfError::InvalidState(_)));
+    assert!(
+        DpuRepository::get(&mock, dpu_name, TEST_NS)
+            .await
+            .unwrap()
+            .is_some(),
+        "the replacement DPU must remain after the rejected delete"
+    );
+}
+
 #[tokio::test]
 async fn test_create_initialization_objects() {
     let mock = InitializationMock::default();
@@ -500,9 +1100,19 @@ async fn bf3_and_gb200_initialization_persists_distinct_resources() {
             .any(|parameter| parameter == "OFF_BOARD_SERIALIZER=1")
     );
     assert!(
+        bf3_nvconfig
+            .iter()
+            .any(|parameter| parameter == "PF_TOTAL_SF=30")
+    );
+    assert!(
         gb200_nvconfig
             .iter()
             .any(|parameter| parameter == "OFF_BOARD_SERIALIZER=1")
+    );
+    assert!(
+        gb200_nvconfig
+            .iter()
+            .any(|parameter| parameter == "PF_TOTAL_SF=128")
     );
 
     let bf3_service = bf3_deployment

--- a/crates/dpf/src/test/sdk_provisioning_flow.rs
+++ b/crates/dpf/src/test/sdk_provisioning_flow.rs
@@ -105,6 +105,9 @@ impl DpuRepository for ProvisioningFlowMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/dpf/src/test/watcher_errors.rs
+++ b/crates/dpf/src/test/watcher_errors.rs
@@ -97,6 +97,9 @@ impl DpuRepository for ErrorCapturingMock {
     async fn delete(&self, _: &str, _: &str) -> Result<(), DpfError> {
         Ok(())
     }
+    async fn delete_if_uid(&self, name: &str, _ns: &str, _uid: &str) -> Result<(), DpfError> {
+        Err(DpfError::not_found("DPU", name))
+    }
     fn watch<F, Fut>(
         &self,
         _: &str,

--- a/crates/libmlx-model/src/nvconfig.rs
+++ b/crates/libmlx-model/src/nvconfig.rs
@@ -22,7 +22,16 @@
 // <https://docs.nvidia.com/networking/display/mftv4341lts/mlxconfig-%E2%80%93-changing-device-configuration-tool>
 // The generic recipe uses PCI_BUS00_SPEED=4, while the validated GB200/B3240
 // platform uses 5. Applying this profile requires a cold host power cycle.
-const GB200_B3240_V1_PARAMETERS: [&str; 18] = [
+/// Number of PF scalable functions required by the GB200 B3240 V1 profile.
+pub const GB200_B3240_V1_PF_TOTAL_SF: u32 = 128;
+
+const GB200_B3240_V1_PARAMETERS: [&str; 28] = [
+    "PF_NUM_PF_MSIX_VALID=1",
+    "PER_PF_NUM_SF=1",
+    "NUM_PF_MSIX_VALID=0",
+    "PF_BAR2_ENABLE=0",
+    "LINK_TYPE_P1=2",
+    "LINK_TYPE_P2=2",
     "OFF_BOARD_SERIALIZER=1",
     "PCI_BUS00_HIERARCHY_TYPE=1",
     "PCI_BUS00_SPEED=5",
@@ -39,6 +48,10 @@ const GB200_B3240_V1_PARAMETERS: [&str; 18] = [
     "PCI_BUS16_HIERARCHY_TYPE=1",
     "PCI_BUS16_SPEED=4",
     "PCI_BUS16_WIDTH=3",
+    "PF_TOTAL_SF=128",
+    "PF_SF_BAR_SIZE=10",
+    "PF_NUM_PF_MSIX=228",
+    "LAG_RESOURCE_ALLOCATION=1",
     "PCI_SWITCH0_UPSTREAM_PORT_BUS=0",
     "PCI_SWITCH0_UPSTREAM_PORT_PEX=0",
 ];
@@ -120,6 +133,12 @@ mod tests {
         assert_eq!(
             parameters,
             &[
+                "PF_NUM_PF_MSIX_VALID=1",
+                "PER_PF_NUM_SF=1",
+                "NUM_PF_MSIX_VALID=0",
+                "PF_BAR2_ENABLE=0",
+                "LINK_TYPE_P1=2",
+                "LINK_TYPE_P2=2",
                 "OFF_BOARD_SERIALIZER=1",
                 "PCI_BUS00_HIERARCHY_TYPE=1",
                 "PCI_BUS00_SPEED=5",
@@ -136,6 +155,10 @@ mod tests {
                 "PCI_BUS16_HIERARCHY_TYPE=1",
                 "PCI_BUS16_SPEED=4",
                 "PCI_BUS16_WIDTH=3",
+                "PF_TOTAL_SF=128",
+                "PF_SF_BAR_SIZE=10",
+                "PF_NUM_PF_MSIX=228",
+                "LAG_RESOURCE_ALLOCATION=1",
                 "PCI_SWITCH0_UPSTREAM_PORT_BUS=0",
                 "PCI_SWITCH0_UPSTREAM_PORT_PEX=0",
             ],

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -80,6 +80,24 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
         node_name: &str,
     ) -> Result<DpuPhase, DpfError>;
 
+    /// Read every requested DPU phase only when one deployment owns the full
+    /// set and each Ready DPU matches its flavor and provisioning source.
+    async fn get_dpu_phases_for_deployment_type(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<Option<BTreeMap<String, DpuPhase>>, DpfError>;
+
+    /// Delete source deployment DPU CRs while preserving target replacements.
+    async fn delete_source_dpus_for_deployment_migration(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError>;
+
     /// Check if a DPU node is waiting for external reboot.
     async fn is_reboot_required(&self, node_name: &str) -> Result<bool, DpfError>;
 
@@ -99,6 +117,17 @@ pub trait DpfOperations: Send + Sync + std::fmt::Debug {
         node_name: &str,
         deployment_type: DpuDeploymentType,
     ) -> Result<bool, DpfError>;
+
+    /// Atomically moves a DPUNode from one deployment selector to another.
+    ///
+    /// A completed transfer does nothing, while a node matching neither selector
+    /// is rejected.
+    async fn transfer_dpu_node_deployment_labels(
+        &self,
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError>;
 
     /// Curated snapshot of all DPF CRs related to one host (DPUNode +
     /// DPUDevices + DPUs). `node_name` is the full DPUNode CR name.
@@ -537,6 +566,34 @@ impl DpfOperations for DpfSdkOps {
         self.sdk.get_dpu_phase(dpu_device_name, node_name).await
     }
 
+    async fn get_dpu_phases_for_deployment_type(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        deployment_type: DpuDeploymentType,
+    ) -> Result<Option<BTreeMap<String, DpuPhase>>, DpfError> {
+        self.sdk
+            .get_dpu_phases_for_deployment_type(dpu_device_names, node_name, deployment_type)
+            .await
+    }
+
+    async fn delete_source_dpus_for_deployment_migration(
+        &self,
+        dpu_device_names: &[String],
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        self.sdk
+            .delete_source_dpus_for_deployment_migration(
+                dpu_device_names,
+                node_name,
+                source_deployment_type,
+                target_deployment_type,
+            )
+            .await
+    }
+
     async fn is_reboot_required(&self, node_name: &str) -> Result<bool, DpfError> {
         self.sdk.is_reboot_required(node_name).await
     }
@@ -585,6 +642,21 @@ impl DpfOperations for DpfSdkOps {
     ) -> Result<bool, DpfError> {
         self.sdk
             .verify_node_labels(node_name, deployment_type)
+            .await
+    }
+
+    async fn transfer_dpu_node_deployment_labels(
+        &self,
+        node_name: &str,
+        source_deployment_type: DpuDeploymentType,
+        target_deployment_type: DpuDeploymentType,
+    ) -> Result<(), DpfError> {
+        self.sdk
+            .transfer_dpu_node_deployment_labels(
+                node_name,
+                source_deployment_type,
+                target_deployment_type,
+            )
             .await
     }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -3650,7 +3650,23 @@ async fn handle_dpu_reprovision(
                 .with_txn(txn),
             )
         }
-        ReprovisionState::NotUnderReprovision => Ok(StateHandlerOutcome::do_nothing()),
+        ReprovisionState::NotUnderReprovision => {
+            if !dpf::deployment_migration_is_parked(state) {
+                return Ok(StateHandlerOutcome::do_nothing());
+            }
+            // Deployment migration is host scoped, while this handler is
+            // called once per DPU. Run it only for the first snapshot so one
+            // controller iteration observes and changes the DPF graph once.
+            if state.dpu_snapshots.first().map(|dpu| &dpu.id) != Some(dpu_machine_id) {
+                return Ok(StateHandlerOutcome::do_nothing());
+            }
+            let dpf = dpf_sdk.ok_or_else(|| {
+                StateHandlerError::GenericError(eyre::eyre!(
+                    "DPF deployment migration reached but DPF is not configured"
+                ))
+            })?;
+            dpf::handle_dpf_deployment_migration(state, ctx, dpf).await
+        }
     }
 }
 

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -20,6 +20,7 @@
 //! 2. Wait for watcher callbacks (DPU ready, reboot required)
 //! 3. Handle cleanup on error/reprovisioning
 
+use std::collections::HashSet;
 use std::net::IpAddr;
 
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase, dpu_node_cr_name};
@@ -28,9 +29,9 @@ use carbide_uuid::machine::MachineId;
 use libredfish::SystemPowerControl;
 use model::hardware_info::HardwareInfo;
 use model::machine::{
-    DpfState, DpuInitState, FailureCause, FailureDetails, FailureSource, InstanceState, Machine,
-    ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation, ReprovisionState,
-    StateMachineArea,
+    DpfState, DpuInitState, DpuReprovisionStates, FailureCause, FailureDetails, FailureSource,
+    InstanceState, Machine, ManagedHostState, ManagedHostStateSnapshot, PerformPowerOperation,
+    ReprovisionState, StateMachineArea,
 };
 use model::rack_type::{RackProductFamily, select_dpu_nvconfig_profile};
 use state_controller::state_handler::{
@@ -41,6 +42,11 @@ use super::helpers::{DpuInitStateHelper, ManagedHostStateHelper, ReprovisionStat
 use super::{handler_host_power_control, host_power_state};
 use crate::context::MachineStateHandlerContextObjects;
 use crate::dpf::DpfOperations;
+
+// `deployment_type_for_dpu_profile` currently refines exactly one deployment:
+// generic BF3 becomes GB200 BF3. Only that forward migration is supported.
+const DEPLOYMENT_MIGRATION_SOURCE: DpuDeploymentType = DpuDeploymentType::Bf3;
+const DEPLOYMENT_MIGRATION_TARGET: DpuDeploymentType = DpuDeploymentType::Bf3Gb200;
 
 fn dpf_error(error: DpfError) -> StateHandlerError {
     ExternalServiceError::with_source("dpf", "", error.to_string(), "dpf_error", error).into()
@@ -59,14 +65,30 @@ fn dpf_id(machine: &Machine) -> Result<String, StateHandlerError> {
     })
 }
 
-async fn host_rack_product_family(
+/// Returns the product family reported by Site Explorer, or falls back to the
+/// configured rack profile when that report does not name a known family.
+async fn host_product_family(
     state: &ManagedHostStateSnapshot,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
 ) -> Result<Option<RackProductFamily>, StateHandlerError> {
+    let mut conn = ctx.services.db_pool.acquire().await?;
+
+    if let Some(host_bmc_ip) = state.host_snapshot.status.bmc_info.ip {
+        let endpoints =
+            db::explored_endpoints::find_by_ips(conn.as_mut(), vec![host_bmc_ip]).await?;
+        if let Some(product_family) = endpoints
+            .first()
+            .and_then(|endpoint| endpoint.report.model())
+            .as_deref()
+            .and_then(RackProductFamily::from_hardware_model)
+        {
+            return Ok(Some(product_family));
+        }
+    }
+
     let Some(rack_id) = state.host_snapshot.rack_id.as_ref() else {
         return Ok(None);
     };
-    let mut conn = ctx.services.db_pool.acquire().await?;
     let Some(rack) = db::rack::find_by(
         conn.as_mut(),
         db::ObjectColumnFilter::One(db::rack::IdColumn, rack_id),
@@ -95,7 +117,7 @@ async fn deployment_types_for_host(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
 ) -> Result<Vec<DpuDeploymentType>, StateHandlerError> {
-    let product_family = host_rack_product_family(state, ctx).await?;
+    let product_family = host_product_family(state, ctx).await?;
     state
         .dpu_snapshots
         .iter()
@@ -136,6 +158,109 @@ fn consistent_deployment_type(
     } else {
         Err("host has mixed DPF deployment types across attached DPUs".to_string())
     }
+}
+
+/// Returns whether any attached DPU reprovision request has started.
+fn any_dpu_reprovision_request_has_started(state: &ManagedHostStateSnapshot) -> bool {
+    state.dpu_snapshots.iter().any(|dpu| {
+        dpu.reprovision_requested
+            .as_ref()
+            .is_some_and(|request| request.started_at.is_some())
+    })
+}
+
+/// Returns whether every attached DPU has a started reprovision request.
+fn all_dpu_reprovision_requests_have_started(state: &ManagedHostStateSnapshot) -> bool {
+    state.dpu_snapshots.iter().all(|dpu| {
+        dpu.reprovision_requested
+            .as_ref()
+            .is_some_and(|request| request.started_at.is_some())
+    })
+}
+
+/// Returns whether inventory, snapshots, and reprovision state describe the
+/// same complete, nonempty set of attached DPUs.
+fn deployment_migration_has_complete_dpu_set(
+    state: &ManagedHostStateSnapshot,
+    dpu_states: &DpuReprovisionStates,
+) -> bool {
+    let expected_dpu_ids = state
+        .host_snapshot
+        .associated_dpu_machine_ids()
+        .into_iter()
+        .collect::<HashSet<_>>();
+    let snapshot_dpu_ids = state
+        .dpu_snapshots
+        .iter()
+        .map(|dpu| dpu.id)
+        .collect::<HashSet<_>>();
+    let state_dpu_ids = dpu_states.states.keys().copied().collect::<HashSet<_>>();
+
+    !expected_dpu_ids.is_empty()
+        && expected_dpu_ids == snapshot_dpu_ids
+        && expected_dpu_ids == state_dpu_ids
+}
+
+/// Returns whether the stored reprovision state may be a parked migration.
+///
+/// The migration handler validates the full DPU set before changing external
+/// resources. Keeping this detector broad turns damaged parked state into a
+/// visible failure instead of leaving every DPU idle indefinitely.
+pub(super) fn deployment_migration_is_parked(state: &ManagedHostStateSnapshot) -> bool {
+    if !state.host_snapshot.config.dpf.used_for_ingestion {
+        return false;
+    }
+
+    let Some(dpu_states) = state.managed_state.dpu_reprovision_states() else {
+        return false;
+    };
+    !dpu_states.states.is_empty()
+        && dpu_states
+            .states
+            .values()
+            .all(|dpu_state| matches!(dpu_state, ReprovisionState::NotUnderReprovision))
+        && any_dpu_reprovision_request_has_started(state)
+}
+
+/// Returns whether every attached DPU has reached the migration handoff point.
+fn deployment_migration_can_start(state: &ManagedHostStateSnapshot) -> bool {
+    let Some(dpu_states) = state.managed_state.dpu_reprovision_states() else {
+        return false;
+    };
+
+    deployment_migration_has_complete_dpu_set(state, dpu_states)
+        && all_dpu_reprovision_requests_have_started(state)
+        && dpu_states.states.values().all(|dpu_state| {
+            matches!(
+                dpu_state,
+                ReprovisionState::DpfStates {
+                    substate: DpfState::Reprovisioning
+                }
+            )
+        })
+}
+
+/// Parks every attached DPU before changing its shared DPUNode selector.
+fn park_for_deployment_migration(
+    state: &ManagedHostStateSnapshot,
+) -> Result<ManagedHostState, StateHandlerError> {
+    // Reuse `NotUnderReprovision` so controllers from the same rollout can
+    // deserialize the state and leave it alone. Persisting it before the
+    // selector change also keeps retries out of ordinary handling for one DPU.
+    ReprovisionState::NotUnderReprovision.next_state_with_all_dpus_updated(
+        &state.managed_state,
+        &state.dpu_snapshots,
+        Vec::new(),
+    )
+}
+
+/// Returns the deterministic DPU names for every attached DPU snapshot.
+fn dpu_device_names(state: &ManagedHostStateSnapshot) -> Result<Vec<String>, StateHandlerError> {
+    state
+        .dpu_snapshots
+        .iter()
+        .map(dpf_id)
+        .collect::<Result<Vec<_>, _>>()
 }
 
 /// Transition all DPU sub-states to the given DPF state, preserving the
@@ -386,6 +511,25 @@ fn dpf_deployment_selection_failed(
     StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
 }
 
+/// Builds the terminal failure used when a deployment was selected but the
+/// host does not meet a migration precondition.
+fn dpf_deployment_migration_failed(
+    state: &ManagedHostStateSnapshot,
+    error: &str,
+) -> StateHandlerOutcome<ManagedHostState> {
+    let details = FailureDetails {
+        cause: FailureCause::DpfProvisioning {
+            err: format!(
+                "DPF deployment migration failed: {error}. Resolve the reported precondition \
+                 before retrying DPU reprovisioning"
+            ),
+        },
+        failed_at: chrono::Utc::now(),
+        source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+    };
+    StateHandlerOutcome::transition(make_failure_state(state, details, state.host_snapshot.id))
+}
+
 /// Handle DpfState::Provisioning: register all DPU devices and the node, then
 /// transition all DPUs to WaitingForReady.
 async fn handle_dpf_provisioning(
@@ -531,17 +675,41 @@ async fn handle_dpf_waiting_for_ready(
     waiting_phase_detail: &Option<String>,
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     dpf_sdk: &dyn DpfOperations,
+    deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let dpu_device_name = dpf_id(dpu_snapshot)?;
-    let current_phase = match dpf_sdk.get_dpu_phase(&dpu_device_name, &node_name).await {
-        Ok(phase) => phase,
+    // During a deployment migration the source and target DPUSet reuse the
+    // deterministic DPU name. Read ownership, phase, and Ready conformance from
+    // one observation scoped to the target so an old source DPU cannot release
+    // the hold, trigger a reboot, or satisfy target readiness.
+    let current_phase = match if deployment_type == DEPLOYMENT_MIGRATION_TARGET {
+        let dpu_device_names = dpu_device_names(state)?;
+        dpf_sdk
+            .get_dpu_phases_for_deployment_type(&dpu_device_names, &node_name, deployment_type)
+            .await
+            .map(|phases| phases.and_then(|phases| phases.get(&dpu_device_name).cloned()))
+    } else {
+        dpf_sdk
+            .get_dpu_phase(&dpu_device_name, &node_name)
+            .await
+            .map(Some)
+    } {
+        Ok(Some(phase)) => phase,
+        Ok(None) => {
+            return Ok(StateHandlerOutcome::wait(
+                "Waiting for DPF to recreate the DPU from the GB200 deployment".to_string(),
+            ));
+        }
         // The operator briefly removes the old DPU CR before recreating a fresh one
         // during reprovision; treat that window as "keep waiting" rather than erroring.
         Err(DpfError::NotFound { .. }) => {
             return Ok(StateHandlerOutcome::wait(
                 "DPU CR not yet recreated after reprovision".to_string(),
             ));
+        }
+        Err(DpfError::InvalidState(error)) if deployment_type == DEPLOYMENT_MIGRATION_TARGET => {
+            return Ok(dpf_deployment_migration_failed(state, &error));
         }
         Err(err) => return Err(dpf_error(err)),
     };
@@ -631,6 +799,95 @@ fn handle_dpf_device_ready(
     Ok(StateHandlerOutcome::transition(next))
 }
 
+/// Moves one host's existing DPF resources from generic BF3 to the GB200
+/// deployment during an active DPU reprovision request.
+///
+/// The DPUNode and initialized DPUDevices stay in place. Parking every DPU in
+/// `NotUnderReprovision` makes the label transfer and DPU deletions retryable
+/// when the process restarts before or after the selector changes.
+pub(super) async fn handle_dpf_deployment_migration(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    dpf_sdk: &dyn DpfOperations,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let Some(dpu_states) = state.managed_state.dpu_reprovision_states() else {
+        return Ok(dpf_deployment_migration_failed(
+            state,
+            "parked state does not contain DPU reprovision state",
+        ));
+    };
+    if !deployment_migration_has_complete_dpu_set(state, dpu_states)
+        || !all_dpu_reprovision_requests_have_started(state)
+    {
+        return Ok(dpf_deployment_migration_failed(
+            state,
+            "parked state does not contain a started request for every attached DPU",
+        ));
+    }
+
+    let deployment_types = deployment_types_for_host(state, ctx, dpf_sdk).await?;
+    let desired_deployment = match consistent_deployment_type(&deployment_types) {
+        Ok(deployment_type) => deployment_type,
+        Err(error) => return Ok(dpf_deployment_selection_failed(state, error.as_str())),
+    };
+    if desired_deployment != DEPLOYMENT_MIGRATION_TARGET {
+        let error = format!(
+            "parked DPF deployment migration now selects {desired_deployment:?}, expected \
+             {DEPLOYMENT_MIGRATION_TARGET:?}"
+        );
+        return Ok(dpf_deployment_migration_failed(state, &error));
+    }
+
+    let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
+    let dpu_device_names = dpu_device_names(state)?;
+
+    dpf_sdk
+        .transfer_dpu_node_deployment_labels(
+            &node_name,
+            DEPLOYMENT_MIGRATION_SOURCE,
+            DEPLOYMENT_MIGRATION_TARGET,
+        )
+        .await
+        .map_err(dpf_error)?;
+
+    dpf_sdk
+        .delete_source_dpus_for_deployment_migration(
+            &dpu_device_names,
+            &node_name,
+            DEPLOYMENT_MIGRATION_SOURCE,
+            DEPLOYMENT_MIGRATION_TARGET,
+        )
+        .await
+        .map_err(dpf_error)?;
+
+    // Keep the durable parked state until one DPF observation contains every
+    // target DPU. Controllers from before migration support ignore this state,
+    // so they cannot accept a source DPU recreated during the selector handoff.
+    match dpf_sdk
+        .get_dpu_phases_for_deployment_type(
+            &dpu_device_names,
+            &node_name,
+            DEPLOYMENT_MIGRATION_TARGET,
+        )
+        .await
+    {
+        Ok(Some(_)) => {}
+        Ok(None) | Err(DpfError::NotFound { .. }) => {
+            return Ok(StateHandlerOutcome::wait(
+                "Waiting for DPF to recreate every DPU from the GB200 deployment".to_string(),
+            ));
+        }
+        Err(DpfError::InvalidState(error)) => {
+            return Ok(dpf_deployment_migration_failed(state, &error));
+        }
+        Err(error) => return Err(dpf_error(error)),
+    }
+
+    let next =
+        transition_all_dpus_to_dpf_state(DpfState::WaitingForReady { phase_detail: None }, state)?;
+    Ok(StateHandlerOutcome::transition(next))
+}
+
 /// Handle DpfState::Reprovisioning
 /// If the DPUNode and DPUDevice CRs do not exist, then create them
 /// and transition to the next state to reprovision all DPUs to DPF.
@@ -698,7 +955,7 @@ pub async fn handle_dpf_state(
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let deployment_types = deployment_types_for_host(state, ctx, dpf_sdk).await?;
-    let deployment_type = match consistent_deployment_type(&deployment_types) {
+    let mut deployment_type = match consistent_deployment_type(&deployment_types) {
         Ok(deployment_type) => deployment_type,
         Err(error) => {
             let selections = state
@@ -713,6 +970,71 @@ pub async fn handle_dpf_state(
             return Ok(dpf_deployment_selection_failed(state, error.as_str()));
         }
     };
+    let node_has_desired_labels = dpf_sdk
+        .verify_node_labels(&node_name, deployment_type)
+        .await
+        .map_err(dpf_error)?;
+    if !node_has_desired_labels {
+        let node_has_migration_source_labels = if deployment_type == DEPLOYMENT_MIGRATION_TARGET {
+            dpf_sdk
+                .verify_node_labels(&node_name, DEPLOYMENT_MIGRATION_SOURCE)
+                .await
+                .map_err(dpf_error)?
+        } else {
+            false
+        };
+
+        if node_has_migration_source_labels
+            && matches!(dpf_state, DpfState::Reprovisioning)
+            && deployment_migration_can_start(state)
+        {
+            tracing::info!(
+                machine_id = %state.host_snapshot.id,
+                node = %node_name,
+                from = ?DEPLOYMENT_MIGRATION_SOURCE,
+                to = ?deployment_type,
+                "parking DPF deployment selector migration"
+            );
+            let next = park_for_deployment_migration(state)?;
+            return Ok(StateHandlerOutcome::transition(next));
+        } else if node_has_migration_source_labels && any_dpu_reprovision_request_has_started(state)
+        {
+            // A controller from before deployment migration support may have
+            // started only part of the DPU set or advanced one DPU before the
+            // rollout completed. Finish that work under its current deployment;
+            // a later host request can migrate the complete DPU set.
+            tracing::warn!(
+                machine_id = %state.host_snapshot.id,
+                node = %node_name,
+                from = ?DEPLOYMENT_MIGRATION_SOURCE,
+                to = ?deployment_type,
+                "deferring DPF deployment migration for work already in progress"
+            );
+            deployment_type = DEPLOYMENT_MIGRATION_SOURCE;
+        } else {
+            tracing::error!(
+                machine_id = %state.host_snapshot.id,
+                node = %node_name,
+                "DPUNode has stale labels, failing for reprovisioning"
+            );
+            let details = FailureDetails {
+                cause: FailureCause::DpfProvisioning {
+                    err: format!(
+                        "DPUNode {node_name} has stale labels; \
+                         must be deleted and reprovisioned"
+                    ),
+                },
+                failed_at: chrono::Utc::now(),
+                source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
+            };
+            return Ok(StateHandlerOutcome::transition(make_failure_state(
+                state,
+                details,
+                state.host_snapshot.id,
+            )));
+        }
+    }
+
     if matches!(dpf_state, DpfState::Provisioning) {
         tracing::info!(
             machine_id = %state.host_snapshot.id,
@@ -720,37 +1042,19 @@ pub async fn handle_dpf_state(
             "selected DPF deployment type for host"
         );
     }
-    if !dpf_sdk
-        .verify_node_labels(&node_name, deployment_type)
-        .await
-        .map_err(dpf_error)?
-    {
-        tracing::error!(
-            machine_id = %state.host_snapshot.id,
-            node = %node_name,
-            "DPUNode has stale labels, failing for reprovisioning"
-        );
-        let details = FailureDetails {
-            cause: FailureCause::DpfProvisioning {
-                err: format!(
-                    "DPUNode {node_name} has stale labels; \
-                     must be deleted and reprovisioned"
-                ),
-            },
-            failed_at: chrono::Utc::now(),
-            source: FailureSource::StateMachineArea(StateMachineArea::MainFlow),
-        };
-        return Ok(StateHandlerOutcome::transition(make_failure_state(
-            state,
-            details,
-            state.host_snapshot.id,
-        )));
-    }
 
     match dpf_state {
         DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk, deployment_type).await,
         DpfState::WaitingForReady { phase_detail } => {
-            handle_dpf_waiting_for_ready(state, dpu_snapshot, phase_detail, ctx, dpf_sdk).await
+            handle_dpf_waiting_for_ready(
+                state,
+                dpu_snapshot,
+                phase_detail,
+                ctx,
+                dpf_sdk,
+                deployment_type,
+            )
+            .await
         }
         DpfState::HandleReboot { op, retry_count } => {
             handle_dpf_handle_reboot(
@@ -780,6 +1084,8 @@ pub async fn handle_dpf_state(
 mod tests {
     use carbide_test_support::{Check, check_values};
     use model::hardware_info::DpuData;
+    use model::machine::ReprovisionRequest;
+    use model::test_support::machine_snapshot::managed_host_state_snapshot;
 
     use super::*;
 
@@ -896,5 +1202,37 @@ mod tests {
             ],
             |deployment_types| consistent_deployment_type(&deployment_types).ok(),
         );
+    }
+
+    #[test]
+    fn non_dpf_reprovision_is_not_a_parked_deployment_migration() {
+        let mut state = managed_host_state_snapshot();
+        let now = chrono::Utc::now();
+
+        for dpu in &mut state.dpu_snapshots {
+            dpu.reprovision_requested = Some(ReprovisionRequest {
+                requested_at: now,
+                initiator: "test".to_string(),
+                update_firmware: false,
+                started_at: Some(now),
+                user_approval_received: false,
+                restart_reprovision_requested_at: now,
+            });
+        }
+        state.managed_state = ManagedHostState::DPUReprovision {
+            dpu_states: DpuReprovisionStates {
+                states: state
+                    .dpu_snapshots
+                    .iter()
+                    .map(|dpu| (dpu.id, ReprovisionState::NotUnderReprovision))
+                    .collect(),
+            },
+        };
+
+        state.host_snapshot.config.dpf.used_for_ingestion = false;
+        assert!(!deployment_migration_is_parked(&state));
+
+        state.host_snapshot.config.dpf.used_for_ingestion = true;
+        assert!(deployment_migration_is_parked(&state));
     }
 }


### PR DESCRIPTION
> [!NOTE]
> While this PR seems large at first glance, just FYI that it contains:
>
> - +1750/-68 lines of test changes.
>
> Don't let it scare you!

This backports the GB200 BF3 provisioning fixes from #5603, #5571, and #5607 to v2.1. Before this change, v2.1 could miss GB200 classification before rack assignment, leave existing DPF resources selected by the generic `Bf3` deployment, and apply a profile with `PF_TOTAL_SF=30` instead of 128.

The backport uses the persisted Site Explorer model before the rack fallback, moves a complete host DPU set from `Bf3` to `Bf3Gb200` during a coordinated reprovision request, and applies the validated GB200 profile with 28 values. It takes the Site Explorer attachment locks before it determines migration eligibility and writes reprovisioning requests, so an attachment update cannot authorize only part of the host DPU set. The Kubernetes label lookup has one 30 second deadline, after which admission locks and reloads the attached DPU requests before writing. Every `Set` request performs the same locked recheck so it cannot overwrite controller progress. It also rejects the shared DPF node marker as a deployment selector key before it can make the generic and GB200 deployments overlap. Other hardware keeps its existing deployment and profile, and the migration detector requires DPF ingestion so Non-DPF reprovisioning remains on its existing path.

The implementation uses the direct DPU flavor and BFB APIs available in v2.1 without pulling Astra, BF4, `DpuFlavorTemplate`, or extension service changes from `main`.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5611

Closes #5611

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Configuration, DPF SDK, and machine controller tests cover selector validation and transfer, retries, target ownership, complete host DPU sets, and Non-DPF exclusion.
- Database reprovisioning tests cover report selection, complete set admission, concurrent attachment and request changes during admission, durable park and resume, and the migration lifecycle. The 18-test reprovisioning module, full Clippy pass, and custom lint pass completed successfully.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The local reviewers checked the semantic backport against the v2.1 diff. Hosted review then checked the final compatibility and concurrency corrections.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 2 | 2 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 10 | 2 | 8 |
| common-nits-reviewer | 0 | 0 | 0 |
| Hosted bot review | 5 | 5 | 0 |
| **Total** | **17** | **9** | **8** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- API admission used rack data while the controller preferred the Site Explorer report. **Resolution:** Both now prefer the report and fall back to rack data.
2. **Adopted** -- The backport initially lacked direct tests for its v2.1 DPF repository operations. **Resolution:** Added coverage for selector transfer, deployment resolution, phase checks, retries, and deletion that preserves replacement resources.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- A Non-DPF request could resemble the parked migration marker. **Resolution:** The detector now requires DPF ingestion, with a direct regression test.
2. **Adopted** -- Deployment selection was logged before a possible fallback to `Bf3`. **Resolution:** The log now records the deployment used after fallback handling.
3. **Declined** -- Wait when the durable parked state has an incomplete DPU set. **Reason:** That mismatch is an invariant violation after admission and parking; a visible failure prevents a partial migration.
4. **Declined** -- Avoid reads scoped to one deployment during initial GB200 provisioning. **Reason:** Initial registration must observe the selected `Bf3Gb200` deployment as well as migration.
5. **Declined** -- Add a maintenance test comparing every overlapping base and GB200 profile value. **Reason:** Exact profile assertions and the expected set of 32 DPF values cover the required release behavior; possible future drift is outside this backport.
6. **Declined** -- Narrow the DPU lookup across the namespace during source deletion. **Reason:** Migration must still find source resources after the selector has moved, and this lookup runs only during that migration.
7. **Declined** -- Hide one UID precondition conflict and retry inside the repository call. **Reason:** Returning the conflict keeps replacement races visible and the controller retries without deleting the replacement.
8. **Declined** -- Cache the Site Explorer report across DPU iterations. **Reason:** The query is bounded by the attached DPU set and keeps controller selection aligned with current persisted data.
9. **Declined** -- Add compatibility for rolling back to a controller that predates the parked migration state. **Reason:** Rollback to a binary without this migration behavior is outside the forward rollout supported by this backport.
10. **Declined** -- Change the admission test for disabled DPF runtime to configure a DPF SDK. **Reason:** That test covers request admission; the detector now has a direct ownership regression test.

### common-nits-reviewer

No findings.

### Hosted bot review

1. **Adopted** -- v2.1 allowed the shared DPF node marker to be used as a deployment selector key. **Resolution:** Reject that reserved key before generic and GB200 selectors can overlap.
2. **Adopted** -- A controller could advance a DPU request during the Kubernetes label read when the target deployment was already active. **Resolution:** Lock and reload the attached DPU requests after every label lookup, then revalidate before writing.
3. **Adopted** -- Kubernetes label reads could retain Site Explorer attachment locks for several minutes. **Resolution:** Bound both sequential checks to one 30 second deadline and return the existing DPF timeout error when it expires.
4. **Adopted** -- An ordinary DPF `Set` request could overwrite controller progress made after its initial validation. **Resolution:** Lock, reload, and revalidate every `Set` request before replacing its request state.
5. **Adopted** -- The public identifier validator documentation did not identify the reserved shared DPF node marker. **Resolution:** Document the reserved key and why deployment selectors cannot use it.

</details>
