### PR TITLE
fix(dpf): validate deployment migration eligibility

### DIFF
--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -2364,6 +2364,9 @@ impl DpfDeploymentsConfig {
     }
 
     /// Validates the final Kubernetes identifiers, their uniqueness, and reserved labels.
+    /// `DPU_ENABLED_NODE_LABEL` and `HOST_BMC_IP_LABEL` are reserved for the
+    /// shared DPF node marker and host BMC IP. Neither can be used as the
+    /// `node_label_key` for an individual deployment.
     /// Returns every error so the operator can fix them all in one pass.
     pub fn validate_unique_identifiers(&self) -> eyre::Result<()> {
         let bf3_gb200 = self.bf3.bf3_gb200();

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -18,6 +18,7 @@
 use std::collections::{HashMap, HashSet};
 use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
+use std::time::Duration;
 
 use ::rpc::errors::RpcDataConversionError;
 use ::rpc::model::{RpcInto, RpcTryFrom};
@@ -62,6 +63,9 @@ use crate::{CarbideError, cfg, ethernet_virtualization};
 /// vxlan48 is special HBN single vxlan device. It handles networking between machines on the
 /// same subnet. It handles the encapsulation into VXLAN and VNI for cross-host comms.
 const HBN_SINGLE_VLAN_DEVICE: &str = "vxlan48";
+
+/// Bounds Kubernetes label reads while Site Explorer attachment locks are held.
+const DPF_DEPLOYMENT_LABEL_CHECK_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// Consolidates host-level and DPU-level `ManagedHostNetworkConfig` into
 /// the single proto sent to `carbide-dpu-agent`. The host layer
@@ -1555,8 +1559,8 @@ fn validate_dpu_reprovisioning_request(
     Ok(())
 }
 
-/// Locks every attached DPU row in stable order before validating a migration
-/// request set and updating any member of it.
+/// Locks every attached DPU row in stable order before revalidating and
+/// updating a reprovisioning request set.
 async fn lock_attached_dpus(
     conn: &mut sqlx::PgConnection,
     snapshot: &ManagedHostStateSnapshot,
@@ -1611,9 +1615,13 @@ async fn load_dpu_reprovisioning_snapshot(
     })
 }
 
-/// Trigger DPU reprovisioning
-/// In case user passes a DPU ID, trigger_dpu_reprovisioning only for that particular DPU.
-/// In case user passes a host id, trigger_dpu_reprovisioning
+/// Triggers DPU reprovisioning for one DPU or every DPU attached to a host.
+///
+/// `Set` and `Clear` intentionally keep the transaction that owns the admin
+/// segment locks open across the DPF Kubernetes read. This prevents Site
+/// Explorer from changing attachments between the authorizing snapshot and
+/// the request writes.
+#[allow(txn_held_across_await)]
 pub(crate) async fn trigger_dpu_reprovisioning(
     api: &Api,
     request: tonic::Request<rpc::DpuReprovisioningRequest>,
@@ -1625,55 +1633,58 @@ pub(crate) async fn trigger_dpu_reprovisioning(
     let machine_id = req.machine_id.as_ref().or(req.dpu_id.as_ref());
     let machine_id = convert_and_log_machine_id(machine_id)?;
 
+    let mode = req.mode();
+    // Set and Clear must choose their complete DPU set from the same attachment
+    // state that authorizes the request writes. Take the Site Explorer lock
+    // order before loading that snapshot so attachment changes cannot make a
+    // previously ineligible host require migration after this check.
+    let admin_lock_admission = if matches!(mode, Mode::Set | Mode::Clear) {
+        Some(db::machine_interface::admin_lock_admission().await)
+    } else {
+        None
+    };
     let mut txn = api.txn_begin().await?;
+    if admin_lock_admission.is_some() {
+        db::machine_interface::lock_all_admin_segments(txn.as_mut()).await?;
+    }
 
     let mut snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
-    let mode = req.mode();
     validate_dpu_reprovisioning_request(api, &snapshot, &machine_id, mode)?;
 
-    // The migration check reads Kubernetes, so release the database transaction
-    // before that external call. Set and Clear both change the request set and
-    // must preserve its empty or complete cardinality while the source selector
-    // remains active.
     let migration_node = if matches!(mode, Mode::Set | Mode::Clear) {
         dpf_deployment_migration_node(api, txn.as_mut(), &snapshot).await?
     } else {
         None
     };
-    let (migration_source_is_active, admin_lock_admission) = if let Some(node_name) = migration_node
-    {
-        txn.rollback().await?;
-        let source_is_active = dpf_deployment_migration_source_is_active(api, &node_name).await?;
-
-        // Site Explorer takes these same locks before it changes DPU
-        // attachments. Hold them through the request writes so the snapshots
-        // and DPU row locks below describe one complete DPU set.
-        let admin_lock_admission = if source_is_active {
-            Some(db::machine_interface::admin_lock_admission().await)
-        } else {
-            None
-        };
-        txn = api.txn_begin().await?;
-
-        if source_is_active {
-            db::machine_interface::lock_all_admin_segments(txn.as_mut()).await?;
-        }
-
-        snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
-
-        if source_is_active {
-            lock_attached_dpus(txn.as_mut(), &snapshot).await?;
-            snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
-        }
-
-        // Recheck all database conditions after the Kubernetes call and after
-        // waiting for the row locks. Only this snapshot can authorize the
-        // writes below.
-        validate_dpu_reprovisioning_request(api, &snapshot, &machine_id, mode)?;
-        (source_is_active, admin_lock_admission)
+    let migration_source_is_active = if let Some(node_name) = migration_node.as_deref() {
+        // Keep the attachment locks through this Kubernetes read and the
+        // request writes. Releasing them here would allow migration eligibility
+        // to change between the two operations.
+        tokio::time::timeout(
+            DPF_DEPLOYMENT_LABEL_CHECK_TIMEOUT,
+            dpf_deployment_migration_source_is_active(api, node_name),
+        )
+        .await
+        .map_err(|_| {
+            CarbideError::DpfError(carbide_dpf::DpfError::timeout(
+                "DPUNode deployment label validation",
+                format!(
+                    "label checks for DPUNode '{node_name}' did not complete within {} seconds",
+                    DPF_DEPLOYMENT_LABEL_CHECK_TIMEOUT.as_secs()
+                ),
+            ))
+        })??
     } else {
-        (false, None)
+        false
     };
+
+    if mode == Mode::Set || migration_node.is_some() {
+        // Set replaces the request JSON, and migration validation depends on
+        // the complete request set. Lock and reload before either can write.
+        lock_attached_dpus(txn.as_mut(), &snapshot).await?;
+        snapshot = load_dpu_reprovisioning_snapshot(api, txn.as_mut(), &machine_id).await?;
+        validate_dpu_reprovisioning_request(api, &snapshot, &machine_id, mode)?;
+    }
 
     match mode {
         Mode::Set => {

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -29,22 +29,23 @@ use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
+use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     DpfState, DpuReprovisionStates, FailureCause, InstanceState, ManagedHostState, ReprovisionState,
 };
 use rpc::forge::dpu_reprovisioning_request::Mode;
 use rpc::forge::forge_server::Forge;
-use tokio::sync::Notify;
 use tokio::time::timeout;
 
 use super::{dpf_config, get_host_state};
 use crate::test_support::builder::TestApiBuilder;
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
-    TEST_RMS_RACK_PROFILE_ID, TestEnvOverrides, TestManagedHost, create_managed_host_with_dpf,
-    create_managed_host_with_dpf_multi, create_test_env_with_overrides, get_config,
-    get_config_with_rack_profiles,
+    TEST_RMS_RACK_PROFILE_ID, TestEnv, TestEnvOverrides, TestManagedHost,
+    create_managed_host_with_dpf, create_managed_host_with_dpf_multi,
+    create_test_env_with_overrides, get_config, get_config_with_rack_profiles,
 };
+use crate::tests::common::postgres::wait_for_blocked_query;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -131,22 +132,11 @@ fn source_deployment_mock_with_verification_observer(
     mock
 }
 
-/// A GB200 deployment migration waits for Site Explorer attachment writes
-/// before it snapshots and updates the complete DPU set.
+/// A request rechecks migration eligibility after Site Explorer changes the
+/// host while holding its attachment locks.
 #[crate::sqlx_test]
-async fn test_gb200_deployment_migration_waits_for_attachment_updates(pool: sqlx::PgPool) {
-    let observe_migration_check = Arc::new(AtomicBool::new(false));
-    let source_deployment_checked = Arc::new(Notify::new());
-    let observe_migration_check_for_mock = observe_migration_check.clone();
-    let source_deployment_checked_for_mock = source_deployment_checked.clone();
-    let mock = source_deployment_mock_with_verification_observer(2, move |deployment| {
-        if observe_migration_check_for_mock.load(Ordering::SeqCst)
-            && deployment == DpuDeploymentType::Bf3
-        {
-            source_deployment_checked_for_mock.notify_one();
-        }
-    });
-
+async fn test_gb200_deployment_migration_rechecks_after_attachment_updates(pool: sqlx::PgPool) {
+    let mock = source_deployment_mock(2);
     let mut config = get_config_with_rack_profiles();
     config.dpf = dpf_config();
     let env = create_test_env_with_overrides(
@@ -157,25 +147,24 @@ async fn test_gb200_deployment_migration_waits_for_attachment_updates(pool: sqlx
     let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf_multi(&env, 2))
         .await
         .expect("timed out during initial provisioning");
-    configure_gb200_b3240_host(&pool, &mh).await;
     mh.mark_machine_for_updates().await;
 
-    // Stand in for Site Explorer while it changes DPU attachments. The API
-    // must wait for this transaction before it chooses the request set.
+    // Stand in for Site Explorer changing the machine from a generic BF3 host
+    // to a GB200 host while the request still sees the earlier data.
     let admin_lock_admission = db::machine_interface::admin_lock_admission().await;
     let mut attachment_txn = pool.begin().await.unwrap();
     db::machine_interface::lock_all_admin_segments(attachment_txn.as_mut())
         .await
         .unwrap();
+    configure_gb200_b3240_host_in_txn(attachment_txn.as_mut(), &mh).await;
 
-    observe_migration_check.store(true, Ordering::SeqCst);
     let api = env.api.clone();
-    let host_id = mh.id;
+    let requested_dpu_id = mh.dpu_ids[0];
     let mut request_task = tokio::spawn(async move {
         api.trigger_dpu_reprovisioning(tonic::Request::new(
             ::rpc::forge::DpuReprovisioningRequest {
-                dpu_id: None,
-                machine_id: host_id.into(),
+                dpu_id: requested_dpu_id.into(),
+                machine_id: None,
                 mode: Mode::Set as i32,
                 initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                 update_firmware: true,
@@ -184,23 +173,21 @@ async fn test_gb200_deployment_migration_waits_for_attachment_updates(pool: sqlx
         .await
     });
 
-    timeout(TEST_TIMEOUT, source_deployment_checked.notified())
-        .await
-        .expect("timed out waiting for the deployment check");
     assert!(
         timeout(Duration::from_millis(250), &mut request_task)
             .await
             .is_err(),
-        "the migration request must wait for attachment updates"
+        "the request must wait for attachment updates before checking migration"
     );
 
     attachment_txn.commit().await.unwrap();
     drop(admin_lock_admission);
-    timeout(TEST_TIMEOUT, request_task)
+    let error = timeout(TEST_TIMEOUT, request_task)
         .await
         .expect("timed out after releasing the attachment locks")
-        .expect("the migration request task panicked")
-        .expect("the migration request failed");
+        .expect("the reprovisioning request task panicked")
+        .expect_err("an individual DPU request must be rejected after GB200 becomes visible");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
 
     let mut txn = pool.begin().await.unwrap();
     let dpu_machines = mh.dpu_db_machines(&mut txn).await;
@@ -208,10 +195,145 @@ async fn test_gb200_deployment_migration_waits_for_attachment_updates(pool: sqlx
     assert!(
         dpu_machines
             .iter()
-            .all(|dpu| dpu.reprovision_requested.is_some()),
-        "the host request must update every attached DPU"
+            .all(|dpu| dpu.reprovision_requested.is_none()),
+        "a rejected partial request must not update any attached DPU"
     );
     txn.commit().await.unwrap();
+}
+
+/// Verifies that a `Set` request preserves controller progress made after its
+/// initial validation.
+async fn assert_dpu_reprovision_set_rechecks_request_updates(
+    pool: &sqlx::PgPool,
+    env: &TestEnv,
+    mh: &TestManagedHost,
+) {
+    let requested_dpu_id = mh.dpu_ids[0];
+    let mut request_txn = pool.begin().await.unwrap();
+    db::machine::trigger_dpu_reprovisioning_request(
+        &requested_dpu_id,
+        request_txn.as_mut(),
+        "test",
+        true,
+    )
+    .await
+    .unwrap();
+    request_txn.commit().await.unwrap();
+
+    // Stand in for the controller owning the DPU row while the API validates
+    // the current request.
+    let mut controller_txn = pool.begin().await.unwrap();
+    let blocker_pid = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(controller_txn.as_mut())
+        .await
+        .unwrap();
+    let locked_dpu = db::machine::find_one(
+        controller_txn.as_mut(),
+        &requested_dpu_id,
+        MachineSearchConfig {
+            for_update: true,
+            ..MachineSearchConfig::default()
+        },
+    )
+    .await
+    .unwrap();
+    assert!(
+        locked_dpu.is_some(),
+        "the controller must lock the test DPU"
+    );
+
+    let api = env.api.clone();
+    let request_task = tokio::spawn(async move {
+        api.trigger_dpu_reprovisioning(tonic::Request::new(
+            ::rpc::forge::DpuReprovisioningRequest {
+                dpu_id: requested_dpu_id.into(),
+                machine_id: None,
+                mode: Mode::Set as i32,
+                initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
+                update_firmware: true,
+            },
+        ))
+        .await
+    });
+
+    // Both the protected row lock and the stale write it replaces must reach
+    // the DPU row after initial validation before the controller moves it.
+    tokio::select! {
+        _ = wait_for_blocked_query(pool, blocker_pid, "SELECT row_to_json") => {}
+        _ = wait_for_blocked_query(
+            pool,
+            blocker_pid,
+            "UPDATE machines SET reprovisioning_requested",
+        ) => {}
+    }
+    db::machine::update_dpu_reprovision_start_time(&requested_dpu_id, controller_txn.as_mut())
+        .await
+        .unwrap();
+    controller_txn.commit().await.unwrap();
+
+    let error = timeout(TEST_TIMEOUT, request_task)
+        .await
+        .expect("timed out after the controller released the DPU row")
+        .expect("the reprovisioning request task panicked")
+        .expect_err("the request must reject controller state advanced after validation");
+    assert_eq!(error.code(), tonic::Code::Internal);
+    assert_eq!(
+        error.message(),
+        "internal error: reprovisioning is already started"
+    );
+
+    let mut txn = pool.begin().await.unwrap();
+    let dpu = db::machine::find_one(txn.as_mut(), &requested_dpu_id, Default::default())
+        .await
+        .unwrap()
+        .unwrap();
+    assert!(
+        dpu.reprovision_requested
+            .is_some_and(|request| request.started_at.is_some()),
+        "the rejected API request must preserve the controller's start time"
+    );
+    txn.commit().await.unwrap();
+}
+
+/// An ordinary DPF reprovision request rechecks controller progress before
+/// replacing the request JSON.
+#[crate::sqlx_test]
+async fn test_dpu_reprovision_set_rechecks_after_request_updates(pool: sqlx::PgPool) {
+    let mock = provisioning_mock(Arc::new(AtomicBool::new(true)));
+    let mut config = get_config();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+    mh.mark_machine_for_updates().await;
+
+    assert_dpu_reprovision_set_rechecks_request_updates(&pool, &env, &mh).await;
+}
+
+/// A GB200 request rechecks controller progress after reading deployment
+/// labels, even when the target deployment is already active.
+#[crate::sqlx_test]
+async fn test_gb200_deployment_migration_rechecks_after_dpu_request_updates(pool: sqlx::PgPool) {
+    let mock = provisioning_mock(Arc::new(AtomicBool::new(true)));
+    let mut config = get_config_with_rack_profiles();
+    config.dpf = dpf_config();
+    let env = create_test_env_with_overrides(
+        pool.clone(),
+        TestEnvOverrides::with_config(config).with_dpf_sdk(Arc::new(mock)),
+    )
+    .await;
+    let mh = timeout(TEST_TIMEOUT, create_managed_host_with_dpf(&env))
+        .await
+        .expect("timed out during initial provisioning");
+    configure_gb200_b3240_host(&pool, &mh).await;
+    mh.mark_machine_for_updates().await;
+
+    assert_dpu_reprovision_set_rechecks_request_updates(&pool, &env, &mh).await;
 }
 
 /// Build the DPU reprovision states map for the given DPF sub-state.
@@ -299,15 +421,22 @@ async fn dpu_device_names(pool: &sqlx::PgPool, mh: &TestManagedHost) -> HashSet<
 /// deployment.
 async fn configure_gb200_b3240_host(pool: &sqlx::PgPool, mh: &TestManagedHost) {
     let mut txn = pool.begin().await.unwrap();
+    configure_gb200_b3240_host_in_txn(txn.as_mut(), mh).await;
+    txn.commit().await.unwrap();
+}
+
+/// Gives a DPF test host the GB200 rack and DPU inventory in an existing
+/// transaction.
+async fn configure_gb200_b3240_host_in_txn(conn: &mut sqlx::PgConnection, mh: &TestManagedHost) {
     let rack_id = TestRackDbBuilder::new()
         .with_rack_profile_id(TEST_RMS_RACK_PROFILE_ID)
-        .persist(txn.as_mut())
+        .persist(&mut *conn)
         .await
         .unwrap();
     let rack_assignment = sqlx::query("UPDATE machines SET rack_id = $1 WHERE id = $2")
         .bind(rack_id.as_str())
         .bind(mh.id)
-        .execute(txn.as_mut())
+        .execute(&mut *conn)
         .await
         .unwrap();
     assert_eq!(
@@ -316,7 +445,7 @@ async fn configure_gb200_b3240_host(pool: &sqlx::PgPool, mh: &TestManagedHost) {
         "the test host must be attached to the GB200 rack profile"
     );
     for dpu_id in &mh.dpu_ids {
-        let dpu = db::machine::find_one(txn.as_mut(), dpu_id, Default::default())
+        let dpu = db::machine::find_one(&mut *conn, dpu_id, Default::default())
             .await
             .unwrap()
             .unwrap();
@@ -329,14 +458,13 @@ async fn configure_gb200_b3240_host(pool: &sqlx::PgPool, mh: &TestManagedHost) {
             .as_mut()
             .expect("fixture DPU should have DPU information")
             .part_number = "900-9D3B6-00CN-PA0".to_string();
-        db::machine_topology::set_topology_update_needed(txn.as_mut(), dpu_id, true)
+        db::machine_topology::set_topology_update_needed(&mut *conn, dpu_id, true)
             .await
             .unwrap();
-        db::machine_topology::create_or_update(txn.as_mut(), dpu_id, &hardware_info)
+        db::machine_topology::create_or_update(&mut *conn, dpu_id, &hardware_info)
             .await
             .unwrap();
     }
-    txn.commit().await.unwrap();
 }
 
 /// Recreates the partial DPF reprovision state that a controller without

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -204,12 +204,16 @@ fn deployment_migration_has_complete_dpu_set(
         && expected_dpu_ids == state_dpu_ids
 }
 
-/// Returns whether the stored reprovision state may be a parked migration.
+/// Returns whether a DPF-managed host may have a parked migration.
 ///
 /// The migration handler validates the full DPU set before changing external
 /// resources. Keeping this detector broad turns damaged parked state into a
 /// visible failure instead of leaving every DPU idle indefinitely.
 pub(super) fn deployment_migration_is_parked(state: &ManagedHostStateSnapshot) -> bool {
+    if !state.host_snapshot.config.dpf.used_for_ingestion {
+        return false;
+    }
+
     let Some(dpu_states) = state.managed_state.dpu_reprovision_states() else {
         return false;
     };
@@ -1075,13 +1079,6 @@ pub(super) async fn handle_dpf_state(
             return Ok(dpf_deployment_selection_failed(state, error.as_str()));
         }
     };
-    if matches!(dpf_state, DpfState::Provisioning) {
-        tracing::info!(
-            machine_id = %state.host_snapshot.id,
-            ?deployment_type,
-            "selected DPF deployment type for host"
-        );
-    }
     let node_has_desired_labels = dpf_sdk
         .verify_node_labels(&node_name, deployment_type)
         .await
@@ -1146,6 +1143,13 @@ pub(super) async fn handle_dpf_state(
             )));
         }
     }
+    if matches!(dpf_state, DpfState::Provisioning) {
+        tracing::info!(
+            machine_id = %state.host_snapshot.id,
+            ?deployment_type,
+            "selected DPF deployment type for host"
+        );
+    }
 
     match dpf_state {
         DpfState::Provisioning => handle_dpf_provisioning(state, dpf_sdk, deployment_type).await,
@@ -1188,6 +1192,8 @@ pub(super) async fn handle_dpf_state(
 mod tests {
     use carbide_test_support::{Check, check_values};
     use model::hardware_info::DpuData;
+    use model::machine::ReprovisionRequest;
+    use model::test_support::machine_snapshot::managed_host_state_snapshot;
 
     use super::*;
 
@@ -1199,6 +1205,54 @@ mod tests {
             }),
             ..Default::default()
         }
+    }
+
+    fn parked_deployment_migration_state(used_for_ingestion: bool) -> ManagedHostStateSnapshot {
+        let mut state = managed_host_state_snapshot();
+        state.host_snapshot.config.dpf.used_for_ingestion = used_for_ingestion;
+        for dpu in &mut state.dpu_snapshots {
+            dpu.reprovision_requested = Some(ReprovisionRequest {
+                requested_at: chrono::DateTime::UNIX_EPOCH,
+                initiator: "test".to_string(),
+                update_firmware: false,
+                started_at: Some(chrono::DateTime::UNIX_EPOCH),
+                user_approval_received: false,
+                restart_reprovision_requested_at: chrono::DateTime::UNIX_EPOCH,
+            });
+        }
+        state.managed_state = ManagedHostState::DPUReprovision {
+            dpu_states: DpuReprovisionStates {
+                states: state
+                    .dpu_snapshots
+                    .iter()
+                    .map(|dpu| (dpu.id, ReprovisionState::NotUnderReprovision))
+                    .collect(),
+            },
+        };
+        state
+    }
+
+    #[test]
+    fn only_dpf_managed_hosts_resume_parked_deployment_migrations() {
+        check_values(
+            [
+                Check {
+                    scenario: "DPF-managed host",
+                    input: true,
+                    expect: true,
+                },
+                Check {
+                    scenario: "Non-DPF host",
+                    input: false,
+                    expect: false,
+                },
+            ],
+            |used_for_ingestion| {
+                deployment_migration_is_parked(&parked_deployment_migration_state(
+                    used_for_ingestion,
+                ))
+            },
+        );
     }
 
     #[test]


### PR DESCRIPTION
> [!NOTE]
> This PR contains +117/-49 lines of production changes and +169/-41 lines of tests.

DPF deployment migration admission can use an attachment snapshot that changes before the request is written. An individual DPU request can therefore pass ordinary reprovisioning checks just before Site Explorer makes the host require coordinated migration. The controller can also mistake a parked Non-DPF reprovision for a DPF migration.

This change takes the existing Site Explorer attachment locks before `Set` and `Clear` load the snapshot that authorizes request writes, then rechecks request state after locking the attached DPU rows. The transaction retains those locks through a label lookup bounded to 30 seconds, then locks and reloads the DPU requests before writing them. Every `Set` request now performs the same locked recheck so it cannot overwrite controller progress. The controller resumes parked migration state only when DPF manages ingestion for the host. The public configuration documentation also identifies the node labels reserved by NICo.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5618

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Database concurrency regressions cover attachment changes during admission and controller progress during the Kubernetes label read.
- The 18 DPF reprovisioning tests and the focused DPF ownership test pass. Full workspace formatting and Clippy also pass.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

This PR applies focused corrections from the #5617 review to `main`, so the local review gate was not repeated. Hosted review found three runtime gaps and one public documentation gap; all were adopted.

</details>

<details>
<summary>Model Findings Details</summary>

1. **Adopted** -- A controller could advance a DPU request during the Kubernetes label read when the target deployment was already active. **Resolution:** Lock and reload the attached DPU requests after every migration label lookup, then revalidate before writing.
2. **Adopted** -- Kubernetes label reads could retain the Site Explorer attachment locks for several minutes. **Resolution:** Bound both sequential label checks to one 30 second deadline and return the existing DPF timeout error when it expires.
3. **Adopted** -- An ordinary DPF `Set` request could overwrite controller progress made after its initial validation. **Resolution:** Lock, reload, and revalidate every `Set` request before replacing its request state.
4. **Adopted** -- The public identifier validator documentation did not identify the node labels reserved by NICo. **Resolution:** Document both reserved labels and their purposes.

</details>


Closes #5618
