### PR TITLE
Machine id subtypes more places

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -40,7 +40,7 @@ use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, CredentialType, Credentials,
 };
 use carbide_site_explorer::{EndpointExplorationService, EndpointExplorer};
-use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::machine::{MachineId, MachineIdSubtypeTrait, MachineInterfaceId};
 use db::db_read::PgPoolReader;
 use db::work_lock_manager::WorkLockManagerHandle;
 use db::{DatabaseError, DatabaseResult, WithTransaction};
@@ -3848,11 +3848,11 @@ impl Api {
     #[track_caller]
     pub(crate) fn load_machine(
         &self,
-        machine_id: &MachineId,
+        machine_id: &impl MachineIdSubtypeTrait,
         search_config: MachineSearchConfig,
     ) -> impl Future<Output = CarbideResult<(Machine, db::Transaction<'_>)>> {
         let loc = Location::caller();
-        let machine_id = *machine_id;
+        let machine_id = machine_id.to_machine_id();
         async move {
             let mut txn =
                 db::Transaction::begin_with_location(&self.database_connection, loc).await?;

--- a/crates/api-core/src/attestation/mod.rs
+++ b/crates/api-core/src/attestation/mod.rs
@@ -74,12 +74,15 @@ pub(crate) async fn backfill_ek_cert_status_for_existing_machines(
 
     let mut txn = Transaction::begin(db_pool).await?;
 
-    let machines: Vec<::carbide_uuid::machine::MachineId> =
-        db::machine::find(&mut txn, ObjectFilter::All, MachineSearchConfig::default())
-            .await?
-            .iter()
-            .map(|machine| machine.id)
-            .collect();
+    let machines: Vec<::carbide_uuid::machine::MachineId> = db::machine::find(
+        &mut txn,
+        ObjectFilter::<MachineId>::All,
+        MachineSearchConfig::default(),
+    )
+    .await?
+    .iter()
+    .map(|machine| machine.id)
+    .collect();
 
     if !machines.is_empty() {
         let topologies =

--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -18,6 +18,7 @@ use std::net::{IpAddr, Ipv4Addr};
 
 use ::rpc::forge as rpc;
 use carbide_network::ip::{IdentifyAddressFamily, IpAddressFamily};
+use carbide_uuid::machine::HostMachineId;
 use db::dhcp_entry::DhcpEntry;
 use db::{self, expected_machine, machine_interface};
 use mac_address::MacAddress;
@@ -340,7 +341,7 @@ async fn handle_overlay_from_dpa(
     db::dpa_interface::update_ip(dpa_if.clone(), false, txn).await?;
 
     Ok(Some(Response::new(rpc::DhcpRecord {
-        machine_id: Some(dpa_if.get_machine_id()),
+        machine_id: Some(dpa_if.get_machine_id().into()),
         machine_interface_id: None,
         segment_id: None,
         subdomain_id: None,
@@ -381,7 +382,7 @@ async fn handle_underlay_from_dpa(
     db::dpa_interface::update_ip(dpa_if.clone(), true, txn).await?;
 
     Ok(Some(Response::new(rpc::DhcpRecord {
-        machine_id: Some(dpa_if.get_machine_id()),
+        machine_id: Some(dpa_if.get_machine_id().into()),
         machine_interface_id: None,
         segment_id: None,
         subdomain_id: None,
@@ -809,7 +810,8 @@ pub(crate) async fn discover_dhcp(
     // Only DPU-backed host admin links are dormant when non-primary. Other non-primary admin
     // interfaces can be valid operator-declared host NICs and must still be allowed to DHCP.
     let is_dpu_backed_host_admin_interface = machine_interface.attached_dpu_machine_id.is_some()
-        && machine_interface.attached_dpu_machine_id != machine_interface.machine_id;
+        && machine_interface.attached_dpu_machine_id.map(Into::into)
+            != machine_interface.machine_id;
     if is_dpu_backed_host_admin_interface
         && !machine_interface.primary_interface
         && segment.config.segment_type == NetworkSegmentType::Admin
@@ -844,7 +846,8 @@ pub(crate) async fn discover_dhcp(
         // the DPUs proxy DHCP on its behalf, so we reject the host's direct
         // DHCP request. Zero-DPU hosts have no such intermediary, so let
         // their DHCP proceed.
-        let dpus = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine_id).await?;
+        let host_machine_id = HostMachineId::try_from(machine_id)?;
+        let dpus = db::machine::find_dpus_by_host_machine_id(&mut txn, &host_machine_id).await?;
         if !dpus.is_empty() {
             return Err(CarbideError::internal(format!(
                 "DHCP request received for instance: {instance_id}. ignoring"

--- a/crates/api-core/src/errors.rs
+++ b/crates/api-core/src/errors.rs
@@ -14,6 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::convert::Infallible;
 use std::fmt::{Display, Formatter};
 use std::panic::Location;
 use std::sync::Arc;
@@ -262,6 +263,20 @@ pub enum CarbideError {
     AttestationError(String),
 }
 
+// Implement From<Infallible> so that we can write generic code that converts between MachineId
+// representations using TryFrom, while supporting "non-converting" cases where the caller is
+// already passing the right type. (The `impl TryFrom<T> for T` blanket impl uses `Infallible` as
+// its error type.)
+impl From<Infallible> for CarbideError {
+    fn from(_: Infallible) -> Self {
+        // We just crash if this is ever called, because the whole point of `Infallible` is that
+        // it's an error variant that is never actually constructed. Future rust versions will use
+        // `!` as the error type for TryFrom<T> for T, and this whole conversion will become
+        // unnecessary (as the compiler will already determine it to be unreachable.)
+        unreachable!()
+    }
+}
+
 impl From<InvalidMachineType> for CarbideError {
     fn from(err: InvalidMachineType) -> Self {
         Self::InvalidArgument(err.to_string())
@@ -286,6 +301,7 @@ impl From<ModelError> for CarbideError {
             ModelError::MissingArgument(e) => Self::MissingArgument(e),
             ModelError::HardwareInfo(e) => Self::HardwareInfoError(e),
             ModelError::InvalidArgument(e) => Self::InvalidArgument(e),
+            ModelError::InvalidMachindId(e) => Self::InvalidArgument(e),
         }
     }
 }

--- a/crates/api-core/src/ethernet_virtualization.rs
+++ b/crates/api-core/src/ethernet_virtualization.rs
@@ -20,7 +20,7 @@ use ::rpc::forge as rpc;
 use carbide_network::virtualization::{VpcVirtualizationType, get_svi_ip};
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::instance::InstanceId;
-use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::machine::{DpuMachineId, MachineInterfaceId};
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
 use db::vpc::{self};
@@ -393,7 +393,7 @@ fn build_ipv6_interface_config(
 pub(crate) async fn admin_network(
     txn: &mut PgConnection,
     snapshot: &ManagedHostStateSnapshot,
-    dpu_machine_id: &MachineId,
+    dpu_machine_id: &DpuMachineId,
     options: AdminNetworkOptions<'_>,
 ) -> Result<(rpc::FlatInterfaceConfig, MachineInterfaceId), tonic::Status> {
     let AdminNetworkOptions {

--- a/crates/api-core/src/handlers/astra.rs
+++ b/crates/api-core/src/handlers/astra.rs
@@ -65,9 +65,16 @@ pub(super) async fn get_astra_config(
 
     let mut txn = api.txn_begin().await?;
 
-    let dpa_interfaces =
-        db::dpa_interface::find_by_machine_id(&mut txn, snapshot.host_snapshot.id, search_config)
-            .await?;
+    let dpa_interfaces = db::dpa_interface::find_by_machine_id(
+        &mut txn,
+        snapshot
+            .host_snapshot
+            .id
+            .try_into()
+            .map_err(CarbideError::from)?,
+        search_config,
+    )
+    .await?;
 
     txn.commit().await?;
 
@@ -223,9 +230,16 @@ pub(super) async fn process_astra_config_status(
         only_astra: true,
     };
 
-    let dpa_interfaces =
-        db::dpa_interface::find_by_machine_id(&mut txn, snapshot.host_snapshot.id, search_config)
-            .await?;
+    let dpa_interfaces = db::dpa_interface::find_by_machine_id(
+        &mut txn,
+        snapshot
+            .host_snapshot
+            .id
+            .try_into()
+            .map_err(CarbideError::from)?,
+        search_config,
+    )
+    .await?;
 
     if dpa_interfaces.is_empty() {
         // This should not happen. How is the DPU reporting the Astra config status if there are no Astra NICs?

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -253,25 +253,19 @@ async fn boot_interface_reconciliation_eligible(
     else {
         return Ok(false);
     };
-    let machine = db::machine::find_one(
-        &mut *txn,
-        machine_id.as_machine_id(),
-        MachineSearchConfig::default(),
-    )
-    .await?
-    .ok_or_else(|| CarbideError::NotFoundError {
-        kind: "machine",
-        id: machine_id.to_string(),
-    })?;
+    let machine = db::machine::find_one(&mut *txn, &machine_id, MachineSearchConfig::default())
+        .await?
+        .ok_or_else(|| CarbideError::NotFoundError {
+            kind: "machine",
+            id: machine_id.to_string(),
+        })?;
     if !matches!(machine.current_state(), ManagedHostState::Ready) {
         return Ok(false);
     }
 
-    Ok(
-        db::instance::find_id_by_machine_id(txn, machine_id.as_machine_id())
-            .await?
-            .is_none(),
-    )
+    Ok(db::instance::find_id_by_machine_id(txn, &machine_id)
+        .await?
+        .is_none())
 }
 
 /// Resolves a required declarative target when the endpoint's actual owner is

--- a/crates/api-core/src/handlers/client_resolution.rs
+++ b/crates/api-core/src/handlers/client_resolution.rs
@@ -19,6 +19,7 @@ use std::collections::HashSet;
 use std::net::IpAddr;
 
 use ::rpc::forge as rpc;
+use carbide_uuid::machine::DpuMachineId;
 use carbide_uuid::network::NetworkSegmentId;
 use db::ObjectColumnFilter;
 use db::db_read::DbReader;
@@ -288,18 +289,18 @@ async fn resolve_dpu_nvconfig_profile(
     let Some(dpu_machine_id) = machine_interface.machine_id.as_ref() else {
         return Ok(None);
     };
-    if !dpu_machine_id.machine_type().is_dpu() {
+    let Ok(dpu_machine_id) = DpuMachineId::try_from(*dpu_machine_id) else {
         return Ok(None);
-    }
+    };
 
-    let Some(host) = db::machine::find_host_by_dpu_machine_id(&mut *conn, dpu_machine_id).await?
+    let Some(host) = db::machine::find_host_by_dpu_machine_id(&mut *conn, &dpu_machine_id).await?
     else {
         return Ok(None);
     };
     let product_family = resolve_host_product_family(api, conn, &host).await?;
 
     let Some(dpu) =
-        db::machine::find_one(&mut *conn, dpu_machine_id, MachineSearchConfig::default()).await?
+        db::machine::find_one(&mut *conn, &dpu_machine_id, MachineSearchConfig::default()).await?
     else {
         return Ok(None);
     };

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -4027,17 +4027,17 @@ mod tests {
         let machines = HashMap::from([
             (rack_id, machine_with_id(rack_scale_machine(), rack_id)),
             (
-                standalone_id,
-                machine_with_id(standalone_machine(), standalone_id),
+                standalone_id.into(),
+                machine_with_id(standalone_machine(), standalone_id.into()),
             ),
         ]);
 
         let (rack, standalone, results) =
-            prepare_dispatch_lists(&machines, &[rack_id, standalone_id], &HashMap::new());
+            prepare_dispatch_lists(&machines, &[rack_id, standalone_id.into()], &HashMap::new());
 
         assert!(results.is_empty());
         assert_eq!(rack, vec![rack_id]);
-        assert_eq!(standalone, vec![standalone_id]);
+        assert_eq!(standalone, vec![standalone_id.into()]);
     }
 
     #[test]
@@ -4067,7 +4067,7 @@ mod tests {
         let machines = HashMap::from([(known, standalone_machine())]);
 
         let (rack, standalone, results) =
-            prepare_dispatch_lists(&machines, &[unknown, known], &HashMap::new());
+            prepare_dispatch_lists(&machines, &[unknown.into(), known], &HashMap::new());
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].component_id, unknown.to_string());
@@ -4085,12 +4085,15 @@ mod tests {
         let fail_id = dpu_machine_id(0);
         let machines = HashMap::from([
             (ok_id, machine_with_id(rack_scale_machine(), ok_id)),
-            (fail_id, machine_with_id(standalone_machine(), fail_id)),
+            (
+                fail_id.into(),
+                machine_with_id(standalone_machine(), fail_id.into()),
+            ),
         ]);
-        let power_ok = HashMap::from([(ok_id, true), (fail_id, false)]);
+        let power_ok = HashMap::from([(ok_id, true), (fail_id.into(), false)]);
 
         let (rack, standalone, results) =
-            prepare_dispatch_lists(&machines, &[ok_id, fail_id], &power_ok);
+            prepare_dispatch_lists(&machines, &[ok_id, fail_id.into()], &power_ok);
 
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].component_id, fail_id.to_string());
@@ -4104,7 +4107,7 @@ mod tests {
 
     #[test]
     fn partition_error_results_reports_one_error_per_machine() {
-        let ids = [host_machine_id(), dpu_machine_id(0)];
+        let ids = [host_machine_id(), dpu_machine_id(0).into()];
         let status = Status::unavailable("backend down");
 
         let results = partition_error_results(&ids, &status);
@@ -4132,10 +4135,10 @@ mod tests {
         no_mac.status.bmc_info.mac = None;
 
         let mut no_ip = standalone_machine();
-        no_ip.id = no_ip_id;
+        no_ip.id = no_ip_id.into();
         no_ip.status.bmc_info.ip = None;
 
-        let machines = HashMap::from([(no_mac_id, no_mac), (no_ip_id, no_ip)]);
+        let machines = HashMap::from([(no_mac_id, no_mac), (no_ip_id.into(), no_ip)]);
         let creds = TestCredentialManager::new(Credentials::UsernamePassword {
             username: "u".into(),
             password: "p".into(),
@@ -4144,7 +4147,7 @@ mod tests {
         let resolved = resolve_compute_tray_endpoints_from_machines(
             &creds,
             &machines,
-            &[missing_id, no_mac_id, no_ip_id],
+            &[missing_id.into(), no_mac_id, no_ip_id.into()],
         )
         .await;
 
@@ -4154,7 +4157,7 @@ mod tests {
             resolved
                 .unresolved
                 .iter()
-                .any(|u| u.id == missing_id && u.reason.contains("machine not found"))
+                .any(|u| u.id == missing_id.into() && u.reason.contains("machine not found"))
         );
         assert!(
             resolved
@@ -4166,7 +4169,7 @@ mod tests {
             resolved
                 .unresolved
                 .iter()
-                .any(|u| u.id == no_ip_id && u.reason.contains("BMC IP"))
+                .any(|u| u.id == no_ip_id.into() && u.reason.contains("BMC IP"))
         );
     }
 
@@ -4304,8 +4307,14 @@ mod tests {
 
         let machines = HashMap::from([
             (id_a, machine_with_rms_job),
-            (id_b, machine_with_id(standalone_machine(), id_b)),
-            (id_c, machine_with_id(standalone_machine(), id_c)),
+            (
+                id_b.into(),
+                machine_with_id(standalone_machine(), id_b.into()),
+            ),
+            (
+                id_c.into(),
+                machine_with_id(standalone_machine(), id_c.into()),
+            ),
         ]);
 
         struct Case {
@@ -4317,7 +4326,7 @@ mod tests {
             expect_fallback_indices: &'static [usize],
         }
 
-        let all_ids = [id_a, id_b, id_c];
+        let all_ids = [id_a, id_b.into(), id_c.into()];
 
         let cases = [
             Case {

--- a/crates/api-core/src/handlers/dpu.rs
+++ b/crates/api-core/src/handlers/dpu.rs
@@ -28,7 +28,7 @@ use carbide_network::virtualization::VpcVirtualizationType;
 use carbide_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
 use carbide_utils::arch::CpuArchitecture;
 use carbide_uuid::instance::InstanceId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, MachineId};
 use db::vpc_prefix::VpcId;
 use db::{
     DatabaseError, ObjectColumnFilter, dpu_agent_upgrade_policy, network_security_group,
@@ -157,7 +157,7 @@ fn tenant_interface_fqdn(
 
 async fn get_managed_host_network_config_inner(
     api: &Api,
-    dpu_machine_id: MachineId,
+    dpu_machine_id: DpuMachineId,
 ) -> Result<rpc::ManagedHostNetworkConfigResponse, tonic::Status> {
     let mut txn = api.txn_begin().await?;
 
@@ -175,7 +175,7 @@ async fn get_managed_host_network_config_inner(
     let dpu_snapshot = match snapshot
         .dpu_snapshots
         .iter()
-        .find(|s| s.id == dpu_machine_id)
+        .find(|s| s.id == dpu_machine_id.into())
     {
         Some(dpu_snapshot) => dpu_snapshot,
         None => {
@@ -200,7 +200,7 @@ async fn get_managed_host_network_config_inner(
     let primary_dpu = db::machine_interface::find_one(&mut txn, primary_dpu_snapshot.id).await?;
     let is_primary_dpu = primary_dpu
         .attached_dpu_machine_id
-        .map(|x| x == dpu_snapshot.id)
+        .map(|x| dpu_snapshot.id == x.into())
         .unwrap_or(false);
 
     let loopback_ip = match dpu_snapshot.loopback_ip() {
@@ -284,7 +284,7 @@ async fn get_managed_host_network_config_inner(
     let (admin_interface_rpc, host_interface_id) = ethernet_virtualization::admin_network(
         &mut txn,
         &snapshot,
-        &dpu_snapshot.id,
+        &dpu_machine_id,
         ethernet_virtualization::AdminNetworkOptions {
             fnn_enabled: use_fnn_over_admin_nw,
             common_pools: &api.common_pools,
@@ -863,7 +863,8 @@ pub(crate) async fn get_managed_host_network_config(
     log_request_data(&request);
 
     let request = request.into_inner();
-    let dpu_machine_id = convert_and_log_machine_id(request.dpu_machine_id.as_ref())?;
+    let dpu_machine_id =
+        convert_and_log_machine_id::<DpuMachineId>(request.dpu_machine_id.as_ref())?;
 
     let resp = get_managed_host_network_config_inner(api, dpu_machine_id).await?;
 
@@ -877,7 +878,7 @@ pub(crate) async fn update_agent_reported_inventory(
     log_request_data(&request);
 
     let request = request.into_inner();
-    let dpu_machine_id = convert_and_log_machine_id(request.machine_id.as_ref())?;
+    let dpu_machine_id = convert_and_log_machine_id::<DpuMachineId>(request.machine_id.as_ref())?;
 
     // For DPF-ingested DPUs the agent runs containerized and cannot enumerate
     // the DPF services directly. Read service versions from the DPF operator
@@ -894,7 +895,7 @@ pub(crate) async fn update_agent_reported_inventory(
         let machine = snapshot
             .dpu_snapshots
             .iter()
-            .find(|d| d.id == dpu_machine_id)
+            .find(|d| d.id == dpu_machine_id.into())
             .ok_or_else(|| CarbideError::NotFoundError {
                 kind: "dpu",
                 id: dpu_machine_id.to_string(),
@@ -979,7 +980,8 @@ pub(crate) async fn record_dpu_network_status(
     log_request_data(&request);
 
     let request = request.into_inner();
-    let dpu_machine_id = convert_and_log_machine_id(request.dpu_machine_id.as_ref())?;
+    let dpu_machine_id =
+        convert_and_log_machine_id::<DpuMachineId>(request.dpu_machine_id.as_ref())?;
 
     let mut txn = api.txn_begin().await?;
 
@@ -1133,7 +1135,7 @@ pub(crate) async fn record_dpu_network_status(
         let dpu_machine = snapshot
             .dpu_snapshots
             .iter()
-            .find(|x| x.id == dpu_machine_id)
+            .find(|x| x.id == dpu_machine_id.into())
             .ok_or_else(|| CarbideError::NotFoundError {
                 kind: "dpu",
                 id: dpu_machine_id.to_string(),
@@ -1192,7 +1194,7 @@ pub(crate) async fn record_dpu_network_status(
         // hand is the reporting DPU rather than the host that stays asleep.
         carbide_instrument::emit(StateHandlerWakeupFailed {
             trigger: WakeupTrigger::DpuNetworkStatus,
-            machine_id: dpu_machine_id,
+            machine_id: dpu_machine_id.into(),
             err: err.to_string(),
         });
     }
@@ -1202,7 +1204,7 @@ pub(crate) async fn record_dpu_network_status(
 
 async fn wakeup_host_state_handler_by_dpu_id(
     api: &Api,
-    dpu_machine_id: &MachineId,
+    dpu_machine_id: &DpuMachineId,
 ) -> Result<(), DatabaseError> {
     let host_machines_by_dpu_ids =
         db::machine::lookup_host_machine_ids_by_dpu_ids(&mut api.db_reader(), &[*dpu_machine_id])
@@ -1211,12 +1213,12 @@ async fn wakeup_host_state_handler_by_dpu_id(
     if let Some(host_machine_id) = host_machines_by_dpu_ids.get(dpu_machine_id)
         && let Err(err) = api
             .machine_state_handler_enqueuer
-            .enqueue_object(host_machine_id.as_machine_id())
+            .enqueue_object(host_machine_id)
             .await
     {
         carbide_instrument::emit(StateHandlerWakeupFailed {
             trigger: WakeupTrigger::DpuNetworkStatus,
-            machine_id: *host_machine_id.as_machine_id(),
+            machine_id: host_machine_id.into(),
             err: err.to_string(),
         });
     }
@@ -1262,12 +1264,8 @@ pub(crate) async fn dpu_agent_upgrade_check(
         ))
     })?;
     log_machine_id(&machine_id);
-    if !machine_id.machine_type().is_dpu() {
-        return Err(CarbideError::InvalidArgument(
-            "upgrade check can only be performed on DPUs".into(),
-        )
-        .into());
-    }
+    let dpu_machine_id = DpuMachineId::try_from(machine_id)
+        .map_err(|error| CarbideError::InvalidArgument(error.to_string()))?;
 
     // We usually want these two to match
     let agent_version = req.current_agent_version;
@@ -1279,7 +1277,7 @@ pub(crate) async fn dpu_agent_upgrade_check(
     let mut txn = api.txn_begin().await?;
 
     let machine =
-        db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?;
+        db::machine::find_one(&mut txn, &dpu_machine_id, MachineSearchConfig::default()).await?;
     let machine = machine.ok_or(CarbideError::NotFoundError {
         kind: "dpu",
         id: machine_id.to_string(),
@@ -1631,7 +1629,7 @@ pub(crate) async fn trigger_dpu_reprovisioning(
     log_request_data(&request);
     let req = request.into_inner();
     let machine_id = req.machine_id.as_ref().or(req.dpu_id.as_ref());
-    let machine_id = convert_and_log_machine_id(machine_id)?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(machine_id)?;
 
     let mode = req.mode();
     // Set and Clear must choose their complete DPU set from the same attachment

--- a/crates/api-core/src/handlers/dpu_remediation.rs
+++ b/crates/api-core/src/handlers/dpu_remediation.rs
@@ -16,6 +16,7 @@
  */
 use ::rpc::forge as rpc;
 use ::rpc::model::RpcTryFrom;
+use carbide_uuid::machine::DpuMachineId;
 use db::dpu_remediation::AppliedRemediationIdQueryType;
 use model::dpu_remediation::{
     ApproveRemediation, DisableRemediation, EnableRemediation, NewRemediation, RevokeRemediation,
@@ -228,7 +229,10 @@ pub(crate) async fn find_applied_remediation_ids(
         (Some(remediation_id), None) => {
             Ok(AppliedRemediationIdQueryType::RemediationId(remediation_id))
         }
-        (None, Some(machine_id)) => Ok(AppliedRemediationIdQueryType::Machine(machine_id)),
+        (None, Some(machine_id)) => Ok(AppliedRemediationIdQueryType::Machine(
+            DpuMachineId::try_from(machine_id)
+                .map_err(|error| CarbideError::InvalidArgument(error.to_string()))?,
+        )),
     }?;
 
     let (remediation_ids, dpu_machine_ids) =
@@ -236,7 +240,7 @@ pub(crate) async fn find_applied_remediation_ids(
 
     let response = rpc::AppliedRemediationIdList {
         remediation_ids,
-        dpu_machine_ids,
+        dpu_machine_ids: dpu_machine_ids.into_iter().map(Into::into).collect(),
     };
 
     txn.commit().await?;

--- a/crates/api-core/src/handlers/health.rs
+++ b/crates/api-core/src/handlers/health.rs
@@ -33,7 +33,7 @@ pub(crate) async fn list_machine_health_reports(
 ) -> Result<Response<rpc::ListHealthReportResponse>, Status> {
     let mut txn = api.txn_begin().await?;
 
-    let machine_id = convert_and_log_machine_id(Some(&machine_id.into_inner()))?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(Some(&machine_id.into_inner()))?;
 
     let machine = db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default())
         .await?
@@ -112,7 +112,7 @@ pub(crate) async fn insert_machine_health_report(
     else {
         return Err(CarbideError::MissingArgument("health_report_entry").into());
     };
-    let machine_id = convert_and_log_machine_id(machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(machine_id.as_ref())?;
     let Some(report) = report else {
         return Err(CarbideError::MissingArgument("report").into());
     };

--- a/crates/api-core/src/handlers/host_reprovisioning.rs
+++ b/crates/api-core/src/handlers/host_reprovisioning.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 use ::rpc::forge as rpc;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use itertools::Itertools;
 use model::machine::{
     HostReprovisionState, InstanceState, LoadSnapshotOptions, ManagedHostState, ScoutUpgradeResult,
@@ -50,7 +50,7 @@ pub(crate) async fn trigger_host_reprovisioning(
 
     log_request_data(&request);
     let req = request.into_inner();
-    let machine_id = convert_and_log_machine_id(req.machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(req.machine_id.as_ref())?;
 
     let mut txn = api.txn_begin().await?;
 
@@ -169,7 +169,7 @@ pub(crate) async fn report_scout_firmware_upgrade_status(
     log_request_data(&request);
 
     let req = request.into_inner();
-    let machine_id = convert_and_log_machine_id(req.machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<HostMachineId>(req.machine_id.as_ref())?;
 
     let (machine, mut txn) = api.load_machine(&machine_id, Default::default()).await?;
 
@@ -268,7 +268,7 @@ pub(crate) async fn report_scout_firmware_upgrade_status(
     {
         carbide_instrument::emit(StateHandlerWakeupFailed {
             trigger: WakeupTrigger::ScoutFirmwareUpgradeStatus,
-            machine_id,
+            machine_id: machine_id.into(),
             err: err.to_string(),
         });
     }

--- a/crates/api-core/src/handlers/instance.rs
+++ b/crates/api-core/src/handlers/instance.rs
@@ -292,7 +292,7 @@ pub(crate) async fn find_by_machine_id(
 ) -> Result<Response<rpc::InstanceList>, Status> {
     log_request_data(&request);
 
-    let machine_id = convert_and_log_machine_id(Some(&request.into_inner()))?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(Some(&request.into_inner()))?;
 
     let mut txn = api.txn_begin().await?;
 
@@ -893,9 +893,13 @@ pub(crate) async fn update_phone_home_last_contact(
         let caller_is_attached_dpu = if caller_is_host {
             false
         } else {
-            db::machine::find_host_by_dpu_machine_id(&mut txn, caller_machine_id)
-                .await?
-                .is_some_and(|host| host.id == instance.machine_id)
+            db::machine::find_host_by_dpu_machine_id(
+                &mut txn,
+                &carbide_uuid::machine::DpuMachineId::try_from(*caller_machine_id)
+                    .map_err(|error| CarbideError::InvalidArgument(error.to_string()))?,
+            )
+            .await?
+            .is_some_and(|host| host.id == instance.machine_id)
         };
 
         if !caller_is_host && !caller_is_attached_dpu {
@@ -2129,8 +2133,11 @@ async fn update_instance_spx_config(
         only_svpc: false,
         only_astra: false,
     };
+    let host_machine_id = carbide_uuid::machine::HostMachineId::try_from(mid)
+        .map_err(|error| CarbideError::internal(error.to_string()))?;
     let dpa_interfaces =
-        db::dpa_interface::find_by_machine_id(txn.as_mut(), mid, dpa_search_config).await?;
+        db::dpa_interface::find_by_machine_id(txn.as_mut(), host_machine_id, dpa_search_config)
+            .await?;
 
     mh_snapshot.dpa_interface_snapshots = dpa_interfaces;
 

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -23,7 +23,7 @@ use ::rpc::forge as rpc;
 use ::rpc::model::machine::ManagedHostStateSnapshotRpc;
 use carbide_redfish::libredfish::RedfishAuth;
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostOrDpuId, MachineId};
 use libredfish::SystemPowerControl;
 use model::bmc_suppression::BmcSuppressionSubsystem;
 use model::hardware_info::MachineNvLinkInfo;
@@ -442,7 +442,9 @@ async fn force_delete_cleanup_txn(
         // Free up all loopback IPs allocated for this DPU.
         db::vpc_dpu_loopback::delete_and_deallocate(
             &api.common_pools,
-            &dpu_machine.id,
+            &dpu_machine.id.try_into().map_err(|error| {
+                CarbideError::internal(format!("invalid DPU machine ID: {error}"))
+            })?,
             &mut txn,
             true,
         )
@@ -601,27 +603,37 @@ pub(crate) async fn admin_force_delete_machine(
     // state controller will use - which already contains the combined state
     let host_machine;
     let dpu_machines;
-    if machine.is_dpu() {
-        if let Some(host) = db::machine::find_host_by_dpu_machine_id(&mut txn, &machine.id).await? {
-            tracing::info!(
-                host_machine_id = %host.id,
-                dpu_machine_id = %machine.id,
-                "Found host machine",
-            );
-            // Get all DPUs attached to this host, in case there are more than one.
-            dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &host.id).await?;
-            host_machine = Some(host);
-        } else {
-            host_machine = None;
-            dpu_machines = vec![machine];
+    match machine.id.host_or_dpu_id() {
+        HostOrDpuId::Dpu(dpu_machine_id) => {
+            if let Some(host) =
+                db::machine::find_host_by_dpu_machine_id(&mut txn, &dpu_machine_id).await?
+            {
+                tracing::info!(
+                    host_machine_id = %host.id,
+                    dpu_machine_id = %machine.id,
+                    "Found host machine",
+                );
+                // Get all DPUs attached to this host, in case there are more than one.
+                let host_machine_id = host.id.try_into().map_err(|error| {
+                    CarbideError::internal(format!("invalid host machine ID: {error}"))
+                })?;
+                dpu_machines =
+                    db::machine::find_dpus_by_host_machine_id(&mut txn, &host_machine_id).await?;
+                host_machine = Some(host);
+            } else {
+                host_machine = None;
+                dpu_machines = vec![machine];
+            }
         }
-    } else {
-        dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine.id).await?;
-        tracing::info!(
-            dpu_machine_ids = ?dpu_machines.iter().map(|m| &m.id).collect::<Vec<_>>(),
-            "Found DPU machines",
-        );
-        host_machine = Some(machine);
+        HostOrDpuId::Host(host_machine_id) => {
+            dpu_machines =
+                db::machine::find_dpus_by_host_machine_id(&mut txn, &host_machine_id).await?;
+            tracing::info!(
+                dpu_machine_ids = ?dpu_machines.iter().map(|m| &m.id).collect::<Vec<_>>(),
+                "Found DPU machines",
+            );
+            host_machine = Some(machine);
+        }
     }
 
     if let Some(host_machine) = &host_machine {

--- a/crates/api-core/src/handlers/machine_discovery.rs
+++ b/crates/api-core/src/handlers/machine_discovery.rs
@@ -21,7 +21,9 @@ use std::sync::atomic::Ordering;
 
 use ::rpc::forge as rpc;
 use carbide_utils::none_if_empty::NoneIfEmpty;
-use carbide_uuid::machine::{MachineIdSource, StableHostMachineId};
+use carbide_uuid::machine::{
+    HostMachineId, MachineId, MachineIdSource, MachineIdSubtype, StableHostMachineId,
+};
 use carbide_uuid::nvlink::NvLinkDomainId;
 use db::WithTransaction;
 use futures_util::FutureExt;
@@ -404,12 +406,20 @@ pub(crate) async fn discover_machine(
         db_machine.id
     } else {
         // Now we know stable machine id for host. Let's update it in db.
+        let stable_host_machine_id = StableHostMachineId::try_from(stable_machine_id)
+            .map_err(|error| CarbideError::InvalidArgument(error.to_string()))?;
+        let current_host_machine_id = caller_interface
+            .machine_id
+            .map(HostMachineId::try_from)
+            .transpose()
+            .map_err(|error| CarbideError::internal(error.to_string()))?;
         db::machine::try_sync_stable_id_with_current_machine_id_for_host(
             &mut txn,
-            &caller_interface.machine_id,
-            &stable_machine_id,
+            current_host_machine_id,
+            &stable_host_machine_id,
         )
         .await?
+        .into()
     };
 
     db::machine_topology::create_or_update_with_bom_validation(
@@ -420,7 +430,7 @@ pub(crate) async fn discover_machine(
     )
     .await?;
 
-    if hardware_info.is_dpu() {
+    if let MachineIdSubtype::Dpu(dpu_machine_id) = machine_id.machine_id_subtype() {
         // Create Host proactively.
         // In case host interface is created, this method will return existing one, instead
         // creating new everytime.
@@ -472,12 +482,15 @@ pub(crate) async fn discover_machine(
             .await?;
 
             // Update host and DPUs state correctly.
+            let host_machine_id = proactive_machine
+                .host_machine_id()
+                .map_err(|error| CarbideError::internal(error.to_string()))?;
             db::machine::update_state(
                 &mut txn,
-                &proactive_machine.id,
+                &host_machine_id,
                 &ManagedHostState::DPUInit {
                     dpu_states: DpuInitStates {
-                        states: HashMap::from([(machine_id, DpuInitState::Init)]),
+                        states: HashMap::from([(dpu_machine_id, DpuInitState::Init)]),
                     },
                 },
             )
@@ -666,7 +679,7 @@ pub(crate) async fn discovery_completed(
     log_request_data(&request);
 
     let req = request.into_inner();
-    let machine_id = convert_and_log_machine_id(req.machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(req.machine_id.as_ref())?;
 
     let (machine, mut txn) = api
         .load_machine(&machine_id, MachineSearchConfig::default())

--- a/crates/api-core/src/handlers/machine_discovery/scout_pci.rs
+++ b/crates/api-core/src/handlers/machine_discovery/scout_pci.rs
@@ -18,7 +18,7 @@
 use std::collections::HashSet;
 
 use carbide_instrument::{DynamicLog, Event, LabelValue, LogAt};
-use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::machine::{DpuMachineId, MachineId, MachineInterfaceId};
 use mac_address::MacAddress;
 use model::hardware_info::HardwareInfo;
 use model::machine::Machine;
@@ -45,7 +45,7 @@ enum ScoutPciComparison {
 struct EligibleInterface {
     machine_interface_id: MachineInterfaceId,
     mac_address: MacAddress,
-    dpu_machine_id: MachineId,
+    dpu_machine_id: DpuMachineId,
 }
 
 /// One eligible interface paired with its parsed scout endpoint BDF.
@@ -279,8 +279,7 @@ fn eligible_interfaces(machine: &Machine) -> Vec<EligibleInterface> {
         .filter_map(|interface| {
             let dpu_machine_id = interface.attached_dpu_machine_id?;
             (interface.machine_id == Some(machine.id)
-                && interface.network_segment_type == Some(NetworkSegmentType::Admin)
-                && dpu_machine_id.machine_type().is_dpu())
+                && interface.network_segment_type == Some(NetworkSegmentType::Admin))
             .then_some(EligibleInterface {
                 machine_interface_id: interface.id,
                 mac_address: interface.mac_address,
@@ -465,7 +464,7 @@ mod tests {
     /// Builds one Admin interface owned by the fixture host and attached to a DPU.
     fn eligible_interface(
         mac_address: MacAddress,
-        dpu_machine_id: MachineId,
+        dpu_machine_id: DpuMachineId,
     ) -> MachineInterfaceSnapshot {
         let mut interface = MachineInterfaceSnapshot::mock_with_mac(mac_address);
         interface.id =

--- a/crates/api-core/src/handlers/machine_hardware_info.rs
+++ b/crates/api-core/src/handlers/machine_hardware_info.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use ::rpc::forge::{MachineHardwareInfoUpdateType, UpdateMachineHardwareInfoRequest};
+use carbide_uuid::machine::MachineId;
 use tonic::{Request, Response, Status};
 
 use crate::CarbideError;
@@ -28,7 +29,8 @@ pub(crate) async fn handle_machine_hardware_info_update(
     log_request_data(&request);
     let update_hardware_info_request = request.into_inner();
 
-    let machine_id = convert_and_log_machine_id(update_hardware_info_request.machine_id.as_ref())?;
+    let machine_id =
+        convert_and_log_machine_id::<MachineId>(update_hardware_info_request.machine_id.as_ref())?;
 
     let request_hardware_info =
         update_hardware_info_request

--- a/crates/api-core/src/handlers/machine_scout.rs
+++ b/crates/api-core/src/handlers/machine_scout.rs
@@ -17,6 +17,7 @@
 use ::rpc::forge::ForgeAgentControlResponse;
 use ::rpc::model::machine::get_action_for_dpu_state;
 use ::rpc::{forge as rpc, forge_agent_control_response as fac, scout_firmware_upgrade as sfu};
+use carbide_uuid::machine::{HostOrDpuId, MachineId, MachineIdSubtype};
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
     BomValidating, CleanupContext, CleanupState, DecommissioningState, DeconfiguringHostState,
@@ -42,7 +43,7 @@ pub(crate) async fn cleanup_machine_completed(
     let cleanup_info = request.into_inner();
     tracing::info!(?cleanup_info, "cleanup_machine_completed");
 
-    let machine_id = convert_and_log_machine_id(cleanup_info.machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(cleanup_info.machine_id.as_ref())?;
 
     // Load machine from DB
     let (machine, mut txn) = api
@@ -119,10 +120,10 @@ pub(crate) async fn cleanup_machine_completed(
 
     // State handler should mark Machine as Adopted and reboot host for bios/bmc lockdown.
     // Wake it up
-    if machine_id.machine_type().is_host()
+    if let MachineIdSubtype::StableHost(host_machine_id) = machine_id.machine_id_subtype()
         && let Err(err) = api
             .machine_state_handler_enqueuer
-            .enqueue_object(&machine_id)
+            .enqueue_object(&host_machine_id.into())
             .await
     {
         carbide_instrument::emit(StateHandlerWakeupFailed {
@@ -169,34 +170,32 @@ pub(crate) async fn forge_agent_control(
 
     use rpc::forge_agent_control_response::Action;
 
-    let machine_id = convert_and_log_machine_id(request.into_inner().machine_id.as_ref())?;
+    let machine_id =
+        convert_and_log_machine_id::<MachineId>(request.into_inner().machine_id.as_ref())?;
 
     let (machine, mut txn) = api
         .load_machine(&machine_id, MachineSearchConfig::default())
         .await?;
 
-    let is_dpu = machine.is_dpu();
-    let host_machine = if !is_dpu {
-        machine.clone()
-    } else {
-        db::machine::find_host_by_dpu_machine_id(&mut txn, &machine_id)
+    let dpu_machine_id = machine.dpu_machine_id();
+    let host_machine = if let Ok(dpu_machine_id) = &dpu_machine_id {
+        db::machine::find_host_by_dpu_machine_id(&mut txn, dpu_machine_id)
             .await?
             .ok_or(CarbideError::NotFoundError {
                 kind: "machine",
                 id: machine_id.to_string(),
             })?
-    };
-
-    if !is_dpu {
+    } else {
         db::machine::update_scout_contact_time(&machine_id, &mut txn).await?;
-    }
+        machine.clone()
+    };
 
     // Respond based on machine current state
     let state = host_machine.current_state();
 
-    let (action, maybe_pending_txn) = if is_dpu {
+    let (action, maybe_pending_txn) = if let Ok(dpu_machine_id) = &dpu_machine_id {
         (
-            get_action_for_dpu_state(state, &machine_id).map_err(CarbideError::from)?,
+            get_action_for_dpu_state(state, dpu_machine_id).map_err(CarbideError::from)?,
             Some(txn),
         )
     } else {
@@ -331,7 +330,12 @@ pub(crate) async fn forge_agent_control(
             } => {
                 // Commit the transaction now, to avoid holding across an unrelated await point
                 txn.commit().await?;
-                match crate::handlers::svpc::process_scout_req(api, machine_id).await {
+                match crate::handlers::svpc::process_scout_req(
+                    api,
+                    machine_id.try_into().map_err(CarbideError::from)?,
+                )
+                .await
+                {
                     Ok(action) => (action, None),
                     Err(e) => {
                         tracing::error!(
@@ -349,7 +353,12 @@ pub(crate) async fn forge_agent_control(
             // RotateKeyUnlocking -> RotateKeyLocking cycle for each card.
             ManagedHostState::RotatingNicLockdown => {
                 txn.commit().await?;
-                match crate::handlers::svpc::process_scout_req(api, machine_id).await {
+                match crate::handlers::svpc::process_scout_req(
+                    api,
+                    machine_id.try_into().map_err(CarbideError::from)?,
+                )
+                .await
+                {
                     Ok(action) => (action, None),
                     Err(error) => {
                         tracing::error!(
@@ -369,7 +378,12 @@ pub(crate) async fn forge_agent_control(
                     },
             } => {
                 txn.commit().await?;
-                match crate::handlers::svpc::process_scout_req(api, machine_id).await {
+                match crate::handlers::svpc::process_scout_req(
+                    api,
+                    machine_id.try_into().map_err(CarbideError::from)?,
+                )
+                .await
+                {
                     Ok(action) => (action, None),
                     Err(error) => {
                         tracing::error!(
@@ -505,7 +519,7 @@ pub(crate) async fn reboot_completed(
     log_request_data(&request);
 
     let req = request.into_inner();
-    let machine_id = convert_and_log_machine_id(req.machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(req.machine_id.as_ref())?;
 
     let (machine, mut txn) = api
         .load_machine(&machine_id, MachineSearchConfig::default())
@@ -519,10 +533,10 @@ pub(crate) async fn reboot_completed(
 
     // Wake up the state handler for the machine
     // Don't do it for DPUs - state handlers only run on hosts
-    if (machine_id.machine_type().is_host() || machine_id.machine_type().is_predicted_host())
+    if let HostOrDpuId::Host(host_machine_id) = machine_id.host_or_dpu_id()
         && let Err(err) = api
             .machine_state_handler_enqueuer
-            .enqueue_object(&machine_id)
+            .enqueue_object(&host_machine_id)
             .await
     {
         carbide_instrument::emit(StateHandlerWakeupFailed {

--- a/crates/api-core/src/handlers/managed_host.rs
+++ b/crates/api-core/src/handlers/managed_host.rs
@@ -16,7 +16,7 @@
  */
 
 use ::rpc::forge as rpc;
-use carbide_uuid::machine::{DpuMachineId, StableHostMachineId};
+use carbide_uuid::machine::{DpuMachineId, HostMachineId, StableHostMachineId};
 use model::machine::ManagedHostState;
 use model::machine::machine_search_config::MachineSearchConfig;
 use tonic::{Request, Response, Status};
@@ -32,13 +32,8 @@ pub(crate) async fn decommission_managed_host(
     request: Request<rpc::DecommissionManagedHostRequest>,
 ) -> Result<Response<rpc::DecommissionManagedHostResponse>, Status> {
     log_request_data(&request);
-    let machine_id = convert_and_log_machine_id(request.into_inner().machine_id.as_ref())?;
-    if machine_id.machine_type().is_dpu() {
-        return Err(CarbideError::InvalidArgument(format!(
-            "machine {machine_id} is a DPU, not a managed host"
-        ))
-        .into());
-    }
+    let machine_id =
+        convert_and_log_machine_id::<HostMachineId>(request.into_inner().machine_id.as_ref())?;
 
     let mut txn = api.txn_begin().await?;
     let machine = db::machine::find_one(
@@ -87,7 +82,7 @@ pub(crate) async fn decommission_managed_host(
         .into());
     }
 
-    db::machine::set_decommission_requested(&mut txn, machine_id).await?;
+    db::machine::set_decommission_requested(&mut txn, machine_id.into()).await?;
     txn.commit().await?;
 
     if let Err(error) = api
@@ -126,7 +121,7 @@ pub(crate) async fn set_primary_dpu(
     #[allow(deprecated)]
     let force_reconcile = request.force_reconcile || request.reboot;
 
-    log_machine_id(host_machine_id.as_machine_id());
+    log_machine_id(&host_machine_id);
 
     set_primary_interface_and_enqueue_reconciliation(
         api,
@@ -159,7 +154,7 @@ pub(crate) async fn set_primary_interface(
     #[allow(deprecated)]
     let force_reconcile = request.force_reconcile || request.reboot;
 
-    log_machine_id(host_machine_id.as_machine_id());
+    log_machine_id(&host_machine_id);
 
     set_primary_interface_and_enqueue_reconciliation(
         api,
@@ -207,17 +202,11 @@ pub(crate) async fn set_maintenance(
         .and_then(|ctx| ctx.get_external_user_name())
         .map(String::from);
     let req = request.into_inner();
-    let machine_id = convert_and_log_machine_id(req.host_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<HostMachineId>(req.host_id.as_ref())?;
 
-    let (host_machine, mut txn) = api
+    let (_, mut txn) = api
         .load_machine(&machine_id, MachineSearchConfig::default())
         .await?;
-    if host_machine.is_dpu() {
-        return Err(CarbideError::InvalidArgument(
-            "DPU ID provided. need managed host".to_string(),
-        )
-        .into());
-    }
     let dpu_machines = db::machine::find_dpus_by_host_machine_id(&mut txn, &machine_id).await?;
     txn.commit().await?;
 

--- a/crates/api-core/src/handlers/mlx_admin.rs
+++ b/crates/api-core/src/handlers/mlx_admin.rs
@@ -1304,8 +1304,10 @@ async fn get_device_lockdown_key(
     // refer to as the "pci_name".
     //
     // In other words, device_id == pci_name.
+    let host_machine_id = carbide_uuid::machine::HostMachineId::try_from(machine_id)
+        .map_err(|error| CarbideError::InvalidArgument(error.to_string()))?;
     let dpa_interface =
-        db::dpa_interface::get_for_pci_name(&api.database_connection, &machine_id, device_id)
+        db::dpa_interface::get_for_pci_name(&api.database_connection, &host_machine_id, device_id)
             .await
             .map_err(|e| {
                 CarbideError::NotFoundError {

--- a/crates/api-core/src/handlers/mod.rs
+++ b/crates/api-core/src/handlers/mod.rs
@@ -111,7 +111,7 @@ pub(crate) async fn resolve_machine_interface_for_test(
 #[cfg(any(test, feature = "test-support"))]
 pub(crate) async fn process_scout_req_for_test(
     api: &crate::Api,
-    machine_id: carbide_uuid::machine::MachineId,
+    machine_id: carbide_uuid::machine::HostMachineId,
 ) -> crate::CarbideResult<rpc::forge_agent_control_response::Action> {
     svpc::process_scout_req(api, machine_id).await
 }

--- a/crates/api-core/src/handlers/primary_interface.rs
+++ b/crates/api-core/src/handlers/primary_interface.rs
@@ -85,10 +85,7 @@ fn scout_may_replace_current_primary(interfaces: &[MachineInterfaceSnapshot]) ->
         return true;
     };
 
-    primary
-        .attached_dpu_machine_id
-        .is_some_and(|machine_id| machine_id.machine_type().is_dpu())
-        && primaries.next().is_none()
+    primary.attached_dpu_machine_id.is_some() && primaries.next().is_none()
 }
 
 /// Builds a desired boot target from a MAC address and optional Redfish interface ID.
@@ -141,34 +138,26 @@ pub(super) async fn update_primary_interface(
     // Site Explorer takes these locks before it changes interface ownership.
     // Matching that order keeps an operator or scout write from deadlocking discovery.
     db::machine_interface::lock_all_admin_segments(&mut txn).await?;
-    let interface_snapshots = db::machine_interface::find_by_machine_id_for_update(
-        &mut txn,
-        host_machine_id.as_machine_id(),
-    )
-    .await?;
+    let interface_snapshots =
+        db::machine_interface::find_by_machine_id_for_update(&mut txn, &host_machine_id).await?;
     // This locks the Machine row with `FOR UPDATE`; the snapshot below is read after that wait.
     db::machine_desired_boot_interface::lock(txn.as_pgconn(), host_machine_id.as_host_machine_id())
         .await?;
-    let machine = db::machine::find_one(
-        &mut txn,
-        host_machine_id.as_machine_id(),
-        MachineSearchConfig::default(),
-    )
-    .await?
-    .ok_or_else(|| CarbideError::Internal {
-        message: format!(
-            "machine {host_machine_id} disappeared while its database record was locked"
-        ),
-    })?;
+    let machine = db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
+        .await?
+        .ok_or_else(|| CarbideError::Internal {
+            message: format!(
+                "machine {host_machine_id} disappeared while its database record was locked"
+            ),
+        })?;
 
     let new_primary_interface_id = match selector {
         PrimaryInterfaceSelector::Interface(interface_id) => interface_id,
         PrimaryInterfaceSelector::Dpu(dpu_machine_id) => {
-            if !interface_snapshots.iter().any(|interface| {
-                interface
-                    .attached_dpu_machine_id
-                    .is_some_and(|machine_id| machine_id.machine_type().is_dpu())
-            }) {
+            if !interface_snapshots
+                .iter()
+                .any(|interface| interface.attached_dpu_machine_id.is_some())
+            {
                 return Err(CarbideError::FailedPrecondition(format!(
                     "host {host_machine_id} has no DPUs; set-primary-dpu does not apply to zero-DPU hosts"
                 )));
@@ -177,8 +166,7 @@ pub(super) async fn update_primary_interface(
             interface_snapshots
                 .iter()
                 .find(|interface| {
-                    interface.attached_dpu_machine_id.as_ref()
-                        == Some(dpu_machine_id.as_machine_id())
+                    interface.attached_dpu_machine_id.as_ref() == Some(&dpu_machine_id)
                 })
                 .map(|interface| interface.id)
                 .ok_or_else(|| {
@@ -220,9 +208,7 @@ pub(super) async fn update_primary_interface(
     }
 
     let host_has_dpu_backed_admin_interface = interface_snapshots.iter().any(|interface| {
-        interface
-            .attached_dpu_machine_id
-            .is_some_and(|machine_id| machine_id.machine_type().is_dpu())
+        interface.attached_dpu_machine_id.is_some()
             && interface.network_segment_type == Some(NetworkSegmentType::Admin)
     });
     if host_has_dpu_backed_admin_interface
@@ -235,8 +221,7 @@ pub(super) async fn update_primary_interface(
     }
 
     let instance =
-        db::instance::find_live_by_machine_id_for_update(&mut txn, host_machine_id.as_machine_id())
-            .await?;
+        db::instance::find_live_by_machine_id_for_update(&mut txn, &host_machine_id).await?;
     let reconciliation_is_pending = machine.pending_boot_interface_config_version().is_some();
     let reconciliation_is_eligible =
         matches!(machine.current_state(), ManagedHostState::Ready) && instance.is_none();
@@ -284,7 +269,7 @@ pub(super) async fn update_primary_interface_from_scout(
     // First, load the machine and compare its stored boot interface with this scout report.
     let machine = db::machine::find_one(
         api.pg_pool(),
-        host_machine_id.as_machine_id(),
+        &host_machine_id,
         MachineSearchConfig::default(),
     )
     .await?
@@ -298,7 +283,7 @@ pub(super) async fn update_primary_interface_from_scout(
         });
     };
     let candidate_interface_id = comparison.candidate_interface_id();
-    comparison.emit(host_machine_id.as_machine_id());
+    comparison.emit(&host_machine_id);
 
     // Then, stop before taking update locks unless this report can drive enabled reconciliation.
     let source_is_replaceable = machine
@@ -321,25 +306,18 @@ pub(super) async fn update_primary_interface_from_scout(
     let _admin_admission = db::machine_interface::admin_lock_admission().await;
     let mut txn = api.txn_begin().await?;
     db::machine_interface::lock_all_admin_segments(&mut txn).await?;
-    let interface_snapshots = db::machine_interface::find_by_machine_id_for_update(
-        &mut txn,
-        host_machine_id.as_machine_id(),
-    )
-    .await?;
+    let interface_snapshots =
+        db::machine_interface::find_by_machine_id_for_update(&mut txn, &host_machine_id).await?;
     // This locks the Machine row with `FOR UPDATE`; the snapshot below is read after that wait.
     db::machine_desired_boot_interface::lock(txn.as_pgconn(), host_machine_id.as_host_machine_id())
         .await?;
-    let machine = db::machine::find_one(
-        &mut txn,
-        host_machine_id.as_machine_id(),
-        MachineSearchConfig::default(),
-    )
-    .await?
-    .ok_or_else(|| CarbideError::Internal {
-        message: format!(
-            "machine {host_machine_id} disappeared while its database record was locked"
-        ),
-    })?;
+    let machine = db::machine::find_one(&mut txn, &host_machine_id, MachineSearchConfig::default())
+        .await?
+        .ok_or_else(|| CarbideError::Internal {
+            message: format!(
+                "machine {host_machine_id} disappeared while its database record was locked"
+            ),
+        })?;
     let Some((new_primary_interface, boot_target)) = select_primary_interface_from_scout(
         txn.as_pgconn(),
         host_machine_id,
@@ -425,7 +403,7 @@ async fn select_primary_interface_from_scout<'a>(
     // Finally, do not compete with a primary interface that Site Explorer has already planned. Its
     // writers take the same global Admin locks as this caller.
     let has_primary_prediction =
-        db::predicted_machine_interface::find_by_machine_id(txn, host_machine_id.as_machine_id())
+        db::predicted_machine_interface::find_by_machine_id(txn, &host_machine_id)
             .await?
             .iter()
             .any(|prediction| prediction.primary_interface);
@@ -435,7 +413,7 @@ async fn select_primary_interface_from_scout<'a>(
 
     // Allocation also locks the Machine row, so it cannot commit concurrently. Read the Instance
     // ID without locking it to avoid reversing the lock order used by release.
-    if db::instance::find_id_by_machine_id(txn, host_machine_id.as_machine_id())
+    if db::instance::find_id_by_machine_id(txn, &host_machine_id)
         .await?
         .is_some()
     {
@@ -482,11 +460,8 @@ async fn apply_primary_interface_update(
         // admin primary skips this pass; reconciliation assigns the address after the primary
         // flag changes.
         if current_primary_is_admin {
-            db::machine_interface::reconcile_admin_addresses_for_host(
-                txn,
-                host_machine_id.as_machine_id(),
-            )
-            .await?;
+            db::machine_interface::reconcile_admin_addresses_for_host(txn, &host_machine_id)
+                .await?;
         }
 
         if let Some(current_primary_interface_id) = current_primary_interface_id {
@@ -494,21 +469,17 @@ async fn apply_primary_interface_update(
                 .await?;
         }
         db::machine_interface::set_primary_interface(&new_primary_interface_id, true, txn).await?;
-        db::machine_interface::reconcile_admin_addresses_for_host(
-            txn,
-            host_machine_id.as_machine_id(),
-        )
-        .await?;
+        db::machine_interface::reconcile_admin_addresses_for_host(txn, &host_machine_id).await?;
 
         let (network_config, network_config_version) =
-            db::machine::get_network_config(txn.as_pgconn(), host_machine_id.as_machine_id())
+            db::machine::get_network_config(txn.as_pgconn(), &host_machine_id)
                 .await?
                 .take();
         // The Machine row was locked before this version was read, so another transaction cannot
         // change the version before this update. The update must therefore match one row.
         if !db::machine::try_update_network_config(
             txn,
-            host_machine_id.as_machine_id(),
+            &host_machine_id,
             network_config_version,
             &network_config,
         )

--- a/crates/api-core/src/handlers/sku.rs
+++ b/crates/api-core/src/handlers/sku.rs
@@ -110,7 +110,7 @@ pub(crate) async fn assign_to_machine(
     let mut txn = api.txn_begin().await?;
 
     let sku_machine_pair = request.into_inner();
-    let machine_id = convert_and_log_machine_id(sku_machine_pair.machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(sku_machine_pair.machine_id.as_ref())?;
 
     let machine =
         db::machine::find_one(&mut txn, &machine_id, MachineSearchConfig::default()).await?;
@@ -177,7 +177,7 @@ pub(crate) async fn verify_for_machine(
     request: Request<MachineId>,
 ) -> Result<Response<()>, Status> {
     log_request_data(&request);
-    let machine_id = convert_and_log_machine_id(Some(&request.into_inner()))?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(Some(&request.into_inner()))?;
 
     let mut txn = api.txn_begin().await?;
 
@@ -216,7 +216,7 @@ pub(crate) async fn remove_sku_association(
 ) -> Result<Response<()>, Status> {
     log_request_data(&request);
     let request = request.into_inner();
-    let machine_id = convert_and_log_machine_id(request.machine_id.as_ref())?;
+    let machine_id = convert_and_log_machine_id::<MachineId>(request.machine_id.as_ref())?;
 
     let mut txn = api.txn_begin().await?;
 

--- a/crates/api-core/src/handlers/svpc.rs
+++ b/crates/api-core/src/handlers/svpc.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 
 use ::rpc::protos::mlx_device as mlx_device_pb;
 use carbide_host_support::dpa_cmds::{DpaCommand, DpaDeviceCommand, OpCode};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use db::dpa_interface;
 use eyre::eyre;
 use libmlx::device::report::MlxDeviceReport;
@@ -48,7 +48,7 @@ use crate::{CarbideError, CarbideResult};
 /// If there is work to be done, return an MLX action with per-device commands.
 pub(super) async fn process_scout_req(
     api: &Api,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
 ) -> CarbideResult<fac::Action> {
     if !api.runtime_config.is_ewethers_enabled() || !api.runtime_config.is_svpc_enabled() {
         tracing::info!(
@@ -168,7 +168,7 @@ pub(super) async fn process_scout_req(
 /// The gate is checked first so the host-scoped DB read is skipped whenever the
 /// gate is on (the answer is already `true`); the force flag is only consulted
 /// when the gate is off.
-async fn resolve_rotate_lockdown_key(api: &Api, machine_id: MachineId) -> CarbideResult<bool> {
+async fn resolve_rotate_lockdown_key(api: &Api, machine_id: HostMachineId) -> CarbideResult<bool> {
     if api.runtime_config.nic_lockdown_ikm_rotation_enabled {
         return Ok(true);
     }
@@ -294,7 +294,7 @@ async fn resolve_unlock_ikm_version(api: &Api, mac: MacAddress) -> CarbideResult
 async fn build_unlock_command(
     api: &Api,
     sn: &DpaInterface,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
     pci_name: &str,
 ) -> CarbideResult<DpaCommand<'static>> {
     // DB-native `i32`; converted to the `u32` the derivation layer uses. The
@@ -333,7 +333,7 @@ async fn build_unlock_command(
 fn build_apply_firmware_command<'a>(
     api: &'a Api,
     sn: &DpaInterface,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
     pci_name: &str,
 ) -> DpaCommand<'a> {
     // Look up a FirmwareFlasherProfile for the device's PN:PSID
@@ -383,7 +383,7 @@ fn build_apply_firmware_command<'a>(
         carbide_instrument::emit(FirmwareUpdateProgress {
             target: FirmwareUpdateTarget::SuperNic,
             phase: FirmwareUpdatePhase::Started,
-            machine_id,
+            machine_id: machine_id.into(),
             detail: format!(
                 "pci_name={pci_name} part_number={part_number} psid={psid} \
                  observed_fw_version={:?} expected_fw_version={}",
@@ -418,7 +418,7 @@ fn build_apply_firmware_command<'a>(
 fn build_apply_profile_command(
     api: &Api,
     interface: &DpaInterface,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
     pci_name: &str,
 ) -> CarbideResult<DpaCommand<'static>> {
     let Some(profile_name) = &interface.mlxconfig_profile else {
@@ -477,7 +477,7 @@ fn build_apply_profile_command(
 async fn build_lock_command(
     api: &Api,
     sn: &DpaInterface,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
     pci_name: &str,
     migrate_to_target: bool,
 ) -> CarbideResult<DpaCommand<'static>> {
@@ -490,7 +490,7 @@ async fn build_lock_command(
 async fn lock_command_for_target(
     api: &Api,
     sn: &DpaInterface,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
     pci_name: &str,
     target_version: i32,
 ) -> CarbideResult<DpaCommand<'static>> {
@@ -578,8 +578,14 @@ async fn process_mlx_observation(
         only_astra: false,
     };
 
-    let dpa_snapshots =
-        db::dpa_interface::find_by_machine_id(&mut txn, machine_id, dpa_search_config).await?;
+    let dpa_snapshots = db::dpa_interface::find_by_machine_id(
+        &mut txn,
+        machine_id.try_into().map_err(|error| {
+            CarbideError::InvalidArgument(format!("invalid host machine ID: {error}"))
+        })?,
+        dpa_search_config,
+    )
+    .await?;
 
     if dpa_snapshots.is_empty() {
         tracing::error!(
@@ -750,7 +756,9 @@ pub(crate) async fn publish_mlx_device_report(
                 let device_description = device_info.device_description.clone();
 
                 let Some(new_interface) = NewDpaInterface::from_device_info(
-                    machine_id,
+                    machine_id.try_into().map_err(|error| {
+                        CarbideError::InvalidArgument(format!("invalid host machine ID: {error}"))
+                    })?,
                     device_info.base_mac,
                     device_type,
                     pci_name.clone(),

--- a/crates/api-core/src/handlers/utils.rs
+++ b/crates/api-core/src/handlers/utils.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use std::net::{IpAddr, SocketAddr};
 
 use carbide_utils::HostPortPair;
-use carbide_uuid::machine::{HostMachineId, MachineId};
+use carbide_uuid::machine::{HostMachineId, MachineId, MachineIdSubtypeTrait};
 use tokio::net::lookup_host;
 
 use crate::CarbideError;
@@ -86,16 +86,19 @@ fn invalid_bmc_address(address: &str, reason: impl std::fmt::Display) -> Carbide
 
 /// Converts a MachineID from RPC format to Model format
 /// and logs the MachineID as MachineID for the current request.
-pub(super) fn convert_and_log_machine_id(
-    id: Option<&MachineId>,
-) -> Result<MachineId, CarbideError> {
+pub(super) fn convert_and_log_machine_id<T>(id: Option<&MachineId>) -> Result<T, CarbideError>
+where
+    T: MachineIdSubtypeTrait,
+    T: TryFrom<MachineId>,
+    CarbideError: From<<T as TryFrom<MachineId>>::Error>,
+{
     let machine_id = match id {
-        Some(id) => *id,
+        Some(id) => T::try_from(*id)?,
         None => {
             return Err(CarbideError::MissingArgument("machine ID"));
         }
     };
-    log_machine_id(&machine_id);
+    log_machine_id(machine_id.as_machine_id());
 
     Ok(machine_id)
 }
@@ -150,7 +153,7 @@ pub(super) async fn enqueue_boot_interface_reconciliation(
 
     if let Err(err) = api
         .machine_state_handler_enqueuer
-        .enqueue_object(machine_id.as_machine_id())
+        .enqueue_object(&machine_id)
         .await
     {
         carbide_instrument::emit(StateHandlerWakeupFailed {

--- a/crates/api-core/src/instance/mod.rs
+++ b/crates/api-core/src/instance/mod.rs
@@ -1871,12 +1871,24 @@ pub(crate) async fn batch_allocate_instances(
     // deduplicated set; each map key is visited exactly once, so `remove` is
     // safe here.
     let dpa_search_config = DpaSearchConfig::default();
-    let snapshot_ids: Vec<MachineId> = snapshot_map.keys().copied().collect();
+    let snapshot_ids: Vec<carbide_uuid::machine::HostMachineId> = snapshot_map
+        .values()
+        .map(|snapshot| {
+            snapshot
+                .host_snapshot
+                .host_machine_id()
+                .map_err(|error| CarbideError::internal(error.to_string()))
+        })
+        .collect::<Result<_, _>>()?;
     let mut dpa_interfaces_by_machine =
         db::dpa_interface::find_by_machine_ids(&mut txn, &snapshot_ids, dpa_search_config).await?;
-    for (machine_id, snapshot) in snapshot_map.iter_mut() {
+    for snapshot in snapshot_map.values_mut() {
+        let host_machine_id = snapshot
+            .host_snapshot
+            .host_machine_id()
+            .map_err(|error| CarbideError::internal(error.to_string()))?;
         snapshot.dpa_interface_snapshots = dpa_interfaces_by_machine
-            .remove(machine_id)
+            .remove(&host_machine_id)
             .unwrap_or_default();
     }
 

--- a/crates/api-core/src/ipxe.rs
+++ b/crates/api-core/src/ipxe.rs
@@ -405,8 +405,10 @@ exit ||
         //
         // The second boot enables HBN.  This is handled here when the DPU is
         // waiting for the network install
-        if machine.is_dpu() {
-            if let Some(reprov_state) = &machine.current_state().as_reprovision_state(&machine_id)
+        if let Ok(dpu_machine_id) = machine.dpu_machine_id() {
+            if let Some(reprov_state) = &machine
+                .current_state()
+                .as_reprovision_state(&dpu_machine_id)
                 && matches!(
                     reprov_state,
                     ReprovisionState::FirmwareUpgrade | ReprovisionState::WaitingForNetworkInstall
@@ -423,7 +425,7 @@ exit ||
 
             match &machine.current_state() {
                 ManagedHostState::DPUInit { dpu_states } => {
-                    let Some(dpu_state) = dpu_states.states.get(&machine_id) else {
+                    let Some(dpu_state) = dpu_states.states.get(&dpu_machine_id) else {
                         return Err(CarbideError::MissingDpu(machine_id));
                     };
 

--- a/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
+++ b/crates/api-core/src/machine_update_manager/dpu_nic_firmware.rs
@@ -21,7 +21,7 @@ use std::sync::atomic::Ordering;
 
 use async_trait::async_trait;
 use carbide_machine_controller::dpf::DpfOperations;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use db::dpu_machine_update;
 use model::dpu_machine_update::{DpuMachineUpdate, OutdatedDpfDpu};
 use model::machine::ManagedHostStateSnapshot;
@@ -80,7 +80,7 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
 
         Ok(current_updating_machines
             .iter()
-            .map(|mu| mu.host_machine_id)
+            .map(|mu| mu.host_machine_id.into())
             .collect())
     }
 
@@ -89,7 +89,7 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
         pool: &sqlx::Pool<sqlx::Postgres>,
         available_updates: i32,
         updating_host_machines: &HashSet<MachineId>,
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<HashSet<MachineId>> {
         let machine_updates: Vec<DpuMachineUpdate> = self
             .check_for_updates(snapshots, available_updates)
@@ -104,7 +104,7 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
 
         for machine_update in machine_updates {
             host_machine_updates
-                .entry(machine_update.host_machine_id)
+                .entry(machine_update.host_machine_id.into())
                 .or_default()
                 .push(machine_update);
         }
@@ -197,14 +197,15 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
                         "Failed to remove machine update markers",
                     );
                 } else if let Ok(mut reported) = self.reported_wrong_versions.lock() {
-                    reported.retain(|(dpu, _)| *dpu != updated_machine.dpu_machine_id);
+                    reported
+                        .retain(|(dpu, _)| dpu != updated_machine.dpu_machine_id.as_machine_id());
                 }
             } else if self
                 .reported_wrong_versions
                 .lock()
                 .is_ok_and(|mut reported| {
                     reported.insert((
-                        updated_machine.dpu_machine_id,
+                        updated_machine.dpu_machine_id.into(),
                         updated_machine.firmware_version.clone(),
                     ))
                 })
@@ -212,7 +213,7 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
                 carbide_instrument::emit(FirmwareUpdateFailed {
                     target: FirmwareUpdateTarget::DpuNic,
                     cause: FirmwareUpdateFailureCause::WrongVersionAfterUpdate,
-                    machine_id: updated_machine.dpu_machine_id,
+                    machine_id: updated_machine.dpu_machine_id.into(),
                     unmatched_dpu_machine_id: String::new(),
                     firmware_version: updated_machine.firmware_version,
                 });
@@ -224,7 +225,7 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
     async fn update_metrics(
         &self,
         pool: &sqlx::Pool<sqlx::Postgres>,
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<()> {
         let dpf_outdated = self.fetch_dpf_outdated().await;
         match DpuMachineUpdate::find_available_outdated_dpus(
@@ -246,7 +247,7 @@ impl MachineUpdateModule for DpuNicFirmwareUpdate {
         let outdated_dpus = DpuMachineUpdate::find_unavailable_outdated_dpus(
             &self.config.dpu_config.dpu_nic_firmware_update_versions,
             snapshots,
-        );
+        )?;
         if let Some(metrics) = &self.metrics {
             metrics
                 .unavailable_dpu_updates
@@ -298,7 +299,7 @@ impl DpuNicFirmwareUpdate {
 
     pub(crate) async fn check_for_updates(
         &self,
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
         available_updates: i32,
     ) -> Vec<DpuMachineUpdate> {
         let dpf_outdated = self.fetch_dpf_outdated().await;

--- a/crates/api-core/src/machine_update_manager/host_firmware.rs
+++ b/crates/api-core/src/machine_update_manager/host_firmware.rs
@@ -23,7 +23,7 @@ use std::time::SystemTime;
 
 use async_trait::async_trait;
 use carbide_firmware::FirmwareConfig;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use db::{self, desired_firmware, host_firmware_config};
 use model::machine::ManagedHostStateSnapshot;
 use model::machine_update_module::HOST_FW_UPDATE_HEALTH_REPORT_SOURCE;
@@ -65,7 +65,7 @@ impl MachineUpdateModule for HostFirmwareUpdate {
         pool: &sqlx::Pool<sqlx::Postgres>,
         available_updates: i32,
         updating_host_machines: &HashSet<MachineId>,
-        _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        _snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<HashSet<MachineId>> {
         let mut txn = db::Transaction::begin(pool).await?;
         if let Ok(mut firmware_catalog_last_read) = self.firmware_catalog_last_read.try_lock() {
@@ -142,7 +142,7 @@ impl MachineUpdateModule for HostFirmwareUpdate {
     async fn update_metrics(
         &self,
         pool: &sqlx::Pool<sqlx::Postgres>,
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<()> {
         let exhausted_retries = snapshots
             .values()

--- a/crates/api-core/src/machine_update_manager/machine_update_module.rs
+++ b/crates/api-core/src/machine_update_manager/machine_update_module.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt;
 
 use async_trait::async_trait;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use model::machine::ManagedHostStateSnapshot;
 use sqlx::PgConnection;
 
@@ -43,7 +43,7 @@ pub(crate) trait MachineUpdateModule: Send + Sync + fmt::Display {
         pool: &sqlx::Pool<sqlx::Postgres>,
         available_updates: i32,
         updating_host_machines: &HashSet<MachineId>,
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<HashSet<MachineId>>;
 
     async fn clear_completed_updates(&self, txn: &mut PgConnection) -> CarbideResult<()>;
@@ -51,6 +51,6 @@ pub(crate) trait MachineUpdateModule: Send + Sync + fmt::Display {
     async fn update_metrics(
         &self,
         pool: &sqlx::Pool<sqlx::Postgres>,
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<()>;
 }

--- a/crates/api-core/src/machine_update_manager/mod.rs
+++ b/crates/api-core/src/machine_update_manager/mod.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 use carbide_machine_controller::dpf::DpfOperations;
 use carbide_utils::managed_loop::{self, LoopManager};
 use carbide_utils::periodic_timer::PeriodicTimer;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 use db::{DatabaseError, ObjectFilter, Transaction};
 use host_firmware::HostFirmwareUpdate;
@@ -162,7 +162,7 @@ impl MachineUpdateManager {
     async fn get_all_snapshots(
         &self,
         txn: &mut PgConnection,
-    ) -> CarbideResult<HashMap<MachineId, ManagedHostStateSnapshot>> {
+    ) -> CarbideResult<HashMap<HostMachineId, ManagedHostStateSnapshot>> {
         let machine_ids = db::machine::find_machine_ids(
             &mut *txn,
             MachineSearchConfig {
@@ -170,7 +170,11 @@ impl MachineUpdateManager {
                 ..Default::default()
             },
         )
-        .await?;
+        .await?
+        .into_iter()
+        .filter_map(|id| HostMachineId::try_from(id).ok())
+        .collect::<Vec<_>>();
+
         db::managed_host::load_by_machine_ids(
             txn,
             &machine_ids,
@@ -323,7 +327,7 @@ impl MachineUpdateManager {
     ) -> Result<HashSet<MachineId>, DatabaseError> {
         let machines = db::machine::find(
             txn,
-            ObjectFilter::All,
+            ObjectFilter::<MachineId>::All,
             MachineSearchConfig {
                 include_predicted_host: true,
                 ..Default::default()

--- a/crates/api-core/src/mqtt_state_change_hook/hook.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/hook.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use carbide_mqtt_common::hook::{MqttPublisher, QueuedMessage, process_events};
 use carbide_mqtt_common::metrics::{MqttHookMetrics, PublishComponent};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use model::machine::ManagedHostState;
 use opentelemetry::metrics::Meter;
 use state_controller::state_change_emitter::{StateChangeEvent, StateChangeHook};
@@ -79,8 +79,8 @@ impl MqttStateChangeHook {
     }
 }
 
-impl StateChangeHook<MachineId, ManagedHostState> for MqttStateChangeHook {
-    fn on_state_changed(&self, event: &StateChangeEvent<'_, MachineId, ManagedHostState>) {
+impl StateChangeHook<HostMachineId, ManagedHostState> for MqttStateChangeHook {
+    fn on_state_changed(&self, event: &StateChangeEvent<'_, HostMachineId, ManagedHostState>) {
         // Serialize immediately to avoid cloning state
         let message = ManagedHostStateMessage {
             machine_id: event.object_id,
@@ -131,19 +131,21 @@ mod tests {
         global::meter("test")
     }
 
-    fn test_machine_id() -> MachineId {
+    fn test_machine_id() -> HostMachineId {
         use carbide_uuid::machine::{MachineIdSource, MachineType};
-        MachineId::new(
+        carbide_uuid::machine::MachineId::new(
             MachineIdSource::ProductBoardChassisSerial,
             [0; 32],
             MachineType::Host,
         )
+        .try_into()
+        .unwrap()
     }
 
     fn make_event<'a>(
-        id: &'a MachineId,
+        id: &'a HostMachineId,
         state: &'a ManagedHostState,
-    ) -> StateChangeEvent<'a, MachineId, ManagedHostState> {
+    ) -> StateChangeEvent<'a, HostMachineId, ManagedHostState> {
         StateChangeEvent {
             object_id: id,
             previous_state: None,

--- a/crates/api-core/src/mqtt_state_change_hook/message.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/message.rs
@@ -17,7 +17,7 @@
 
 //! Message types shared by the MQTT state change hook and periodic republisher.
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use chrono::{DateTime, Utc};
 use model::machine::ManagedHostState;
 use serde::Serialize;
@@ -29,7 +29,7 @@ use serde::Serialize;
 #[derive(Debug, Clone, Serialize)]
 pub(super) struct ManagedHostStateMessage<'a> {
     /// Unique identifier for the managed host machine.
-    pub(super) machine_id: &'a MachineId,
+    pub(super) machine_id: &'a HostMachineId,
     /// ISO 8601 timestamp when the state was observed for publishing.
     pub(super) timestamp: DateTime<Utc>,
     /// The managed host state.
@@ -67,8 +67,14 @@ mod tests {
     }
 
     #[allow(deprecated)]
-    fn test_machine_id() -> MachineId {
-        MachineId::default()
+    fn test_machine_id() -> HostMachineId {
+        carbide_uuid::machine::MachineId::new(
+            carbide_uuid::machine::MachineIdSource::ProductBoardChassisSerial,
+            [0; 32],
+            carbide_uuid::machine::MachineType::Host,
+        )
+        .try_into()
+        .unwrap()
     }
 
     #[test]

--- a/crates/api-core/src/mqtt_state_change_hook/republisher.rs
+++ b/crates/api-core/src/mqtt_state_change_hook/republisher.rs
@@ -22,7 +22,6 @@ use std::time::Duration;
 use carbide_mqtt_common::hook::{MqttPublisher, publish_with_deadline};
 use carbide_mqtt_common::metrics::{MqttHookMetrics, PublishComponent};
 use carbide_utils::managed_loop::{self, LoopManager};
-use carbide_uuid::machine::MachineId;
 use chrono::{DateTime, Utc};
 use db::work_lock_manager::{AcquireLockError, WorkLockManagerHandle};
 use health_report::HealthReport;
@@ -221,7 +220,7 @@ impl<P: MqttPublisher> ManagedHostStateRepublisher<P> {
                 &self.topic_prefix,
                 self.publish_timeout,
                 &self.metrics,
-                &snapshot.host_snapshot.id,
+                &machine_id,
                 &snapshot.managed_state,
                 Utc::now(),
             )
@@ -283,7 +282,7 @@ async fn publish_state<P: MqttPublisher>(
     topic_prefix: &str,
     publish_timeout: Duration,
     metrics: &MqttHookMetrics,
-    machine_id: &MachineId,
+    machine_id: &carbide_uuid::machine::HostMachineId,
     state: &ManagedHostState,
     timestamp: DateTime<Utc>,
 ) {
@@ -337,12 +336,14 @@ mod tests {
         MqttHookMetrics::without_queue_depth(PublishComponent::ManagedHostRepublish)
     }
 
-    fn test_machine_id() -> MachineId {
-        MachineId::new(
+    fn test_machine_id() -> carbide_uuid::machine::HostMachineId {
+        carbide_uuid::machine::MachineId::new(
             MachineIdSource::ProductBoardChassisSerial,
             [0; 32],
             MachineType::Host,
         )
+        .try_into()
+        .unwrap()
     }
 
     /// Publisher that forwards each published (topic, payload) over a channel.

--- a/crates/api-core/src/test_support/mod.rs
+++ b/crates/api-core/src/test_support/mod.rs
@@ -70,7 +70,7 @@ impl Api {
 
     pub async fn process_scout_req_for_test(
         &self,
-        machine_id: carbide_uuid::machine::MachineId,
+        machine_id: carbide_uuid::machine::HostMachineId,
     ) -> crate::CarbideResult<rpc::forge_agent_control_response::Action> {
         crate::handlers::process_scout_req_for_test(self, machine_id).await
     }

--- a/crates/api-core/src/tests/boot_interface_resolution.rs
+++ b/crates/api-core/src/tests/boot_interface_resolution.rs
@@ -25,7 +25,7 @@
 //! appear in the Redfish simulator.
 
 use carbide_redfish::libredfish::test_support::RedfishSimAction;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use chrono::{DateTime, Utc};
 use ipnetwork::IpNetwork;
 use model::machine::{InstanceState, ManagedHostState};
@@ -53,7 +53,7 @@ async fn host_with_moved_primary(
     env: &api_fixtures::TestEnv,
 ) -> Result<
     (
-        MachineId,
+        HostMachineId,
         MachineBootInterfaceTarget,
         MachineBootInterfaceTarget,
     ),
@@ -62,7 +62,7 @@ async fn host_with_moved_primary(
     let host =
         api_fixtures::site_explorer::new_host(env, ManagedHostConfig::default().with_dpu_count(2))
             .await?;
-    let host_id = host.host_snapshot.id;
+    let host_id: HostMachineId = host.host_snapshot.id.try_into()?;
 
     let (original_target, promote_id, promote_target) = {
         let mut txn = env.pool.begin().await?;
@@ -90,7 +90,7 @@ async fn host_with_moved_primary(
 
     env.api
         .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
-            host_machine_id: Some(host_id),
+            host_machine_id: Some(host_id.into()),
             interface_id: Some(promote_id),
             force_reconcile: false,
             ..Default::default()
@@ -103,7 +103,7 @@ async fn host_with_moved_primary(
 /// Clears any pending machine-controller wakeup for a test host.
 async fn clear_controller_queue(
     pool: &sqlx::PgPool,
-    machine_id: &MachineId,
+    machine_id: &HostMachineId,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("DELETE FROM machine_state_controller_queued_objects WHERE object_id = $1")
         .bind(machine_id.to_string())
@@ -115,7 +115,7 @@ async fn clear_controller_queue(
 /// Returns the number of pending machine-controller wakeups for a test host.
 async fn controller_queue_count(
     pool: &sqlx::PgPool,
-    machine_id: &MachineId,
+    machine_id: &HostMachineId,
 ) -> Result<i64, sqlx::Error> {
     sqlx::query_scalar(
         "SELECT count(*) FROM machine_state_controller_queued_objects WHERE object_id = $1",
@@ -134,7 +134,7 @@ async fn test_set_dpu_first_persists_managed_host_intent_without_redfish(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
     let (host_id, original_target, promote_target) = host_with_moved_primary(&env).await?;
-    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("moving the primary should persist its target");
     assert_eq!(before.value, promote_target);
@@ -159,10 +159,9 @@ async fn test_set_dpu_first_persists_managed_host_intent_without_redfish(
         queued, 1,
         "an unassigned Ready host should be enqueued after commit",
     );
-    let reapplied =
-        db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
-            .await?
-            .expect("the explicit reapply should leave a desired target");
+    let reapplied = db::machine_desired_boot_interface::get(&env.pool, &host_id)
+        .await?
+        .expect("the explicit reapply should leave a desired target");
     assert_eq!(reapplied.value, promote_target);
     assert_ne!(
         reapplied.version, before.version,
@@ -182,7 +181,7 @@ async fn test_set_dpu_first_persists_managed_host_intent_without_redfish(
         actions.is_empty(),
         "changing managed intent should not make request-path Redfish calls",
     );
-    let desired = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let desired = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("the managed request should persist its selected target");
     assert_eq!(desired.value, original_target);
@@ -360,7 +359,7 @@ async fn test_set_dpu_first_does_not_enqueue_an_assigned_host(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
     let (host_id, _, target) = host_with_moved_primary(&env).await?;
-    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("moving the primary should persist its target");
 
@@ -394,7 +393,7 @@ async fn test_set_dpu_first_does_not_enqueue_an_assigned_host(
         queued, 0,
         "an assigned host should not be enqueued for boot reconciliation",
     );
-    let after = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let after = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("the assigned host should retain its desired target");
     assert_eq!(after.value, target);
@@ -415,7 +414,7 @@ async fn test_machine_setup_forces_managed_host_reconciliation_without_redfish(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = api_fixtures::create_test_env(pool).await;
     let (host_id, _, promote_target) = host_with_moved_primary(&env).await?;
-    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("moving the primary should persist its target");
 
@@ -433,7 +432,7 @@ async fn test_machine_setup_forces_managed_host_reconciliation_without_redfish(
         actions.is_empty(),
         "the machine controller, not machine_setup, should perform Redfish work",
     );
-    let desired = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let desired = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("machine_setup should retain its resolved target");
     assert_eq!(desired.value, promote_target);
@@ -492,7 +491,7 @@ async fn test_set_dpu_first_persists_a_zero_dpu_host_target_without_redfish(
     env.run_network_segment_controller_iteration().await;
 
     let host = api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::zero_dpu()).await?;
-    let host_id = host.host_snapshot.id;
+    let host_id: HostMachineId = host.host_snapshot.id.try_into()?;
 
     let inband_target = {
         let mut txn = env.pool.begin().await?;
@@ -509,7 +508,6 @@ async fn test_set_dpu_first_persists_a_zero_dpu_host_target_without_redfish(
         )
         .expect("the HostInband interface should resolve an exact target")
     };
-
     let timepoint = env.redfish_sim.timepoint();
 
     env.api
@@ -525,7 +523,7 @@ async fn test_set_dpu_first_persists_a_zero_dpu_host_target_without_redfish(
         actions.is_empty(),
         "managed zero-DPU hosts should also defer Redfish to the controller",
     );
-    let desired = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let desired = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("the zero-DPU request should persist its resolved target");
     assert_eq!(desired.value, inband_target);
@@ -546,7 +544,7 @@ async fn test_boot_interface_candidates_skips_dpu_machines(
     let host =
         api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(1))
             .await?;
-    let host_id = host.host_snapshot.id;
+    let host_id = HostMachineId::try_from(host.host_snapshot.id)?;
     let dpu_id = host
         .dpu_snapshots
         .first()
@@ -567,7 +565,7 @@ async fn test_boot_interface_candidates_skips_dpu_machines(
         "an unowned endpoint should not resolve boot-interface rows",
     );
     let (has_primary_interface, predicted_is_empty) =
-        summarize_boot_interface_candidates_for_test(txn.as_mut(), Some(host_id))
+        summarize_boot_interface_candidates_for_test(txn.as_mut(), Some(host_id.into()))
             .await?
             .expect("a host machine should resolve its boot-interface candidates");
     assert!(
@@ -626,13 +624,13 @@ async fn test_machine_setup_keeps_unowned_endpoint_redfish_direct(
     let host =
         api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(1))
             .await?;
-    let host_id = host.host_snapshot.id;
+    let host_id = HostMachineId::try_from(host.host_snapshot.id)?;
     let bmc_info = &host.host_snapshot.status.bmc_info;
     let bmc_ip = bmc_info.ip.expect("host should have a BMC IP");
     let bmc_interface_id = bmc_info
         .machine_interface_id
         .expect("host should have a BMC interface");
-    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let before = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("site explorer should initialize the host target");
 
@@ -664,7 +662,7 @@ async fn test_machine_setup_keeps_unowned_endpoint_redfish_direct(
             .any(|action| matches!(action, RedfishSimAction::MachineSetup { .. })),
         "an unowned endpoint should retain direct machine_setup behavior",
     );
-    let after = db::machine_desired_boot_interface::get(&env.pool, &host_id.try_into().unwrap())
+    let after = db::machine_desired_boot_interface::get(&env.pool, &host_id)
         .await?
         .expect("the former owner's desired target should remain");
     assert_eq!(after.value, before.value);
@@ -685,7 +683,7 @@ async fn test_managed_host_without_a_resolvable_target_preserves_action_requirem
     let host =
         api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(1))
             .await?;
-    let host_id = host.host_snapshot.id;
+    let host_id: HostMachineId = host.host_snapshot.id.try_into()?;
 
     let mut txn = env.pool.begin().await?;
     sqlx::query("DELETE FROM machine_boot_interfaces WHERE machine_id = $1")
@@ -769,20 +767,19 @@ async fn test_machine_setup_uses_the_bmc_endpoints_actual_owner(
     let caller_supplied =
         api_fixtures::site_explorer::new_host(&env, ManagedHostConfig::default().with_dpu_count(1))
             .await?;
-    let actual_id = actual.host_snapshot.id;
-    let caller_supplied_id = caller_supplied.host_snapshot.id;
+    let actual_id: HostMachineId = actual.host_snapshot.id.try_into()?;
+    let caller_supplied_id: HostMachineId = caller_supplied.host_snapshot.id.try_into()?;
     let actual_bmc_ip = actual
         .host_snapshot
         .status
         .bmc_info
         .ip
         .expect("host should have a BMC IP");
-    let actual_before =
-        db::machine_desired_boot_interface::get(&env.pool, &actual_id.try_into().unwrap())
-            .await?
-            .expect("site explorer should initialize the actual owner");
+    let actual_before = db::machine_desired_boot_interface::get(&env.pool, &actual_id)
+        .await?
+        .expect("site explorer should initialize the actual owner");
     let caller_supplied_before =
-        db::machine_desired_boot_interface::get(&env.pool, &caller_supplied_id.try_into().unwrap())
+        db::machine_desired_boot_interface::get(&env.pool, &caller_supplied_id)
             .await?
             .expect("site explorer should initialize the caller-supplied host");
 
@@ -805,17 +802,16 @@ async fn test_machine_setup_uses_the_bmc_endpoints_actual_owner(
             .is_empty(),
         "the actual managed owner should keep the request declarative",
     );
-    let actual_after =
-        db::machine_desired_boot_interface::get(&env.pool, &actual_id.try_into().unwrap())
-            .await?
-            .expect("the actual owner should retain desired state");
+    let actual_after = db::machine_desired_boot_interface::get(&env.pool, &actual_id)
+        .await?
+        .expect("the actual owner should retain desired state");
     assert_eq!(actual_after.value, actual_before.value);
     assert_ne!(
         actual_after.version, actual_before.version,
         "the actual owner should receive the forced generation",
     );
     let caller_supplied_after =
-        db::machine_desired_boot_interface::get(&env.pool, &caller_supplied_id.try_into().unwrap())
+        db::machine_desired_boot_interface::get(&env.pool, &caller_supplied_id)
             .await?
             .expect("the caller-supplied host should retain desired state");
     assert_eq!(caller_supplied_after.value, caller_supplied_before.value);
@@ -867,6 +863,7 @@ async fn test_set_dpu_first_persists_predicted_host_intent_without_redfish(
         .expect("the prediction always supplies a MAC");
         (predicted.machine_id, target)
     };
+    let machine_id = HostMachineId::try_from(machine_id)?;
 
     let timepoint = env.redfish_sim.timepoint();
 
@@ -883,16 +880,15 @@ async fn test_set_dpu_first_persists_predicted_host_intent_without_redfish(
         actions.is_empty(),
         "a predicted host should defer Redfish work to the machine controller",
     );
-    let desired =
-        db::machine_desired_boot_interface::get(&env.pool, &machine_id.try_into().unwrap())
-            .await?
-            .expect("the predicted host should retain its resolved target");
+    let desired = db::machine_desired_boot_interface::get(&env.pool, &machine_id)
+        .await?
+        .expect("the predicted host should retain its resolved target");
     assert_eq!(desired.value, predicted_target);
     let report = env
         .api
         .get_machine_boot_interfaces(tonic::Request::new(
             forge::GetMachineBootInterfacesRequest {
-                machine_id: Some(machine_id),
+                machine_id: Some(machine_id.into()),
             },
         ))
         .await?

--- a/crates/api-core/src/tests/client_resolution.rs
+++ b/crates/api-core/src/tests/client_resolution.rs
@@ -363,7 +363,7 @@ async fn test_zero_dpu_cloud_init_prefers_instance_when_ip_matches_host_interfac
     let instance = env
         .api
         .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
-            machine_id: Some(mh.host().id),
+            machine_id: Some(mh.id.into()),
             instance_type_id: None,
             config: Some(rpc::InstanceConfig {
                 tenant: Some(rpc::TenantConfig {
@@ -578,7 +578,7 @@ async fn test_cloud_init_local_hostname_set_from_instance_name(pool: sqlx::PgPoo
     let instance = env
         .api
         .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
-            machine_id: Some(mh.host().id),
+            machine_id: Some(mh.id.into()),
             instance_type_id: None,
             config: Some(rpc::InstanceConfig {
                 tenant: Some(rpc::TenantConfig {
@@ -684,7 +684,7 @@ async fn test_cloud_init_local_hostname_omitted_when_instance_name_is_not_a_vali
     let instance = env
         .api
         .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
-            machine_id: Some(mh.host().id),
+            machine_id: Some(mh.id.into()),
             instance_type_id: None,
             config: Some(rpc::InstanceConfig {
                 tenant: Some(rpc::TenantConfig {

--- a/crates/api-core/src/tests/common/api_fixtures/dpu.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/dpu.rs
@@ -46,7 +46,7 @@ pub(in crate::tests) const TEST_DOCA_TELEMETRY_VERSION: &str = "1.14.2-doca2.2.0
 pub(in crate::tests) async fn create_dpu_machine(
     env: &TestEnv,
     host_config: &ManagedHostConfig,
-) -> carbide_uuid::machine::MachineId {
+) -> carbide_uuid::machine::DpuMachineId {
     site_explorer::new_dpu(env, host_config.clone())
         .await
         .unwrap()

--- a/crates/api-core/src/tests/common/api_fixtures/host.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/host.rs
@@ -17,7 +17,7 @@
 
 //! Contains host related fixtures
 
-use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::machine::{DpuMachineId, HostMachineId, MachineId, MachineInterfaceId};
 use db::{ObjectColumnFilter, network_prefix};
 use model::hardware_info::HardwareInfo;
 use model::machine::MachineState::UefiSetup;
@@ -59,7 +59,7 @@ pub(in crate::tests) const GB200_COMPUTE_TRAY_5_INFO_JSON: &[u8] = include_bytes
 pub(in crate::tests) async fn host_discover_dhcp(
     env: &TestEnv,
     host_config: &ManagedHostConfig,
-    dpu_machine_id: &MachineId,
+    dpu_machine_id: &DpuMachineId,
 ) -> MachineInterfaceId {
     let mut txn = env.pool.begin().await.unwrap();
     let loopback_ip = super::dpu::loopback_ip(&mut txn, dpu_machine_id).await;
@@ -100,7 +100,7 @@ pub(in crate::tests) async fn host_discover_machine(
     env: &TestEnv,
     host_config: &ManagedHostConfig,
     machine_interface_id: MachineInterfaceId,
-) -> MachineId {
+) -> HostMachineId {
     let mut discovery_info = DiscoveryInfo::try_from(HardwareInfo::from(host_config)).unwrap();
 
     discovery_info.attest_key_info = Some(AttestKeyInfo {
@@ -121,7 +121,11 @@ pub(in crate::tests) async fn host_discover_machine(
         .unwrap()
         .into_inner();
 
-    response.machine_id.expect("machine_id must be set")
+    response
+        .machine_id
+        .expect("machine_id must be set")
+        .try_into()
+        .unwrap()
 }
 
 pub(in crate::tests) async fn host_discover_machine_with_reporter(
@@ -155,8 +159,8 @@ pub(in crate::tests) async fn host_discover_machine_with_reporter(
     response.machine_id.expect("machine_id must be set")
 }
 
-pub(in crate::tests) async fn host_uefi_setup(env: &TestEnv, host_machine_id: &MachineId) {
-    let machine = TestMachine::new(*host_machine_id, env.api.clone());
+pub(in crate::tests) async fn host_uefi_setup(env: &TestEnv, host_machine_id: HostMachineId) {
+    let machine = TestMachine::new(host_machine_id, env.api.clone());
 
     // Wait until we are past through the last UefiSetupState and then assert we went through all
     const MAX_ITERATIONS: usize = 20;
@@ -190,7 +194,7 @@ pub(in crate::tests) async fn host_uefi_setup(env: &TestEnv, host_machine_id: &M
             return;
         }
 
-        let response = forge_agent_control(env, *host_machine_id).await;
+        let response = forge_agent_control(env, host_machine_id.into()).await;
         assert!(matches!(response.action, Some(Action::Noop(_))));
         assert_eq!(response.legacy_action, LegacyAction::Noop as i32);
     }

--- a/crates/api-core/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/instance.rs
@@ -130,7 +130,7 @@ impl<'a, 'b> TestInstanceBuilder<'a, 'b> {
             .api
             .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
                 instance_id: None,
-                machine_id: Some(self.mh.host().id),
+                machine_id: Some(self.mh.host().id.into()),
                 instance_type_id: None,
                 config: Some(self.config),
                 metadata: self.metadata,

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -73,7 +73,7 @@ use carbide_switch_controller::io::SwitchStateControllerIO;
 use carbide_utils::test_support::test_meter::TestMeter;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::instance_type::InstanceTypeId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId, MachineId};
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
@@ -163,7 +163,7 @@ pub(in crate::tests) mod test_managed_host;
 pub(in crate::tests) mod tpm_attestation;
 pub(in crate::tests) mod vpc;
 
-pub(in crate::tests) type TestMachine = test_machine::TestMachine;
+pub(in crate::tests) type TestMachine<ID> = test_machine::TestMachine<ID>;
 pub(in crate::tests) type TestManagedHost = test_managed_host::TestManagedHost;
 
 #[derive(Clone, Debug, Default)]
@@ -510,7 +510,7 @@ impl TestEnv {
 
     pub(in crate::tests) async fn run_machine_state_controller_iteration_until_state_matches(
         &self,
-        host_machine_id: &MachineId,
+        host_machine_id: &HostMachineId,
         max_iterations: u32,
         expected_state: ManagedHostState,
     ) {
@@ -530,7 +530,7 @@ impl TestEnv {
     /// allows the caller to use "matches!" to compare patterns instead of concrete values.
     pub(in crate::tests) async fn run_machine_state_controller_iteration_until_state_condition(
         &self,
-        host_machine_id: &MachineId,
+        host_machine_id: &HostMachineId,
         max_iterations: u32,
         state_check: impl Fn(&Machine) -> bool,
     ) -> ManagedHostState {
@@ -739,11 +739,11 @@ impl TestEnv {
     // Returns all machines using FindMachinesByIds call.
     pub(in crate::tests) async fn find_machine(
         &self,
-        id: carbide_uuid::machine::MachineId,
+        id: &carbide_uuid::machine::MachineId,
     ) -> Vec<rpc::forge::Machine> {
         self.api
             .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-                machine_ids: vec![id],
+                machine_ids: vec![*id],
                 include_history: true,
             }))
             .await
@@ -2139,14 +2139,11 @@ fn pool_defs(fabric_len: u8) -> HashMap<String, resource_pool::ResourcePoolDef> 
 }
 
 /// Emulates the `DiscoveryCompleted` request of a DPU/Host
-pub(in crate::tests) async fn discovery_completed(
-    env: &TestEnv,
-    machine_id: carbide_uuid::machine::MachineId,
-) {
+pub(in crate::tests) async fn discovery_completed(env: &TestEnv, machine_id: &MachineId) {
     let _response = env
         .api
         .discovery_completed(Request::new(rpc::forge::MachineDiscoveryCompletedRequest {
-            machine_id: Some(machine_id),
+            machine_id: Some(*machine_id),
         }))
         .await
         .unwrap()
@@ -2154,7 +2151,10 @@ pub(in crate::tests) async fn discovery_completed(
 }
 
 /// Fake an iteration of forge-dpu-agent requesting network config, applying it, and reporting back
-pub(in crate::tests) async fn network_configured(env: &TestEnv, dpu_machine_ids: &Vec<MachineId>) {
+pub(in crate::tests) async fn network_configured(
+    env: &TestEnv,
+    dpu_machine_ids: &Vec<DpuMachineId>,
+) {
     for dpu_machine_id in dpu_machine_ids {
         network_configured_with_health(env, dpu_machine_id, None).await
     }
@@ -2164,7 +2164,7 @@ pub(in crate::tests) async fn network_configured(env: &TestEnv, dpu_machine_ids:
 /// When reporting back, the health reported by the DPU can be overrridden
 pub(in crate::tests) async fn network_configured_with_health(
     env: &TestEnv,
-    dpu_machine_id: &MachineId,
+    dpu_machine_id: &DpuMachineId,
     dpu_health: Option<rpc::health::HealthReport>,
 ) {
     network_configured_with_health_and_ext_services(env, dpu_machine_id, dpu_health, None).await
@@ -2176,7 +2176,7 @@ pub(in crate::tests) async fn network_configured_with_health(
 #[allow(deprecated)]
 pub(in crate::tests) async fn network_configured_with_health_and_ext_services(
     env: &TestEnv,
-    dpu_machine_id: &MachineId,
+    dpu_machine_id: &DpuMachineId,
     dpu_health: Option<rpc::health::HealthReport>,
     extension_services_state: Option<rpc::forge::DpuExtensionServiceDeploymentStatus>,
 ) {
@@ -2184,7 +2184,7 @@ pub(in crate::tests) async fn network_configured_with_health_and_ext_services(
         .api
         .get_managed_host_network_config(Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: Some(*dpu_machine_id),
+                dpu_machine_id: Some((*dpu_machine_id).into()),
             },
         ))
         .await
@@ -2199,7 +2199,7 @@ pub(in crate::tests) async fn network_configured_with_health_and_ext_services(
         };
     let instance: Option<rpc::Instance> = env
         .api
-        .find_instance_by_machine_id(Request::new(*dpu_machine_id))
+        .find_instance_by_machine_id(Request::new(dpu_machine_id.into()))
         .await
         .unwrap()
         .into_inner()
@@ -2299,7 +2299,7 @@ pub(in crate::tests) async fn network_configured_with_health_and_ext_services(
             .collect();
 
     let status = rpc::forge::DpuNetworkStatus {
-        dpu_machine_id: Some(*dpu_machine_id),
+        dpu_machine_id: Some((*dpu_machine_id).into()),
         dpu_agent_version: Some(dpu::TEST_DPU_AGENT_VERSION.to_string()),
         observed_at: None,
         dpu_health: Some(dpu_health),
@@ -2451,8 +2451,19 @@ pub(in crate::tests) async fn create_managed_host_with_dpf_multi_hw(
         .await
         .expect("Failed to create a new host");
     TestManagedHost {
-        id: mh.host_snapshot.id,
-        dpu_ids: mh.dpu_snapshots.iter().map(|dpu| dpu.id).collect(),
+        id: mh
+            .host_snapshot
+            .id
+            .try_into()
+            .expect("managed host snapshot ID should be a valid HostMachineId"),
+        dpu_ids: mh
+            .dpu_snapshots
+            .iter()
+            .map(|dpu| {
+                DpuMachineId::try_from(dpu.id)
+                    .expect("DPU snapshot ID should be a valid DpuMachineId")
+            })
+            .collect(),
         api: env.api.clone(),
     }
 }
@@ -2491,11 +2502,18 @@ pub(in crate::tests) async fn create_managed_host_with_config(
     let dpu_ids = mh
         .dpu_snapshots
         .iter()
-        .map(|snapshot| snapshot.id)
+        .map(|snapshot| {
+            DpuMachineId::try_from(snapshot.id)
+                .expect("dpu_snapshot ID should be valid DpuMachineId")
+        })
         .collect();
 
     TestManagedHost {
-        id: mh.host_snapshot.id,
+        id: mh
+            .host_snapshot
+            .id
+            .try_into()
+            .expect("managed host snapshot ID should be a valid HostMachineId"),
         dpu_ids,
         api: env.api.clone(),
     }
@@ -2510,8 +2528,19 @@ pub(in crate::tests) async fn create_host_with_machine_validation(
         .await
         .unwrap();
     TestManagedHost {
-        id: mh.host_snapshot.id,
-        dpu_ids: mh.dpu_snapshots.into_iter().map(|s| s.id).collect(),
+        id: mh
+            .host_snapshot
+            .id
+            .try_into()
+            .expect("managed host ID should be valid HostMachineId"),
+        dpu_ids: mh
+            .dpu_snapshots
+            .into_iter()
+            .map(|snapshot| {
+                DpuMachineId::try_from(snapshot.id)
+                    .expect("DPU snapshot ID should be a valid DpuMachineId")
+            })
+            .collect(),
         api: env.api.clone(),
     }
 }
@@ -2524,8 +2553,19 @@ pub(in crate::tests) async fn create_managed_host_with_hardware_info_template(
     let config = ManagedHostConfig::default().with_hardware_info_template(hardware_info_template);
     let mh = site_explorer::new_host(env, config).await.unwrap();
     TestManagedHost {
-        id: mh.host_snapshot.id,
-        dpu_ids: mh.dpu_snapshots.into_iter().map(|s| s.id).collect(),
+        id: mh
+            .host_snapshot
+            .id
+            .try_into()
+            .expect("managed host snapshot ID should be a valid HostMachineId"),
+        dpu_ids: mh
+            .dpu_snapshots
+            .into_iter()
+            .map(|s| {
+                DpuMachineId::try_from(s.id)
+                    .expect("DPU snapshot ID should be a valid DpuMachineId")
+            })
+            .collect(),
         api: env.api.clone(),
     }
 }
@@ -2724,7 +2764,7 @@ pub(in crate::tests) async fn machine_validation_completed(
 /// if needed, as part of the auto-approval process.
 pub(in crate::tests) async fn inject_machine_measurements(
     env: &TestEnv,
-    machine_id: carbide_uuid::machine::MachineId,
+    machine_id: HostMachineId,
 ) {
     let _response = env
         .api

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -20,7 +20,7 @@ use std::iter;
 use std::net::IpAddr;
 
 use carbide_secrets::credentials::{BmcCredentialType, CredentialKey, Credentials};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId, MachineId};
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use carbide_uuid::switch::SwitchId;
@@ -85,7 +85,7 @@ async fn ensure_admin_interface_primary(
 
 async fn current_host_state_and_cleanup_needed(
     env: &TestEnv,
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
 ) -> (ManagedHostState, bool) {
     let mut txn = env.db_txn().await;
     let machine = db::machine::find_one(
@@ -103,7 +103,10 @@ async fn current_host_state_and_cleanup_needed(
     )
 }
 
-async fn complete_initial_discovery_cleanup_if_needed(env: &TestEnv, host_machine_id: MachineId) {
+async fn complete_initial_discovery_cleanup_if_needed(
+    env: &TestEnv,
+    host_machine_id: HostMachineId,
+) {
     // Keep the shared fixture usable with both lifecycle shapes: older flows stay in discovery,
     // while newer flows require state-machine-owned cleanup before discovery can complete.
     let mut state = env
@@ -172,13 +175,13 @@ async fn complete_initial_discovery_cleanup_if_needed(env: &TestEnv, host_machin
         .await;
     }
 
-    let response = forge_agent_control(env, host_machine_id).await;
+    let response = forge_agent_control(env, host_machine_id.into()).await;
     assert!(matches!(response.action, Some(Action::Reset(_))));
     assert_eq!(response.legacy_action, LegacyAction::Reset as i32);
 
     env.api
         .cleanup_machine_completed(Request::new(rpc::MachineCleanupInfo {
-            machine_id: host_machine_id.into(),
+            machine_id: Some(host_machine_id.into()),
             ..Default::default()
         }))
         .await
@@ -204,7 +207,7 @@ pub(in crate::tests) struct MockExploredHost<'a> {
     pub(in crate::tests) dpu_bmc_ips: HashMap<u8, IpAddr>,
     pub(in crate::tests) host_dhcp_response: Option<forge::DhcpRecord>,
     pub(in crate::tests) machine_discovery_response: Option<forge::MachineDiscoveryResult>,
-    pub(in crate::tests) dpu_machine_ids: HashMap<u8, MachineId>,
+    pub(in crate::tests) dpu_machine_ids: HashMap<u8, DpuMachineId>,
 }
 
 impl MockExploredHost<'_> {
@@ -511,10 +514,11 @@ impl<'a> MockExploredHost<'a> {
                 .await
                 .unwrap()
                 .unwrap()
-                .id;
+                .host_machine_id()
+                .unwrap();
 
         for machine_id in self.dpu_machine_ids.values() {
-            create_machine_inventory(self.test_env, *machine_id).await;
+            create_machine_inventory(self.test_env, machine_id.into()).await;
         }
 
         self.test_env
@@ -535,7 +539,7 @@ impl<'a> MockExploredHost<'a> {
                                     },
                                 )
                             })
-                            .collect::<HashMap<MachineId, DpuInitState>>(),
+                            .collect::<HashMap<DpuMachineId, DpuInitState>>(),
                     },
                 },
             )
@@ -565,14 +569,14 @@ impl<'a> MockExploredHost<'a> {
         }
 
         for machine_id in self.dpu_machine_ids.values() {
-            let response = forge_agent_control(self.test_env, *machine_id).await;
+            let response = forge_agent_control(self.test_env, machine_id.into()).await;
             assert!(matches!(response.action, Some(Action::Discovery(_))));
             assert_eq!(
                 response.legacy_action,
                 rpc::forge_agent_control_response::LegacyAction::Discovery as i32
             );
 
-            discovery_completed(self.test_env, *machine_id).await;
+            discovery_completed(self.test_env, machine_id).await;
         }
 
         txn.commit().await.unwrap();
@@ -588,7 +592,7 @@ impl<'a> MockExploredHost<'a> {
                             .clone()
                             .into_values()
                             .map(|machine_id| (machine_id, DpuInitState::WaitingForNetworkConfig))
-                            .collect::<HashMap<MachineId, DpuInitState>>(),
+                            .collect::<HashMap<DpuMachineId, DpuInitState>>(),
                     },
                 },
             )
@@ -609,10 +613,11 @@ impl<'a> MockExploredHost<'a> {
                 .await
                 .unwrap()
                 .unwrap()
-                .id;
+                .host_machine_id()
+                .unwrap();
 
         for machine_id in self.dpu_machine_ids.values() {
-            create_machine_inventory(self.test_env, *machine_id).await;
+            create_machine_inventory(self.test_env, machine_id.into()).await;
         }
 
         self.test_env
@@ -626,7 +631,7 @@ impl<'a> MockExploredHost<'a> {
                             .clone()
                             .into_values()
                             .map(|machine_id| (machine_id, DpuInitState::Init))
-                            .collect::<HashMap<MachineId, DpuInitState>>(),
+                            .collect::<HashMap<DpuMachineId, DpuInitState>>(),
                     },
                 },
             )
@@ -656,14 +661,14 @@ impl<'a> MockExploredHost<'a> {
         }
 
         for machine_id in self.dpu_machine_ids.values() {
-            let response = forge_agent_control(self.test_env, *machine_id).await;
+            let response = forge_agent_control(self.test_env, machine_id.into()).await;
             assert!(matches!(response.action, Some(Action::Discovery(_)),));
             assert_eq!(
                 response.legacy_action,
                 rpc::forge_agent_control_response::LegacyAction::Discovery as i32
             );
 
-            discovery_completed(self.test_env, *machine_id).await;
+            discovery_completed(self.test_env, machine_id).await;
         }
 
         self.test_env
@@ -677,7 +682,7 @@ impl<'a> MockExploredHost<'a> {
                             .clone()
                             .into_values()
                             .map(|machine_id| (machine_id, DpuInitState::WaitingForNetworkConfig))
-                            .collect::<HashMap<MachineId, DpuInitState>>(),
+                            .collect::<HashMap<DpuMachineId, DpuInitState>>(),
                     },
                 },
             )
@@ -715,10 +720,11 @@ impl<'a> MockExploredHost<'a> {
                 .await
                 .unwrap()
                 .unwrap()
-                .id;
+                .host_machine_id()
+                .unwrap();
 
         for machine_id in self.dpu_machine_ids.values() {
-            create_machine_inventory(self.test_env, *machine_id).await;
+            create_machine_inventory(self.test_env, machine_id.into()).await;
         }
 
         self.test_env
@@ -732,7 +738,7 @@ impl<'a> MockExploredHost<'a> {
                             .clone()
                             .into_values()
                             .map(|machine_id| (machine_id, DpuInitState::Init))
-                            .collect::<HashMap<MachineId, DpuInitState>>(),
+                            .collect::<HashMap<DpuMachineId, DpuInitState>>(),
                     },
                 },
             )
@@ -762,7 +768,7 @@ impl<'a> MockExploredHost<'a> {
         }
 
         for machine_id in self.dpu_machine_ids.values() {
-            discovery_completed(self.test_env, *machine_id).await;
+            discovery_completed(self.test_env, machine_id).await;
         }
 
         self.test_env
@@ -776,7 +782,7 @@ impl<'a> MockExploredHost<'a> {
                             .clone()
                             .into_values()
                             .map(|machine_id| (machine_id, DpuInitState::WaitingForNetworkConfig))
-                            .collect::<HashMap<MachineId, DpuInitState>>(),
+                            .collect::<HashMap<DpuMachineId, DpuInitState>>(),
                     },
                 },
             )
@@ -788,11 +794,13 @@ impl<'a> MockExploredHost<'a> {
     }
 
     pub(in crate::tests) async fn host_state_controller_iterations(self) -> Self {
-        let host_machine_id = self
+        let host_machine_id: HostMachineId = self
             .machine_discovery_response
             .as_ref()
             .unwrap()
             .machine_id
+            .unwrap()
+            .try_into()
             .unwrap();
 
         let expected_state = self.managed_host.expected_state.clone();
@@ -856,14 +864,14 @@ impl<'a> MockExploredHost<'a> {
                     ),
                     ..Default::default()
                 }),
-                machine_id: Some(host_machine_id),
+                machine_id: Some(host_machine_id.into()),
             }))
             .await
             .expect("Failed to add hardware health report to newly created machine");
 
-        discovery_completed(self.test_env, host_machine_id).await;
+        discovery_completed(self.test_env, &host_machine_id).await;
         self.test_env.run_ib_fabric_monitor_iteration().await;
-        host_uefi_setup(self.test_env, &host_machine_id).await;
+        host_uefi_setup(self.test_env, host_machine_id).await;
 
         let stop_state = self
             .test_env
@@ -1033,7 +1041,7 @@ impl<'a> MockExploredHost<'a> {
             return self;
         }
 
-        let response = forge_agent_control(self.test_env, host_machine_id).await;
+        let response = forge_agent_control(self.test_env, host_machine_id.into()).await;
         assert!(matches!(response.action, Some(Action::Noop(_))));
         assert_eq!(
             response.legacy_action,
@@ -1076,11 +1084,13 @@ impl<'a> MockExploredHost<'a> {
         machine_validation_result_data: Option<rpc::forge::MachineValidationResult>,
         error: Option<String>,
     ) -> Self {
-        let host_machine_id = self
+        let host_machine_id: HostMachineId = self
             .machine_discovery_response
             .as_ref()
             .unwrap()
             .machine_id
+            .unwrap()
+            .try_into()
             .unwrap();
         let mut machine_validation_result = machine_validation_result_data.unwrap_or_default();
         complete_initial_discovery_cleanup_if_needed(self.test_env, host_machine_id).await;
@@ -1095,14 +1105,14 @@ impl<'a> MockExploredHost<'a> {
                     ),
                     ..Default::default()
                 }),
-                machine_id: Some(host_machine_id),
+                machine_id: Some(host_machine_id.into()),
             }))
             .await
             .expect("Failed to add hardware health report to newly created machine");
 
-        discovery_completed(self.test_env, host_machine_id).await;
+        discovery_completed(self.test_env, &host_machine_id).await;
         self.test_env.run_ib_fabric_monitor_iteration().await;
-        host_uefi_setup(self.test_env, &host_machine_id).await;
+        host_uefi_setup(self.test_env, host_machine_id).await;
 
         self.test_env
             .run_machine_state_controller_iteration_until_state_matches(
@@ -1168,7 +1178,7 @@ impl<'a> MockExploredHost<'a> {
                 },
             }
         ) {
-            let response = forge_agent_control(self.test_env, host_machine_id).await;
+            let response = forge_agent_control(self.test_env, host_machine_id.into()).await;
             let uuid = &response.data.unwrap().pair[1].value;
             let validation_id: MachineValidationId = uuid.parse().unwrap();
             let success = update_machine_validation_run(
@@ -1238,7 +1248,7 @@ impl<'a> MockExploredHost<'a> {
 
                 txn.commit().await.unwrap();
             } else if machine_validation_result.exit_code == 0 {
-                let _ = forge_agent_control(self.test_env, host_machine_id).await;
+                let _ = forge_agent_control(self.test_env, host_machine_id.into()).await;
 
                 self.test_env
                     .run_machine_state_controller_iteration_until_state_matches(
@@ -1252,7 +1262,7 @@ impl<'a> MockExploredHost<'a> {
                     )
                     .await;
 
-                let response = forge_agent_control(self.test_env, host_machine_id).await;
+                let response = forge_agent_control(self.test_env, host_machine_id.into()).await;
                 assert!(matches!(response.action, Some(Action::Noop(_))));
                 assert_eq!(response.legacy_action, LegacyAction::Noop as i32);
                 self.test_env
@@ -1275,7 +1285,7 @@ impl<'a> MockExploredHost<'a> {
                                 failed_at: chrono::Utc::now(),
                                 source: FailureSource::Scout,
                             },
-                            machine_id: host_machine_id,
+                            machine_id: host_machine_id.into(),
                             retry_count: 0,
                         },
                     )
@@ -1327,7 +1337,7 @@ impl<'a> MockExploredHost<'a> {
 
     async fn assign_sku_if_needed(
         &self,
-        host_machine_id: &MachineId,
+        host_machine_id: &HostMachineId,
         state: ManagedHostState,
         expected_state: &ManagedHostState,
     ) -> ManagedHostState {
@@ -1736,7 +1746,7 @@ pub(in crate::tests) async fn new_host_with_machine_validation(
 pub(in crate::tests) async fn new_dpu(
     env: &TestEnv,
     config: ManagedHostConfig,
-) -> eyre::Result<MachineId> {
+) -> eyre::Result<DpuMachineId> {
     register_expected_machine(env, &config, None).await;
     let mut mock_explored_host = MockExploredHost::new(env, config);
 
@@ -1809,7 +1819,9 @@ pub(in crate::tests) async fn new_dpu_in_network_install(
         .id;
 
     Ok(TestManagedHost {
-        id: host_machine_id,
+        id: host_machine_id
+            .try_into()
+            .expect("discovered host ID should be a valid HostMachineId"),
         dpu_ids: vec![dpu_machine_id],
         api: env.api.clone(),
     })
@@ -2029,7 +2041,7 @@ pub(in crate::tests) async fn new_mock_host_with_dpf(
         .boxed()
         .await;
 
-    let dpu_ids: Vec<MachineId> = mock_explored_host
+    let dpu_ids: Vec<DpuMachineId> = mock_explored_host
         .dpu_machine_ids
         .values()
         .copied()

--- a/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/test_machine/mod.rs
@@ -19,7 +19,7 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use carbide_utils::redfish::BmcAccessInfo;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::MachineIdSubtypeTrait;
 use model::machine::{Machine, ManagedHostState};
 use rpc::forge::forge_server::Forge;
 use tonic::Request;
@@ -30,22 +30,22 @@ pub(in crate::tests) mod interface;
 
 pub(in crate::tests) type TestMachineInterface = interface::TestMachineInterface;
 
-pub(in crate::tests) struct TestMachine {
-    pub(in crate::tests) id: MachineId,
+pub(in crate::tests) struct TestMachine<ID: MachineIdSubtypeTrait> {
+    pub(in crate::tests) id: ID,
     api: Arc<Api>,
 }
 
 type Txn<'a> = sqlx::Transaction<'a, sqlx::Postgres>;
 
-impl TestMachine {
-    pub(in crate::tests) fn new(id: MachineId, api: Arc<Api>) -> Self {
+impl<ID: MachineIdSubtypeTrait> TestMachine<ID> {
+    pub(in crate::tests) fn new(id: ID, api: Arc<Api>) -> Self {
         Self { id, api }
     }
 
     pub(in crate::tests) async fn rpc_machine(&self) -> rpc::Machine {
         self.api
             .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-                machine_ids: vec![self.id],
+                machine_ids: vec![self.id.into()],
                 include_history: true,
             }))
             .await
@@ -98,7 +98,7 @@ impl TestMachine {
         let response = self
             .api
             .reboot_completed(Request::new(rpc::forge::MachineRebootCompletedRequest {
-                machine_id: self.id.into(),
+                machine_id: Some(self.id.into()),
             }))
             .await
             .unwrap()
@@ -116,7 +116,7 @@ impl TestMachine {
         self.reboot_completed().await;
         self.api
             .forge_agent_control(Request::new(rpc::forge::ForgeAgentControlRequest {
-                machine_id: self.id.into(),
+                machine_id: Some(self.id.into()),
             }))
             .await
             .unwrap()
@@ -126,7 +126,7 @@ impl TestMachine {
     pub(in crate::tests) async fn discovery_completed(&self) {
         self.api
             .discovery_completed(Request::new(rpc::forge::MachineDiscoveryCompletedRequest {
-                machine_id: self.id.into(),
+                machine_id: Some(self.id.into()),
             }))
             .await
             .unwrap()
@@ -142,7 +142,7 @@ impl TestMachine {
             .trigger_dpu_reprovisioning(tonic::Request::new(
                 ::rpc::forge::DpuReprovisioningRequest {
                     dpu_id: None,
-                    machine_id: self.id.into(),
+                    machine_id: Some(self.id.into()),
                     mode: mode as i32,
                     initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                     update_firmware,

--- a/crates/api-core/src/tests/common/api_fixtures/test_managed_host.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/test_managed_host.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use carbide_uuid::instance::InstanceId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 // `PgPoolReader` and `LoadSnapshotOptions` are only used by the `#[cfg(test)]`
 // `TestManagedHostSnapshots` trait below, so gate them out of test-support-only builds.
 #[cfg(test)]
@@ -38,12 +38,12 @@ use crate::tests::common::api_fixtures::instance::TestInstanceBuilder;
 use crate::tests::common::api_fixtures::{Api, TestEnv, TestMachine};
 
 pub(in crate::tests) struct TestManagedHost {
-    pub(in crate::tests) id: MachineId,
-    pub(in crate::tests) dpu_ids: Vec<MachineId>,
+    pub(in crate::tests) id: HostMachineId,
+    pub(in crate::tests) dpu_ids: Vec<DpuMachineId>,
     pub(in crate::tests) api: Arc<Api>,
 }
 
-impl From<TestManagedHost> for (MachineId, MachineId) {
+impl From<TestManagedHost> for (HostMachineId, DpuMachineId) {
     fn from(mut v: TestManagedHost) -> Self {
         (v.id, v.dpu_ids.remove(0))
     }
@@ -58,7 +58,11 @@ impl TestManagedHost {
     #[allow(deprecated)]
     pub(in crate::tests) fn from_rpc_machine(m: &rpc::Machine, api: Arc<Api>) -> Self {
         TestManagedHost {
-            id: m.id.unwrap(),
+            id: m
+                .id
+                .unwrap()
+                .try_into()
+                .expect("MachineId should be a HostMachineId"),
             dpu_ids: m
                 .status
                 .as_ref()
@@ -74,21 +78,25 @@ impl TestManagedHost {
                         .iter()
                         .filter_map(|i| i.attached_dpu_machine_id)
                         .collect()
-                }),
+                })
+                .into_iter()
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<DpuMachineId>, _>>()
+                .expect("attachec_dpu_machine_id should be a valid DpuMachineId"),
             api,
         }
     }
 
-    pub(in crate::tests) fn dpu(&self) -> TestMachine {
+    pub(in crate::tests) fn dpu(&self) -> TestMachine<DpuMachineId> {
         TestMachine::new(self.dpu_ids[0], self.api.clone())
     }
 
-    pub(in crate::tests) fn dpu_n(&self, n: usize) -> TestMachine {
+    pub(in crate::tests) fn dpu_n(&self, n: usize) -> TestMachine<DpuMachineId> {
         assert!(n < self.dpu_ids.len());
         TestMachine::new(self.dpu_ids[n], self.api.clone())
     }
 
-    pub(in crate::tests) fn host(&self) -> TestMachine {
+    pub(in crate::tests) fn host(&self) -> TestMachine<HostMachineId> {
         TestMachine::new(self.id, self.api.clone())
     }
 
@@ -111,7 +119,7 @@ impl TestManagedHost {
     ) -> ManagedHostState {
         ManagedHostState::DPUReprovision {
             dpu_states: model::machine::DpuReprovisionStates {
-                states: HashMap::from([(self.dpu().id, state)]),
+                states: HashMap::from([(self.dpu_ids[0], state)]),
             },
         }
     }
@@ -140,7 +148,7 @@ impl TestManagedHost {
         ManagedHostState::Assigned {
             instance_state: InstanceState::DPUReprovision {
                 dpu_states: model::machine::DpuReprovisionStates {
-                    states: HashMap::from([(self.dpu().id, state)]),
+                    states: HashMap::from([(self.dpu_ids[0], state)]),
                 },
             },
         }
@@ -165,7 +173,7 @@ impl TestManagedHost {
         self.api
             .machine_validation_completed(Request::new(
                 rpc::forge::MachineValidationCompletedRequest {
-                    machine_id: self.id.into(),
+                    machine_id: Some(self.id.into()),
                     machine_validation_error: None,
                     validation_id: Some(validation_id),
                 },
@@ -195,7 +203,7 @@ pub(in crate::tests) trait TestManagedHostSnapshots {
         &self,
         txn: &mut PgPoolReader,
         load_options: LoadSnapshotOptions,
-    ) -> HashMap<MachineId, ManagedHostStateSnapshot>;
+    ) -> HashMap<HostMachineId, ManagedHostStateSnapshot>;
 }
 
 #[cfg(test)]
@@ -204,13 +212,10 @@ impl TestManagedHostSnapshots for Vec<TestManagedHost> {
         &self,
         txn: &mut PgPoolReader,
         load_options: LoadSnapshotOptions,
-    ) -> HashMap<MachineId, ManagedHostStateSnapshot> {
-        db::managed_host::load_by_machine_ids(
-            txn,
-            &self.iter().map(|m| m.id).collect::<Vec<_>>(),
-            load_options,
-        )
-        .await
-        .unwrap()
+    ) -> HashMap<HostMachineId, ManagedHostStateSnapshot> {
+        let machine_ids = self.iter().map(|machine| machine.id).collect::<Vec<_>>();
+        db::managed_host::load_by_machine_ids(txn, &machine_ids, load_options)
+            .await
+            .unwrap()
     }
 }

--- a/crates/api-core/src/tests/dpf/dpu_service_sync.rs
+++ b/crates/api-core/src/tests/dpf/dpu_service_sync.rs
@@ -30,7 +30,7 @@ use std::time::Duration;
 
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 use model::machine::{DpfState, DpuInitState, DpuInitStates, ManagedHostState};
 use model::machine_pending_action::MachinePendingActionKind::DpuServiceSync;
 use tokio::time::timeout;
@@ -139,14 +139,14 @@ pub(super) async fn provisioned_with_sync(
     }
 }
 
-pub(super) async fn request_sync(pool: &sqlx::PgPool, host_id: &MachineId) {
+pub(super) async fn request_sync(pool: &sqlx::PgPool, host_id: &HostMachineId) {
     let mut conn = pool.acquire().await.unwrap();
     db::machine_pending_action::request(&mut conn, host_id, DpuServiceSync)
         .await
         .expect("recorded pending action");
 }
 
-pub(super) async fn is_outstanding(pool: &sqlx::PgPool, host_id: &MachineId) -> bool {
+pub(super) async fn is_outstanding(pool: &sqlx::PgPool, host_id: &HostMachineId) -> bool {
     db::machine_pending_action::is_outstanding(pool, host_id, DpuServiceSync)
         .await
         .expect("read pending action")
@@ -156,8 +156,8 @@ pub(super) async fn is_outstanding(pool: &sqlx::PgPool, host_id: &MachineId) -> 
 /// handler runs again without replaying the whole operator workflow.
 pub(super) async fn reset_host_to_waiting_for_ready(
     pool: &sqlx::PgPool,
-    host_id: &MachineId,
-    dpu_id: &MachineId,
+    host_id: &HostMachineId,
+    dpu_id: &DpuMachineId,
 ) {
     let state = ManagedHostState::DPUInit {
         dpu_states: DpuInitStates {

--- a/crates/api-core/src/tests/dpf/dpu_service_sync_release.rs
+++ b/crates/api-core/src/tests/dpf/dpu_service_sync_release.rs
@@ -27,7 +27,7 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use ::rpc::forge as rpc;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{MachineId, MachineIdSubtypeTrait};
 use rpc::DpuServiceSyncReleaseStatus as ReleaseStatus;
 use rpc::forge_server::Forge;
 use tonic::Request;
@@ -37,12 +37,12 @@ use super::dpu_service_sync::{
     reset_host_to_waiting_for_ready,
 };
 
-fn by_machine_ids(ids: &[MachineId]) -> rpc::ReleaseDpuServiceSyncHoldRequest {
+fn by_machine_ids(ids: &[impl MachineIdSubtypeTrait]) -> rpc::ReleaseDpuServiceSyncHoldRequest {
     rpc::ReleaseDpuServiceSyncHoldRequest {
         target: Some(
             rpc::release_dpu_service_sync_hold_request::Target::MachineIds(
                 ::rpc::common::MachineIdList {
-                    machine_ids: ids.to_vec(),
+                    machine_ids: ids.iter().copied().map(Into::into).collect::<Vec<_>>(),
                 },
             ),
         ),
@@ -219,7 +219,7 @@ async fn a_mixed_batch_reports_one_result_per_machine_in_request_order(pool: sql
     let results = release(&fixture, by_machine_ids(&[fixture.mh.id, fixture.mh.id])).await;
 
     assert_eq!(results.len(), 2, "one result per named machine");
-    assert_eq!(results[0].0, fixture.mh.id);
+    assert_eq!(results[0].0, fixture.mh.id.into());
     assert_eq!(results[0].1, ReleaseStatus::Released);
     assert_eq!(results[1].1, ReleaseStatus::NotPending);
 }
@@ -272,7 +272,7 @@ async fn an_assigned_host_named_by_instance_id_is_released(pool: sqlx::PgPool) {
     .await;
 
     assert_eq!(results.len(), 1, "the instance resolves to its one host");
-    assert_eq!(results[0].0, fixture.mh.id);
+    assert_eq!(results[0].0, fixture.mh.id.into());
     assert_eq!(results[0].1, ReleaseStatus::Released);
     assert!(!is_outstanding(&fixture.pool, &fixture.mh.id).await);
 }
@@ -293,7 +293,10 @@ async fn an_unknown_machine_rejects_the_whole_call_before_releasing(pool: sqlx::
     let status = fixture
         .env
         .api
-        .release_dpu_service_sync_hold(Request::new(by_machine_ids(&[fixture.mh.id, unknown])))
+        .release_dpu_service_sync_hold(Request::new(by_machine_ids(&[
+            fixture.mh.id.into(),
+            unknown,
+        ])))
         .await
         .expect_err("unknown machine should be rejected");
 
@@ -334,7 +337,7 @@ async fn the_worklist_empties_on_release_and_the_history_records_the_operator(po
     request_sync(&fixture.pool, &fixture.mh.id).await;
 
     let worklist = worklist_ids(&fixture).await;
-    assert_eq!(worklist, vec![fixture.mh.id]);
+    assert_eq!(worklist, vec![fixture.mh.id.into()]);
 
     let detail = fixture
         .env
@@ -367,7 +370,7 @@ async fn the_worklist_empties_on_release_and_the_history_records_the_operator(po
         .env
         .api
         .list_dpu_service_sync_history(Request::new(rpc::ListDpuServiceSyncHistoryRequest {
-            machine_id: Some(fixture.mh.id),
+            machine_id: Some(fixture.mh.id.into()),
         }))
         .await
         .expect("history")

--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -208,8 +208,8 @@ async fn test_dpf_inventory_uses_host_context_and_preserves_last_good_value(pool
 
     // Read both records through the public API and derive the expected CR name
     // independently from their reported BMC MAC addresses.
-    let host = env.find_machine(managed_host.id).await.remove(0);
-    let dpu = env.find_machine(managed_host.dpu_ids[0]).await.remove(0);
+    let host = env.find_machine(&managed_host.id).await.remove(0);
+    let dpu = env.find_machine(&managed_host.dpu_ids[0]).await.remove(0);
     assert!(
         host.config
             .as_ref()
@@ -245,7 +245,7 @@ async fn test_dpf_inventory_uses_host_context_and_preserves_last_good_value(pool
     // Report an incomplete agent inventory and confirm the operator value wins.
     let report = || {
         Request::new(rpc::DpuAgentInventoryReport {
-            machine_id: Some(managed_host.dpu_ids[0]),
+            machine_id: Some(managed_host.dpu_ids[0].into()),
             inventory: Some(rpc::MachineInventory {
                 components: vec![rpc::MachineInventorySoftwareComponent {
                     name: "agent-only".to_string(),
@@ -266,7 +266,7 @@ async fn test_dpf_inventory_uses_host_context_and_preserves_last_good_value(pool
         vec![expected_dpu_name]
     );
     let stored_inventory = env
-        .find_machine(managed_host.dpu_ids[0])
+        .find_machine(&managed_host.dpu_ids[0])
         .await
         .remove(0)
         .inventory
@@ -287,7 +287,7 @@ async fn test_dpf_inventory_uses_host_context_and_preserves_last_good_value(pool
         .await
         .expect_err("incomplete DPF inventory must be rejected");
     let inventory_after_error = env
-        .find_machine(managed_host.dpu_ids[0])
+        .find_machine(&managed_host.dpu_ids[0])
         .await
         .remove(0)
         .inventory

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 use carbide_uuid::rack::RackId;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
@@ -164,7 +164,7 @@ async fn test_gb200_deployment_migration_rechecks_after_attachment_updates(pool:
     let mut request_task = tokio::spawn(async move {
         api.trigger_dpu_reprovisioning(tonic::Request::new(
             ::rpc::forge::DpuReprovisioningRequest {
-                dpu_id: requested_dpu_id.into(),
+                dpu_id: Some(requested_dpu_id.into()),
                 machine_id: None,
                 mode: Mode::Set as i32,
                 initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
@@ -247,7 +247,7 @@ async fn assert_dpu_reprovision_set_rechecks_request_updates(
     let request_task = tokio::spawn(async move {
         api.trigger_dpu_reprovisioning(tonic::Request::new(
             ::rpc::forge::DpuReprovisioningRequest {
-                dpu_id: requested_dpu_id.into(),
+                dpu_id: Some(requested_dpu_id.into()),
                 machine_id: None,
                 mode: Mode::Set as i32,
                 initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
@@ -339,10 +339,10 @@ async fn test_gb200_deployment_migration_rechecks_after_dpu_request_updates(pool
 
 /// Build the DPU reprovision states map for the given DPF sub-state.
 fn build_dpf_reprovision_states(
-    dpu_ids: &[MachineId],
+    dpu_ids: &[DpuMachineId],
     dpf_state: DpfState,
 ) -> DpuReprovisionStates {
-    let states: HashMap<MachineId, ReprovisionState> = dpu_ids
+    let states: HashMap<DpuMachineId, ReprovisionState> = dpu_ids
         .iter()
         .map(|id| {
             (
@@ -357,7 +357,7 @@ fn build_dpf_reprovision_states(
 }
 
 /// Write a managed-host state directly to the database.
-async fn write_host_state(pool: &sqlx::PgPool, host_id: &MachineId, state: &ManagedHostState) {
+async fn write_host_state(pool: &sqlx::PgPool, host_id: &HostMachineId, state: &ManagedHostState) {
     let state_json = serde_json::to_value(state).unwrap();
     let version = format!("V999-T{}", chrono::Utc::now().timestamp_micros());
 
@@ -379,8 +379,8 @@ async fn write_host_state(pool: &sqlx::PgPool, host_id: &MachineId, state: &Mana
 /// Set the host to `DPUReprovision` with the given DPF sub-state for each DPU.
 async fn set_reprovision_dpf_state(
     pool: &sqlx::PgPool,
-    host_id: &MachineId,
-    dpu_ids: &[MachineId],
+    host_id: &HostMachineId,
+    dpu_ids: &[DpuMachineId],
     dpf_state: DpfState,
 ) {
     let state = ManagedHostState::DPUReprovision {
@@ -393,8 +393,8 @@ async fn set_reprovision_dpf_state(
 /// The host must already have a real instance allocated via `instance_builer().build_and_return()`.
 async fn set_assigned_reprovision_dpf_state(
     pool: &sqlx::PgPool,
-    host_id: &MachineId,
-    dpu_ids: &[MachineId],
+    host_id: &HostMachineId,
+    dpu_ids: &[DpuMachineId],
     dpf_state: DpfState,
 ) {
     let state = ManagedHostState::Assigned {
@@ -900,7 +900,7 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment_from_report_or_rack(p
     assert_eq!(classified.len(), mh.dpu_ids.len());
     assert_eq!(
         classified.into_iter().collect::<HashSet<_>>(),
-        mh.dpu_ids.iter().copied().collect()
+        mh.dpu_ids.iter().copied().map(Into::into).collect()
     );
     assert_eq!(
         *verified_deployments.lock().unwrap(),
@@ -1004,7 +1004,7 @@ async fn test_runtime_dpf_disable_skips_deployment_migration_probe(pool: sqlx::P
         .trigger_dpu_reprovisioning(tonic::Request::new(
             ::rpc::forge::DpuReprovisioningRequest {
                 dpu_id: None,
-                machine_id: mh.id.into(),
+                machine_id: Some(mh.id.into()),
                 mode: Mode::Set as i32,
                 initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                 update_firmware: true,
@@ -1125,7 +1125,7 @@ async fn test_gb200_deployment_migration_requires_every_dpu(pool: sqlx::PgPool) 
         .trigger_dpu_reprovisioning(tonic::Request::new(
             ::rpc::forge::DpuReprovisioningRequest {
                 dpu_id: None,
-                machine_id: mh.dpu_ids[0].into(),
+                machine_id: Some(mh.dpu_ids[0].into()),
                 mode: Mode::Set as i32,
                 initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                 update_firmware: true,
@@ -1169,7 +1169,7 @@ async fn test_gb200_deployment_migration_requires_every_dpu(pool: sqlx::PgPool) 
         .trigger_dpu_reprovisioning(tonic::Request::new(
             ::rpc::forge::DpuReprovisioningRequest {
                 dpu_id: None,
-                machine_id: mh.dpu_ids[0].into(),
+                machine_id: Some(mh.dpu_ids[0].into()),
                 mode: Mode::Clear as i32,
                 initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                 update_firmware: true,

--- a/crates/api-core/src/tests/dpf/stale_labels.rs
+++ b/crates/api-core/src/tests/dpf/stale_labels.rs
@@ -29,7 +29,7 @@ use std::time::Duration;
 
 use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 use model::machine::{DpfState, DpuInitState, FailureCause, FailureDetails, ManagedHostState};
 use tokio::time::timeout;
 
@@ -55,7 +55,11 @@ fn provisioning_mock_with_labels_valid(labels_valid: Arc<AtomicBool>) -> MockDpf
     mock
 }
 
-async fn reset_host_to_provisioning(pool: &sqlx::PgPool, host_id: &MachineId, dpu_id: &MachineId) {
+async fn reset_host_to_provisioning(
+    pool: &sqlx::PgPool,
+    host_id: &HostMachineId,
+    dpu_id: &DpuMachineId,
+) {
     let state = ManagedHostState::DPUInit {
         dpu_states: model::machine::DpuInitStates {
             states: HashMap::from([(
@@ -87,8 +91,8 @@ async fn reset_host_to_provisioning(pool: &sqlx::PgPool, host_id: &MachineId, dp
 
 async fn reset_host_to_waiting_for_ready(
     pool: &sqlx::PgPool,
-    host_id: &MachineId,
-    dpu_id: &MachineId,
+    host_id: &HostMachineId,
+    dpu_id: &DpuMachineId,
 ) {
     let state = ManagedHostState::DPUInit {
         dpu_states: model::machine::DpuInitStates {

--- a/crates/api-core/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api-core/src/tests/dpf/waiting_for_ready.rs
@@ -26,7 +26,7 @@ use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_redfish::libredfish::RedfishClientPool;
 use carbide_redfish::libredfish::test_support::RedfishSimAction;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 use db::TransactionVending;
 use libredfish::SystemPowerControl;
 use model::machine::{DpfState, DpuInitState, ManagedHostState, PerformPowerOperation};
@@ -67,8 +67,8 @@ fn expect_provisioning(mock: &mut MockDpfOperations) {
 /// transition without replaying the preceding operator workflow.
 async fn reset_host_to_dpf_state(
     pool: &sqlx::PgPool,
-    host_id: &MachineId,
-    dpu_id: &MachineId,
+    host_id: &HostMachineId,
+    dpu_id: &DpuMachineId,
     dpf_state: DpfState,
 ) {
     let state = ManagedHostState::DPUInit {
@@ -101,8 +101,8 @@ async fn reset_host_to_dpf_state(
 /// decisions after their initial DPF ingestion has completed.
 async fn reset_host_to_waiting_for_ready(
     pool: &sqlx::PgPool,
-    host_id: &MachineId,
-    dpu_id: &MachineId,
+    host_id: &HostMachineId,
+    dpu_id: &DpuMachineId,
 ) {
     reset_host_to_dpf_state(
         pool,
@@ -183,7 +183,7 @@ async fn test_waiting_for_ready_reboot_flow(pool: sqlx::PgPool) {
         actions
     );
 
-    reboot_completed(&env, mh.id).await;
+    reboot_completed(&env, mh.id.into()).await;
 
     // Complete On, observe DPU readiness, then cross the DeviceReady barrier.
     timeout(TEST_TIMEOUT, async {
@@ -691,7 +691,7 @@ async fn test_waiting_for_ready_host_already_off(pool: sqlx::PgPool) {
         actions
     );
 
-    reboot_completed(&env, mh.id).await;
+    reboot_completed(&env, mh.id.into()).await;
 
     // Complete On, observe DPU readiness, then cross the DeviceReady barrier.
     timeout(TEST_TIMEOUT, async {
@@ -714,8 +714,8 @@ async fn test_waiting_for_ready_host_already_off(pool: sqlx::PgPool) {
 /// a stale/invalid state stored by a previous implementation.
 async fn write_unknown_dpf_init_state(
     pool: &sqlx::PgPool,
-    host_id: &MachineId,
-    dpu_id: &MachineId,
+    host_id: &HostMachineId,
+    dpu_id: &DpuMachineId,
 ) {
     let state_json: serde_json::Value = serde_json::json!({
         "state": "dpuinit",

--- a/crates/api-core/src/tests/dpu_machine_update.rs
+++ b/crates/api-core/src/tests/dpu_machine_update.rs
@@ -16,11 +16,10 @@
  */
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use common::api_fixtures::{create_managed_host, create_managed_host_multi_dpu, create_test_env};
 use db::DatabaseError;
 use model::dpu_machine_update::DpuMachineUpdate;
-use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::network::MachineNetworkStatusObservation;
 use model::machine::{LoadSnapshotOptions, Machine, ManagedHostStateSnapshot};
 use sqlx::PgConnection;
@@ -52,7 +51,7 @@ pub(in crate::tests) async fn update_nic_firmware_version(
 async fn create_machines(
     test_env: &TestEnv,
     machine_count: usize,
-) -> HashMap<MachineId, ManagedHostStateSnapshot> {
+) -> HashMap<HostMachineId, ManagedHostStateSnapshot> {
     let mut machines = Vec::default();
     for _ in 0..machine_count {
         let machine = create_managed_host(test_env).await;
@@ -69,7 +68,10 @@ async fn create_machines(
 
     db::managed_host::load_by_machine_ids(
         &mut test_env.db_reader(),
-        &machines.iter().map(|m| m.id).collect::<Vec<_>>(),
+        &machines
+            .iter()
+            .map(|machine| machine.id)
+            .collect::<Vec<_>>(),
         LoadSnapshotOptions {
             include_history: false,
             include_instance_data: false,
@@ -82,17 +84,9 @@ async fn create_machines(
 
 pub(in crate::tests) async fn get_all_snapshots(
     test_env: &TestEnv,
-) -> HashMap<MachineId, ManagedHostStateSnapshot> {
+) -> HashMap<HostMachineId, ManagedHostStateSnapshot> {
     let mut txn = test_env.pool.begin().await.unwrap();
-    let machine_ids = db::machine::find_machine_ids(
-        txn.as_mut(),
-        MachineSearchConfig {
-            include_predicted_host: true,
-            ..Default::default()
-        },
-    )
-    .await
-    .unwrap();
+    let machine_ids = db::managed_host::load_host_ids(txn.as_mut()).await.unwrap();
 
     db::managed_host::load_by_machine_ids(
         txn.as_mut(),
@@ -237,7 +231,7 @@ async fn test_find_unavailable_outdated_dpus_when_none(
     let dpus = DpuMachineUpdate::find_unavailable_outdated_dpus(
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+    )?;
 
     assert_eq!(dpus.len(), 0);
     Ok(())
@@ -262,11 +256,11 @@ async fn test_find_unavailable_outdated_dpus(
     let dpus = DpuMachineUpdate::find_unavailable_outdated_dpus(
         &env.config.dpu_config.dpu_nic_firmware_update_versions,
         &snapshots,
-    );
+    )?;
 
     assert_eq!(dpus.len(), 1);
-    assert_eq!(dpus.first().unwrap().dpu_machine_id, mh.dpu().id);
-    assert_eq!(dpus.first().unwrap().host_machine_id, mh.host().id);
+    assert_eq!(dpus.first().unwrap().dpu_machine_id, mh.dpu_ids[0]);
+    assert_eq!(dpus.first().unwrap().host_machine_id, mh.id);
 
     Ok(())
 }
@@ -287,7 +281,7 @@ async fn test_find_available_outdated_dpus_multidpu(
 
     let snapshots = db::managed_host::load_by_machine_ids(
         txn.as_mut(),
-        &[mh.host().id],
+        &[mh.id],
         LoadSnapshotOptions {
             include_history: false,
             include_instance_data: false,
@@ -322,8 +316,8 @@ async fn test_find_available_outdated_dpus_multidpu_one_under_reprov(
     db::dpu_machine_update::trigger_reprovisioning_for_managed_host(
         &mut txn,
         &[DpuMachineUpdate {
-            host_machine_id: mh.host().id,
-            dpu_machine_id: mh.dpu_n(0).id,
+            host_machine_id: mh.id,
+            dpu_machine_id: mh.dpu_ids[0],
             firmware_version: "test_version".to_string(),
             dpf_managed: false,
         }],
@@ -335,7 +329,7 @@ async fn test_find_available_outdated_dpus_multidpu_one_under_reprov(
     let mut txn = env.pool.begin().await?;
     let snapshots = db::managed_host::load_by_machine_ids(
         txn.as_mut(),
-        &[mh.host().id],
+        &[mh.id],
         LoadSnapshotOptions {
             include_history: false,
             include_instance_data: false,
@@ -362,7 +356,7 @@ async fn test_find_available_outdated_dpus_multidpu_one_under_reprov(
         .partition(|x| x.reprovision_requested.is_some());
     assert_eq!(dpu_under_reprov.len(), 1);
     assert_eq!(dpu_not_under_reprov.len(), 1);
-    assert_eq!(dpu_under_reprov[0].id, mh.dpu_n(0).id);
+    assert_eq!(dpu_under_reprov[0].id, *mh.dpu_n(0).id);
 
     Ok(())
 }
@@ -381,14 +375,14 @@ async fn test_find_available_outdated_dpus_multidpu_both_under_reprov(
         &mut txn,
         &[
             DpuMachineUpdate {
-                host_machine_id: mh.host().id,
-                dpu_machine_id: all_dpus[1].id,
+                host_machine_id: mh.id,
+                dpu_machine_id: all_dpus[1].id.try_into()?,
                 firmware_version: "test_version".to_string(),
                 dpf_managed: false,
             },
             DpuMachineUpdate {
-                host_machine_id: mh.host().id,
-                dpu_machine_id: all_dpus[0].id,
+                host_machine_id: mh.id,
+                dpu_machine_id: all_dpus[0].id.try_into()?,
                 firmware_version: "test_version".to_string(),
                 dpf_managed: false,
             },
@@ -401,7 +395,7 @@ async fn test_find_available_outdated_dpus_multidpu_both_under_reprov(
     let mut txn = env.pool.begin().await?;
     let snapshots = db::managed_host::load_by_machine_ids(
         txn.as_mut(),
-        &[mh.host().id],
+        &[mh.id],
         LoadSnapshotOptions {
             include_history: false,
             include_instance_data: false,

--- a/crates/api-core/src/tests/dpu_reprovisioning.rs
+++ b/crates/api-core/src/tests/dpu_reprovisioning.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 use carbide_machine_controller::handler::MachineStateHandlerBuilder;
 use carbide_redfish::libredfish::test_support::RedfishSimAction;
+use carbide_uuid::machine::{DpuMachineId, MachineIdSubtypeTrait};
 use chrono::Utc;
 use common::api_fixtures::{
     create_managed_host_multi_dpu, create_managed_host_with_hardware_info_template,
@@ -131,7 +132,7 @@ fn has_dpu_reprovision_state(
 
 async fn assert_dpu_reprovision_host_boot_repair(
     env: &TestEnv,
-    machine: &TestMachine,
+    machine: &TestMachine<impl MachineIdSubtypeTrait>,
     expected_states: Vec<ManagedHostState>,
 ) -> Machine {
     env.redfish_sim.set_lockdown(EnabledDisabled::Enabled);
@@ -263,7 +264,7 @@ async fn assert_dpu_reprovision_host_boot_repair(
 async fn prepare_dpu_reprovision_host_boot_check(
     env: &TestEnv,
     mh: &TestManagedHost,
-) -> TestMachine {
+) -> TestMachine<DpuMachineId> {
     let dpu_machine = mh.dpu();
     let mut txn = env.pool.begin().await.unwrap();
     db::machine::update_state(
@@ -588,7 +589,7 @@ async fn test_dpu_for_reprovisioning_fail_if_maintenance_not_set(pool: sqlx::PgP
             .trigger_dpu_reprovisioning(tonic::Request::new(
                 ::rpc::forge::DpuReprovisioningRequest {
                     dpu_id: None,
-                    machine_id: mh.dpu().id.into(),
+                    machine_id: Some(mh.dpu().id.into()),
                     mode: rpc::forge::dpu_reprovisioning_request::Mode::Set as i32,
                     initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                     update_firmware: true
@@ -609,7 +610,7 @@ async fn test_dpu_for_reprovisioning_fail_if_state_is_not_ready(pool: sqlx::PgPo
             .trigger_dpu_reprovisioning(tonic::Request::new(
                 ::rpc::forge::DpuReprovisioningRequest {
                     dpu_id: None,
-                    machine_id: dpu_machine_id.into(),
+                    machine_id: Some(dpu_machine_id.into()),
                     mode: rpc::forge::dpu_reprovisioning_request::Mode::Set as i32,
                     initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                     update_firmware: true
@@ -1141,7 +1142,7 @@ async fn test_dpu_for_set_but_clear_failed(pool: sqlx::PgPool) {
         .into_inner();
 
     assert_eq!(res.dpus.len(), 1);
-    assert_eq!(res.dpus[0].id, mh.dpu().id.into());
+    assert_eq!(res.dpus[0].id, Some(mh.dpu().id.into()));
 
     db::machine::update_dpu_reprovision_start_time(&mh.dpu().id, &mut txn)
         .await
@@ -1152,7 +1153,7 @@ async fn test_dpu_for_set_but_clear_failed(pool: sqlx::PgPool) {
             .trigger_dpu_reprovisioning(tonic::Request::new(
                 ::rpc::forge::DpuReprovisioningRequest {
                     dpu_id: None,
-                    machine_id: mh.dpu().id.into(),
+                    machine_id: Some(mh.dpu().id.into()),
                     mode: rpc::forge::dpu_reprovisioning_request::Mode::Clear as i32,
                     initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                     update_firmware: true
@@ -1433,7 +1434,7 @@ async fn test_clear_maintenance_when_reprov_is_set(pool: sqlx::PgPool) {
     assert!(
         env.api
             .set_maintenance(tonic::Request::new(::rpc::forge::MaintenanceRequest {
-                host_id: mh.id.into(),
+                host_id: Some(mh.id.into()),
                 operation: 1,
                 reference: Some("no reference".to_string()),
             }))
@@ -1464,7 +1465,7 @@ async fn test_dpu_reset(pool: sqlx::PgPool) {
         4,
         ManagedHostState::DPUInit {
             dpu_states: model::machine::DpuInitStates {
-                states: HashMap::from([(mh.dpu().id, DpuInitState::WaitingForNetworkConfig)]),
+                states: HashMap::from([(mh.dpu_ids[0], DpuInitState::WaitingForNetworkConfig)]),
             },
         },
     )
@@ -1488,7 +1489,7 @@ async fn test_restart_dpu_reprov(pool: sqlx::PgPool) {
             .trigger_dpu_reprovisioning(tonic::Request::new(
                 ::rpc::forge::DpuReprovisioningRequest {
                     dpu_id: None,
-                    machine_id: mh.id.into(),
+                    machine_id: Some(mh.id.into()),
                     mode: Mode::Restart as i32,
                     initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                     update_firmware: false,
@@ -1580,7 +1581,7 @@ async fn test_restart_dpu_reprov_unassigned_host_boot_failure(pool: sqlx::PgPool
         &mut txn,
         &mh.id,
         &ManagedHostState::Failed {
-            machine_id: mh.id,
+            machine_id: mh.id.into(),
             retry_count: 0,
             details: FailureDetails {
                 cause: FailureCause::BiosSetupFailed {
@@ -2106,7 +2107,7 @@ async fn test_instance_reprov_restart_failed_impl(pool: sqlx::PgPool) {
             .trigger_dpu_reprovisioning(tonic::Request::new(
                 ::rpc::forge::DpuReprovisioningRequest {
                     dpu_id: None,
-                    machine_id: mh.id.into(),
+                    machine_id: Some(mh.id.into()),
                     mode: Mode::Restart as i32,
                     initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                     update_firmware: false,
@@ -2222,7 +2223,7 @@ async fn test_dpu_for_reprovisioning_cannot_restart_if_not_started(pool: sqlx::P
         .trigger_dpu_reprovisioning(tonic::Request::new(
             ::rpc::forge::DpuReprovisioningRequest {
                 dpu_id: None,
-                machine_id: mh.id.into(),
+                machine_id: Some(mh.id.into()),
                 mode: rpc::forge::dpu_reprovisioning_request::Mode::Restart as i32,
                 initiator: ::rpc::forge::UpdateInitiator::AdminCli as i32,
                 update_firmware: true,
@@ -2242,7 +2243,7 @@ impl TestManagedHost {
         self.api
             .insert_machine_health_report(tonic::Request::new(
                 rpc::forge::InsertMachineHealthReportRequest {
-                    machine_id: self.id.into(),
+                    machine_id: Some(self.id.into()),
                     health_report_entry: Some(rpc::forge::HealthReportEntry {
                         report: Some(
                             health_report::HealthReport {

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -676,7 +676,7 @@ async fn test_get_linked_expected_machines_completed(pool: sqlx::PgPool) {
         common::api_fixtures::create_managed_host_with_config(&env, host_config)
             .await
             .into();
-    let host_machine = env.find_machine(host_machine_id).await.remove(0);
+    let host_machine = env.find_machine(&host_machine_id).await.remove(0);
     let bmc_ip = host_machine.bmc_info.as_ref().unwrap().ip();
 
     // The test

--- a/crates/api-core/src/tests/explored_endpoint_find.rs
+++ b/crates/api-core/src/tests/explored_endpoint_find.rs
@@ -117,7 +117,7 @@ async fn test_admin_bmc_reset(db_pool: sqlx::PgPool) -> Result<(), eyre::Report>
     // Setup
     let env = create_test_env(db_pool.clone()).await;
     let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
-    let host_machine = env.find_machine(host_machine_id).await.remove(0);
+    let host_machine = env.find_machine(&host_machine_id).await.remove(0);
 
     let bmc_ip = host_machine.bmc_info.as_ref().unwrap().ip();
 

--- a/crates/api-core/src/tests/finder.rs
+++ b/crates/api-core/src/tests/finder.rs
@@ -348,7 +348,7 @@ async fn test_identify_mac(db_pool: sqlx::PgPool) -> Result<(), eyre::Report> {
     let res = env
         .api
         .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-            machine_ids: vec![host_machine_id],
+            machine_ids: vec![host_machine_id.into()],
             ..Default::default()
         }))
         .await

--- a/crates/api-core/src/tests/firmware_component_manager.rs
+++ b/crates/api-core/src/tests/firmware_component_manager.rs
@@ -130,7 +130,7 @@ async fn compute_tray_direct_dispatch_forwards_force_update(
                     rpc::update_component_firmware_request::Target::ComputeTrays(
                         rpc::UpdateComputeTrayFirmwareTarget {
                             machine_ids: Some(::rpc::common::MachineIdList {
-                                machine_ids: vec![managed_host.id],
+                                machine_ids: vec![managed_host.id.into()],
                             }),
                             components: vec![],
                         },

--- a/crates/api-core/src/tests/host_bmc_firmware_test.rs
+++ b/crates/api-core/src/tests/host_bmc_firmware_test.rs
@@ -22,6 +22,7 @@ use std::time::Duration;
 use carbide_firmware::test_support::script_setup;
 use carbide_machine_controller::config::{FirmwareGlobal, TimePeriod};
 use carbide_machine_controller::handler::MAX_NEW_FIRMWARE_REPORTED_RESET_RETRIES;
+use carbide_uuid::machine::HostMachineId;
 use common::api_fixtures::instance::TestInstance;
 use common::api_fixtures::{
     self, TestEnv, TestManagedHost, create_test_env_with_overrides, get_config,
@@ -818,7 +819,7 @@ async fn test_instance_upgrading_actual_part_2(
     );
     txn.commit().await.unwrap();
 
-    let request = Request::new(mh.id);
+    let request = Request::new(mh.id.into());
     env.api.reset_host_reprovisioning(request).await?;
 
     // Next one should start a UEFI upgrade
@@ -1649,7 +1650,7 @@ async fn test_explicit_update(pool: sqlx::PgPool) -> CarbideResult<()> {
 
     // Start time in the future
     db::machine::update_firmware_update_time_window_start_end(
-        &[mh.id],
+        &[mh.id.into()],
         chrono::Utc::now()
             .checked_add_signed(chrono::TimeDelta::seconds(100))
             .unwrap(),
@@ -1672,7 +1673,7 @@ async fn test_explicit_update(pool: sqlx::PgPool) -> CarbideResult<()> {
 
     // End time in the past
     db::machine::update_firmware_update_time_window_start_end(
-        &[mh.id],
+        &[mh.id.into()],
         chrono::Utc::now()
             .checked_add_signed(chrono::TimeDelta::seconds(-100))
             .unwrap(),
@@ -1695,7 +1696,7 @@ async fn test_explicit_update(pool: sqlx::PgPool) -> CarbideResult<()> {
 
     // Now a start and end around us
     db::machine::update_firmware_update_time_window_start_end(
-        &[mh.id],
+        &[mh.id.into()],
         chrono::Utc::now()
             .checked_add_signed(chrono::TimeDelta::seconds(-100))
             .unwrap(),
@@ -1876,7 +1877,7 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
     env.run_machine_state_controller_iteration().await;
 
     // reboot makes it move forward from MachineValidating
-    common::api_fixtures::reboot_completed(&env, mh.host().id).await;
+    common::api_fixtures::reboot_completed(&env, mh.host().id.into()).await;
 
     // Validation (MachineValidating) -> HostInit
     env.run_machine_state_controller_iteration().await;
@@ -1896,7 +1897,7 @@ async fn test_manual_firmware_upgrade_workflow(pool: sqlx::PgPool) -> CarbideRes
 /// Helper: set `host` to WaitingForScoutUpgrade with the given deadline and result.
 async fn put_in_waiting_for_scout_upgrade(
     env: &common::api_fixtures::TestEnv,
-    host: &common::api_fixtures::test_machine::TestMachine,
+    host: &common::api_fixtures::test_machine::TestMachine<HostMachineId>,
     deadline: chrono::DateTime<chrono::Utc>,
     power_drains_needed: Option<u32>,
     result: Option<model::machine::ScoutUpgradeResult>,

--- a/crates/api-core/src/tests/ib_fabric_monitor.rs
+++ b/crates/api-core/src/tests/ib_fabric_monitor.rs
@@ -1019,7 +1019,7 @@ async fn test_ib_port_down_sets_prevent_allocations_alert(
         txn.commit().await?;
     }
 
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let discovery_info = machine
         .status
         .as_ref()
@@ -1029,7 +1029,7 @@ async fn test_ib_port_down_sets_prevent_allocations_alert(
         .unwrap();
     let guid1 = discovery_info.infiniband_interfaces[0].guid.clone();
 
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let health = machine
         .status
         .as_ref()
@@ -1048,7 +1048,7 @@ async fn test_ib_port_down_sets_prevent_allocations_alert(
 
     env.run_ib_fabric_monitor_iteration().await;
 
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let health = machine
         .status
         .as_ref()
@@ -1080,7 +1080,7 @@ async fn test_ib_port_down_sets_prevent_allocations_alert(
     env.run_ib_fabric_monitor_iteration().await;
 
     // Verify IbPortDown alert is cleared
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let health = machine
         .status
         .as_ref()
@@ -1114,7 +1114,7 @@ async fn test_ib_multiple_ports_down(pool: sqlx::PgPool) -> Result<(), Box<dyn s
         txn.commit().await?;
     }
 
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let discovery_info = machine
         .status
         .as_ref()
@@ -1132,7 +1132,7 @@ async fn test_ib_multiple_ports_down(pool: sqlx::PgPool) -> Result<(), Box<dyn s
 
     env.run_ib_fabric_monitor_iteration().await;
 
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let health = machine
         .status
         .as_ref()
@@ -1169,7 +1169,7 @@ async fn test_ib_multiple_ports_down(pool: sqlx::PgPool) -> Result<(), Box<dyn s
     ib_manager.set_port_state(&guid1, true);
     env.run_ib_fabric_monitor_iteration().await;
 
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let health = machine
         .status
         .as_ref()
@@ -1199,7 +1199,7 @@ async fn test_ib_multiple_ports_down(pool: sqlx::PgPool) -> Result<(), Box<dyn s
     ib_manager.set_port_state(&guid2, true);
     env.run_ib_fabric_monitor_iteration().await;
 
-    let machine = env.find_machine(host_machine_id).await.remove(0);
+    let machine = env.find_machine(&host_machine_id).await.remove(0);
     let health = machine
         .status
         .as_ref()

--- a/crates/api-core/src/tests/ib_instance.rs
+++ b/crates/api-core/src/tests/ib_instance.rs
@@ -251,7 +251,7 @@ async fn create_ib_transition_fixture(pool: sqlx::PgPool) -> IbTransitionFixture
 
     IbTransitionFixture {
         env,
-        machine_id: managed_host.id,
+        machine_id: managed_host.id.into(),
         instance_id,
         initial_config_version,
         requested_config,
@@ -802,7 +802,7 @@ async fn test_create_instance_with_ib_config(pool: sqlx::PgPool) {
         "0"
     );
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 

--- a/crates/api-core/src/tests/ib_machine.rs
+++ b/crates/api-core/src/tests/ib_machine.rs
@@ -57,11 +57,11 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
 
     for host_machine_id in host_machines.iter().copied() {
         println!("Testing host machine {host_machine_id}");
-        let rpc_machine_id: MachineId = host_machine_id;
+        let rpc_machine_id: MachineId = host_machine_id.into();
 
-        let machine = env.find_machine(rpc_machine_id).await.remove(0);
+        let machine = env.find_machine(&rpc_machine_id).await.remove(0);
 
-        let machine_guids = guids.entry(host_machine_id).or_default();
+        let machine_guids = guids.entry(host_machine_id.into()).or_default();
 
         let discovery_info = machine
             .status
@@ -311,9 +311,9 @@ async fn monitor_ib_status_and_fix_incorrect_pkey_associations(pool: sqlx::PgPoo
     active_lids.clear();
     for host_machine_id in host_machines.iter().copied() {
         println!("Testing host machine {host_machine_id}");
-        let rpc_machine_id: MachineId = host_machine_id;
+        let rpc_machine_id: MachineId = host_machine_id.into();
 
-        let machine = env.find_machine(rpc_machine_id).await.remove(0);
+        let machine = env.find_machine(&rpc_machine_id).await.remove(0);
 
         let discovery_info = machine
             .status

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -239,7 +239,7 @@ async fn test_allocate_and_release_instance_impl(
     let snapshot = mh.snapshot(&mut txn).await;
 
     let fetched_instance = snapshot.instance.unwrap();
-    assert_eq!(&fetched_instance.machine_id, &mh.host().id);
+    assert_eq!(&fetched_instance.machine_id, &mh.host().id.into());
     for (segment_index, segment_id) in segment_ids.iter().enumerate() {
         let expected_count = if segment_index < instance_interface_count {
             1
@@ -397,7 +397,7 @@ async fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_faile
     txn.commit().await.unwrap();
 
     let device_locator = host_machine
-        .get_device_locator_for_dpu_id(&mh.dpu().id)
+        .get_device_locator_for_dpu_id(&mh.dpu_ids[0])
         .unwrap();
 
     // send the request to create the instance
@@ -419,7 +419,7 @@ async fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_faile
         .api
         .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: Some(mh.host().id),
+            machine_id: Some(mh.host().id.into()),
             instance_type_id: None,
             config: Some(instance_config),
             metadata: None,
@@ -480,7 +480,7 @@ async fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_faile
     let snapshot = mh.snapshot(&mut txn).await;
 
     let fetched_instance = snapshot.instance.unwrap();
-    assert_eq!(fetched_instance.machine_id, mh.host().id);
+    assert_eq!(fetched_instance.machine_id, mh.host().id.into());
     assert_eq!(
         db::instance_address::count_by_segment_id(&mut txn, &segment_id)
             .await
@@ -880,7 +880,7 @@ async fn test_allocate_instance_with_labels(_: PgPoolOptions, options: PgConnect
     let snapshot = mh.snapshot(&mut txn).await;
 
     let fetched_instance = snapshot.instance.unwrap();
-    assert_eq!(fetched_instance.machine_id, mh.host().id);
+    assert_eq!(fetched_instance.machine_id, mh.host().id.into());
 
     assert_eq!(fetched_instance.metadata.name, "test_instance_with_labels");
     assert_eq!(
@@ -914,7 +914,10 @@ async fn test_allocate_instance_with_labels(_: PgPoolOptions, options: PgConnect
                 metadata
             });
 
-    assert_eq!(instance_matched_by_label.machine_id.unwrap(), mh.host().id);
+    assert_eq!(
+        instance_matched_by_label.machine_id.unwrap(),
+        mh.host().id.into()
+    );
 
     assert_eq!(instance_matched_by_label.metadata, Some(instance_metadata));
 }
@@ -1060,7 +1063,7 @@ async fn test_instance_dns_resolution(_: PgPoolOptions, options: PgConnectOption
         .api
         .get_managed_host_network_config(tonic::Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: mh.dpu().id.into(),
+                dpu_machine_id: Some(mh.dpu().id.into()),
             },
         ))
         .await
@@ -1122,7 +1125,7 @@ async fn test_instance_null_hostname(_: PgPoolOptions, options: PgConnectOptions
         .api
         .get_managed_host_network_config(tonic::Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: mh.dpu().id.into(),
+                dpu_machine_id: Some(mh.dpu().id.into()),
             },
         ))
         .await
@@ -1464,7 +1467,7 @@ async fn test_instance_waits_for_primary_dpu_bgp_before_pxe_reboot(
     let env = create_test_env(pool).await;
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let mh = create_managed_host(&env).await;
-    let dpu_id = mh.dpu().id;
+    let dpu_id = mh.dpu_ids[0];
 
     let config = InstanceConfig::default_tenant_and_os()
         .network(single_interface_network_config(segment_id));
@@ -1735,7 +1738,7 @@ async fn test_can_not_create_instance_for_dpu(_: PgPoolOptions, options: PgConne
     let dpu_machine_id = dpu::create_dpu_machine(&env, &host_config).await;
     let request = crate::instance::InstanceAllocationRequest {
         instance_id: InstanceId::new(),
-        machine_id: dpu_machine_id,
+        machine_id: dpu_machine_id.into(),
         instance_type_id: None,
         config: model::instance::config::InstanceConfig {
             os: default_os_config().try_into().unwrap(),
@@ -1877,7 +1880,7 @@ async fn test_instance_address_creation(_: PgPoolOptions, options: PgConnectOpti
         .api
         .get_managed_host_network_config(tonic::Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: mh.dpu().id.into(),
+                dpu_machine_id: Some(mh.dpu().id.into()),
             },
         ))
         .await
@@ -2381,7 +2384,7 @@ async fn test_allocate_instance_with_old_network_segemnt(
     let snapshot = mh.snapshot(&mut txn).await;
 
     let fetched_instance = snapshot.instance.unwrap();
-    assert_eq!(fetched_instance.machine_id, mh.id);
+    assert_eq!(fetched_instance.machine_id, mh.id.into());
 
     let network_config = fetched_instance.config.network;
     assert_eq!(fetched_instance.network_config_version.version_nr(), 1);
@@ -2587,7 +2590,7 @@ async fn test_allocate_and_release_instance_vpc_prefix_id(
     let snapshot = mh.snapshot(&mut txn).await;
 
     let fetched_instance = snapshot.instance.unwrap();
-    assert_eq!(fetched_instance.machine_id, mh.id);
+    assert_eq!(fetched_instance.machine_id, mh.id.into());
     assert_eq!(
         db::instance_address::count_by_segment_id(
             &mut txn,
@@ -3107,7 +3110,7 @@ async fn test_slaac_vpc_allocation_preserves_prefix_without_ipv6_address(pool: P
         .api
         .get_managed_host_network_config(Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: managed_host.dpu().id.into(),
+                dpu_machine_id: Some(managed_host.dpu().id.into()),
             },
         ))
         .await
@@ -3320,7 +3323,7 @@ async fn test_slaac_vpc_allocation_preserves_prefix_without_ipv6_address(pool: P
         .api
         .get_managed_host_network_config(Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: dual_stack_host.dpu().id.into(),
+                dpu_machine_id: Some(dual_stack_host.dpu().id.into()),
             },
         ))
         .await
@@ -4289,7 +4292,7 @@ async fn assert_ipv6_only_resolution(
         .api
         .get_managed_host_network_config(Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: managed_host.dpu().id.into(),
+                dpu_machine_id: Some(managed_host.dpu().id.into()),
             },
         ))
         .await
@@ -4433,7 +4436,7 @@ async fn assert_dual_stack_resolution(
         .api
         .get_managed_host_network_config(Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: managed_host.dpu().id.into(),
+                dpu_machine_id: Some(managed_host.dpu().id.into()),
             },
         ))
         .await
@@ -5380,7 +5383,7 @@ async fn test_fnn_vrf_loopbacks_are_per_vpc_for_pf_and_vf_on_one_dpu(pool: sqlx:
     let first_vpc = first_vpc.expect("first VPC should be present");
     let second_vpc = second_vpc.expect("second VPC should be present");
     let mh = create_managed_host(&env).await;
-    let dpu_id = mh.dpu().id;
+    let dpu_id = mh.dpu_ids[0];
     let instance = mh
         .instance_builer(&env)
         .network(single_interface_network_config_with_vfs(vec![
@@ -5395,7 +5398,7 @@ async fn test_fnn_vrf_loopbacks_are_per_vpc_for_pf_and_vf_on_one_dpu(pool: sqlx:
         .api
         .get_managed_host_network_config(Request::new(
             rpc::forge::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: Some(dpu_id),
+                dpu_machine_id: Some(dpu_id.into()),
             },
         ))
         .await
@@ -6184,7 +6187,7 @@ async fn test_instance_creation_when_reprovision_is_triggered_parallel(
     // Step 2: Trigger DPU reprovision.
     let mut txn = env.db_txn().await;
     let machine_update = DpuMachineUpdate {
-        host_machine_id: mh.host().id,
+        host_machine_id: mh.id,
         dpu_machine_id: mh.dpu_ids[0],
         firmware_version: "test".to_string(),
         dpf_managed: false,
@@ -6535,7 +6538,7 @@ async fn test_public_instance_endpoints_reject_out_of_range_wire_vfs(
         let create_error = env
             .api
             .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
-                machine_id: Some(create_host.id),
+                machine_id: Some(create_host.id.into()),
                 config: Some(config_with_wire_vf(wire_vf_id)),
                 instance_id: None,
                 instance_type_id: None,
@@ -6572,7 +6575,7 @@ async fn test_public_instance_endpoints_reject_out_of_range_wire_vfs(
     // VF15 is the inclusive boundary and must pass the same public create and update paths.
     env.api
         .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
-            machine_id: Some(create_host.id),
+            machine_id: Some(create_host.id.into()),
             config: Some(config_with_wire_vf(15)),
             instance_id: None,
             instance_type_id: None,
@@ -6708,7 +6711,7 @@ async fn test_allocate_instance_with_extension_services_rejected_on_dpf_host(
     let result = env
         .api
         .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
-            machine_id: Some(mh.id),
+            machine_id: Some(mh.id.into()),
             config: Some(rpc::InstanceConfig {
                 tenant: Some(default_tenant_config()),
                 os: Some(default_os_config()),
@@ -6860,7 +6863,7 @@ async fn test_allocate_instance_with_duplicate_extension_services(
     let instance = env
         .api
         .allocate_instance(tonic::Request::new(rpc::forge::InstanceAllocationRequest {
-            machine_id: mh.id.into(),
+            machine_id: Some(mh.id.into()),
             config: Some(rpc::InstanceConfig {
                 network_security_group_id: None,
                 tenant: Some(default_tenant_config()),
@@ -7352,7 +7355,7 @@ async fn test_extension_service_removed_after_all_dpus_report_terminated(
     let instance_id = tinstance.id;
 
     // Explicitly mock healthy/running extension-service status from the DPU.
-    network_configured_with_health_and_ext_services(&env, &mh.dpu().id, None, None).await;
+    network_configured_with_health_and_ext_services(&env, &mh.dpu_ids[0], None, None).await;
 
     // Remove all extension services from desired config.
     env.api
@@ -7431,7 +7434,7 @@ async fn test_extension_service_removed_after_all_dpus_report_terminated(
     // Instance config and status should no long have the extension services.
     network_configured_with_health_and_ext_services(
         &env,
-        &mh.dpu().id,
+        &mh.dpu_ids[0],
         None,
         Some(rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceTerminated),
     )
@@ -7535,7 +7538,7 @@ async fn test_extension_services_status_observation(
     let dpu_observation = instance_snapshot
         .observations
         .extension_services
-        .get(&mh.dpu().id)
+        .get(&mh.dpu_ids[0])
         .and_then(|observations| {
             observations
                 .for_service_type(model::extension_service::ExtensionServiceType::KubernetesPod)
@@ -7591,7 +7594,7 @@ async fn test_extension_services_status_observation(
     assert_eq!(service_status.dpu_statuses.len(), 1,);
 
     let dpu_status = &service_status.dpu_statuses[0];
-    assert_eq!(dpu_status.dpu_machine_id, Some(mh.dpu().id));
+    assert_eq!(dpu_status.dpu_machine_id, Some(mh.dpu().id.into()));
     assert_eq!(
         dpu_status.status,
         rpc::forge::DpuExtensionServiceDeploymentStatus::DpuExtensionServiceRunning as i32,
@@ -7629,7 +7632,7 @@ async fn test_allocate_instance_with_invalid_os_image(
     let result = env
         .api
         .allocate_instance(tonic::Request::new(rpc::forge::InstanceAllocationRequest {
-            machine_id: mh.id.into(),
+            machine_id: Some(mh.id.into()),
             config: Some(rpc::InstanceConfig {
                 network_security_group_id: None,
                 tenant: Some(default_tenant_config()),
@@ -7692,7 +7695,7 @@ async fn test_allocate_instance_with_invalid_ib_partition(
     let result = env
         .api
         .allocate_instance(tonic::Request::new(rpc::forge::InstanceAllocationRequest {
-            machine_id: mh.id.into(),
+            machine_id: Some(mh.id.into()),
             config: Some(rpc::InstanceConfig {
                 network_security_group_id: None,
                 tenant: Some(default_tenant_config()),
@@ -7745,7 +7748,7 @@ async fn test_can_not_create_instances_with_machine_in_quarantine(
     env.api
         .set_managed_host_quarantine_state(tonic::Request::new(
             rpc::forge::SetManagedHostQuarantineStateRequest {
-                machine_id: Some(host_machine_id),
+                machine_id: Some(host_machine_id.into()),
                 quarantine_state: Some(rpc::forge::ManagedHostQuarantineState {
                     mode: ManagedHostQuarantineMode::BlockAllTraffic as i32,
                     reason: Some("test".to_string()),

--- a/crates/api-core/src/tests/instance_allocate.rs
+++ b/crates/api-core/src/tests/instance_allocate.rs
@@ -283,7 +283,7 @@ async fn test_allocate_instance_rejects_interface_anycast_prefix_outside_vpc_pro
     let err = env
         .api
         .allocate_instance(tonic::Request::new(forge::InstanceAllocationRequest {
-            machine_id: Some(mh.host().id),
+            machine_id: Some(mh.host().id.into()),
             instance_type_id: None,
             config: Some(forge::InstanceConfig {
                 tenant: Some(forge::TenantConfig {
@@ -496,7 +496,7 @@ async fn test_zero_dpu_instance_allocation_auto(
     // not strictly testing instance allocation, it's very related, because cloud-api will be using
     // the static_vpc_id field to determine where allocation should happen.
     let rpc_machine: forge::Machine = env
-        .find_machine(zero_dpu_host.host_snapshot.id)
+        .find_machine(&zero_dpu_host.host_snapshot.id)
         .await
         .remove(0);
 
@@ -1281,7 +1281,7 @@ async fn test_zero_dpu_host_verifies_boot_order_during_platform_configuration(
     // (including SetBootOrder to CheckBootOrder, where `is_boot_order_setup`
     // is called).
     env.run_machine_state_controller_iteration_until_state_matches(
-        &zero_dpu_host.host_snapshot.id,
+        &zero_dpu_host.host_snapshot.id.try_into().unwrap(),
         10,
         ManagedHostState::Ready,
     )

--- a/crates/api-core/src/tests/instance_batch_allocate.rs
+++ b/crates/api-core/src/tests/instance_batch_allocate.rs
@@ -380,7 +380,7 @@ fn build_test_instance_allocation_request(
     segment_id: NetworkSegmentId,
 ) -> rpc::forge::InstanceAllocationRequest {
     rpc::forge::InstanceAllocationRequest {
-        machine_id: Some(mh.host().id),
+        machine_id: Some(mh.host().id.into()),
         config: Some(rpc::forge::InstanceConfig {
             tenant: Some(default_tenant_config()),
             os: Some(default_os_config()),

--- a/crates/api-core/src/tests/instance_os.rs
+++ b/crates/api-core/src/tests/instance_os.rs
@@ -334,7 +334,7 @@ async fn test_allocate_instance_rejects_inactive_os(_: PgPoolOptions, options: P
     let result = env
         .api
         .allocate_instance(tonic::Request::new(rpc::forge::InstanceAllocationRequest {
-            machine_id: mh.id.into(),
+            machine_id: Some(mh.id.into()),
             config: Some(rpc::InstanceConfig {
                 tenant: Some(default_tenant_config()),
                 os: Some(rpc::forge::InstanceOperatingSystemConfig {
@@ -422,7 +422,7 @@ async fn test_allocate_instance_rejects_not_ready_os(_: PgPoolOptions, options: 
     let result = env
         .api
         .allocate_instance(tonic::Request::new(rpc::forge::InstanceAllocationRequest {
-            machine_id: mh.id.into(),
+            machine_id: Some(mh.id.into()),
             config: Some(rpc::InstanceConfig {
                 tenant: Some(default_tenant_config()),
                 os: Some(rpc::forge::InstanceOperatingSystemConfig {

--- a/crates/api-core/src/tests/instance_type.rs
+++ b/crates/api-core/src/tests/instance_type.rs
@@ -474,7 +474,7 @@ async fn test_instance_type_delete(pool: sqlx::PgPool) -> Result<(), Box<dyn std
         .api
         .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: tmp_mh.host().id.into(),
+            machine_id: Some(tmp_mh.host().id.into()),
             instance_type_id: Some(id.to_string()),
             config: Some(rpc::InstanceConfig {
                 tenant: Some(default_tenant_config()),
@@ -500,7 +500,7 @@ async fn test_instance_type_delete(pool: sqlx::PgPool) -> Result<(), Box<dyn std
 
     advance_created_instance_into_ready_state(&env, &tmp_mh).await;
 
-    let orig_machine = env.find_machine(tmp_mh.host().id).await.remove(0);
+    let orig_machine = env.find_machine(&tmp_mh.host().id).await.remove(0);
 
     // Try to delete the instance type.  This should fail
     // because there's an instance associated with the machine associated
@@ -528,7 +528,7 @@ async fn test_instance_type_delete(pool: sqlx::PgPool) -> Result<(), Box<dyn std
         .unwrap();
 
     // Grab the machine so we can verify that it actually got the update
-    let machine = env.find_machine(tmp_mh.host().id).await.remove(0);
+    let machine = env.find_machine(&tmp_mh.host().id).await.remove(0);
 
     // Check that it has had its instance type id automatically removed.
     assert_eq!(machine.config.as_ref().unwrap().instance_type_id, None);
@@ -636,7 +636,7 @@ async fn test_instance_type_associate(
 
     let tmp_mh = create_managed_host(&env).await;
 
-    let orig_machine = env.find_machine(tmp_mh.host().id).await.remove(0);
+    let orig_machine = env.find_machine(&tmp_mh.host().id).await.remove(0);
 
     // Associate the machine with the instance type
     let _ = env
@@ -651,7 +651,7 @@ async fn test_instance_type_associate(
         .unwrap();
 
     // Grab the machine so we can verify that it actually got the update
-    let machine = env.find_machine(tmp_mh.host().id).await.remove(0);
+    let machine = env.find_machine(&tmp_mh.host().id).await.remove(0);
 
     // Check that it has the instance type ID we expect.
     assert_eq!(
@@ -679,7 +679,7 @@ async fn test_instance_type_associate(
         .api
         .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: tmp_mh.host().id.into(),
+            machine_id: Some(tmp_mh.host().id.into()),
             instance_type_id: Some("1fcd4e9a-be16-11ef-b892-0fad889bcd2b".to_string()),
             config: Some(rpc::InstanceConfig {
                 network_security_group_id: None,
@@ -706,7 +706,7 @@ async fn test_instance_type_associate(
         .api
         .allocate_instance(tonic::Request::new(rpc::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: tmp_mh.host().id.into(),
+            machine_id: Some(tmp_mh.host().id.into()),
             instance_type_id: machine.config.as_ref().unwrap().instance_type_id.clone(),
             config: Some(rpc::InstanceConfig {
                 network_security_group_id: None,
@@ -789,7 +789,7 @@ async fn test_instance_type_associate(
         .unwrap();
 
     // Grab the machine so we can verify that it actually got the update
-    let machine = env.find_machine(tmp_mh.host().id).await.remove(0);
+    let machine = env.find_machine(&tmp_mh.host().id).await.remove(0);
 
     // Check that the machine no longer has the instance type ID
     assert!(machine.config.as_ref().unwrap().instance_type_id.is_none());

--- a/crates/api-core/src/tests/ipxe.rs
+++ b/crates/api-core/src/tests/ipxe.rs
@@ -98,7 +98,7 @@ async fn get_pxe_instructions(
 async fn test_pxe_dpu_ready(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
     let (_host_id, dpu_id) = common::api_fixtures::create_managed_host(&env).await.into();
-    move_machine_to_needed_state(dpu_id, &ManagedHostState::Ready, &env.pool).await;
+    move_machine_to_needed_state(dpu_id.into(), &ManagedHostState::Ready, &env.pool).await;
 
     let mut txn = env
         .pool
@@ -146,7 +146,7 @@ async fn test_pxe_dpu_waiting_for_network_install(pool: sqlx::PgPool) {
         machine.current_state(),
         &ManagedHostState::DPUInit {
             dpu_states: model::machine::DpuInitStates {
-                states: HashMap::from([(mh.dpu().id, DpuInitState::WaitingForNetworkConfig,)]),
+                states: HashMap::from([(mh.dpu_ids[0], DpuInitState::WaitingForNetworkConfig)]),
             },
         }
     );
@@ -317,7 +317,7 @@ async fn test_pxe_host(pool: sqlx::PgPool) {
         .id;
     txn.commit().await.unwrap();
     move_machine_to_needed_state(
-        host_id,
+        host_id.into(),
         &ManagedHostState::HostInit {
             machine_state: MachineState::WaitingForDiscovery,
         },
@@ -341,7 +341,7 @@ async fn test_pxe_host(pool: sqlx::PgPool) {
     );
 
     move_machine_to_needed_state(
-        host_id,
+        host_id.into(),
         &ManagedHostState::HostInit {
             machine_state: MachineState::Discovered {
                 skip_reboot_wait: false,
@@ -361,7 +361,7 @@ async fn test_pxe_host(pool: sqlx::PgPool) {
     assert!(instructions.pxe_script.contains("x86_64/scout.efi"));
 
     move_machine_to_needed_state(
-        host_id,
+        host_id.into(),
         &ManagedHostState::BootConfiguring {
             desired_version: ConfigVersion::new(7),
             desired_boot_interface: MachineBootInterfaceTarget::MacOnly(
@@ -390,7 +390,7 @@ async fn test_pxe_host(pool: sqlx::PgPool) {
     assert!(instructions.pxe_script.contains("x86_64/scout.efi"));
 
     move_machine_to_needed_state(
-        host_id,
+        host_id.into(),
         &ManagedHostState::HostReprovision {
             reprovision_state: HostReprovisionState::WaitingForManualUpgrade {
                 manual_upgrade_started: Utc::now(),
@@ -411,7 +411,7 @@ async fn test_pxe_host(pool: sqlx::PgPool) {
     assert!(instructions.pxe_script.contains("x86_64/scout.efi"));
 
     move_machine_to_needed_state(
-        host_id,
+        host_id.into(),
         &ManagedHostState::WaitingForCleanup {
             cleanup_state: model::machine::CleanupState::Init,
             cleanup_context: CleanupContext::Deprovision,
@@ -551,7 +551,7 @@ async fn test_cloud_init_after_dpu_update(pool: sqlx::PgPool) {
 
     let (_host_id, dpu_id) = common::api_fixtures::create_managed_host(&env).await.into();
     move_machine_to_needed_state(
-        dpu_id,
+        dpu_id.into(),
         &ManagedHostState::DPUInit {
             dpu_states: model::machine::DpuInitStates {
                 states: HashMap::from([(dpu_id, DpuInitState::Init)]),
@@ -562,7 +562,7 @@ async fn test_cloud_init_after_dpu_update(pool: sqlx::PgPool) {
     .await;
 
     // Interface is created. Let's fetch interface id.
-    let machine = env.find_machine(dpu_id).await.remove(0);
+    let machine = env.find_machine(&dpu_id).await.remove(0);
     assert_eq!(machine.status.as_ref().unwrap().interfaces.len(), 1);
 
     let cloud_init_cfg = env

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -211,7 +211,7 @@ async fn test_admin_force_delete_dpu_and_host_by_dpu_machine_id(pool: sqlx::PgPo
     validate_delete_response(&response, Some(&host_machine_id), &dpu_machine_id);
     assert!(response.all_done, "Host must be deleted");
 
-    for id in [host_machine_id, dpu_machine_id] {
+    for id in [host_machine_id.into(), dpu_machine_id.into()] {
         validate_machine_deletion(&env, &id, None).await;
     }
 }
@@ -235,7 +235,7 @@ async fn test_admin_force_delete_dpu_and_host_by_host_machine_id(pool: sqlx::PgP
 
     let bmc_addrs = vec![
         IpAddr::from_str(
-            env.find_machine(host_machine_id)
+            env.find_machine(&host_machine_id)
                 .await
                 .first()
                 .unwrap()
@@ -248,7 +248,7 @@ async fn test_admin_force_delete_dpu_and_host_by_host_machine_id(pool: sqlx::PgP
         )
         .unwrap(),
         IpAddr::from_str(
-            env.find_machine(dpu_machine_id)
+            env.find_machine(&dpu_machine_id)
                 .await
                 .first()
                 .unwrap()
@@ -296,8 +296,8 @@ async fn test_admin_force_delete_dpu_and_host_by_host_machine_id(pool: sqlx::PgP
     let response = force_delete(&env, &host_machine_id).await;
     validate_delete_response(&response, Some(&host_machine_id), &dpu_machine_id);
 
-    assert!(env.find_machine(host_machine_id).await.is_empty());
-    assert!(env.find_machine(dpu_machine_id).await.is_empty());
+    assert!(env.find_machine(&host_machine_id).await.is_empty());
+    assert!(env.find_machine(&dpu_machine_id).await.is_empty());
 
     assert!(response.all_done, "Host and DPU must be deleted");
     assert!(
@@ -306,7 +306,7 @@ async fn test_admin_force_delete_dpu_and_host_by_host_machine_id(pool: sqlx::PgP
     );
 
     // Everything should be gone now
-    for id in [host_machine_id, dpu_machine_id] {
+    for id in [host_machine_id.into(), dpu_machine_id.into()] {
         validate_machine_deletion(&env, &id, Some(&bmc_addrs)).await;
     }
 }
@@ -330,7 +330,7 @@ async fn test_admin_force_delete_dpu_and_partially_discovered_host(pool: sqlx::P
         .into_inner();
     assert_eq!(ifaces.interfaces.len(), 1);
     let iface = ifaces.interfaces.remove(0);
-    assert_eq!(iface.attached_dpu_machine_id, Some(dpu_machine_id));
+    assert_eq!(iface.attached_dpu_machine_id, Some(dpu_machine_id.into()));
 
     let mut txn = env.pool.begin().await.unwrap();
     let host = db::machine::find_host_by_dpu_machine_id(&mut txn, &dpu_machine_id)
@@ -522,9 +522,11 @@ async fn test_admin_force_delete_orders_endpoint_locks_by_address(pool: sqlx::Pg
     for machine_id in managed_host
         .dpu_ids
         .iter()
-        .chain(std::iter::once(&managed_host.id))
+        .copied()
+        .map(MachineId::from)
+        .chain(std::iter::once(managed_host.id.into()))
     {
-        validate_machine_deletion(&env, machine_id, None).await;
+        validate_machine_deletion(&env, &machine_id, None).await;
     }
 }
 
@@ -636,7 +638,7 @@ async fn force_delete(
         .into_inner()
 }
 
-fn force_delete_request(machine_id: &MachineId) -> AdminForceDeleteMachineRequest {
+fn force_delete_request(machine_id: &impl std::fmt::Display) -> AdminForceDeleteMachineRequest {
     AdminForceDeleteMachineRequest {
         host_query: machine_id.to_string(),
         delete_interfaces: false,
@@ -732,7 +734,7 @@ async fn validate_machine_deletion(
     bmc_addrs: Option<&Vec<IpAddr>>,
 ) {
     // The machine should be now be gone in the API
-    let response = env.find_machine(*machine_id).await;
+    let response = env.find_machine(machine_id).await;
     assert!(response.is_empty());
 
     // And it should also be gone on the DB layer
@@ -856,7 +858,7 @@ async fn test_admin_force_delete_reads_instance_after_machine_lock(pool: sqlx::P
     db::instance::batch_persist(
         vec![NewInstance {
             instance_id,
-            machine_id: managed_host.id,
+            machine_id: managed_host.id.into(),
             instance_type_id: None,
             config: &config,
             metadata: Metadata::default(),
@@ -890,9 +892,11 @@ async fn test_admin_force_delete_reads_instance_after_machine_lock(pool: sqlx::P
     for machine_id in managed_host
         .dpu_ids
         .iter()
-        .chain(std::iter::once(&managed_host.id))
+        .copied()
+        .map(MachineId::from)
+        .chain(std::iter::once(managed_host.id.into()))
     {
-        validate_machine_deletion(&env, machine_id, None).await;
+        validate_machine_deletion(&env, &machine_id, None).await;
     }
 }
 
@@ -981,7 +985,7 @@ async fn test_admin_force_delete_rereads_config_committed_before_marker(pool: sq
     let (response, ()) = tokio::join!(force_delete, orchestrate);
     let response = response.unwrap().into_inner();
     validate_delete_response(&response, Some(&managed_host.id), &managed_host.dpu().id);
-    for machine_id in [managed_host.id, managed_host.dpu().id] {
+    for machine_id in [managed_host.id.into(), managed_host.dpu().id.into()] {
         validate_machine_deletion(&env, &machine_id, None).await;
     }
     let generated_segment_is_deleted: bool =
@@ -1057,7 +1061,7 @@ async fn test_admin_force_delete_marker_rejects_started_config_update(pool: sqlx
     let (response, ()) = tokio::join!(force_delete, orchestrate);
     let response = response.unwrap().into_inner();
     validate_delete_response(&response, Some(&managed_host.id), &managed_host.dpu().id);
-    for machine_id in [managed_host.id, managed_host.dpu().id] {
+    for machine_id in [managed_host.id.into(), managed_host.dpu().id.into()] {
         validate_machine_deletion(&env, &machine_id, None).await;
     }
 }
@@ -1185,7 +1189,7 @@ async fn test_admin_force_delete_host_with_ib_instance(pool: sqlx::PgPool) {
     txn.commit().await.unwrap();
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(check_instance.machine_id(), mh.id);
+    assert_eq!(check_instance.machine_id(), mh.id.into());
     assert_eq!(check_instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -1277,8 +1281,8 @@ async fn test_admin_force_delete_host_with_ib_instance(pool: sqlx::PgPool) {
     };
     assert_eq!(ib_fabric.find_ib_port(Some(filter)).await.unwrap().len(), 0);
 
-    assert!(env.find_machine(mh.id).await.is_empty());
-    assert!(env.find_machine(mh.dpu().id).await.is_empty());
+    assert!(env.find_machine(&mh.id).await.is_empty());
+    assert!(env.find_machine(&mh.dpu().id).await.is_empty());
 
     assert_eq!(response.ufm_unregistrations, 1);
     assert!(response.all_done, "Host and DPU must be deleted");
@@ -1306,7 +1310,7 @@ async fn test_admin_force_delete_host_with_ib_instance(pool: sqlx::PgPool) {
     );
 
     // Everything should be gone now
-    for id in [mh.id, mh.dpu().id] {
+    for id in [mh.id.into(), mh.dpu().id.into()] {
         validate_machine_deletion(&env, &id, None).await;
     }
 }
@@ -1344,7 +1348,7 @@ async fn test_admin_force_delete_managed_host_multi_dpu(pool: sqlx::PgPool) {
 
     validate_delete_response_multi_dpu(&response, Some(&mh.host().id), dpu_ids.as_slice());
 
-    for id in [&[mh.host().id], dpu_ids.as_slice()].concat().iter() {
+    for id in [&[mh.host().id.into()], dpu_ids.as_slice()].concat().iter() {
         validate_machine_deletion(&env, id, None).await;
     }
 }
@@ -1358,6 +1362,7 @@ async fn test_admin_force_delete_dpu_from_managed_host_multi_dpu(pool: sqlx::PgP
         .dpu_ids
         .clone()
         .into_iter()
+        .map(Into::into)
         .collect::<Vec<carbide_uuid::machine::MachineId>>();
     assert_eq!(
         mh.dpu_ids.len(),
@@ -1381,8 +1386,14 @@ async fn test_admin_force_delete_dpu_from_managed_host_multi_dpu(pool: sqlx::PgP
 
     validate_delete_response_multi_dpu(&response, Some(&mh.host().id), &rpc_dpu_ids);
 
-    for id in mh.dpu_ids.iter().chain([&mh.id]) {
-        validate_machine_deletion(&env, id, None).await;
+    for id in mh
+        .dpu_ids
+        .iter()
+        .copied()
+        .map(MachineId::from)
+        .chain([mh.id.into()])
+    {
+        validate_machine_deletion(&env, &id, None).await;
     }
 }
 
@@ -1502,7 +1513,7 @@ async fn test_admin_force_delete_with_instance_type(pool: sqlx::PgPool) {
         response.all_done,
         "the machine should delete once its instance type association is cleared"
     );
-    assert!(env.find_machine(tmp_machine_id).await.is_empty());
+    assert!(env.find_machine(&tmp_machine_id).await.is_empty());
 }
 
 /// Force delete with DPF: the node_id and dpu_device_names passed to

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -949,7 +949,7 @@ async fn test_machine_dhcp_with_api_for_instance_physical_virtual(
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(mh.dpu().id),
+            dpu_machine_id: Some(mh.dpu().id.into()),
         }))
         .await
         .unwrap()
@@ -1073,7 +1073,7 @@ async fn test_dpu_machine_dhcp_for_existing_dpu(
     let host_config = env.managed_host_config();
     let dpu_machine_id = dpu::create_dpu_machine(&env, &host_config).await;
 
-    let machine = env.find_machine(dpu_machine_id).await.remove(0);
+    let machine = env.find_machine(&dpu_machine_id).await.remove(0);
     let mac = machine.status.as_ref().unwrap().interfaces[0]
         .mac_address
         .clone();
@@ -2110,7 +2110,7 @@ async fn test_dhcp_v6_find_existing_machine_uses_link_address(
     .await?;
     let mut txn = pool.begin().await?;
     let machine_id = db::machine::find_existing_machine(&mut txn, host_mac, link_address).await?;
-    assert_eq!(machine_id, Some(host.host().id));
+    assert_eq!(machine_id, Some(host.host().id.into()));
     txn.rollback().await?;
 
     Ok(())
@@ -3406,7 +3406,7 @@ async fn test_discover_dhcp_dangling_address_is_not_found(
 /// see in production.
 async fn host_interface_and_gateway(
     env: &TestEnv,
-    host_machine_id: carbide_uuid::machine::MachineId,
+    host_machine_id: carbide_uuid::machine::HostMachineId,
 ) -> Result<(MacAddress, IpAddr), Box<dyn std::error::Error>> {
     let mut txn = env.pool.begin().await?;
     let interfaces_by_machine =
@@ -3434,7 +3434,7 @@ async fn host_interface_and_gateway(
 /// `instances.machine_id`, so a minimal INSERT is enough.
 async fn attach_bare_instance(
     env: &TestEnv,
-    machine_id: carbide_uuid::machine::MachineId,
+    machine_id: carbide_uuid::machine::HostMachineId,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let mut txn = env.pool.begin().await?;
     sqlx::query("INSERT INTO instances (machine_id) VALUES ($1)")
@@ -3495,7 +3495,7 @@ async fn test_dhcp_allows_host_bmc_with_instance_on_dpu_host(
     let bmc_interface = interfaces
         .iter()
         .find(|interface| {
-            interface.machine_id == Some(mh.host().id)
+            interface.machine_id == Some(mh.host().id.into())
                 && interface.interface_type == InterfaceType::Bmc
         })
         .ok_or("host has no BMC machine_interface")?;

--- a/crates/api-core/src/tests/machine_discovery.rs
+++ b/crates/api-core/src/tests/machine_discovery.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use std::sync::atomic::Ordering;
 
 use carbide_authn::middleware::ConnectionAttributes;
-use carbide_uuid::machine::{MachineId, MachineInterfaceId, StableHostMachineId};
+use carbide_uuid::machine::{HostMachineId, MachineInterfaceId, StableHostMachineId};
 use carbide_uuid::network::NetworkSegmentId;
 use common::api_fixtures::dpu::create_dpu_machine;
 use common::api_fixtures::host::{host_discover_dhcp, host_discover_machine_with_reporter};
@@ -115,7 +115,7 @@ struct ScoutPciSelectionState {
 /// Loads only the primary, address, network, state, queue, and desired boot interface selection fields.
 async fn load_scout_pci_selection_state(
     pool: &sqlx::PgPool,
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
 ) -> Result<ScoutPciSelectionState, Box<dyn std::error::Error>> {
     let state = sqlx::query_as::<_, ScoutPciSelectionState>(
         "SELECT (
@@ -164,7 +164,7 @@ struct ScoutPciInterfaces {
 
 async fn load_scout_pci_interfaces(
     pool: &sqlx::PgPool,
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
 ) -> Result<ScoutPciInterfaces, Box<dyn std::error::Error>> {
     let machine = db::machine::find_one(pool, &host_machine_id, MachineSearchConfig::default())
         .await?
@@ -232,7 +232,7 @@ fn scout_pci_report(host_config: &ManagedHostConfig, winning_mac: MacAddress) ->
 
 async fn set_scout_test_source(
     pool: &sqlx::PgPool,
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
     source: BootInterfaceSelectionSource,
 ) -> Result<(), sqlx::Error> {
     sqlx::query(
@@ -250,7 +250,7 @@ async fn set_scout_test_source(
 
 async fn clear_scout_test_queue(
     pool: &sqlx::PgPool,
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
 ) -> Result<(), sqlx::Error> {
     sqlx::query("DELETE FROM machine_state_controller_queued_objects WHERE object_id = $1")
         .bind(host_machine_id.to_string())
@@ -262,7 +262,7 @@ async fn clear_scout_test_queue(
 async fn create_scout_test_host(
     env: &common::api_fixtures::TestEnv,
     source: BootInterfaceSelectionSource,
-) -> Result<(ManagedHostConfig, MachineId, ScoutPciInterfaces), Box<dyn std::error::Error>> {
+) -> Result<(ManagedHostConfig, HostMachineId, ScoutPciInterfaces), Box<dyn std::error::Error>> {
     let host_config = env.managed_host_config().with_dpu_count(2);
     let host = create_managed_host_with_config(env, host_config.clone()).await;
     let host_machine_id = host.host().id;
@@ -274,7 +274,7 @@ async fn create_scout_test_host(
 
 async fn submit_scout_pci_report(
     api: &crate::api::Api,
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
     caller_interface_id: MachineInterfaceId,
     hardware_info: HardwareInfo,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -296,7 +296,7 @@ async fn submit_scout_pci_report(
     ))
     .await;
     let response = response?.into_inner();
-    assert_eq!(response.machine_id, Some(host_machine_id));
+    assert_eq!(response.machine_id, Some(host_machine_id.into()));
     assert_eq!(response.machine_interface_id, Some(caller_interface_id));
 
     Ok(scout_pci_comparisons(&logs, host_machine_id))
@@ -304,7 +304,7 @@ async fn submit_scout_pci_report(
 
 fn scout_pci_comparisons(
     logs: &[carbide_instrument::testing::CapturedLog],
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
 ) -> Vec<String> {
     let host_machine_id = host_machine_id.to_string();
     logs.iter()
@@ -326,7 +326,7 @@ fn scout_pci_comparisons(
 
 async fn run_scout_pci_reconciliation(
     api: &crate::api::Api,
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
     hardware_info: &HardwareInfo,
 ) -> Result<bool, Box<dyn std::error::Error>> {
     let host_machine_id = StableHostMachineId::try_from(host_machine_id)?;
@@ -341,12 +341,12 @@ async fn run_scout_pci_reconciliation(
 }
 
 fn scout_test_allocation_request(
-    host_machine_id: MachineId,
+    host_machine_id: HostMachineId,
     segment_id: NetworkSegmentId,
 ) -> rpc::InstanceAllocationRequest {
     rpc::InstanceAllocationRequest {
         instance_id: None,
-        machine_id: Some(host_machine_id),
+        machine_id: Some(host_machine_id.into()),
         instance_type_id: None,
         config: Some(rpc::InstanceConfig {
             tenant: Some(default_tenant_config()),
@@ -378,7 +378,7 @@ async fn allocated_host_for_secure_discovery(
     let managed_host = create_managed_host_with_config(env, host_config).await;
     assert_eq!(
         from_hardware_info(&hardware_info).unwrap(),
-        managed_host.host().id
+        managed_host.host().id.into()
     );
 
     let instance = managed_host
@@ -558,10 +558,10 @@ async fn test_discover_2_managed_hosts(
     let env: common::api_fixtures::TestEnv = create_test_env(pool).await;
     let (host1_id, dpu1_id) = create_managed_host(&env).await.into();
     let (host2_id, dpu2_id) = create_managed_host(&env).await.into();
-    assert!(host1_id.machine_type().is_host());
-    assert!(host2_id.machine_type().is_host());
-    assert!(dpu1_id.machine_type().is_dpu());
-    assert!(dpu2_id.machine_type().is_dpu());
+    assert!(&host1_id.machine_type().is_host());
+    assert!(&host2_id.machine_type().is_host());
+    assert!(&dpu1_id.machine_type().is_dpu());
+    assert!(&dpu2_id.machine_type().is_dpu());
     assert_ne!(host1_id, host2_id);
     assert_ne!(dpu1_id, dpu2_id);
 
@@ -871,7 +871,7 @@ async fn test_secure_discovery_from_instance_address_accepts_same_machine_interf
             .await?
             .into_inner();
 
-        assert_eq!(response.machine_id, Some(managed_host.host().id));
+        assert_eq!(response.machine_id, Some(managed_host.host().id.into()));
         assert_eq!(
             response.machine_interface_id,
             Some(interface_id),
@@ -1075,7 +1075,7 @@ async fn test_secure_discovery_accepts_zero_dpu_host_inband_owner(
         .discover_machine(discovery_request_from(&hardware_info, None, host_ip))
         .await?
         .into_inner();
-    assert_eq!(response.machine_id, Some(managed_host.host().id));
+    assert_eq!(response.machine_id, Some(managed_host.host().id.into()));
     assert_eq!(response.machine_interface_id, Some(expected_interface_id));
 
     Ok(())

--- a/crates/api-core/src/tests/machine_find.rs
+++ b/crates/api-core/src/tests/machine_find.rs
@@ -51,7 +51,7 @@ async fn test_find_machine_by_id(pool: sqlx::PgPool) {
         .await
         .unwrap()
         .expect("expect DPU to be found");
-    assert_eq!(machine.id, dpu_machine_id);
+    assert_eq!(machine.id, dpu_machine_id.into());
     assert!(machine.is_dpu());
 
     // We shouldn't find a machine that doesn't exist
@@ -93,7 +93,7 @@ async fn test_find_machine_by_ip(pool: sqlx::PgPool) {
         .await
         .unwrap()
         .expect("expect DPU to be found");
-    assert_eq!(machine.id, dpu_machine_id);
+    assert_eq!(machine.id, dpu_machine_id.into());
     assert_eq!(&machine.status.interfaces[0].addresses[0], ip);
 
     // We shouldn't find a machine that doesn't exist
@@ -143,7 +143,7 @@ async fn test_find_machine_by_ipv6(pool: sqlx::PgPool) {
         .await
         .unwrap()
         .expect("should find machine by IPv6 address");
-    assert_eq!(machine.id, dpu_machine_id);
+    assert_eq!(machine.id, dpu_machine_id.into());
 }
 
 #[crate::sqlx_test]
@@ -248,7 +248,7 @@ async fn test_find_machine_by_rack_id(pool: sqlx::PgPool) {
         .machine_ids;
 
     assert_eq!(machine_ids.len(), 1);
-    assert_eq!(machine_ids[0], machine_id);
+    assert_eq!(machine_ids[0], machine_id.into());
 }
 
 #[crate::sqlx_test]
@@ -275,7 +275,7 @@ async fn test_find_machine_by_mac(pool: sqlx::PgPool) {
         .await
         .unwrap()
         .expect("expect DPU to be found");
-    assert_eq!(machine.id, dpu_machine_id);
+    assert_eq!(machine.id, dpu_machine_id.into());
     assert_eq!(&machine.status.interfaces[0].mac_address, mac);
     assert!(DPU_OOB_MAC_ADDRESS_POOL.contains(machine.status.interfaces[0].mac_address));
 
@@ -316,7 +316,7 @@ async fn test_find_machine_by_hostname(pool: sqlx::PgPool) {
         .await
         .unwrap()
         .expect("expect DPU to be found");
-    assert_eq!(machine.id, dpu_machine_id);
+    assert_eq!(machine.id, dpu_machine_id.into());
     assert_eq!(&machine.status.interfaces[0].hostname, hostname);
 
     // We shouldn't find a machine that doesn't exist
@@ -375,7 +375,7 @@ async fn test_find_machine_ids_with_and_without_dpus(pool: sqlx::PgPool) {
 async fn test_find_all_machines_when_there_arent_any(pool: sqlx::PgPool) {
     let machines = db::machine::find(
         &pool,
-        ObjectFilter::All,
+        ObjectFilter::<MachineId>::All,
         crate::tests::machine_find::MachineSearchConfig {
             include_history: true,
             ..Default::default()
@@ -451,7 +451,7 @@ async fn test_find_machine_ids(pool: sqlx::PgPool) {
         .unwrap();
 
     assert_eq!(machine_ids.len(), 1);
-    assert_eq!(machine_ids[0], host_machine_id);
+    assert_eq!(machine_ids[0], host_machine_id.into());
 }
 
 #[crate::sqlx_test]
@@ -720,7 +720,7 @@ async fn test_find_machine_by_instance_type(
 
     // Confirm that what we found is the right
     // machine
-    assert_eq!(machines[0], tmp_machine_id);
+    assert_eq!(machines[0], tmp_machine_id.into());
 
     Ok(())
 }

--- a/crates/api-core/src/tests/machine_health.rs
+++ b/crates/api-core/src/tests/machine_health.rs
@@ -716,7 +716,7 @@ async fn test_double_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
     let _ = env
         .api
         .insert_machine_health_report(Request::new(rpc::forge::InsertMachineHealthReportRequest {
-            machine_id: Some(host_machine_id),
+            machine_id: Some(host_machine_id.into()),
             health_report_entry: Some(rpc::forge::HealthReportEntry {
                 report: Some(health_report::HealthReport::empty("over".to_string()).into()),
                 mode: health_report::HealthReportApplyMode::Replace as i32,
@@ -738,7 +738,7 @@ async fn test_double_insert(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error
     let _ = env
         .api
         .insert_machine_health_report(Request::new(rpc::forge::InsertMachineHealthReportRequest {
-            machine_id: Some(host_machine_id),
+            machine_id: Some(host_machine_id.into()),
             health_report_entry: Some(rpc::forge::HealthReportEntry {
                 report: Some(merge_hr.clone().into()),
                 mode: health_report::HealthReportApplyMode::Merge as i32,
@@ -784,7 +784,7 @@ async fn test_insert_machine_health_report_retains_in_alert_since(
         env.api
             .insert_machine_health_report(Request::new(
                 rpc::forge::InsertMachineHealthReportRequest {
-                    machine_id: Some(host_machine_id),
+                    machine_id: Some(host_machine_id.into()),
                     health_report_entry: Some(rpc::forge::HealthReportEntry {
                         report: Some(report.into()),
                         mode: HealthReportApplyMode::Merge as i32,

--- a/crates/api-core/src/tests/machine_history.rs
+++ b/crates/api-core/src/tests/machine_history.rs
@@ -62,12 +62,12 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
     let expected_initial_states: Vec<serde_json::Value> =
         expected_initial_states_json.as_array().unwrap().clone();
 
-    for machine_id in &[host_machine_id, dpu_machine_id] {
+    for machine_id in [host_machine_id.into(), dpu_machine_id.into()] {
         let mut txn = env.pool.begin().await?;
 
         let machine = db::machine::find_one(
             txn.as_mut(),
-            &dpu_machine_id,
+            &machine_id,
             model::machine::machine_search_config::MachineSearchConfig {
                 include_history: true,
                 ..Default::default()
@@ -97,7 +97,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         let rpc_machine = env
             .api
             .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-                machine_ids: vec![*machine_id],
+                machine_ids: vec![machine_id],
                 include_history: true,
             }))
             .await?
@@ -118,7 +118,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .api
             .find_machine_state_histories(tonic::Request::new(
                 rpc::forge::MachineStateHistoriesRequest {
-                    machine_ids: vec![*machine_id],
+                    machine_ids: vec![machine_id],
                 },
             ))
             .await?
@@ -206,7 +206,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         .unwrap()
         .into_inner();
 
-    assert!(env.find_machine(host_machine_id).await.is_empty());
+    assert!(env.find_machine(&host_machine_id).await.is_empty());
 
     let mut txn = env.pool.begin().await?;
     let power_entry = db::power_options::get_all(&mut txn).await?;
@@ -216,7 +216,7 @@ async fn test_machine_state_history(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         .api
         .find_machine_state_histories(tonic::Request::new(
             rpc::forge::MachineStateHistoriesRequest {
-                machine_ids: vec![host_machine_id],
+                machine_ids: vec![host_machine_id.into()],
             },
         ))
         .await?

--- a/crates/api-core/src/tests/machine_interfaces.rs
+++ b/crates/api-core/src/tests/machine_interfaces.rs
@@ -264,7 +264,7 @@ async fn reconcile_admin_addresses_allows_non_dpu_primary_admin_interface(
     .await?;
     db::machine_interface::associate_interface_with_machine(
         &active_interface.id,
-        MachineInterfaceAssociation::Machine(mh.id),
+        MachineInterfaceAssociation::Machine(mh.id.into()),
         &mut txn,
     )
     .await?;
@@ -376,7 +376,7 @@ async fn reconcile_admin_addresses_allows_host_inband_primary_with_dormant_dpu_l
     .await?;
     db::machine_interface::associate_interface_with_machine(
         &host_nic.id,
-        MachineInterfaceAssociation::Machine(mh.id),
+        MachineInterfaceAssociation::Machine(mh.id.into()),
         &mut txn,
     )
     .await?;

--- a/crates/api-core/src/tests/machine_network.rs
+++ b/crates/api-core/src/tests/machine_network.rs
@@ -25,7 +25,7 @@ use ::rpc::forge::{
 };
 use carbide_instrument::testing::MetricsCapture;
 use carbide_secrets::credentials::{BgpCredentialType, CredentialKey, Credentials};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use common::api_fixtures::network_segment::{
     FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS, create_tenant_network_segment,
 };
@@ -44,7 +44,7 @@ use crate::tests::common::rpc_builder::VpcCreationRequest;
 
 async fn set_use_admin_network_changed(
     env: &api_fixtures::TestEnv,
-    dpu_machine_id: MachineId,
+    dpu_machine_id: DpuMachineId,
     value: bool,
 ) {
     let mut txn = env.db_txn().await;
@@ -56,7 +56,7 @@ async fn set_use_admin_network_changed(
 
 async fn use_admin_network_changed(
     env: &api_fixtures::TestEnv,
-    dpu_machine_id: MachineId,
+    dpu_machine_id: DpuMachineId,
 ) -> Option<bool> {
     let mut txn = env.db_txn().await;
     let dpu = db::machine::find_one(txn.deref_mut(), &dpu_machine_id, Default::default())
@@ -67,7 +67,10 @@ async fn use_admin_network_changed(
     dpu.network_config.value.use_admin_network_changed
 }
 
-async fn bump_dpu_network_config_version(env: &api_fixtures::TestEnv, dpu_machine_id: MachineId) {
+async fn bump_dpu_network_config_version(
+    env: &api_fixtures::TestEnv,
+    dpu_machine_id: DpuMachineId,
+) {
     let mut txn = env.db_txn().await;
     let dpu = db::machine::find_one(txn.deref_mut(), &dpu_machine_id, Default::default())
         .await
@@ -83,12 +86,12 @@ async fn bump_dpu_network_config_version(env: &api_fixtures::TestEnv, dpu_machin
 
 async fn record_dpu_network_status(
     env: &api_fixtures::TestEnv,
-    dpu_machine_id: MachineId,
+    dpu_machine_id: DpuMachineId,
     network_config_version: Option<String>,
 ) {
     env.api
         .record_dpu_network_status(tonic::Request::new(DpuNetworkStatus {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
             dpu_agent_version: Some(dpu::TEST_DPU_AGENT_VERSION.to_string()),
             observed_at: Some(SystemTime::now().into()),
             dpu_health: Some(rpc::health::HealthReport {
@@ -164,7 +167,7 @@ async fn test_managed_host_network_config(pool: sqlx::PgPool) {
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -208,7 +211,7 @@ async fn test_managed_host_network_config_does_not_clear_use_admin_network_chang
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -233,7 +236,7 @@ async fn test_record_dpu_network_status_clears_use_admin_network_changed_for_mat
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -334,7 +337,7 @@ async fn test_managed_host_network_config_with_sitewide_bgp_password(pool: sqlx:
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -449,7 +452,7 @@ async fn test_managed_host_network_config_narrows_interface_anycast_prefixes(poo
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(mh.dpu().id),
+            dpu_machine_id: Some(mh.dpu().id.into()),
         }))
         .await
         .unwrap()
@@ -626,7 +629,7 @@ async fn test_managed_host_network_config_includes_per_vpc_routing_profiles(pool
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(mh.dpu().id),
+            dpu_machine_id: Some(mh.dpu().id.into()),
         }))
         .await
         .unwrap()
@@ -719,7 +722,7 @@ async fn test_managed_host_network_config_omits_fnn_vrf_loopback_by_default(pool
 
     // Allocate a managed host on the FNN segment.
     let mh = create_managed_host(&env).await;
-    let dpu_machine_id = mh.dpu().id;
+    let dpu_machine_id = mh.dpu_ids[0];
     mh.instance_builer(&env)
         .tenant_org(tenant.organization_id)
         .single_interface_network_config(segment_id)
@@ -730,7 +733,7 @@ async fn test_managed_host_network_config_omits_fnn_vrf_loopback_by_default(pool
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -798,7 +801,7 @@ async fn test_managed_host_network_config_includes_fnn_vrf_loopback_when_enabled
 
     // Allocate a managed host on the FNN segment.
     let mh = create_managed_host(&env).await;
-    let dpu_machine_id = mh.dpu().id;
+    let dpu_machine_id = mh.dpu_ids[0];
     mh.instance_builer(&env)
         .tenant_org(tenant.organization_id)
         .single_interface_network_config(segment_id)
@@ -809,7 +812,7 @@ async fn test_managed_host_network_config_includes_fnn_vrf_loopback_when_enabled
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -873,13 +876,13 @@ async fn test_managed_host_network_config_omits_admin_fnn_vrf_loopback_by_defaul
 
     // Create a managed host that stays on the admin network.
     let mh = create_managed_host(&env).await;
-    let dpu_machine_id = mh.dpu().id;
+    let dpu_machine_id = mh.dpu_ids[0];
 
     // Fetch the DPU config and verify the FNN admin interface has no loopback.
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -963,7 +966,7 @@ async fn test_managed_host_network_config_errors_when_sitewide_bgp_password_miss
     let err = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .expect_err("missing site-wide BGP password should fail");
@@ -1103,13 +1106,13 @@ async fn test_managed_host_network_status(pool: sqlx::PgPool) {
         ],
         alerts: vec![],
     };
-    network_configured_with_health(&env, &mh.dpu().id, Some(dpu_health.clone())).await;
+    network_configured_with_health(&env, &mh.dpu_ids[0], Some(dpu_health.clone())).await;
 
     // Query the aggregate health.
     let reported_health = env
         .api
         .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-            machine_ids: vec![mh.dpu().id],
+            machine_ids: vec![mh.dpu().id.into()],
             include_history: false,
         }))
         .await
@@ -1129,7 +1132,7 @@ async fn test_managed_host_network_status(pool: sqlx::PgPool) {
     // Now fetch the instance and check that knows its configs have synced
     let response = env
         .api
-        .find_instance_by_machine_id(tonic::Request::new(mh.id))
+        .find_instance_by_machine_id(tonic::Request::new(mh.id.into()))
         .await
         .unwrap()
         .into_inner();
@@ -1264,7 +1267,7 @@ async fn test_managed_host_network_config_with_extension_services(pool: sqlx::Pg
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_1_id),
+            dpu_machine_id: Some(dpu_1_id.into()),
         }))
         .await
         .unwrap()
@@ -1318,7 +1321,7 @@ async fn test_dpu_health_is_required(pool: sqlx::PgPool) {
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -1330,7 +1333,7 @@ async fn test_dpu_health_is_required(pool: sqlx::PgPool) {
     let err = env
         .api
         .record_dpu_network_status(tonic::Request::new(DpuNetworkStatus {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
             dpu_agent_version: Some(dpu::TEST_DPU_AGENT_VERSION.to_string()),
             observed_at: Some(SystemTime::now().into()),
             dpu_health: None,
@@ -1396,7 +1399,7 @@ async fn test_retain_in_alert_since(pool: sqlx::PgPool) {
     let reported_health = env
         .api
         .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-            machine_ids: vec![dpu_machine_id],
+            machine_ids: vec![dpu_machine_id.into()],
             include_history: false,
         }))
         .await
@@ -1425,7 +1428,7 @@ async fn test_retain_in_alert_since(pool: sqlx::PgPool) {
     let reported_health = env
         .api
         .find_machines_by_ids(tonic::Request::new(rpc::forge::MachinesByIdsRequest {
-            machine_ids: vec![dpu_machine_id],
+            machine_ids: vec![dpu_machine_id.into()],
             include_history: false,
         }))
         .await
@@ -1462,7 +1465,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .api
             .get_managed_host_quarantine_state(tonic::Request::new(
                 rpc::forge::GetManagedHostQuarantineStateRequest {
-                    machine_id: Some(host_machine_id),
+                    machine_id: Some(host_machine_id.into()),
                 },
             ))
             .await?
@@ -1498,7 +1501,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .api
             .set_managed_host_quarantine_state(tonic::Request::new(
                 rpc::forge::SetManagedHostQuarantineStateRequest {
-                    machine_id: Some(host_machine_id),
+                    machine_id: Some(host_machine_id.into()),
                     quarantine_state: Some(rpc::forge::ManagedHostQuarantineState {
                         mode: rpc::forge::ManagedHostQuarantineMode::BlockAllTraffic as i32,
                         reason: Some("test reason 1".to_string()),
@@ -1527,7 +1530,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .machine_ids;
         assert_eq!(
             ids,
-            vec![host_machine_id],
+            vec![host_machine_id.into()],
             "Finding machine ID's with only_quarantine should have returned the quarantined host"
         );
     }
@@ -1555,7 +1558,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .api
             .get_managed_host_quarantine_state(tonic::Request::new(
                 rpc::forge::GetManagedHostQuarantineStateRequest {
-                    machine_id: Some(host_machine_id),
+                    machine_id: Some(host_machine_id.into()),
                 },
             ))
             .await?
@@ -1579,7 +1582,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .api
             .set_managed_host_quarantine_state(tonic::Request::new(
                 rpc::forge::SetManagedHostQuarantineStateRequest {
-                    machine_id: Some(host_machine_id),
+                    machine_id: Some(host_machine_id.into()),
                     quarantine_state: Some(rpc::forge::ManagedHostQuarantineState {
                         mode: rpc::forge::ManagedHostQuarantineMode::BlockAllTraffic as i32,
                         reason: Some("test reason 2".to_string()),
@@ -1622,7 +1625,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .api
             .get_managed_host_quarantine_state(tonic::Request::new(
                 rpc::forge::GetManagedHostQuarantineStateRequest {
-                    machine_id: Some(host_machine_id),
+                    machine_id: Some(host_machine_id.into()),
                 },
             ))
             .await?
@@ -1646,7 +1649,7 @@ async fn test_quarantine_state_crud(pool: sqlx::PgPool) -> Result<(), Box<dyn st
             .api
             .clear_managed_host_quarantine_state(tonic::Request::new(
                 rpc::forge::ClearManagedHostQuarantineStateRequest {
-                    machine_id: Some(host_machine_id),
+                    machine_id: Some(host_machine_id.into()),
                 },
             ))
             .await?

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -28,7 +28,7 @@ use carbide_redfish::libredfish::test_support::{RedfishSimAction, RedfishSimPlat
 use carbide_site_explorer::MachineCreator;
 use carbide_site_explorer::config::SiteExplorerConfig;
 use carbide_utils::arch::CpuArchitecture;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId, MachineId};
 use carbide_uuid::machine_validation::MachineValidationId;
 use chrono::{Duration, Utc};
 use common::api_fixtures::dpu::{
@@ -627,7 +627,8 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         "Bluefield 3 SmartNIC Main Card".to_string()
     );
 
-    let host_machine = db::machine::find_host_by_dpu_machine_id(&mut txn, &dpu_machine.id)
+    let dpu_machine_subtype_id = DpuMachineId::try_from(dpu_machine.id).unwrap();
+    let host_machine = db::machine::find_host_by_dpu_machine_id(&mut txn, &dpu_machine_subtype_id)
         .await?
         .unwrap();
     let host_machine_id = host_machine.id;
@@ -682,7 +683,9 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         dpu_machine.current_state(),
         &ManagedHostState::DpuDiscoveringState {
             dpu_states: model::machine::DpuDiscoveringStates {
-                states: HashMap::from([(dpu_machine.id, DpuDiscoveringState::Configuring)]),
+                states: HashMap::from([
+                    (dpu_machine_subtype_id, DpuDiscoveringState::Configuring,)
+                ]),
             },
         }
     );
@@ -704,7 +707,9 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         dpu_machine.current_state(),
         &ManagedHostState::DpuDiscoveringState {
             dpu_states: model::machine::DpuDiscoveringStates {
-                states: HashMap::from([(dpu_machine.id, DpuDiscoveringState::EnableRshim,)]),
+                states: HashMap::from([
+                    (dpu_machine_subtype_id, DpuDiscoveringState::EnableRshim,)
+                ]),
             },
         }
     );
@@ -727,7 +732,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         &ManagedHostState::DpuDiscoveringState {
             dpu_states: model::machine::DpuDiscoveringStates {
                 states: HashMap::from([(
-                    dpu_machine.id,
+                    dpu_machine_subtype_id,
                     DpuDiscoveringState::EnableSecureBoot {
                         enable_secure_boot_state: SetSecureBootState::CheckSecureBootStatus,
                         count: 0,
@@ -755,7 +760,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         &ManagedHostState::DpuDiscoveringState {
             dpu_states: model::machine::DpuDiscoveringStates {
                 states: HashMap::from([(
-                    dpu_machine.id,
+                    dpu_machine_subtype_id,
                     DpuDiscoveringState::EnableSecureBoot {
                         enable_secure_boot_state: SetSecureBootState::SetSecureBoot,
                         count: 0,
@@ -787,7 +792,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         &ManagedHostState::DPUInit {
             dpu_states: model::machine::DpuInitStates {
                 states: HashMap::from([(
-                    dpu_machine.id,
+                    dpu_machine_subtype_id,
                     DpuInitState::InstallDpuOs {
                         substate: InstallDpuOsState::InstallingBFB
                     }
@@ -815,7 +820,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         dpu_machine.current_state(),
         &ManagedHostState::DPUInit {
             dpu_states: model::machine::DpuInitStates {
-                states: HashMap::from([(dpu_machine.id, DpuInitState::Init,)]),
+                states: HashMap::from([(dpu_machine_subtype_id, DpuInitState::Init)]),
             },
         },
     );
@@ -894,7 +899,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         host_machine.current_state(),
         &ManagedHostState::DPUInit {
             dpu_states: model::machine::DpuInitStates {
-                states: HashMap::from([(dpu_machine.id, DpuInitState::Init,)]),
+                states: HashMap::from([(dpu_machine_subtype_id, DpuInitState::Init)]),
             },
         }
     );
@@ -955,7 +960,7 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
     let host = mh.host().db_machine(&mut txn).await;
 
     let clean_failed_req = tonic::Request::new(rpc::MachineCleanupInfo {
-        machine_id: mh.id.into(),
+        machine_id: Some(mh.id.into()),
         nvme: Some(
             rpc::protos::forge::machine_cleanup_info::CleanupStepResult {
                 result: rpc::protos::forge::machine_cleanup_info::CleanupResult::Error as i32,
@@ -996,7 +1001,7 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
 
     // Fail again
     let clean_failed_req = tonic::Request::new(rpc::MachineCleanupInfo {
-        machine_id: mh.id.into(),
+        machine_id: Some(mh.id.into()),
         nvme: Some(
             rpc::protos::forge::machine_cleanup_info::CleanupStepResult {
                 result: rpc::protos::forge::machine_cleanup_info::CleanupResult::Error as i32,
@@ -1030,7 +1035,7 @@ async fn test_nvme_clean_failed_state_host(pool: sqlx::PgPool) {
     ));
     // Now the host cleans up successfully.
     let clean_succeeded_req = tonic::Request::new(rpc::MachineCleanupInfo {
-        machine_id: mh.id.into(),
+        machine_id: Some(mh.id.into()),
         ..Default::default()
     });
     env.api
@@ -1164,7 +1169,7 @@ async fn test_repeated_initial_discovery_cleanup_failure_preserves_host_init_sou
     txn.commit().await.unwrap();
 
     env.api
-        .cleanup_machine_completed(cleanup_failed_request(mh.id))
+        .cleanup_machine_completed(cleanup_failed_request(mh.id.into()))
         .await
         .unwrap();
     env.run_machine_state_controller_iteration().await;
@@ -1192,7 +1197,7 @@ async fn test_repeated_initial_discovery_cleanup_failure_preserves_host_init_sou
     tokio::time::sleep(std::time::Duration::from_millis(1)).await;
 
     env.api
-        .cleanup_machine_completed(cleanup_failed_request(mh.id))
+        .cleanup_machine_completed(cleanup_failed_request(mh.id.into()))
         .await
         .unwrap();
 
@@ -1210,7 +1215,7 @@ async fn test_repeated_initial_discovery_cleanup_failure_preserves_host_init_sou
 
     env.api
         .cleanup_machine_completed(Request::new(rpc::MachineCleanupInfo {
-            machine_id: mh.id.into(),
+            machine_id: Some(mh.id.into()),
             ..Default::default()
         }))
         .await
@@ -1244,7 +1249,7 @@ async fn test_hdd_clean_failed_state_host(pool: sqlx::PgPool) {
     let host = mh.host().db_machine(&mut txn).await;
 
     let clean_failed_req = tonic::Request::new(rpc::MachineCleanupInfo {
-        machine_id: mh.id.into(),
+        machine_id: Some(mh.id.into()),
         hdd: Some(
             rpc::protos::forge::machine_cleanup_info::CleanupStepResult {
                 result: rpc::protos::forge::machine_cleanup_info::CleanupResult::Error as i32,
@@ -1469,11 +1474,11 @@ async fn test_failed_state_host_discovery_recovery(pool: sqlx::PgPool) {
 
     assert!(pxe.pxe_script.contains("scout.efi"));
 
-    let response = forge_agent_control(&env, mh.id).await;
+    let response = forge_agent_control(&env, mh.id.into()).await;
     assert!(matches!(response.action, Some(Action::Discovery(_))));
     assert_eq!(response.legacy_action, LegacyAction::Discovery as i32);
 
-    discovery_completed(&env, mh.id).await;
+    discovery_completed(&env, &mh.id).await;
 
     env.run_machine_state_controller_iteration().await;
     assert_eq!(
@@ -1562,7 +1567,7 @@ async fn test_failed_state_host_discovery_recovery(pool: sqlx::PgPool) {
     );
     txn.commit().await.unwrap();
 
-    let response = forge_agent_control(&env, mh.id).await;
+    let response = forge_agent_control(&env, mh.id.into()).await;
     assert!(matches!(response.action, Some(Action::Noop(_))));
     assert_eq!(response.legacy_action, LegacyAction::Noop as i32);
     env.run_machine_state_controller_iteration_until_state_matches(
@@ -1688,7 +1693,7 @@ async fn test_state_outcome(pool: sqlx::PgPool) {
     txn.rollback().await.unwrap();
     let expected_state = ManagedHostState::DPUInit {
         dpu_states: model::machine::DpuInitStates {
-            states: HashMap::from([(mh.dpu().id, DpuInitState::WaitingForNetworkConfig)]),
+            states: HashMap::from([(mh.dpu_ids[0], DpuInitState::WaitingForNetworkConfig)]),
         },
     };
     assert_eq!(
@@ -1783,7 +1788,7 @@ async fn test_predicted_host_parked_in_created_waits_for_initial_state_sync(
         let predicted = db::predicted_machine_interface::find_by_mac_address(&mut txn, inband_mac)
             .await?
             .expect("zero-DPU ingest should have minted a predicted interface");
-        predicted.machine_id
+        HostMachineId::try_from(predicted.machine_id).unwrap()
     };
     assert!(
         machine_id.machine_type().is_predicted_host(),
@@ -1846,7 +1851,7 @@ async fn test_state_sla(pool: sqlx::PgPool) {
                 failed_at: chrono::Utc::now(),
                 source: FailureSource::NoError,
             },
-            machine_id: mh.id,
+            machine_id: mh.id.into(),
             retry_count: 1,
         },
     )
@@ -2335,7 +2340,7 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
                 ),
                 ..Default::default()
             }),
-            machine_id: Some(host_machine_id),
+            machine_id: Some(host_machine_id.into()),
         }))
         .await
         .expect("Failed to add hardware health report to newly created machine");
@@ -2362,7 +2367,7 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
 
     env.api
         .cleanup_machine_completed(Request::new(rpc::MachineCleanupInfo {
-            machine_id: mh.id.into(),
+            machine_id: Some(mh.id.into()),
             ..Default::default()
         }))
         .await
@@ -2383,7 +2388,7 @@ async fn test_measurement_host_init_failed_to_waiting_for_measurements_to_pendin
 
     mh.host().discovery_completed().await;
 
-    host_uefi_setup(env, &host_machine_id).await;
+    host_uefi_setup(env, host_machine_id).await;
 
     env.run_machine_state_controller_iteration_until_state_matches(
         &host_machine_id,
@@ -2838,7 +2843,7 @@ async fn create_zero_dpu_test_env_with_overrides(
 
 /// Places a host directly in HostInit/SetBootOrder at the start of the
 /// boot-order flow, backdated so it reads as freshly entered.
-async fn set_host_stuck_in_set_boot_order(env: &TestEnv, host_id: MachineId) {
+async fn set_host_stuck_in_set_boot_order(env: &TestEnv, host_id: HostMachineId) {
     set_host_controller_state_stuck_in(
         env,
         host_id,
@@ -2887,7 +2892,7 @@ async fn drive_until_past_set_boot_order(
 /// boot-order phase resolves and targets. Looked up by segment type (the same
 /// way the admin boot-interface resolution tests locate it), since a zero-DPU
 /// host boots from its HostInband NIC.
-async fn host_inband_nic_mac(env: &TestEnv, host_id: MachineId) -> MacAddress {
+async fn host_inband_nic_mac(env: &TestEnv, host_id: HostMachineId) -> MacAddress {
     let mut txn = env.pool.begin().await.unwrap();
     db::machine_interface::find_by_machine_ids(txn.as_mut(), &[host_id])
         .await
@@ -3354,7 +3359,7 @@ async fn test_ready_boot_config_waits_for_all_dpu_network_config_versions(pool: 
     let mut txn = env.db_txn().await;
     db::machine::set_machine_maintenance_requested(
         txn.as_mut(),
-        mh.host().id,
+        mh.host().id.into(),
         "test",
         MachineMaintenanceOperation::PowerOff,
     )
@@ -4077,7 +4082,7 @@ async fn test_ready_periodic_boot_interface_drift_reenters_convergence(pool: sql
 #[crate::sqlx_test]
 async fn test_assigned_periodic_boot_interface_drift_defers_convergence(pool: sqlx::PgPool) {
     let (env, managed_host) = zero_dpu_host_with_instance(pool).await;
-    set_assigned_state(&env, &managed_host.host().id, InstanceState::Ready).await;
+    set_assigned_state(&env, &managed_host.id, InstanceState::Ready).await;
     let host_before = backdate_boot_interface_observation(&env, &managed_host).await;
     let desired_before = host_before
         .config
@@ -4515,7 +4520,7 @@ async fn test_ready_boot_config_machine_failure_does_not_wait_for_redfish(pool: 
         post_lock_verification_retry_count: 0,
         boot_config_state: ReadyBootConfigState::LockHost {
             post_lock_action: Some(ReadyBootConfigPostLockAction::Machine {
-                machine_id: mh.host().id,
+                machine_id: mh.host().id.into(),
                 details: details.clone(),
             }),
         },
@@ -4532,7 +4537,7 @@ async fn test_ready_boot_config_machine_failure_does_not_wait_for_redfish(pool: 
         host.current_state(),
         &ManagedHostState::Failed {
             details,
-            machine_id: mh.host().id,
+            machine_id: mh.host().id.into(),
             retry_count: 0,
         }
     );
@@ -4757,7 +4762,7 @@ async fn test_set_boot_order_skips_reapply_when_config_already_in_place(pool: sq
         mh.dpu_ids.is_empty(),
         "zero-DPU fixture should produce no DPU machines"
     );
-    let host_id = mh.host().id;
+    let host_id = mh.id;
 
     // Default sim: the HTTP-boot device and the boot order both read configured.
     set_host_stuck_in_set_boot_order(&env, host_id).await;
@@ -5768,11 +5773,17 @@ async fn test_validation_bios_setup_exhaustion_completes_active_validation(pool:
 
     let mh = create_managed_host(&env).await;
     let host_id = mh.host().id;
-    let validation_id =
-        on_demand_machine_validation(&env, host_id, Vec::new(), Vec::new(), false, Vec::new())
-            .await
-            .validation_id
-            .expect("on-demand validation should return an id");
+    let validation_id = on_demand_machine_validation(
+        &env,
+        host_id.into(),
+        Vec::new(),
+        Vec::new(),
+        false,
+        Vec::new(),
+    )
+    .await
+    .validation_id
+    .expect("on-demand validation should return an id");
 
     env.redfish_sim.set_is_bios_setup(false);
     set_host_controller_state_stuck_in(
@@ -5972,7 +5983,7 @@ async fn test_hpc_polling_bios_setup_exhausted_enters_failed_and_recovers_when_b
 
 async fn set_host_controller_state_stuck_in(
     env: &TestEnv,
-    host_id: MachineId,
+    host_id: HostMachineId,
     state: &ManagedHostState,
     minutes_in_state: i64,
 ) {
@@ -6015,7 +6026,7 @@ async fn test_scout_heartbeat_timeout_alert_cleared_on_ready_transition(pool: sq
 
     env.run_machine_state_controller_iteration().await;
 
-    on_demand_machine_validation(&env, host_machine_id, vec![], vec![], false, vec![]).await;
+    on_demand_machine_validation(&env, host_machine_id.into(), vec![], vec![], false, vec![]).await;
 
     let mut reached_validation = false;
     for _ in 0..5 {
@@ -6069,7 +6080,7 @@ async fn test_scout_heartbeat_timeout_alert_cleared_on_instance_creation_transit
     env.api
         .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: Some(host_machine_id),
+            machine_id: Some(host_machine_id.into()),
             instance_type_id: None,
             config: Some(rpc::InstanceConfig {
                 tenant: Some(default_tenant_config()),
@@ -6152,7 +6163,7 @@ async fn test_scout_heartbeat_timeout_alert_not_cleared_when_unhealthy_allocatio
         .api
         .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: Some(host_machine_id),
+            machine_id: Some(host_machine_id.into()),
             instance_type_id: None,
             config: Some(rpc::InstanceConfig {
                 tenant: Some(default_tenant_config()),
@@ -6309,7 +6320,7 @@ async fn zero_dpu_host_with_instance(pool: sqlx::PgPool) -> (TestEnv, TestManage
 
 /// Set the host directly into an `Assigned { instance_state }` state
 /// and commit so the next state controller iteration picks it up.
-async fn set_assigned_state(env: &TestEnv, host_id: &MachineId, instance_state: InstanceState) {
+async fn set_assigned_state(env: &TestEnv, host_id: &HostMachineId, instance_state: InstanceState) {
     let mut txn = env.db_txn().await;
     db::machine::update_state(
         txn.as_mut(),
@@ -6321,7 +6332,7 @@ async fn set_assigned_state(env: &TestEnv, host_id: &MachineId, instance_state: 
     txn.commit().await.unwrap();
 }
 
-async fn load_host_state(env: &TestEnv, host_id: &MachineId) -> ManagedHostState {
+async fn load_host_state(env: &TestEnv, host_id: &HostMachineId) -> ManagedHostState {
     db::machine::find_one(
         &env.pool,
         host_id,
@@ -6337,7 +6348,7 @@ async fn load_host_state(env: &TestEnv, host_id: &MachineId) -> ManagedHostState
 #[crate::sqlx_test]
 async fn test_waiting_for_reboot_requires_completion_when_phone_home_disabled(pool: sqlx::PgPool) {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.host().id;
+    let host_id = mh.id;
     let mut txn = env.db_txn().await;
     let snapshot = mh.snapshot(&mut txn).await;
     assert!(!snapshot.instance.unwrap().config.os.phone_home_enabled);
@@ -6360,7 +6371,7 @@ async fn test_waiting_for_reboot_requires_completion_when_phone_home_disabled(po
     assert_eq!(restart.verification_attempts, Some(0));
     txn.commit().await.unwrap();
 
-    reboot_completed(&env, host_id).await;
+    reboot_completed(&env, host_id.into()).await;
     env.run_machine_state_controller_iteration().await;
     assert_eq!(
         load_host_state(&env, &host_id).await,
@@ -6373,7 +6384,7 @@ async fn test_waiting_for_reboot_requires_completion_when_phone_home_disabled(po
 #[crate::sqlx_test]
 async fn test_waiting_for_reboot_restarts_after_power_on_substitution(pool: sqlx::PgPool) {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.host().id;
+    let host_id = mh.id;
 
     let mut txn = env.db_txn().await;
     let snapshot = mh.snapshot(&mut txn).await;
@@ -6434,7 +6445,7 @@ async fn test_waiting_for_reboot_restarts_after_power_on_substitution(pool: sqlx
 #[crate::sqlx_test]
 async fn test_waiting_for_reboot_keeps_transient_bmc_error_retryable(pool: sqlx::PgPool) {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.host().id;
+    let host_id = mh.id;
     env.redfish_sim.set_bmc_event_log_supported(true);
     set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
     env.run_machine_state_controller_iteration().await;
@@ -6483,7 +6494,7 @@ async fn test_waiting_for_reboot_keeps_transient_bmc_error_retryable(pool: sqlx:
 #[crate::sqlx_test]
 async fn test_waiting_for_reboot_exhausted_verification_is_non_destructive(pool: sqlx::PgPool) {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.host().id;
+    let host_id = mh.id;
     env.redfish_sim.set_bmc_event_log_supported(true);
     set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
     env.run_machine_state_controller_iteration().await;
@@ -6542,7 +6553,7 @@ async fn test_waiting_for_reboot_exhausted_verification_is_non_destructive(pool:
 #[crate::sqlx_test]
 async fn test_waiting_for_reboot_accepts_bmc_verification(pool: sqlx::PgPool) {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.host().id;
+    let host_id = mh.id;
     set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
     env.run_machine_state_controller_iteration().await;
 
@@ -6566,7 +6577,7 @@ async fn test_waiting_for_reboot_accepts_bmc_verification(pool: sqlx::PgPool) {
 #[crate::sqlx_test]
 async fn test_waiting_for_reboot_checks_health_for_zero_dpu(pool: sqlx::PgPool) {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.host().id;
+    let host_id = mh.id;
     set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
 
     let health_source = "test-reboot-health-gate";
@@ -6618,7 +6629,7 @@ async fn test_waiting_for_reboot_checks_health_for_zero_dpu(pool: sqlx::PgPool) 
         }
     );
 
-    reboot_completed(&env, host_id).await;
+    reboot_completed(&env, host_id.into()).await;
     env.run_machine_state_controller_iteration().await;
     assert_eq!(
         load_host_state(&env, &host_id).await,
@@ -6635,7 +6646,7 @@ async fn test_waiting_for_extension_services_config_skips_for_zero_dpu(
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
     set_assigned_state(
         &env,
-        &mh.host().id,
+        &mh.id,
         InstanceState::WaitingForExtensionServicesConfig,
     )
     .await;
@@ -6643,7 +6654,7 @@ async fn test_waiting_for_extension_services_config_skips_for_zero_dpu(
     env.run_machine_state_controller_iteration().await;
 
     assert!(matches!(
-        load_host_state(&env, &mh.host().id).await,
+        load_host_state(&env, &mh.id).await,
         ManagedHostState::Assigned {
             instance_state: InstanceState::WaitingForRebootToReady,
         }
@@ -6656,7 +6667,7 @@ async fn test_waiting_for_dpus_to_up_skips_wait_for_zero_dpu(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    set_assigned_state(&env, &mh.host().id, InstanceState::WaitingForDpusToUp).await;
+    set_assigned_state(&env, &mh.id, InstanceState::WaitingForDpusToUp).await;
 
     env.run_machine_state_controller_iteration().await;
 
@@ -6664,7 +6675,7 @@ async fn test_waiting_for_dpus_to_up_skips_wait_for_zero_dpu(
     // "Waiting for DPUs to come up" wait and the state would be
     // unchanged. With the guard, we proceed past the wait into the
     // termination/reboot path.
-    let state = load_host_state(&env, &mh.host().id).await;
+    let state = load_host_state(&env, &mh.id).await;
     assert!(
         !matches!(
             state,
@@ -6684,7 +6695,7 @@ async fn test_dpu_reprovision_errors_for_zero_dpu(
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
     set_assigned_state(
         &env,
-        &mh.host().id,
+        &mh.id,
         InstanceState::DPUReprovision {
             dpu_states: DpuReprovisionStates {
                 states: HashMap::new(),
@@ -6699,7 +6710,7 @@ async fn test_dpu_reprovision_errors_for_zero_dpu(
     // as a handler failure rather than silently advancing. The host
     // should not have transitioned out of DPUReprovision.
     assert!(matches!(
-        load_host_state(&env, &mh.host().id).await,
+        load_host_state(&env, &mh.id).await,
         ManagedHostState::Assigned {
             instance_state: InstanceState::DPUReprovision { .. },
         }
@@ -6723,7 +6734,7 @@ async fn test_host_level_dpu_reprovision_errors_for_zero_dpu(
     let mut txn = env.db_txn().await;
     db::machine::update_state(
         txn.as_mut(),
-        &mh.host().id,
+        &mh.id,
         &ManagedHostState::DPUReprovision {
             dpu_states: DpuReprovisionStates {
                 states: HashMap::new(),
@@ -6740,7 +6751,7 @@ async fn test_host_level_dpu_reprovision_errors_for_zero_dpu(
     // a handler failure rather than silently advancing. The host stays in
     // DPUReprovision.
     assert!(matches!(
-        load_host_state(&env, &mh.host().id).await,
+        load_host_state(&env, &mh.id).await,
         ManagedHostState::DPUReprovision { .. }
     ));
     Ok(())

--- a/crates/api-core/src/tests/machine_topology.rs
+++ b/crates/api-core/src/tests/machine_topology.rs
@@ -78,7 +78,7 @@ async fn test_find_machine_ids_by_bmc_ips(db_pool: sqlx::PgPool) -> Result<(), e
     // Setup
     let env = create_test_env(db_pool.clone()).await;
     let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
-    let host_machine = env.find_machine(host_machine_id).await.remove(0);
+    let host_machine = env.find_machine(&host_machine_id).await.remove(0);
 
     let bmc_ip = host_machine.bmc_info.as_ref().unwrap().ip();
     let req = tonic::Request::new(rpc::forge::BmcIpList {

--- a/crates/api-core/src/tests/machine_update_manager.rs
+++ b/crates/api-core/src/tests/machine_update_manager.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use async_trait::async_trait;
 use carbide_machine_controller::health_report::create_host_update_health_report;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use common::api_fixtures::create_test_env;
 use figment::Figment;
 use figment::providers::{Format, Toml};
@@ -65,7 +65,7 @@ impl MachineUpdateModule for TestUpdateModule {
         _pool: &sqlx::Pool<sqlx::Postgres>,
         _available_updates: i32,
         _updating_machines: &HashSet<MachineId>,
-        _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        _snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<HashSet<MachineId>> {
         if let Ok(mut guard) = self.start_updates_called.lock() {
             (*guard) += 1;
@@ -84,7 +84,7 @@ impl MachineUpdateModule for TestUpdateModule {
     async fn update_metrics(
         &self,
         _pool: &sqlx::Pool<sqlx::Postgres>,
-        _snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        _snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
     ) -> CarbideResult<()> {
         Ok(())
     }
@@ -133,7 +133,7 @@ async fn test_max_outstanding_updates(
     );
 
     let mut machines_started = HashSet::default();
-    machines_started.insert(dpu_machine_id);
+    machines_started.insert(dpu_machine_id.into());
 
     let module1 = Box::new(TestUpdateModule::new(vec![], machines_started));
     let module2 = Box::new(TestUpdateModule::new(vec![], HashSet::default()));
@@ -377,7 +377,10 @@ async fn test_get_updating_machines(pool: sqlx::PgPool) -> Result<(), Box<dyn st
         .unwrap();
 
     assert_eq!(machines.len(), 1);
-    assert_eq!(machines.iter().next().unwrap(), &host_machine_id1);
+    assert_eq!(
+        machines.iter().next().unwrap(),
+        host_machine_id1.as_machine_id()
+    );
 
     Ok(())
 }

--- a/crates/api-core/src/tests/machine_validation.rs
+++ b/crates/api-core/src/tests/machine_validation.rs
@@ -200,7 +200,7 @@ async fn test_machine_validation_with_error(
     env.api
         .machine_validation_completed(tonic::Request::new(
             rpc::forge::MachineValidationCompletedRequest {
-                machine_id: Some(mh.host().id),
+                machine_id: Some(mh.host().id.into()),
                 machine_validation_error: None,
                 validation_id: Some(validation_id),
             },
@@ -2019,7 +2019,7 @@ async fn test_machine_validation_manager_reconciles_stale_run(
     env.api
         .machine_validation_completed(tonic::Request::new(
             rpc::forge::MachineValidationCompletedRequest {
-                machine_id: Some(mh.host().id),
+                machine_id: Some(mh.host().id.into()),
                 machine_validation_error: None,
                 validation_id: Some(validation_id),
             },

--- a/crates/api-core/src/tests/maintenance.rs
+++ b/crates/api-core/src/tests/maintenance.rs
@@ -37,7 +37,7 @@ async fn test_maintenance_multi_dpu(db_pool: sqlx::PgPool) -> Result<(), eyre::R
     // enable maintenance mode
     let req = rpcf::MaintenanceRequest {
         operation: rpcf::MaintenanceOperation::Enable.into(),
-        host_id: Some(mh.host().id),
+        host_id: Some(mh.host().id.into()),
         reference: Some("https://jira.example.com/ABC-123".to_string()),
     };
     env.api
@@ -60,7 +60,7 @@ async fn test_maintenance_multi_dpu(db_pool: sqlx::PgPool) -> Result<(), eyre::R
     // allocate: should fail
     let req = rpcf::InstanceAllocationRequest {
         instance_id: None,
-        machine_id: Some(mh.host().id),
+        machine_id: Some(mh.host().id.into()),
         instance_type_id: None,
         config: Some(instance_config.clone()),
         metadata: Some(rpcf::Metadata {
@@ -98,14 +98,14 @@ async fn test_maintenance_multi_dpu(db_pool: sqlx::PgPool) -> Result<(), eyre::R
     assert_eq!(machine_ids.len(), 1); // Host
     assert_eq!(
         machine_ids[0],
-        mh.host().id,
+        mh.host().id.into(),
         "Listing maintenance machines return incorrectly machines"
     );
 
     // disable maintenance
     let req = tonic::Request::new(rpcf::MaintenanceRequest {
         operation: rpcf::MaintenanceOperation::Disable.into(),
-        host_id: Some(mh.host().id),
+        host_id: Some(mh.host().id.into()),
         reference: None,
     });
     env.api.set_maintenance(req).await.unwrap();
@@ -127,7 +127,7 @@ async fn test_maintenance_multi_dpu(db_pool: sqlx::PgPool) -> Result<(), eyre::R
     // allocate: should succeed
     let req = rpcf::InstanceAllocationRequest {
         instance_id: None,
-        machine_id: Some(mh.host().id),
+        machine_id: Some(mh.host().id.into()),
         instance_type_id: None,
         config: Some(instance_config),
         metadata: Some(rpc::Metadata {
@@ -156,7 +156,7 @@ async fn test_maintenance_suppresses_state_machine_sla_alert(
 ) -> Result<(), eyre::Report> {
     let env = create_test_env(db_pool.clone()).await;
     let (host_id, _dpu_id) = create_managed_host(&env).await.into();
-    let rpc_host_id: MachineId = host_id;
+    let rpc_host_id: MachineId = host_id.into();
 
     // force the host into Failed state (0-second SLA).
     // this is what would otherwise drive `carbide_machines_per_state_above_sla > 0`
@@ -171,7 +171,7 @@ async fn test_maintenance_suppresses_state_machine_sla_alert(
                 failed_at: chrono::Utc::now(),
                 source: FailureSource::NoError,
             },
-            machine_id: host_id,
+            machine_id: host_id.into(),
             retry_count: 1,
         },
     )
@@ -181,7 +181,7 @@ async fn test_maintenance_suppresses_state_machine_sla_alert(
 
     // with no maintenance override, the machine reports as
     // above-SLA and would be counted by the stuck-instance alert metric.
-    let machine = env.find_machine(rpc_host_id).await.remove(0);
+    let machine = env.find_machine(&rpc_host_id).await.remove(0);
     let sla = machine.state_sla.as_ref().unwrap();
     assert!(
         sla.time_in_state_above_sla,
@@ -201,7 +201,7 @@ async fn test_maintenance_suppresses_state_machine_sla_alert(
     // SetMaintenance now adds the ExcludeFromStateMachineSla
     // classification, so state_sla() short-circuits to no_sla() and the
     // host stops contributing to the stuck-instance Prometheus metric.
-    let machine = env.find_machine(rpc_host_id).await.remove(0);
+    let machine = env.find_machine(&rpc_host_id).await.remove(0);
     let sla = machine.state_sla.as_ref().unwrap();
     assert!(
         !sla.time_in_state_above_sla,
@@ -222,7 +222,7 @@ async fn test_maintenance_suppresses_state_machine_sla_alert(
         .await
         .unwrap();
 
-    let machine = env.find_machine(rpc_host_id).await.remove(0);
+    let machine = env.find_machine(&rpc_host_id).await.remove(0);
     let sla = machine.state_sla.as_ref().unwrap();
     assert!(
         sla.time_in_state_above_sla,

--- a/crates/api-core/src/tests/managed_host_decommissioning.rs
+++ b/crates/api-core/src/tests/managed_host_decommissioning.rs
@@ -44,7 +44,7 @@ async fn decommission_requires_redfish_bfb_install_support(pool: sqlx::PgPool) {
     let error = env
         .api
         .decommission_managed_host(Request::new(DecommissionManagedHostRequest {
-            machine_id: Some(managed_host.id),
+            machine_id: Some(managed_host.id.into()),
         }))
         .await
         .unwrap_err();
@@ -78,7 +78,7 @@ async fn decommission_requires_redfish_bfb_install_support(pool: sqlx::PgPool) {
 
     env.api
         .decommission_managed_host(Request::new(DecommissionManagedHostRequest {
-            machine_id: Some(managed_host.id),
+            machine_id: Some(managed_host.id.into()),
         }))
         .await
         .unwrap();

--- a/crates/api-core/src/tests/nvl_instance.rs
+++ b/crates/api-core/src/tests/nvl_instance.rs
@@ -219,7 +219,7 @@ async fn test_create_instance_with_nvl_config(pool: sqlx::PgPool) {
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -395,7 +395,7 @@ async fn test_detach_gpus_from_partition_by_clearing_nvlink_config(pool: sqlx::P
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -614,7 +614,7 @@ async fn test_with_multiple_nv_link_logical_partitions(pool: sqlx::PgPool) {
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -1198,7 +1198,7 @@ async fn test_instance_delete_with_nvl_config(pool: sqlx::PgPool) {
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -1310,7 +1310,7 @@ async fn test_create_instance_add_to_existing_partition(pool: sqlx::PgPool) {
     assert_eq!(&machine1.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh1.id);
+    assert_eq!(instance.machine_id(), mh1.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -1390,7 +1390,7 @@ async fn test_create_instance_add_to_existing_partition(pool: sqlx::PgPool) {
     let machine2 = mh2.host().rpc_machine().await;
     assert_eq!(&machine2.state, "Assigned/Ready");
     let check_instance2 = tinstance2.rpc_instance().await;
-    assert_eq!(instance2.machine_id(), mh2.id);
+    assert_eq!(instance2.machine_id(), mh2.id.into());
     assert_eq!(instance2.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance2, check_instance2);
 
@@ -1503,7 +1503,7 @@ async fn test_logical_partition_delete_with_instance_config(pool: sqlx::PgPool) 
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -1837,7 +1837,7 @@ async fn test_create_instance_gpu_in_unknown_partition(pool: sqlx::PgPool) {
     assert_eq!(&machine1.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh1.id);
+    assert_eq!(instance.machine_id(), mh1.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -2047,7 +2047,7 @@ async fn run_create_instance_with_nvl_config_nmxc_simulator_scenario(
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -2381,11 +2381,20 @@ async fn test_rack_switch_create_instance_with_nvl_config_use_nmxc_simulator(poo
     .await
     .expect("create managed host");
     let mh = TestManagedHost {
-        id: mh_snapshot.host_snapshot.id,
+        id: mh_snapshot
+            .host_snapshot
+            .id
+            .try_into()
+            .expect("host snapshot ID should be a valid HostMachineId"),
         dpu_ids: mh_snapshot
             .dpu_snapshots
             .into_iter()
-            .map(|snapshot| snapshot.id)
+            .map(|snapshot| {
+                snapshot
+                    .id
+                    .try_into()
+                    .expect("DPU snapshot ID should be a valid DpuMachineId")
+            })
             .collect(),
         api: env.api.clone(),
     };
@@ -2434,7 +2443,7 @@ async fn test_rack_switch_create_instance_with_nvl_config_use_nmxc_simulator(poo
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 
@@ -2897,7 +2906,7 @@ async fn test_instance_delete_with_nvl_config_use_nmxc_simulator(pool: sqlx::PgP
     assert_eq!(&machine.state, "Assigned/Ready");
 
     let check_instance = tinstance.rpc_instance().await;
-    assert_eq!(instance.machine_id(), mh.id);
+    assert_eq!(instance.machine_id(), mh.id.into());
     assert_eq!(instance.status().tenant(), rpc::TenantState::Ready);
     assert_eq!(instance, check_instance);
 

--- a/crates/api-core/src/tests/primary_interface.rs
+++ b/crates/api-core/src/tests/primary_interface.rs
@@ -1066,7 +1066,7 @@ async fn test_set_primary_interface_rejects_deleted_instance_and_rolls_back_writ
     let mut deletion = env.pool.begin().await?;
     db::instance::mark_as_deleted(instance.id, deletion.as_mut()).await?;
     deletion.commit().await?;
-    let state_before = load_set_primary_persistence_state(&env.pool, host_id).await?;
+    let state_before = load_set_primary_persistence_state(&env.pool, host_id.into()).await?;
 
     struct Case {
         name: &'static str,
@@ -1090,7 +1090,7 @@ async fn test_set_primary_interface_rejects_deleted_instance_and_rolls_back_writ
         let error = env
             .api
             .set_primary_interface(tonic::Request::new(forge::SetPrimaryInterfaceRequest {
-                host_machine_id: Some(host_id),
+                host_machine_id: Some(host_id.into()),
                 interface_id: Some(case.interface_id),
                 force_reconcile: case.force_reconcile,
                 ..Default::default()
@@ -1103,7 +1103,7 @@ async fn test_set_primary_interface_rejects_deleted_instance_and_rolls_back_writ
             format!("instance {} is being deleted", instance.id),
         );
 
-        let state_after = load_set_primary_persistence_state(&env.pool, host_id).await?;
+        let state_after = load_set_primary_persistence_state(&env.pool, host_id.into()).await?;
         assert_eq!(state_after, state_before, "{} persisted state", case.name);
     }
 

--- a/crates/api-core/src/tests/site_explorer.rs
+++ b/crates/api-core/src/tests/site_explorer.rs
@@ -510,7 +510,7 @@ async fn test_get_machine_position_info(pool: PgPool) -> Result<(), Box<dyn std:
     let (_host_machine_id, dpu_machine_id) =
         common::api_fixtures::create_managed_host(&env).await.into();
 
-    let dpu_machine = env.find_machine(dpu_machine_id).await.remove(0);
+    let dpu_machine = env.find_machine(&dpu_machine_id).await.remove(0);
     let bmc_ip: IpAddr = dpu_machine.bmc_info.as_ref().unwrap().ip().parse().unwrap();
 
     // Get the existing explored endpoint (created by create_managed_host) and update it with position info
@@ -540,7 +540,7 @@ async fn test_get_machine_position_info(pool: PgPool) -> Result<(), Box<dyn std:
     let response = env
         .api
         .get_machine_position_info(tonic::Request::new(rpc::forge::MachinePositionQuery {
-            machine_ids: vec![dpu_machine_id],
+            machine_ids: vec![dpu_machine_id.into()],
         }))
         .await?
         .into_inner();
@@ -548,7 +548,7 @@ async fn test_get_machine_position_info(pool: PgPool) -> Result<(), Box<dyn std:
     // Verify the response
     assert_eq!(response.machine_position_info.len(), 1);
     let info = &response.machine_position_info[0];
-    assert_eq!(info.machine_id, Some(dpu_machine_id));
+    assert_eq!(info.machine_id, Some(dpu_machine_id.into()));
     assert_eq!(info.physical_slot_number, Some(5));
     assert_eq!(info.compute_tray_index, Some(2));
     assert_eq!(info.topology_id, Some(10));
@@ -574,7 +574,7 @@ async fn test_get_machine_position_info_no_endpoint(
     let response = env
         .api
         .get_machine_position_info(tonic::Request::new(rpc::forge::MachinePositionQuery {
-            machine_ids: vec![dpu_machine_id],
+            machine_ids: vec![dpu_machine_id.into()],
         }))
         .await?
         .into_inner();
@@ -582,7 +582,7 @@ async fn test_get_machine_position_info_no_endpoint(
     // Machine should be in the response but with all None position info
     assert_eq!(response.machine_position_info.len(), 1);
     let info = &response.machine_position_info[0];
-    assert_eq!(info.machine_id, Some(dpu_machine_id));
+    assert_eq!(info.machine_id, Some(dpu_machine_id.into()));
     assert_eq!(info.physical_slot_number, None);
     assert_eq!(info.compute_tray_index, None);
     assert_eq!(info.topology_id, None);

--- a/crates/api-core/src/tests/spdm.rs
+++ b/crates/api-core/src/tests/spdm.rs
@@ -66,7 +66,7 @@ pub(in crate::tests) mod tests {
         let status = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
-                machine_id: Some(machine_id),
+                machine_id: Some(machine_id.into()),
                 redfish_timeout_secs: u32::MAX,
             }))
             .await
@@ -102,7 +102,7 @@ pub(in crate::tests) mod tests {
         let response = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
-                machine_id: Some(machine_id),
+                machine_id: Some(machine_id.into()),
                 redfish_timeout_secs: u32::MAX,
             }))
             .await?;
@@ -138,7 +138,7 @@ pub(in crate::tests) mod tests {
         let response = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
-                machine_id: Some(machine_id),
+                machine_id: Some(machine_id.into()),
                 redfish_timeout_secs: u32::MAX,
             }))
             .await?;
@@ -199,7 +199,7 @@ pub(in crate::tests) mod tests {
         let response = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
-                machine_id: Some(machine_id),
+                machine_id: Some(machine_id.into()),
                 redfish_timeout_secs: u32::MAX,
             }))
             .await?;
@@ -284,7 +284,7 @@ pub(in crate::tests) mod tests {
         let _ = env
             .api
             .trigger_machine_attestation(Request::new(SpdmMachineAttestationTriggerRequest {
-                machine_id: Some(machine_id),
+                machine_id: Some(machine_id.into()),
                 redfish_timeout_secs: u32::MAX,
             }))
             .await?;

--- a/crates/api-core/src/tests/vpc_peering.rs
+++ b/crates/api-core/src/tests/vpc_peering.rs
@@ -16,7 +16,7 @@
  */
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, MachineId};
 use carbide_uuid::vpc::VpcId;
 use carbide_uuid::vpc_peering::VpcPeeringId;
 use futures_util::{FutureExt, TryFutureExt};
@@ -46,7 +46,7 @@ async fn create_test_vpcs(
     env: &TestEnv,
     count: i32,
     vtype: Option<VpcVirtualizationType>,
-) -> Result<MachineId, Box<dyn std::error::Error>> {
+) -> Result<DpuMachineId, Box<dyn std::error::Error>> {
     let default_tenant = default_tenant_config();
     let tenant_organization_id =
         if matches!(vtype, Some(VpcVirtualizationType::Fnn)) && env.config.fnn.is_some() {
@@ -430,7 +430,7 @@ async fn create_vpc_peering(
     env: &TestEnv,
     vtype1: VpcVirtualizationType,
     vtype2: VpcVirtualizationType,
-) -> Result<(VpcId, VpcId, u32, u32, MachineId), Box<dyn std::error::Error>> {
+) -> Result<(VpcId, VpcId, u32, u32, DpuMachineId), Box<dyn std::error::Error>> {
     let default_tenant = default_tenant_config();
     let peer_tenant_organization_id = "Tenant2";
     let use_fixture_tenants = env.config.fnn.is_some()
@@ -508,7 +508,7 @@ async fn test_vpc_peering_network_config(
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -555,7 +555,7 @@ async fn test_vpc_peering_network_config_exclusive_etv(
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -588,7 +588,7 @@ async fn test_vpc_peering_deletion_upon_vpc_deletion(
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -613,7 +613,7 @@ async fn test_vpc_peering_deletion_upon_vpc_deletion(
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .unwrap()
@@ -685,7 +685,7 @@ async fn test_vpc_peering_network_config_ordered_peerings(
     let response = env
         .api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await?
         .into_inner();

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -615,7 +615,7 @@ async fn test_deleted_vpc_prefix_cannot_allocate_new_instance_interface(
         .api
         .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: Some(managed_host.host().id),
+            machine_id: Some(managed_host.host().id.into()),
             instance_type_id: None,
             config: Some(rpc::forge::InstanceConfig {
                 tenant: Some(fixture_tenant_config()),

--- a/crates/api-core/tests/integration/compute_allocation.rs
+++ b/crates/api-core/tests/integration/compute_allocation.rs
@@ -25,7 +25,7 @@ use carbide_test_harness::dns::TestDomain;
 use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
 use carbide_uuid::instance_type::InstanceTypeId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use carbide_uuid::network::NetworkSegmentId;
 use model::instance_type::InstanceTypeMachineCapabilityFilter;
 use model::machine::capabilities::MachineCapabilityType;
@@ -79,7 +79,7 @@ impl TestEnvOverrides {
 }
 
 struct TestManagedHost {
-    id: MachineId,
+    id: HostMachineId,
 }
 
 async fn create_test_env(pool: PgPool) -> TestEnv {
@@ -256,7 +256,7 @@ async fn allocate_instance(
     env.api
         .allocate_instance(Request::new(rpc::forge::InstanceAllocationRequest {
             instance_id: None,
-            machine_id: Some(host.id),
+            machine_id: Some(host.id.into()),
             instance_type_id: instance_type_id.map(str::to_string),
             config: Some(rpc::forge::InstanceConfig {
                 tenant: Some(rpc::forge::TenantConfig {
@@ -1506,7 +1506,7 @@ async fn test_remove_machine_association(
     let bound_instance_type = env
         .api
         .find_machines_by_ids(Request::new(rpc::forge::MachinesByIdsRequest {
-            machine_ids: vec![host_to_remove.id],
+            machine_ids: vec![host_to_remove.id.into()],
             ..Default::default()
         }))
         .await

--- a/crates/api-core/tests/integration/dns_resolution.rs
+++ b/crates/api-core/tests/integration/dns_resolution.rs
@@ -167,7 +167,10 @@ async fn test_dns(pool: PgPool) {
 
     // And now check to make sure the DNS records exist and,
     // of course, that they are correct.
-    let machine_ids: [MachineId; 2] = [managed_host.host.id, managed_host.first_dpu().id];
+    let machine_ids: [MachineId; 2] = [
+        managed_host.host.id.into(),
+        managed_host.first_dpu().id.into(),
+    ];
     for machine_id in &machine_ids {
         let mut txn = env.db_txn().await;
 

--- a/crates/api-core/tests/integration/dpa_interfaces.rs
+++ b/crates/api-core/tests/integration/dpa_interfaces.rs
@@ -44,7 +44,7 @@ async fn dpa_api_test_cases(pool: PgPool) -> Result<(), Box<dyn std::error::Erro
 
     let cr_request = tonic::Request::new(DpaInterfaceCreationRequest {
         mac_addr: "00:11:22:33:44:55".to_string(),
-        machine_id: Some(managed_host.host.id),
+        machine_id: Some(managed_host.host.id.into()),
         device_type: "BlueField3".to_string(),
         pci_name: "0000:cc:00.0".to_string(),
         device_description: Some("NVIDIA BlueField-3 B3140L E-Series FHHL SuperNIC; 400GbE / NDR IB (default mode); Single-port QSFP112
@@ -105,7 +105,7 @@ async fn dpa_scout_request_returns_typed_mlx_action(
         .api()
         .create_dpa_interface(tonic::Request::new(DpaInterfaceCreationRequest {
             mac_addr: "00:11:22:33:44:55".to_string(),
-            machine_id: Some(managed_host.host.id),
+            machine_id: Some(managed_host.host.id.into()),
             device_type: "BlueField3".to_string(),
             pci_name: "0000:cc:00.0".to_string(),
             device_description: Some("NVIDIA BlueField-3 B3140L E-Series FHHL SuperNIC; 400GbE / NDR IB (default mode); Single-port QSFP112".to_string()),

--- a/crates/api-core/tests/integration/dpu_agent_upgrade.rs
+++ b/crates/api-core/tests/integration/dpu_agent_upgrade.rs
@@ -23,7 +23,7 @@ use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::{
     FixtureDefault as _, ManagedHostConfigExt as _,
 };
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use chrono::{Duration, Utc};
 use health_report::{HealthAlertClassification, HealthProbeAlert, HealthProbeId};
 use model::test_support::ManagedHostConfig;
@@ -55,10 +55,10 @@ async fn init(pool: PgPool) -> (TestHarness, TestManagedHost) {
 }
 
 /// Helper: call record_dpu_network_status with an old agent version.
-async fn report_old_agent_version(env: &TestHarness, dpu_machine_id: MachineId) {
+async fn report_old_agent_version(env: &TestHarness, dpu_machine_id: DpuMachineId) {
     env.api()
         .record_dpu_network_status(tonic::Request::new(rpc::DpuNetworkStatus {
-            dpu_machine_id: dpu_machine_id.into(),
+            dpu_machine_id: Some(dpu_machine_id.into()),
             dpu_agent_version: Some("v2023.06-rc2-1-gc5c05de3".to_string()),
             observed_at: None,
             dpu_health: Some(::rpc::health::HealthReport {
@@ -85,7 +85,7 @@ async fn report_old_agent_version(env: &TestHarness, dpu_machine_id: MachineId) 
         .unwrap();
 }
 
-async fn upgrade_needed(env: &TestHarness, dpu_machine_id: MachineId) -> bool {
+async fn upgrade_needed(env: &TestHarness, dpu_machine_id: DpuMachineId) -> bool {
     env.api()
         .dpu_agent_upgrade_check(tonic::Request::new(rpc::DpuAgentUpgradeCheckRequest {
             machine_id: dpu_machine_id.to_string(),
@@ -193,7 +193,7 @@ async fn test_upgrade_check(db_pool: PgPool) -> Result<(), eyre::Report> {
         .api()
         .get_managed_host_network_config(tonic::Request::new(
             rpc::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: dpu_machine_id.into(),
+                dpu_machine_id: Some(dpu_machine_id.into()),
             },
         ))
         .await?
@@ -204,7 +204,7 @@ async fn test_upgrade_check(db_pool: PgPool) -> Result<(), eyre::Report> {
     let network_config_version = response.managed_host_config_version.clone();
     env.api()
         .record_dpu_network_status(tonic::Request::new(rpc::DpuNetworkStatus {
-            dpu_machine_id: dpu_machine_id.into(),
+            dpu_machine_id: Some(dpu_machine_id.into()),
             // BEGIN This is the important line for this test
             dpu_agent_version: Some("v2023.06-rc2-1-gc5c05de3".to_string()),
             // END
@@ -310,7 +310,7 @@ async fn test_dpu_agent_version_staleness(db_pool: PgPool) -> Result<(), eyre::R
         .api()
         .get_managed_host_network_config(tonic::Request::new(
             rpc::ManagedHostNetworkConfigRequest {
-                dpu_machine_id: mh.first_dpu().id.into(),
+                dpu_machine_id: Some(mh.first_dpu().id.into()),
             },
         ))
         .await?
@@ -400,7 +400,7 @@ impl TestManagedHostDpuAgentExt for TestManagedHost {
         test_env
             .api()
             .record_dpu_network_status(tonic::Request::new(rpc::DpuNetworkStatus {
-                dpu_machine_id: self.first_dpu().id.into(),
+                dpu_machine_id: Some(self.first_dpu().id.into()),
                 dpu_agent_version: agent_version.map(Into::into),
                 observed_at: None,
                 dpu_health: Some(::rpc::health::HealthReport {
@@ -438,7 +438,7 @@ impl TestManagedHostDpuAgentExt for TestManagedHost {
         let alerts = test_env
             .api()
             .find_machines_by_ids(tonic::Request::new(rpc::MachinesByIdsRequest {
-                machine_ids: vec![self.host.id],
+                machine_ids: vec![self.host.id.into()],
                 include_history: false,
             }))
             .await

--- a/crates/api-core/tests/integration/dpu_info_list.rs
+++ b/crates/api-core/tests/integration/dpu_info_list.rs
@@ -67,7 +67,7 @@ async fn test_get_dpu_info_list(pool: PgPool) {
     // Persist a current network status with fabric interface data for one DPU.
     env.api()
         .record_dpu_network_status(tonic::Request::new(DpuNetworkStatus {
-            dpu_machine_id: Some(dpu_machine_id_1),
+            dpu_machine_id: Some(dpu_machine_id_1.into()),
             dpu_agent_version: Some("test".to_string()),
             observed_at: Some(heartbeat_timestamp),
             dpu_health: Some(rpc::health::HealthReport {

--- a/crates/api-core/tests/integration/dpu_machine_inventory.rs
+++ b/crates/api-core/tests/integration/dpu_machine_inventory.rs
@@ -49,7 +49,7 @@ async fn test_create_inventory(pool: PgPool) -> Result<(), eyre::Report> {
 
     env.api()
         .update_agent_reported_inventory(Request::new(rpc::DpuAgentInventoryReport {
-            machine_id: Some(dpu.id),
+            machine_id: Some(dpu.id.into()),
             inventory: Some(expected_inventory.clone()),
         }))
         .await?;

--- a/crates/api-core/tests/integration/forge_agent_control.rs
+++ b/crates/api-core/tests/integration/forge_agent_control.rs
@@ -405,7 +405,7 @@ async fn failed_discovery_returns_discovery(pool: PgPool) {
             failed_at: chrono::Utc::now(),
             source: FailureSource::Scout,
         },
-        machine_id: mh.host.id,
+        machine_id: mh.host.id.into(),
         retry_count: 0,
     })
     .await;

--- a/crates/api-core/tests/integration/machine_boot_interfaces.rs
+++ b/crates/api-core/tests/integration/machine_boot_interfaces.rs
@@ -78,7 +78,7 @@ async fn test_expected_machine_selection_source_survives_ingestion(
         .api()
         .get_machine_boot_interfaces(tonic::Request::new(
             forge::GetMachineBootInterfacesRequest {
-                machine_id: Some(host.host.id),
+                machine_id: Some(host.host.id.into()),
             },
         ))
         .await?
@@ -167,13 +167,15 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
         // the owned primary -- naming the same boot NIC, so it adds no new
         // distinct boot-MAC signal and leaves the divergence verdict to the
         // conflicting prediction.
-        let bmc_ip: std::net::IpAddr =
-            db::machine_topology::find_machine_bmc_pairs_by_machine_id(txn.as_mut(), vec![host_id])
-                .await?
-                .into_iter()
-                .find_map(|(_, ip)| ip)
-                .expect("the ingested host should have a BMC address")
-                .parse()?;
+        let bmc_ip: std::net::IpAddr = db::machine_topology::find_machine_bmc_pairs_by_machine_id(
+            txn.as_mut(),
+            vec![host_id.into()],
+        )
+        .await?
+        .into_iter()
+        .find_map(|(_, ip)| ip)
+        .expect("the ingested host should have a BMC address")
+        .parse()?;
         db::explored_endpoints::set_boot_interface(
             bmc_ip,
             &model::machine_boot_interface::MachineBootInterface {
@@ -200,13 +202,13 @@ async fn test_get_machine_boot_interfaces_gathers_all_four_stores(
         .api()
         .get_machine_boot_interfaces(tonic::Request::new(
             forge::GetMachineBootInterfacesRequest {
-                machine_id: Some(host_id),
+                machine_id: Some(host_id.into()),
             },
         ))
         .await?
         .into_inner();
 
-    assert_eq!(report.machine_id, Some(host_id));
+    assert_eq!(report.machine_id, Some(host_id.into()));
 
     // The desired-state view names the boot target Site Explorer persisted for
     // this host. The fixture runs Site Explorer but no machine-controller
@@ -377,7 +379,7 @@ async fn test_get_machine_boot_interfaces_agrees_when_only_owned_rows_exist(
         .api()
         .get_machine_boot_interfaces(tonic::Request::new(
             forge::GetMachineBootInterfacesRequest {
-                machine_id: Some(host_id),
+                machine_id: Some(host_id.into()),
             },
         ))
         .await?

--- a/crates/api-core/tests/integration/power_options.rs
+++ b/crates/api-core/tests/integration/power_options.rs
@@ -67,14 +67,14 @@ async fn creates_and_updates_power_options(pool: PgPool) -> Result<(), Box<dyn s
     env.api()
         .set_maintenance(Request::new(MaintenanceRequest {
             operation: MaintenanceOperation::Enable as i32,
-            host_id: Some(mh.host.id),
+            host_id: Some(mh.host.id.into()),
             reference: Some("testing".to_string()),
         }))
         .await?;
 
     env.api()
         .update_power_option(Request::new(PowerOptionUpdateRequest {
-            machine_id: Some(mh.host.id),
+            machine_id: Some(mh.host.id.into()),
             power_state: rpc::forge::PowerState::Off as i32,
         }))
         .await?;
@@ -104,7 +104,7 @@ async fn rejects_update_without_maintenance(
     let error = env
         .api()
         .update_power_option(Request::new(PowerOptionUpdateRequest {
-            machine_id: Some(mh.host.id),
+            machine_id: Some(mh.host.id.into()),
             power_state: rpc::forge::PowerState::Off as i32,
         }))
         .await

--- a/crates/api-core/tests/integration/scout_firmware_upgrade_status.rs
+++ b/crates/api-core/tests/integration/scout_firmware_upgrade_status.rs
@@ -77,7 +77,7 @@ fn status_request(
     upgrade_task_id: &str,
 ) -> rpc::forge::ScoutFirmwareUpgradeStatusRequest {
     rpc::forge::ScoutFirmwareUpgradeStatusRequest {
-        machine_id: Some(mh.host.id),
+        machine_id: Some(mh.host.id.into()),
         success: true,
         exit_code: 0,
         stdout: String::new(),

--- a/crates/api-core/tests/integration/set_primary_dpu.rs
+++ b/crates/api-core/tests/integration/set_primary_dpu.rs
@@ -72,7 +72,7 @@ async fn test_set_primary_dpu_rejects_zero_dpu_host(
     let result = env
         .api()
         .set_primary_dpu(tonic::Request::new(forge::SetPrimaryDpuRequest {
-            host_machine_id: Some(zero_dpu_host.host.id),
+            host_machine_id: Some(zero_dpu_host.host.id.into()),
             // Any well-formed DPU id; the handler bails before reading it.
             dpu_machine_id: Some(MachineId::new(
                 MachineIdSource::ProductBoardChassisSerial,
@@ -152,8 +152,8 @@ async fn test_set_primary_dpu_rejects_a_stale_host_relationship_without_writes(
         (
             original_primary.id,
             stale_interface.id,
-            stale_dpu_id,
-            surviving_dpu_id,
+            stale_dpu_id.into(),
+            surviving_dpu_id.into(),
         )
     };
 
@@ -166,12 +166,10 @@ async fn test_set_primary_dpu_rejects_a_stale_host_relationship_without_writes(
         .bind(stale_interface_id)
         .execute(&env.api().database_connection)
         .await?;
-    let desired_before = db::machine_desired_boot_interface::get(
-        &env.api().database_connection,
-        &host_id.try_into().unwrap(),
-    )
-    .await?
-    .expect("ingestion should initialize the desired target");
+    let desired_before =
+        db::machine_desired_boot_interface::get(&env.api().database_connection, &host_id)
+            .await?
+            .expect("ingestion should initialize the desired target");
     sqlx::query("DELETE FROM machine_state_controller_queued_objects WHERE object_id = $1")
         .bind(host_id.to_string())
         .execute(&env.api().database_connection)
@@ -180,7 +178,7 @@ async fn test_set_primary_dpu_rejects_a_stale_host_relationship_without_writes(
     let error = env
         .api()
         .set_primary_dpu(tonic::Request::new(forge::SetPrimaryDpuRequest {
-            host_machine_id: Some(host_id),
+            host_machine_id: Some(host_id.into()),
             dpu_machine_id: Some(stale_dpu_id),
             force_reconcile: false,
             ..Default::default()
@@ -208,12 +206,10 @@ async fn test_set_primary_dpu_rejects_a_stale_host_relationship_without_writes(
         primary_ids
     };
     assert_eq!(primary_ids, vec![original_primary_id]);
-    let desired_after = db::machine_desired_boot_interface::get(
-        &env.api().database_connection,
-        &host_id.try_into().unwrap(),
-    )
-    .await?
-    .expect("the original desired target should remain");
+    let desired_after =
+        db::machine_desired_boot_interface::get(&env.api().database_connection, &host_id)
+            .await?
+            .expect("the original desired target should remain");
     assert_eq!(desired_after.value, desired_before.value);
     assert_eq!(desired_after.version, desired_before.version);
 

--- a/crates/api-db/src/dpa_interface.rs
+++ b/crates/api-db/src/dpa_interface.rs
@@ -20,7 +20,7 @@ use std::net::IpAddr;
 
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
 use carbide_uuid::dpa_interface::{DpaInterfaceId, NULL_DPA_INTERFACE_ID};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use config_version::ConfigVersion;
 use mac_address::MacAddress;
 use model::controller_outcome::PersistentStateHandlerOutcome;
@@ -196,7 +196,7 @@ pub async fn find_by_ip(
 // are found, because multiple would not make sense.
 pub async fn get_for_pci_name(
     txn: impl DbReader<'_>,
-    machine_id: &MachineId,
+    machine_id: &HostMachineId,
     pci_name: &str,
 ) -> Result<DpaInterface, DatabaseError> {
     let query = "SELECT row_to_json(m.*) from (select * from dpa_interfaces WHERE deleted is NULL AND machine_id = $1 AND pci_name = $2) m";
@@ -248,7 +248,7 @@ pub async fn find_by_mac_addr(
 /// is always available.
 pub async fn update_device_info(
     txn: &mut PgConnection,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
     pci_name: &str,
     device_info: &MlxDeviceInfo,
 ) -> Result<(), DatabaseError> {
@@ -291,7 +291,7 @@ fn validate_search_config(search_config: &DpaSearchConfig) -> Result<(), Databas
 // Used by the machine statemachine controller to find all DPAs associated with a given machine
 pub async fn find_by_machine_id(
     txn: impl DbReader<'_>,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
     search_config: DpaSearchConfig,
 ) -> Result<Vec<DpaInterface>, DatabaseError> {
     validate_search_config(&search_config)?;
@@ -331,9 +331,9 @@ pub async fn find_by_machine_id(
 /// (callers default such machines to an empty list).
 pub async fn find_by_machine_ids(
     txn: impl DbReader<'_>,
-    machine_ids: &[MachineId],
+    machine_ids: &[HostMachineId],
     search_config: DpaSearchConfig,
-) -> Result<std::collections::HashMap<MachineId, Vec<DpaInterface>>, DatabaseError> {
+) -> Result<std::collections::HashMap<HostMachineId, Vec<DpaInterface>>, DatabaseError> {
     validate_search_config(&search_config)?;
 
     // No machines means no interfaces; skip the round trip entirely.
@@ -364,7 +364,7 @@ pub async fn find_by_machine_ids(
         .map_err(|e| DatabaseError::query(builder.sql(), e))?;
 
     Ok(interfaces.into_iter().fold(
-        std::collections::HashMap::<MachineId, Vec<DpaInterface>>::new(),
+        std::collections::HashMap::<HostMachineId, Vec<DpaInterface>>::new(),
         |mut by_machine, interface| {
             by_machine
                 .entry(interface.machine_id)
@@ -500,7 +500,7 @@ pub async fn delete(value: DpaInterface, txn: &mut PgConnection) -> Result<(), D
 
 pub async fn is_machine_dpa_capable(
     txn: &mut PgConnection,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
 ) -> Result<bool, DatabaseError> {
     let result = batch_is_machine_dpa_capable(txn, &[machine_id]).await?;
     Ok(result.contains(&machine_id))
@@ -510,8 +510,8 @@ pub async fn is_machine_dpa_capable(
 /// Returns a HashSet of machine IDs that have DPA interfaces.
 pub async fn batch_is_machine_dpa_capable(
     txn: &mut PgConnection,
-    machine_ids: &[MachineId],
-) -> Result<HashSet<MachineId>, DatabaseError> {
+    machine_ids: &[HostMachineId],
+) -> Result<HashSet<HostMachineId>, DatabaseError> {
     if machine_ids.is_empty() {
         return Ok(HashSet::new());
     }
@@ -519,20 +519,12 @@ pub async fn batch_is_machine_dpa_capable(
     let query = "SELECT DISTINCT machine_id FROM dpa_interfaces
                  WHERE deleted IS NULL AND machine_id = ANY($1)";
 
-    let rows: Vec<(String,)> = sqlx::query_as(query)
-        .bind(
-            machine_ids
-                .iter()
-                .map(|id| id.to_string())
-                .collect::<Vec<_>>(),
-        )
+    Ok(sqlx::query_scalar(query)
+        .bind(machine_ids)
         .fetch_all(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))?;
-
-    Ok(rows
+        .map_err(|e| DatabaseError::query(query, e))?
         .into_iter()
-        .filter_map(|(id,)| id.parse::<MachineId>().ok())
         .collect())
 }
 
@@ -569,7 +561,9 @@ mod test {
 
     use carbide_libmlx_model::device::info::MlxDeviceInfo;
     use carbide_test_support::query_counter::count_queries;
-    use carbide_uuid::machine::{MachineId, MachineIdSource, MachineType};
+    use carbide_uuid::machine::{
+        HostMachineId as MachineId, MachineId as GenericMachineId, MachineIdSource, MachineType,
+    };
     use mac_address::MacAddress;
     use model::dpa_interface::{
         DpaInterfaceControllerState, DpaInterfaceType, DpaSearchConfig, NewDpaInterface,
@@ -605,11 +599,13 @@ mod test {
             for i in offset..(offset + n) {
                 let mut hash = [0u8; 32];
                 hash[..8].copy_from_slice(&(i as u64).to_be_bytes());
-                let id = MachineId::new(
+                let id: MachineId = GenericMachineId::new(
                     MachineIdSource::ProductBoardChassisSerial,
                     hash,
                     MachineType::Host,
-                );
+                )
+                .try_into()
+                .unwrap();
                 machine::create(&mut txn, None, &id, ManagedHostState::Ready, None, 2).await?;
                 crate::dpa_interface::persist(
                     NewDpaInterface {

--- a/crates/api-db/src/dpu_machine_update.rs
+++ b/crates/api-db/src/dpu_machine_update.rs
@@ -15,7 +15,6 @@
  * limitations under the License.
  */
 use model::dpu_machine_update::DpuMachineUpdate;
-use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{HostHealthConfig, LoadSnapshotOptions, ManagedHostState, ReprovisionRequest};
 use model::machine_update_module::{
     AutomaticFirmwareUpdateReference, DPU_FIRMWARE_UPDATE_TARGET, DpuReprovisionInitiator,
@@ -104,14 +103,7 @@ pub async fn get_updated_machines(
     txn: &mut PgConnection,
     host_health_config: HostHealthConfig,
 ) -> Result<Vec<DpuMachineUpdate>, DatabaseError> {
-    let machine_ids = crate::machine::find_machine_ids(
-        &mut *txn,
-        MachineSearchConfig {
-            include_predicted_host: true,
-            ..Default::default()
-        },
-    )
-    .await?;
+    let machine_ids = crate::managed_host::load_host_ids(&mut *txn).await?;
     let snapshots = crate::managed_host::load_by_machine_ids(
         txn,
         &machine_ids,
@@ -159,25 +151,29 @@ pub async fn get_updated_machines(
             // We only signal an update as complete once ALL DPUs are done
             // That prevents removing the updating flags from the Host
             // if just one DPU completes the update
-            let completed_updates: Vec<DpuMachineUpdate> = managed_host
+            let completed_updates: Result<Vec<DpuMachineUpdate>, DatabaseError> = managed_host
                 .dpu_snapshots
                 .iter()
-                .map(|dpu| DpuMachineUpdate {
-                    host_machine_id: machine_id,
-                    dpu_machine_id: dpu.id,
-                    firmware_version: dpu
-                        .status
-                        .hardware_info
-                        .as_ref()
-                        .and_then(|info| info.dpu_info.as_ref())
-                        .map(|dpu_info| dpu_info.firmware_version.clone())
-                        .unwrap_or_default(),
-                    dpf_managed,
+                .map(|dpu| {
+                    Ok(DpuMachineUpdate {
+                        host_machine_id: machine_id,
+                        dpu_machine_id: dpu.dpu_machine_id()?,
+                        firmware_version: dpu
+                            .status
+                            .hardware_info
+                            .as_ref()
+                            .and_then(|info| info.dpu_info.as_ref())
+                            .map(|dpu_info| dpu_info.firmware_version.clone())
+                            .unwrap_or_default(),
+                        dpf_managed,
+                    })
                 })
                 .collect();
 
             Some(completed_updates)
         })
+        .collect::<Result<Vec<_>, _>>()?
+        .into_iter()
         .flatten()
         .collect();
 

--- a/crates/api-db/src/dpu_remediation.rs
+++ b/crates/api-db/src/dpu_remediation.rs
@@ -17,7 +17,7 @@
 use std::ops::DerefMut;
 
 use carbide_uuid::dpu_remediations::RemediationId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, MachineId};
 use model::dpu_remediation::{
     AppliedRemediation, ApproveRemediation, DisableRemediation, EnableRemediation,
     NewAppliedRemediation, NewRemediation, Remediation, RemediationApplicationStatus,
@@ -206,14 +206,14 @@ impl ColumnInfo<'_> for AppliedRemediationDpuMachineIdColumn {
 }
 
 pub enum AppliedRemediationIdQueryType {
-    Machine(MachineId),
+    Machine(DpuMachineId),
     RemediationId(RemediationId),
 }
 
 pub async fn find_applied_remediation_ids(
     txn: &mut sqlx::Transaction<'_, Postgres>,
     id_query_args: AppliedRemediationIdQueryType,
-) -> Result<(Vec<RemediationId>, Vec<MachineId>), DatabaseError> {
+) -> Result<(Vec<RemediationId>, Vec<DpuMachineId>), DatabaseError> {
     let ids = match id_query_args {
         AppliedRemediationIdQueryType::Machine(machine_id) => {
             let remediation_ids = find_applied_remediations_by(

--- a/crates/api-db/src/lib.rs
+++ b/crates/api-db/src/lib.rs
@@ -109,6 +109,7 @@ pub mod work_lock_manager;
 pub mod test_support;
 
 use std::backtrace::{Backtrace, BacktraceStatus};
+use std::convert::Infallible;
 use std::error::Error;
 use std::fmt::{Display, Formatter};
 use std::ops::{Deref, DerefMut};
@@ -118,6 +119,7 @@ use std::pin::Pin;
 use carbide_instrument::{Event, LabelValue, emit};
 #[cfg(test)]
 pub(crate) use carbide_macros::sqlx_test;
+use carbide_uuid::machine::InvalidMachineType;
 use mac_address::MacAddress;
 use model::ConfigValidationError;
 use model::hardware_info::HardwareInfoError;
@@ -408,6 +410,26 @@ pub enum DatabaseError {
     TryAgain,
     #[error("no site-wide rotation target for credential type: {0:?}")]
     MissingSitewideRotationTarget(crate::credential_rotation::CredentialRotationType),
+}
+
+// Implement From<Infallible> so that we can write generic code that converts between MachineId
+// representations using TryFrom, while supporting "non-converting" cases where the caller is
+// already passing the right type. (The `impl TryFrom<T> for T` blanket impl uses `Infallible` as
+// its error type.)
+impl From<Infallible> for DatabaseError {
+    fn from(_: Infallible) -> Self {
+        // We just crash if this is ever called, because the whole point of `Infallible` is that
+        // it's an error variant that is never actually constructed. Future rust versions will use
+        // `!` as the error type for TryFrom<T> for T, and this whole conversion will become
+        // unnecessary (as the compiler will already determine it to be unreachable.)
+        unreachable!()
+    }
+}
+
+impl From<InvalidMachineType> for DatabaseError {
+    fn from(value: InvalidMachineType) -> Self {
+        Self::internal(value.to_string())
+    }
 }
 
 impl DatabaseError {

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -24,7 +24,9 @@ use std::str::FromStr;
 
 use carbide_uuid::dpa_interface::DpaInterfaceId;
 use carbide_uuid::instance_type::InstanceTypeId;
-use carbide_uuid::machine::{HostMachineId, MachineId, MachineType};
+use carbide_uuid::machine::{
+    DpuMachineId, HostMachineId, MachineId, MachineIdSubtypeTrait, MachineType, StableHostMachineId,
+};
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use chrono::{DateTime, Utc};
@@ -213,14 +215,19 @@ pub async fn get_or_create(
     }
 }
 
-pub async fn find_one(
+pub async fn find_one<ID>(
     txn: impl DbReader<'_>,
-    id: &MachineId,
+    id: &ID,
     search_config: MachineSearchConfig,
-) -> Result<Option<Machine>, DatabaseError> {
-    Ok(find(txn, ObjectFilter::One(*id), search_config)
-        .await?
-        .pop())
+) -> Result<Option<Machine>, DatabaseError>
+where
+    ID: MachineIdSubtypeTrait,
+{
+    Ok(
+        find(txn, ObjectFilter::One(*id.as_machine_id()), search_config)
+            .await?
+            .pop(),
+    )
 }
 
 pub async fn find_existing_machine(
@@ -327,11 +334,14 @@ pub async fn advance(
 /// * `filter`        - An ObjectFilter to control the size of the response set
 /// * `search_config` - A MachineSearchConfig with search options to control the
 ///   records selected
-pub async fn find(
+pub async fn find<ID>(
     txn: impl DbReader<'_>,
-    filter: ObjectFilter<'_, MachineId>,
+    filter: ObjectFilter<'_, ID>,
     search_config: MachineSearchConfig,
-) -> Result<Vec<Machine>, DatabaseError> {
+) -> Result<Vec<Machine>, DatabaseError>
+where
+    ID: MachineIdSubtypeTrait,
+{
     // The TRUE will be optimized away by the query planner,
     // but it simplifies the rest of the building for us.
     lazy_static! {
@@ -875,7 +885,7 @@ pub async fn update_last_scout_observed_version(
 
 pub async fn find_host_by_dpu_machine_id(
     txn: &mut PgConnection,
-    dpu_machine_id: &MachineId,
+    dpu_machine_id: &DpuMachineId,
 ) -> Result<Option<Machine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
@@ -897,15 +907,15 @@ pub async fn find_host_by_dpu_machine_id(
 
 pub async fn lookup_host_machine_ids_by_dpu_ids(
     conn: impl DbReader<'_>,
-    dpu_machine_ids: &[MachineId],
-) -> Result<HashMap<MachineId, HostMachineId>, DatabaseError> {
+    dpu_machine_ids: &[DpuMachineId],
+) -> Result<HashMap<DpuMachineId, HostMachineId>, DatabaseError> {
     let query = r#"SELECT mi.attached_dpu_machine_id, mi.machine_id
         FROM machine_interfaces mi
         WHERE mi.attached_dpu_machine_id != mi.machine_id
         AND mi.interface_type != 'Bmc'
         AND mi.attached_dpu_machine_id = ANY($1)"#;
 
-    let dpu_id_host_id_pairs: Vec<(MachineId, HostMachineId)> = sqlx::query_as(query)
+    let dpu_id_host_id_pairs: Vec<(DpuMachineId, HostMachineId)> = sqlx::query_as(query)
         .bind(
             dpu_machine_ids
                 .iter()
@@ -960,7 +970,7 @@ pub async fn get_host_use_admin_network_for_dpa_interface(
 
 pub async fn find_dpus_by_host_machine_id(
     txn: &mut PgConnection,
-    host_machine_id: &MachineId,
+    host_machine_id: &HostMachineId,
 ) -> Result<Vec<Machine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
@@ -1628,9 +1638,9 @@ pub async fn clear_use_admin_network_changed_if_version_matches(
 /// so updating host id must not interfere state machine handling.
 pub async fn try_sync_stable_id_with_current_machine_id_for_host(
     txn: &mut PgConnection,
-    current_machine_id: &Option<MachineId>,
-    stable_machine_id: &MachineId,
-) -> Result<MachineId, DatabaseError> {
+    current_machine_id: Option<HostMachineId>,
+    stable_machine_id: &StableHostMachineId,
+) -> Result<StableHostMachineId, DatabaseError> {
     let Some(current_machine_id) = current_machine_id else {
         return Err(DatabaseError::NotFoundError {
             kind: "machine_id",
@@ -1639,9 +1649,9 @@ pub async fn try_sync_stable_id_with_current_machine_id_for_host(
     };
 
     // This is repeated call. Machine is already updated with stable ID.
-    if !current_machine_id.machine_type().is_predicted_host() {
-        return match find_one(txn, current_machine_id, MachineSearchConfig::default()).await? {
-            Some(machine) => Ok(machine.id),
+    if let Ok(current_stable_id) = StableHostMachineId::try_from(current_machine_id) {
+        return match find_one(txn, &current_stable_id, MachineSearchConfig::default()).await? {
+            Some(_machine) => Ok(current_stable_id),
             None => Err(DatabaseError::NotFoundError {
                 kind: "machine",
                 id: current_machine_id.to_string(),
@@ -1653,8 +1663,8 @@ pub async fn try_sync_stable_id_with_current_machine_id_for_host(
     crate::state_history::update_object_ids(
         txn,
         crate::state_history::StateHistoryTableId::Machine,
-        current_machine_id,
-        stable_machine_id,
+        &current_machine_id,
+        &stable_machine_id,
     )
     .await?;
     crate::health_history::update_object_ids(
@@ -2327,7 +2337,7 @@ pub async fn find_machine_ids(
 
 pub async fn update_state(
     txn: &mut PgConnection,
-    host_id: &MachineId,
+    host_id: &HostMachineId,
     new_state: &ManagedHostState,
 ) -> Result<(), DatabaseError> {
     let host = find_one(
@@ -2477,9 +2487,10 @@ pub async fn find_dpu_infos(txn: &mut PgConnection) -> Result<Vec<DpuInfo>, Data
         .into_iter()
         .map(
             |(id, loopback_ip, controller_state, network_status_observation, firmware_version)| {
-                let dpu_id = MachineId::from_str(&id).map_err(|e| {
+                let dpu_id = DpuMachineId::try_from(MachineId::from_str(&id).map_err(|e| {
                     DatabaseError::internal(format!("Invalid DPU machine ID {id}: {e}"))
-                })?;
+                })?)
+                .map_err(|e| DatabaseError::internal(e.to_string()))?;
                 let network_status_observation = network_status_observation.0;
                 let representors = network_status_observation
                     .as_ref()
@@ -2941,7 +2952,7 @@ pub async fn clear_lockdown_ikm_credential_rotation_requested(
 /// mirroring the idle rekey path.
 pub async fn get_lockdown_ikm_credential_rotation_requested(
     conn: &mut PgConnection,
-    machine_id: MachineId,
+    machine_id: HostMachineId,
 ) -> DatabaseResult<bool> {
     let query = "SELECT lockdown_ikm_credential_rotation_requested FROM machines WHERE id = $1";
     sqlx::query_scalar::<_, bool>(query)
@@ -3468,7 +3479,7 @@ pub async fn get_backend_firmware_object_job_id(
 }
 
 pub fn count_healthy_unhealthy_host_machines(
-    all_machines: &HashMap<MachineId, model::machine::ManagedHostStateSnapshot>,
+    all_machines: &HashMap<impl MachineIdSubtypeTrait, model::machine::ManagedHostStateSnapshot>,
 ) -> (i32, i32) {
     let without_fault_count = all_machines
         .iter()
@@ -3494,7 +3505,9 @@ mod test {
     use std::sync::{Arc, Mutex};
 
     use carbide_instrument::testing::{MetricsCapture, capture_logs_async};
-    use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+    use carbide_uuid::machine::{
+        HostMachineId, MachineId, MachineInterfaceId, StableHostMachineId,
+    };
     use carbide_uuid::network::NetworkSegmentId;
     use model::allocation_type::AllocationType;
     use model::bmc_info::BmcInfo;
@@ -3560,8 +3573,8 @@ mod test {
             )
         }
 
-        let predicted_id = machine_id(1, MachineType::PredictedHost);
-        let stable_id = machine_id(1, MachineType::Host);
+        let predicted_id = HostMachineId::try_from(machine_id(1, MachineType::PredictedHost))?;
+        let stable_id = StableHostMachineId::try_from(machine_id(1, MachineType::Host))?;
 
         let mut txn = pool.begin().await?;
 
@@ -3594,7 +3607,7 @@ mod test {
         // rows reference the old id: the ON UPDATE CASCADE FK moves them.
         let renamed = super::try_sync_stable_id_with_current_machine_id_for_host(
             &mut txn,
-            &Some(predicted_id),
+            Some(predicted_id),
             &stable_id,
         )
         .await?;
@@ -3613,7 +3626,7 @@ mod test {
 
         let under_stable = crate::dpa_interface::find_by_machine_id(
             txn.as_mut(),
-            stable_id,
+            *stable_id.as_host_machine_id(),
             DpaSearchConfig::default(),
         )
         .await?;

--- a/crates/api-db/src/machine_desired_boot_interface.rs
+++ b/crates/api-db/src/machine_desired_boot_interface.rs
@@ -1166,7 +1166,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(1);
-        let initial_machine_version = seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        let initial_machine_version = seed_machine(txn.as_mut(), &machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 0, 1]);
         let initial_target = MachineBootInterfaceTarget::MacOnly(mac_address);
 
@@ -1233,7 +1233,7 @@ mod tests {
         ];
 
         for (index, (machine_id, state, expect_assumed)) in cases.into_iter().enumerate() {
-            seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+            seed_machine(txn.as_mut(), &machine_id).await?;
             set_controller_state(txn.as_mut(), &machine_id, state).await?;
             let target =
                 MachineBootInterfaceTarget::MacOnly(MacAddress::new([2, 0, 0, 0, 3, index as u8]));
@@ -1272,7 +1272,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(34);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let target = MachineBootInterfaceTarget::MacOnly(MacAddress::new([2, 0, 0, 0, 3, 4]));
         let initialized =
             initialize_if_unset(txn.as_mut(), &machine_id, &target, RedfishUefiPci).await?;
@@ -1302,13 +1302,10 @@ mod tests {
             (Some(initialized.version), Some(observed_at), false)
         );
 
-        let machine = crate::machine::find_one(
-            txn.as_mut(),
-            machine_id.as_ref(),
-            MachineSearchConfig::default(),
-        )
-        .await?
-        .expect("machine snapshot");
+        let machine =
+            crate::machine::find_one(txn.as_mut(), &machine_id, MachineSearchConfig::default())
+                .await?
+                .expect("machine snapshot");
         let observation = machine
             .status
             .boot_interface_status_observation
@@ -1346,7 +1343,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(44);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let inspected_target = MachineBootInterfaceTarget::Pair(MachineBootInterface {
             mac_address: MacAddress::new([2, 0, 0, 0, 4, 4]),
             interface_id: "NIC.Slot.4-1-1".to_string(),
@@ -1396,7 +1393,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(45);
-        let initial_machine_version = seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        let initial_machine_version = seed_machine(txn.as_mut(), &machine_id).await?;
         let inspected_target = MachineBootInterfaceTarget::Pair(MachineBootInterface {
             mac_address: MacAddress::new([2, 0, 0, 0, 4, 6]),
             interface_id: "NIC.Slot.4-1-2".to_string(),
@@ -1469,7 +1466,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = predicted_host_machine_id(2);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 0, 3]);
         let pair = MachineBootInterfaceTarget::Pair(MachineBootInterface {
             mac_address,
@@ -1581,7 +1578,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(5);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 0, 8]);
         let pair = MachineBootInterfaceTarget::Pair(MachineBootInterface {
             mac_address,
@@ -1671,7 +1668,7 @@ mod tests {
 
         for (index, case) in cases.into_iter().enumerate() {
             let machine_id = predicted_host_machine_id(70 + index as u8);
-            seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+            seed_machine(txn.as_mut(), &machine_id).await?;
             let target =
                 MachineBootInterfaceTarget::MacOnly(MacAddress::new([2, 0, 0, 0, 7, index as u8]));
             initialize_if_unset(txn.as_mut(), &machine_id, &target, case.source).await?;
@@ -1719,7 +1716,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(37);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 3, 10]);
         let pair = MachineBootInterfaceTarget::Pair(MachineBootInterface {
             mac_address,
@@ -1774,7 +1771,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let attributed_machine_id = host_machine_id(61);
-        seed_machine(txn.as_mut(), attributed_machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &attributed_machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 6, 1]);
         let pair = MachineBootInterfaceTarget::Pair(MachineBootInterface {
             mac_address,
@@ -1841,7 +1838,7 @@ mod tests {
         );
 
         let uninitialized_machine_id = host_machine_id(62);
-        seed_machine(txn.as_mut(), uninitialized_machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &uninitialized_machine_id).await?;
         let unknown = force_reconcile(
             txn.as_mut(),
             &uninitialized_machine_id,
@@ -1870,7 +1867,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(63);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 6, 4]);
         let initial = initialize_if_unset(
             txn.as_mut(),
@@ -1933,7 +1930,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(3);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 0, 5]);
         let target = MachineBootInterfaceTarget::MacOnly(mac_address);
         let initialized =
@@ -2008,7 +2005,7 @@ mod tests {
     ) -> Result<(), Box<dyn std::error::Error>> {
         let mut txn = pool.begin().await?;
         let machine_id = host_machine_id(36);
-        seed_machine(txn.as_mut(), machine_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &machine_id).await?;
         let mac_address = MacAddress::new([2, 0, 0, 0, 3, 8]);
         let initialized = initialize_if_unset(
             txn.as_mut(),
@@ -2061,10 +2058,10 @@ mod tests {
         let complete_host = host_machine_id(13);
         let dpu = dpu_machine_id(14);
         for machine_id in [
-            unset_host.as_machine_id(),
-            mac_only_host.as_machine_id(),
-            unset_prediction.as_machine_id(),
-            complete_host.as_machine_id(),
+            &unset_host,
+            &mac_only_host,
+            &unset_prediction,
+            &complete_host,
             &dpu,
         ] {
             seed_machine(txn.as_mut(), machine_id).await?;
@@ -2118,7 +2115,7 @@ mod tests {
         let mut txn = pool.begin().await?;
         let predicted_id = predicted_host_machine_id(20);
         let dpu_id = dpu_machine_id(21);
-        seed_machine(txn.as_mut(), predicted_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &predicted_id).await?;
         seed_machine(txn.as_mut(), &dpu_id).await?;
         txn.commit().await?;
 
@@ -2205,8 +2202,8 @@ mod tests {
         let preexisting_id = predicted_host_machine_id(60);
         let defaulted_insert_id = host_machine_id(61);
         let mut txn = pool.begin().await?;
-        seed_machine(txn.as_mut(), preexisting_id.as_ref()).await?;
-        seed_machine(txn.as_mut(), defaulted_insert_id.as_ref()).await?;
+        seed_machine(txn.as_mut(), &preexisting_id).await?;
+        seed_machine(txn.as_mut(), &defaulted_insert_id).await?;
         txn.commit().await?;
 
         sqlx::raw_sql(MIGRATION).execute(&pool).await?;
@@ -2310,8 +2307,8 @@ mod tests {
         let mut txn = pool.begin().await?;
         let existing_host = host_machine_id(40);
         let in_flight_host = host_machine_id(42);
-        seed_machine(txn.as_mut(), existing_host.as_ref()).await?;
-        seed_machine(txn.as_mut(), in_flight_host.as_ref()).await?;
+        seed_machine(txn.as_mut(), &existing_host).await?;
+        seed_machine(txn.as_mut(), &in_flight_host).await?;
         set_controller_state(txn.as_mut(), &existing_host, ManagedHostState::Ready).await?;
         set_controller_state(
             txn.as_mut(),

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -21,7 +21,7 @@ use std::net::IpAddr;
 use carbide_network::ip::{IdentifyAddressFamily, IpAddressFamily};
 use carbide_utils::redfish::BmcAccessInfo;
 use carbide_uuid::domain::DomainId;
-use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::machine::{MachineId, MachineIdSubtypeTrait, MachineInterfaceId};
 use carbide_uuid::network::{NetworkPrefixId, NetworkSegmentId};
 use carbide_uuid::power_shelf::PowerShelfId;
 use carbide_uuid::switch::SwitchId;
@@ -468,20 +468,38 @@ pub async fn find_all(txn: &mut PgConnection) -> DatabaseResult<Vec<MachineInter
     find_by(txn, ObjectColumnFilter::All::<IdColumn>).await
 }
 
-pub async fn find_by_machine_ids(
+pub async fn find_by_machine_ids<ID>(
     txn: &mut PgConnection,
-    machine_ids: &[MachineId],
-) -> Result<std::collections::HashMap<MachineId, Vec<MachineInterfaceSnapshot>>, DatabaseError> {
+    machine_ids: &[ID],
+) -> Result<std::collections::HashMap<ID, Vec<MachineInterfaceSnapshot>>, DatabaseError>
+where
+    ID: MachineIdSubtypeTrait,
+{
     use itertools::Itertools;
-    // The .unwrap() in the `group_map_by` call is ok - because we are only
-    // searching for Machines which have associated MachineIds
-    Ok(
-        find_by(txn, ObjectColumnFilter::List(MachineIdColumn, machine_ids))
-            .await?
-            .into_iter()
-            .filter(|interface| interface.interface_type != InterfaceType::Bmc)
-            .into_group_map_by(|interface| interface.machine_id.unwrap()),
+    Ok(find_by(
+        txn,
+        ObjectColumnFilter::List(
+            MachineIdColumn,
+            machine_ids
+                .iter()
+                .map(MachineIdSubtypeTrait::to_machine_id)
+                .collect::<Vec<_>>()
+                .as_slice(),
+        ),
     )
+    .await?
+    .into_iter()
+    .filter_map(|interface| {
+        let Some(Ok(interface_id)) = interface.machine_id.map(ID::try_from) else {
+            return None;
+        };
+        if interface.interface_type != InterfaceType::Bmc {
+            Some((interface_id, interface))
+        } else {
+            None
+        }
+    })
+    .into_group_map())
 }
 
 /// `find_by_machine_id_for_update` locks one host's non-BMC interface rows in

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -428,7 +428,7 @@ async fn test_expected_declaration_does_not_reclassify_attached_dpu_interface(
     .await?;
     txn.commit().await?;
 
-    assert_eq!(reconciled.attached_dpu_machine_id, Some(dpu_id));
+    assert_eq!(reconciled.attached_dpu_machine_id, Some(dpu_id.try_into()?));
     assert_eq!(reconciled.interface_type, InterfaceType::Data);
     assert!(reconciled.primary_interface);
 
@@ -502,7 +502,10 @@ async fn test_expected_interface_settings_do_not_overwrite_concurrent_dpu_associ
         Some(false),
     )
     .await?;
-    assert_eq!(stale_interface.attached_dpu_machine_id, Some(dpu_id));
+    assert_eq!(
+        stale_interface.attached_dpu_machine_id,
+        Some(dpu_id.try_into()?)
+    );
     assert_eq!(stale_interface.interface_type, InterfaceType::Data);
     assert!(stale_interface.primary_interface);
     expected_txn.commit().await?;
@@ -511,7 +514,7 @@ async fn test_expected_interface_settings_do_not_overwrite_concurrent_dpu_associ
     let reconciled = find_one(verify_txn.as_pgconn(), interface.id).await?;
     verify_txn.commit().await?;
 
-    assert_eq!(reconciled.attached_dpu_machine_id, Some(dpu_id));
+    assert_eq!(reconciled.attached_dpu_machine_id, Some(dpu_id.try_into()?));
     assert_eq!(reconciled.interface_type, InterfaceType::Data);
     assert!(reconciled.primary_interface);
 

--- a/crates/api-db/src/machine_topology.rs
+++ b/crates/api-db/src/machine_topology.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{MachineId, MachineIdSubtypeTrait};
 use chrono::{TimeDelta, Utc};
 use itertools::Itertools;
 use model::bmc_info::BmcInfo;
@@ -55,15 +55,16 @@ async fn update(
 
 pub async fn create_or_update(
     txn: &mut PgConnection,
-    machine_id: &MachineId,
+    machine_id: &impl MachineIdSubtypeTrait,
     hardware_info: &HardwareInfo,
 ) -> DatabaseResult<MachineTopology> {
-    let topology_data = find_latest_by_machine_ids(txn, &[*machine_id]).await?;
-    let topology_data = topology_data.get(machine_id);
+    let machine_id = machine_id.to_machine_id();
+    let topology_data = find_latest_by_machine_ids(txn, &[machine_id]).await?;
+    let topology_data = topology_data.get(&machine_id);
 
     if let Some(topology) = topology_data {
         if topology.topology_update_needed {
-            return update(txn, machine_id, hardware_info).await;
+            return update(txn, &machine_id, hardware_info).await;
         }
         return Ok(topology.clone());
     }
@@ -188,10 +189,10 @@ pub async fn lock_by_machine_id(
     Ok(())
 }
 
-pub async fn find_by_machine_ids(
+pub async fn find_by_machine_ids<ID: MachineIdSubtypeTrait>(
     txn: &mut PgConnection,
-    machine_ids: &[MachineId],
-) -> Result<HashMap<MachineId, Vec<MachineTopology>>, DatabaseError> {
+    machine_ids: &[ID],
+) -> Result<HashMap<ID, Vec<MachineTopology>>, DatabaseError> {
     // TODO: Actually this shouldn't be able to return multiple entries,
     // since there is a check in create that for existing interfaces
     // But due to race conditions we can likely still have multiple of those interfaces
@@ -203,14 +204,15 @@ pub async fn find_by_machine_ids(
         .await
         .map_err(|e| DatabaseError::query(query, e))?
         .into_iter()
-        .into_group_map_by(|t: &MachineTopology| t.machine_id);
+        .filter_map(|t: MachineTopology| Some((ID::try_from(t.machine_id).ok()?, t)))
+        .into_group_map();
     Ok(topologies)
 }
 
-pub async fn find_latest_by_machine_ids(
+pub async fn find_latest_by_machine_ids<ID: MachineIdSubtypeTrait>(
     txn: &mut PgConnection,
-    machine_ids: &[MachineId],
-) -> Result<HashMap<MachineId, MachineTopology>, DatabaseError> {
+    machine_ids: &[ID],
+) -> Result<HashMap<ID, MachineTopology>, DatabaseError> {
     // TODO: So far this just moved code around
     // This way of doing fetching the latest topology is inefficient, because it will still fetch all
     // information. We can change the query - however if we store information
@@ -387,12 +389,12 @@ pub async fn find_freetext(
 
 pub async fn set_topology_update_needed(
     txn: &mut PgConnection,
-    machine_id: &MachineId,
+    machine_id: &impl MachineIdSubtypeTrait,
     value: bool,
 ) -> Result<(), DatabaseError> {
     let query = "UPDATE machine_topologies SET topology_update_needed=$2 WHERE machine_id=$1 RETURNING machine_id";
     let _id = sqlx::query_as::<_, MachineId>(query)
-        .bind(machine_id)
+        .bind(machine_id.as_machine_id())
         .bind(value)
         .fetch_one(txn)
         .await

--- a/crates/api-db/src/managed_host.rs
+++ b/crates/api-db/src/managed_host.rs
@@ -21,7 +21,9 @@ use std::collections::HashMap;
 use std::ops::Deref;
 
 use carbide_uuid::instance::InstanceId;
-use carbide_uuid::machine::{MachineId, MachineType};
+use carbide_uuid::machine::{
+    HostMachineId, HostOrDpuId, MachineId, MachineIdSubtypeTrait, MachineType,
+};
 use carbide_uuid::rack::RackId;
 use itertools::Itertools;
 use lazy_static::lazy_static;
@@ -32,16 +34,30 @@ use crate::db_read::DbReader;
 use crate::{DatabaseError, queries};
 
 /// Loads a ManagedHost snapshot from the database
-pub async fn load_snapshot<DB>(
+pub async fn load_snapshot<DB, ID>(
     txn: &mut DB,
-    machine_id: &MachineId,
+    machine_id: &ID,
+    options: LoadSnapshotOptions,
+) -> Result<Option<ManagedHostStateSnapshot>, DatabaseError>
+where
+    for<'db> &'db mut DB: DbReader<'db>,
+    ID: MachineIdSubtypeTrait,
+    DatabaseError: From<<ID as TryFrom<MachineId>>::Error>,
+{
+    let mut snapshots = load_by_machine_ids(txn, &[*machine_id], options).await?;
+    Ok(snapshots.remove(machine_id))
+}
+
+/// Loads a managed-host snapshot for a host or predicted-host ID.
+pub async fn load_host_snapshot<DB>(
+    txn: &mut DB,
+    machine_id: &HostMachineId,
     options: LoadSnapshotOptions,
 ) -> Result<Option<ManagedHostStateSnapshot>, DatabaseError>
 where
     for<'db> &'db mut DB: DbReader<'db>,
 {
-    let mut snapshots = load_by_machine_ids(txn, &[*machine_id], options).await?;
-    Ok(snapshots.remove(machine_id))
+    load_snapshot(txn, machine_id, options).await
 }
 
 /// Loads all ManagedHosts, including predicted hosts
@@ -74,8 +90,8 @@ pub async fn load_all(
 /// per-host snapshot JSON aggregation. Callers that need to process a very
 /// large fleet without holding every snapshot in memory can page the IDs and
 /// hydrate snapshots in bounded batches via [`load_by_machine_ids`].
-pub async fn load_host_ids(txn: impl DbReader<'_>) -> Result<Vec<MachineId>, DatabaseError> {
-    sqlx::query_scalar::<_, MachineId>("SELECT id FROM machines WHERE NOT starts_with(id, $1)")
+pub async fn load_host_ids(txn: impl DbReader<'_>) -> Result<Vec<HostMachineId>, DatabaseError> {
+    sqlx::query_scalar::<_, HostMachineId>("SELECT id FROM machines WHERE NOT starts_with(id, $1)")
         .bind(MachineType::Dpu.id_prefix())
         .fetch_all(txn)
         .await
@@ -116,19 +132,25 @@ pub async fn find_assigned_hosts_in_rack(
 /// The method works for Host and DPU Machine IDs
 /// When used for DPU Machine IDs, the returned HashMap will contain an entry
 /// that maps from the DPU Machine ID to the ManagedHost snapshot
-pub async fn load_by_machine_ids<DB>(
+pub async fn load_by_machine_ids<DB, ID>(
     txn: &mut DB,
-    requested_machine_ids: &[MachineId],
+    requested_machine_ids: &[ID],
     options: LoadSnapshotOptions,
-) -> Result<HashMap<MachineId, ManagedHostStateSnapshot>, DatabaseError>
+) -> Result<HashMap<ID, ManagedHostStateSnapshot>, DatabaseError>
 where
     for<'db> &'db mut DB: DbReader<'db>,
+    ID: MachineIdSubtypeTrait,
+    DatabaseError: From<<ID as TryFrom<MachineId>>::Error>,
 {
     // Partition the ID's by whether or not they're DPU's.
-    let (requested_dpu_ids, requested_host_ids): (Vec<MachineId>, Vec<MachineId>) =
-        requested_machine_ids
-            .iter()
-            .partition(|id| id.machine_type().is_dpu());
+    let mut requested_dpu_ids = Vec::new();
+    let mut requested_host_ids = Vec::new();
+    for machine_id in requested_machine_ids {
+        match machine_id.host_or_dpu_id() {
+            HostOrDpuId::Dpu(dpu_machine_id) => requested_dpu_ids.push(dpu_machine_id),
+            HostOrDpuId::Host(host_machine_id) => requested_host_ids.push(*host_machine_id),
+        }
+    }
 
     // Perf optimization: Joining through machine_interfaces to look up by DPU ID is slower by 100x
     // or so. If we're searching for DPU ID's, resolve their host ID's now.
@@ -203,10 +225,10 @@ where
                 host_ids_by_dpu_id.get(&dpu_id).and_then(|host_id| {
                     snapshots_by_host_id
                         .get(host_id)
-                        .map(|snapshot| (dpu_id, snapshot.clone()))
+                        .map(|snapshot| Ok((dpu_id.to_machine_id().try_into()?, snapshot.clone())))
                 })
             })
-            .collect::<Vec<_>>(),
+            .collect::<Result<Vec<_>, DatabaseError>>()?,
         // Then extract the explicitly requested host snapshots. Since we already scanned through
         // requested DPUs, we can move them out of the map
         requested_host_ids
@@ -214,9 +236,9 @@ where
             .filter_map(|host_id| {
                 snapshots_by_host_id
                     .remove(&host_id)
-                    .map(|snapshot| (host_id, snapshot))
+                    .map(|snapshot| Ok((host_id.to_machine_id().try_into()?, snapshot)))
             })
-            .collect::<Vec<_>>(),
+            .collect::<Result<Vec<_>, DatabaseError>>()?,
     ]
     .concat()
     .into_iter()

--- a/crates/api-db/src/tenant_identity_config.rs
+++ b/crates/api-db/src/tenant_identity_config.rs
@@ -18,7 +18,7 @@
 //! Tenant identity config for SPIFFE JWT-SVID machine identity.
 //! Stores per-org identity config and signing keys in `tenant_identity_config` table.
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostOrDpuId, MachineId};
 use chrono::{DateTime, Duration as ChronoDuration, Utc};
 use model::tenant::identity_config::SigningKeyPublicV1;
 use model::tenant::{
@@ -318,10 +318,11 @@ async fn instance_machine_id_for_identity_lookup(
     txn: &mut PgConnection,
     machine_id: &MachineId,
 ) -> DatabaseResult<MachineId> {
-    if !machine_id.machine_type().is_dpu() {
+    let HostOrDpuId::Dpu(dpu_machine_id) = machine_id.host_or_dpu_id() else {
         return Ok(*machine_id);
-    }
-    let Some(host) = crate::machine::find_host_by_dpu_machine_id(txn, machine_id).await? else {
+    };
+    let Some(host) = crate::machine::find_host_by_dpu_machine_id(txn, &dpu_machine_id).await?
+    else {
         return Ok(*machine_id);
     };
     Ok(host.id)

--- a/crates/api-db/src/vpc_dpu_loopback.rs
+++ b/crates/api-db/src/vpc_dpu_loopback.rs
@@ -16,7 +16,7 @@
  */
 use std::net::IpAddr;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use carbide_uuid::vpc::VpcId;
 use model::vpc::VpcDpuLoopback;
 use sqlx::PgConnection;
@@ -40,7 +40,7 @@ pub async fn persist(
 
 pub async fn delete_and_deallocate(
     common_pools: &model::resource_pool::common::CommonPools,
-    dpu_id: &MachineId,
+    dpu_id: &DpuMachineId,
     txn: &mut PgConnection,
     delete_admin_loopback_also: bool,
 ) -> Result<(), DatabaseError> {
@@ -96,7 +96,7 @@ pub async fn delete_and_deallocate(
 /// Deletes and deallocates loopbacks for a DPU scoped to specific VPCs.
 pub async fn delete_and_deallocate_for_vpcs(
     common_pools: &model::resource_pool::common::CommonPools,
-    dpu_id: &MachineId,
+    dpu_id: &DpuMachineId,
     vpc_ids: &[VpcId],
     txn: &mut PgConnection,
 ) -> Result<(), DatabaseError> {
@@ -132,7 +132,7 @@ pub async fn delete_and_deallocate_for_vpcs(
 
 pub async fn find(
     txn: &mut PgConnection,
-    dpu_id: &MachineId,
+    dpu_id: &DpuMachineId,
     vpc_id: &VpcId,
 ) -> Result<Option<VpcDpuLoopback>, DatabaseError> {
     let query = "SELECT * from vpc_dpu_loopbacks WHERE dpu_id=$1 AND vpc_id=$2";
@@ -150,7 +150,7 @@ pub async fn find(
 pub async fn get_or_allocate_loopback_ip_for_vpc(
     common_pools: &model::resource_pool::common::CommonPools,
     txn: &mut PgConnection,
-    dpu_id: &MachineId,
+    dpu_id: &DpuMachineId,
     vpc_id: &VpcId,
 ) -> Result<IpAddr, DatabaseError> {
     let loopback_ip = match find(txn, dpu_id, vpc_id).await? {

--- a/crates/api-model/src/dpa_interface/mod.rs
+++ b/crates/api-model/src/dpa_interface/mod.rs
@@ -22,7 +22,7 @@ use std::net::IpAddr;
 use carbide_libmlx_model::device::info::MlxDeviceInfo;
 use carbide_libmlx_model::firmware::result::FirmwareFlashReport;
 use carbide_uuid::dpa_interface::DpaInterfaceId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use carbide_uuid::spx::NULL_SPX_PARTITION_ID;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
@@ -211,7 +211,7 @@ pub fn state_sla(state: &DpaInterfaceControllerState, state_version: &ConfigVers
 #[derive(Clone, Debug)]
 pub struct DpaInterface {
     pub id: DpaInterfaceId,
-    pub machine_id: MachineId,
+    pub machine_id: HostMachineId,
 
     pub mac_address: MacAddress,
     pub pci_name: String,
@@ -261,7 +261,7 @@ pub struct DpaInterface {
 
 #[derive(Clone, Debug)]
 pub struct NewDpaInterface {
-    pub machine_id: MachineId,
+    pub machine_id: HostMachineId,
     pub mac_address: MacAddress,
     pub device_type: String,
     pub pci_name: String,
@@ -280,7 +280,7 @@ impl NewDpaInterface {
     /// what is effectively a (machine_id, mac_address) compound primary key,
     /// it's kind of important to have.
     pub fn from_device_info(
-        machine_id: MachineId,
+        machine_id: HostMachineId,
         base_mac: Option<MacAddress>,
         device_type: String,
         pci_name: String,
@@ -303,7 +303,7 @@ impl DpaInterface {
         self.network_config.use_admin_network.unwrap_or(true)
     }
 
-    pub fn get_machine_id(&self) -> MachineId {
+    pub fn get_machine_id(&self) -> HostMachineId {
         self.machine_id
     }
 
@@ -388,7 +388,7 @@ impl<'r> FromRow<'r, PgRow> for DpaInterface {
 #[derive(Serialize, Deserialize)]
 pub struct DpaInterfaceSnapshotPgJson {
     pub id: DpaInterfaceId,
-    pub machine_id: MachineId,
+    pub machine_id: HostMachineId,
     pub mac_address: MacAddress,
     pub created: DateTime<Utc>,
     pub updated: DateTime<Utc>,
@@ -467,6 +467,7 @@ mod tests {
 
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, check_cases, scenarios, value_scenarios};
+    use carbide_uuid::machine::HostMachineId as MachineId;
 
     use super::*;
 

--- a/crates/api-model/src/dpu_machine_update.rs
+++ b/crates/api-model/src/dpu_machine_update.rs
@@ -16,7 +16,7 @@
  */
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 use sqlx::FromRow;
 
 use crate::errors::ModelError;
@@ -24,8 +24,8 @@ use crate::machine::{ManagedHostState, ManagedHostStateSnapshot};
 
 #[derive(Debug, FromRow)]
 pub struct DpuMachineUpdate {
-    pub host_machine_id: MachineId,
-    pub dpu_machine_id: MachineId,
+    pub host_machine_id: HostMachineId,
+    pub dpu_machine_id: DpuMachineId,
     pub firmware_version: String,
     /// Whether the owning host is ingested through DPF. DPF decides staleness
     /// from the DPUDeployment's expected BFB, not from
@@ -42,7 +42,7 @@ pub struct DpuMachineUpdate {
 /// snapshots by [`DpuMachineUpdate::find_outdated_dpus_dpf`].
 #[derive(Debug, Clone)]
 pub struct OutdatedDpfDpu {
-    pub dpu_machine_id: MachineId,
+    pub dpu_machine_id: DpuMachineId,
     /// Expected provisioning source: a BFB filename (e.g.
     /// `dpf-operator-system-bf-bundle-<hash>.bfb`) or a BlueFieldSoftware CR
     /// name, depending on which one the owning DPUDeployment declares. Used as
@@ -66,7 +66,7 @@ impl DpuMachineUpdate {
     pub fn find_available_outdated_dpus(
         limit: Option<i32>,
         dpu_nic_firmware_update_versions: &[String],
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
         dpf_outdated: &[OutdatedDpfDpu],
     ) -> Result<Vec<DpuMachineUpdate>, ModelError> {
         if limit.is_some_and(|l| l <= 0) {
@@ -74,8 +74,8 @@ impl DpuMachineUpdate {
         }
 
         let mut outdated_dpus =
-            Self::find_outdated_dpus(dpu_nic_firmware_update_versions, snapshots);
-        outdated_dpus.extend(Self::find_outdated_dpus_dpf(dpf_outdated, snapshots));
+            Self::find_outdated_dpus(dpu_nic_firmware_update_versions, snapshots)?;
+        outdated_dpus.extend(Self::find_outdated_dpus_dpf(dpf_outdated, snapshots)?);
 
         let mut scheduled_host_updates = 0;
         let available_outdated_dpus: Vec<DpuMachineUpdate> = outdated_dpus
@@ -101,9 +101,9 @@ impl DpuMachineUpdate {
 
     pub fn find_unavailable_outdated_dpus(
         dpu_nic_firmware_update_versions: &[String],
-        snapshots: &HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) -> Vec<DpuMachineUpdate> {
-        let outdated_dpus = Self::find_outdated_dpus(dpu_nic_firmware_update_versions, snapshots);
+        snapshots: &HashMap<HostMachineId, ManagedHostStateSnapshot>,
+    ) -> Result<Vec<DpuMachineUpdate>, ModelError> {
+        let outdated_dpus = Self::find_outdated_dpus(dpu_nic_firmware_update_versions, snapshots)?;
 
         let unavailable_outdated_dpus: Vec<DpuMachineUpdate> = outdated_dpus
             .into_iter()
@@ -116,55 +116,62 @@ impl DpuMachineUpdate {
             .flatten()
             .collect();
 
-        unavailable_outdated_dpus
+        Ok(unavailable_outdated_dpus)
     }
 
     pub fn find_outdated_dpus<'a>(
         dpu_nic_firmware_update_versions: &[String],
-        snapshots: &'a HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) -> Vec<OutdatedHost<'a>> {
+        snapshots: &'a HashMap<HostMachineId, ManagedHostStateSnapshot>,
+    ) -> Result<Vec<OutdatedHost<'a>>, ModelError> {
         snapshots
             .iter()
-            .filter_map(|(machine_id, managed_host)| {
-                let outdated_dpus: Vec<DpuMachineUpdate> = managed_host
+            .map(|(machine_id, managed_host)| {
+                let outdated_dpus: Result<Vec<Option<DpuMachineUpdate>>, ModelError> = managed_host
                     .dpu_snapshots
                     .iter()
-                    .filter_map(|dpu| {
+                    .map(|dpu| {
                         // TODO: implement the logic to find the outdated DPUs which are ingested
                         // using DPF.
                         if managed_host.host_snapshot.config.dpf.used_for_ingestion {
-                            return None;
+                            return Ok(None);
                         }
                         let firmware_version = dpu
                             .status
                             .hardware_info
                             .as_ref()
                             .and_then(|info| info.dpu_info.as_ref())
-                            .map(|dpu_info| dpu_info.firmware_version.trim().to_owned())?;
+                            .map(|dpu_info| dpu_info.firmware_version.trim().to_owned());
+                        let Some(firmware_version) = firmware_version else {
+                            return Ok(None);
+                        };
 
                         if dpu_nic_firmware_update_versions.contains(&firmware_version) {
-                            return None;
+                            return Ok(None);
                         }
 
-                        Some(DpuMachineUpdate {
+                        Ok(Some(DpuMachineUpdate {
                             host_machine_id: *machine_id,
-                            dpu_machine_id: dpu.id,
+                            dpu_machine_id: dpu.dpu_machine_id().map_err(|error| {
+                                ModelError::DatabaseTypeConversionError(error.to_string())
+                            })?,
                             firmware_version,
                             dpf_managed: false,
-                        })
+                        }))
                     })
                     .collect();
+                let outdated_dpus = outdated_dpus?.into_iter().flatten().collect::<Vec<_>>();
 
                 if outdated_dpus.is_empty() {
-                    return None;
+                    return Ok(None);
                 }
 
-                Some(OutdatedHost {
+                Ok(Some(OutdatedHost {
                     managed_host,
                     outdated_dpus,
-                })
+                }))
             })
-            .collect()
+            .collect::<Result<Vec<_>, ModelError>>()
+            .map(|hosts| hosts.into_iter().flatten().collect())
     }
 
     /// Join DPF-identified outdated DPUs (by `MachineId`) to their owning host
@@ -173,18 +180,24 @@ impl DpuMachineUpdate {
     /// layer is responsible for logging that case.
     pub fn find_outdated_dpus_dpf<'a>(
         dpf_outdated: &[OutdatedDpfDpu],
-        snapshots: &'a HashMap<MachineId, ManagedHostStateSnapshot>,
-    ) -> Vec<OutdatedHost<'a>> {
+        snapshots: &'a HashMap<HostMachineId, ManagedHostStateSnapshot>,
+    ) -> Result<Vec<OutdatedHost<'a>>, ModelError> {
         if dpf_outdated.is_empty() {
-            return vec![];
+            return Ok(vec![]);
         }
 
-        let dpu_to_host: HashMap<MachineId, MachineId> = snapshots
+        let dpu_to_host: HashMap<DpuMachineId, HostMachineId> = snapshots
             .iter()
-            .flat_map(|(host_id, snap)| snap.dpu_snapshots.iter().map(move |d| (d.id, *host_id)))
-            .collect();
+            .flat_map(|(host_id, snap)| {
+                snap.dpu_snapshots.iter().map(move |d| {
+                    d.dpu_machine_id()
+                        .map(|id| (id, *host_id))
+                        .map_err(|error| ModelError::DatabaseTypeConversionError(error.to_string()))
+                })
+            })
+            .collect::<Result<_, _>>()?;
 
-        let mut by_host: HashMap<MachineId, Vec<DpuMachineUpdate>> = HashMap::new();
+        let mut by_host: HashMap<HostMachineId, Vec<DpuMachineUpdate>> = HashMap::new();
         for outdated in dpf_outdated {
             let Some(&host_id) = dpu_to_host.get(&outdated.dpu_machine_id) else {
                 continue;
@@ -197,7 +210,7 @@ impl DpuMachineUpdate {
             });
         }
 
-        by_host
+        Ok(by_host
             .into_iter()
             .filter_map(|(host_id, outdated_dpus)| {
                 let managed_host = snapshots.get(&host_id)?;
@@ -206,7 +219,7 @@ impl DpuMachineUpdate {
                     outdated_dpus,
                 })
             })
-            .collect()
+            .collect())
     }
 }
 

--- a/crates/api-model/src/dpu_remediation.rs
+++ b/crates/api-model/src/dpu_remediation.rs
@@ -18,7 +18,7 @@ use std::collections::HashMap;
 use std::fmt::{Display, Formatter};
 
 use carbide_uuid::dpu_remediations::RemediationId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use chrono::{DateTime, Utc};
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
@@ -139,7 +139,7 @@ pub struct NewAppliedRemediation {
 #[derive(Clone, Debug)]
 pub struct AppliedRemediation {
     pub id: RemediationId,
-    pub dpu_machine_id: MachineId,
+    pub dpu_machine_id: DpuMachineId,
     pub attempt: i32,
     pub succeeded: bool,
     pub status: HashMap<String, String>,

--- a/crates/api-model/src/errors.rs
+++ b/crates/api-model/src/errors.rs
@@ -17,7 +17,7 @@
 use std::fmt::{self, Display};
 use std::str::FromStr;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{InvalidMachineType, MachineId};
 use serde::de::Error as _;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
@@ -288,6 +288,17 @@ pub enum ModelError {
     HardwareInfo(#[from] HardwareInfoError),
     #[error("argument is invalid: {0}")]
     InvalidArgument(String),
+    #[error("{0}")]
+    InvalidMachindId(String),
+}
+
+impl From<InvalidMachineType> for ModelError {
+    #[track_caller]
+    fn from(err: InvalidMachineType) -> Self {
+        // Having a wrong machine type represents a bug in the code, so track the caller
+        let caller = std::panic::Location::caller();
+        ModelError::InvalidMachindId(format!("bug: wrong machine type at {caller}: {err}"))
+    }
 }
 
 pub type ModelResult<T> = Result<T, ModelError>;

--- a/crates/api-model/src/instance/config/network.rs
+++ b/crates/api-model/src/instance/config/network.rs
@@ -19,7 +19,7 @@ use std::collections::{HashMap, HashSet};
 use std::fmt::Display;
 use std::net::IpAddr;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use carbide_uuid::network::{NetworkPrefixId, NetworkSegmentId};
 use carbide_uuid::vpc::{VpcId, VpcPrefixId};
 use ipnetwork::IpNetwork;
@@ -255,9 +255,9 @@ impl InstanceNetworkConfig {
     /// Returns the DPU machine IDs used by the instance network configuration.
     pub fn get_used_dpus(
         &self,
-        device_to_id_map: &HashMap<String, Vec<MachineId>>,
-        primary_dpu_machine_id: Option<MachineId>,
-    ) -> Vec<MachineId> {
+        device_to_id_map: &HashMap<String, Vec<DpuMachineId>>,
+        primary_dpu_machine_id: Option<DpuMachineId>,
+    ) -> Vec<DpuMachineId> {
         let device_locators: Vec<&DeviceLocator> = self
             .interfaces
             .iter()
@@ -281,7 +281,7 @@ impl InstanceNetworkConfig {
             return primary_dpu_machine_id.into_iter().collect();
         }
 
-        let used_dpus: Vec<MachineId> = device_locators
+        let used_dpus: Vec<DpuMachineId> = device_locators
             .iter()
             .filter_map(|device_locator| {
                 device_to_id_map

--- a/crates/api-model/src/instance/status.rs
+++ b/crates/api-model/src/instance/status.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use serde::{Deserialize, Serialize};
 
 use crate::machine::ReprovisionRequest;
@@ -81,12 +81,12 @@ pub enum SyncState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InstanceStatusObservations {
     /// Observed status of the networking subsystem
-    pub network: HashMap<MachineId, network::InstanceNetworkStatusObservation>,
+    pub network: HashMap<DpuMachineId, network::InstanceNetworkStatusObservation>,
 
     /// Observed extension-service status, partitioned by service type. Each
     /// service type has one authoritative writer.
     pub extension_services:
-        HashMap<MachineId, extension_service::InstanceExtensionServiceStatusObservationByType>,
+        HashMap<DpuMachineId, extension_service::InstanceExtensionServiceStatusObservationByType>,
 
     /// Has the instance phoned home?
     pub phone_home_last_contact: Option<chrono::DateTime<chrono::Utc>>,

--- a/crates/api-model/src/instance/status/extension_service.rs
+++ b/crates/api-model/src/instance/status/extension_service.rs
@@ -19,7 +19,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 
 use carbide_utils::none_if_empty::NoneIfEmpty;
 use carbide_uuid::extension_service::ExtensionServiceId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
 use serde::{Deserialize, Serialize};
@@ -47,9 +47,9 @@ impl InstanceExtensionServicesStatus {
     /// observation remains unsynced/Unknown rather than being guessed to be a
     /// Kubernetes Pod service.
     pub fn from_config_and_type_observations(
-        dpu_ids: &[MachineId],
+        dpu_ids: &[DpuMachineId],
         config: Versioned<&InstanceExtensionServicesConfig>,
-        observations: &HashMap<MachineId, InstanceExtensionServiceStatusObservationByType>,
+        observations: &HashMap<DpuMachineId, InstanceExtensionServiceStatusObservationByType>,
         is_instance_deleted: bool,
     ) -> Self {
         let dpf_service_ids =
@@ -85,10 +85,10 @@ impl InstanceExtensionServicesStatus {
     pub fn from_config_and_service_type_observations(
         config: Versioned<&InstanceExtensionServicesConfig>,
         service_types: &HashMap<ExtensionServiceId, ExtensionServiceType>,
-        kubernetes_pod_required_dpus: &[MachineId],
-        dpf_helm_chart_required_dpus: &[MachineId],
+        kubernetes_pod_required_dpus: &[DpuMachineId],
+        dpf_helm_chart_required_dpus: &[DpuMachineId],
         instance_deleted_at: Option<&DateTime<Utc>>,
-        observations: &HashMap<MachineId, InstanceExtensionServiceStatusObservationByType>,
+        observations: &HashMap<DpuMachineId, InstanceExtensionServiceStatusObservationByType>,
     ) -> Self {
         // This means the instance has no extension services configured and all once terminating
         // services has been terminated from all DPUs and hence not present any more
@@ -308,7 +308,7 @@ impl InstanceExtensionServicesStatus {
 
 // Derive service id types from observations
 fn observed_service_ids(
-    observations: &HashMap<MachineId, InstanceExtensionServiceStatusObservationByType>,
+    observations: &HashMap<DpuMachineId, InstanceExtensionServiceStatusObservationByType>,
     service_type: ExtensionServiceType,
 ) -> HashSet<ExtensionServiceId> {
     observations
@@ -328,7 +328,7 @@ fn observed_service_ids(
 #[derive(Clone, Debug)]
 pub struct MachineExtensionServiceStatus {
     /// The ID of the DPU this status is from
-    pub machine_id: MachineId,
+    pub machine_id: DpuMachineId,
     /// The deployment status of the extension service on this specific DPU
     pub status: ExtensionServiceDeploymentStatus,
     /// Optional error message if the service encountered issues on this DPU
@@ -442,12 +442,15 @@ impl InstanceExtensionServiceStatusObservationByType {
     }
 
     /// Aggregates persisted type-partitioned observations.
-    pub fn aggregate_instance_observation(dpu_snapshots: &[Machine]) -> HashMap<MachineId, Self> {
+    pub fn aggregate_instance_observation(
+        dpu_snapshots: &[Machine],
+    ) -> HashMap<DpuMachineId, Self> {
         dpu_snapshots
             .iter()
             .filter_map(|dpu| {
+                let dpu_id = dpu.dpu_machine_id().ok()?;
                 let observations = dpu.status.extension_service_status_observations.clone();
-                (!observations.by_service_type.is_empty()).then_some((dpu.id, observations))
+                (!observations.by_service_type.is_empty()).then_some((dpu_id, observations))
             })
             .collect()
     }
@@ -560,6 +563,7 @@ mod tests {
     use std::str::FromStr;
 
     use carbide_test_support::value_scenarios;
+    use carbide_uuid::machine::DpuMachineId as MachineId;
     use chrono::{TimeZone, Utc};
 
     use super::*;
@@ -925,7 +929,7 @@ mod tests {
             InstanceExtensionServiceStatusObservationByType::aggregate_instance_observation(&[
                 dpu.clone()
             ]);
-        let aggregated = &aggregated[&dpu.id];
+        let aggregated = &aggregated[&dpu.dpu_machine_id().unwrap()];
         assert!(
             aggregated
                 .for_service_type(ExtensionServiceType::KubernetesPod)
@@ -1551,7 +1555,6 @@ mod tests {
         observation_with_dpf_status
             .extension_service_statuses
             .push(dpf_status);
-
         assert!(!observation.any_observed_version_changed(&observation_with_dpf_status));
     }
 

--- a/crates/api-model/src/instance/status/network.rs
+++ b/crates/api-model/src/instance/status/network.rs
@@ -19,7 +19,7 @@ use std::collections::HashMap;
 use std::convert::Into;
 use std::net::IpAddr;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use carbide_uuid::vpc::VpcId;
 use chrono::{DateTime, Utc};
 use config_version::{ConfigVersion, Versioned};
@@ -91,9 +91,9 @@ impl InstanceNetworkStatus {
     /// because the observation might have been related to a different config,
     /// and the interfaces therefore won't match.
     pub fn from_config_and_observations(
-        dpu_id_to_device_map: HashMap<String, Vec<MachineId>>,
+        dpu_id_to_device_map: HashMap<String, Vec<DpuMachineId>>,
         config: Versioned<&InstanceNetworkConfig>,
-        observations: &HashMap<MachineId, InstanceNetworkStatusObservation>,
+        observations: &HashMap<DpuMachineId, InstanceNetworkStatusObservation>,
         is_network_config_request_pending: bool,
     ) -> Self {
         if is_network_config_request_pending {
@@ -108,7 +108,7 @@ impl InstanceNetworkStatus {
         }
 
         // Observations without interfaces are from unused DPUs.  filter them out
-        let observations: HashMap<&MachineId, &InstanceNetworkStatusObservation> = observations
+        let observations: HashMap<&DpuMachineId, &InstanceNetworkStatusObservation> = observations
             .iter()
             .filter(|obs| !obs.1.interfaces.is_empty())
             .collect();
@@ -481,10 +481,13 @@ impl InstanceNetworkStatusObservation {
 
     pub fn aggregate_instance_observation(
         dpu_snapshots: &[Machine],
-    ) -> HashMap<MachineId, InstanceNetworkStatusObservation> {
+    ) -> HashMap<DpuMachineId, InstanceNetworkStatusObservation> {
         let mut observation_map = HashMap::default();
 
         for dpu_snapshot in dpu_snapshots {
+            let Ok(dpu_machine_id) = dpu_snapshot.dpu_machine_id() else {
+                continue;
+            };
             if let Some(obs) = dpu_snapshot
                 .network_status_observation
                 .as_ref()
@@ -496,7 +499,7 @@ impl InstanceNetworkStatusObservation {
                     observed_at: m.observed_at,
                 })
             {
-                observation_map.insert(dpu_snapshot.id, obs);
+                observation_map.insert(dpu_machine_id, obs);
             }
         }
 
@@ -554,6 +557,7 @@ mod tests {
     use std::fmt::Write;
     use std::str::FromStr;
 
+    use carbide_uuid::machine::DpuMachineId as MachineId;
     use carbide_uuid::network::{NetworkPrefixId, NetworkSegmentId};
     use carbide_uuid::vpc::VpcPrefixId;
 

--- a/crates/api-model/src/machine/capabilities.rs
+++ b/crates/api-model/src/machine/capabilities.rs
@@ -18,7 +18,7 @@
 use std::collections::HashMap;
 use std::fmt;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use serde::{Deserialize, Serialize};
 
 use super::infiniband::MachineInfinibandStatusObservation;
@@ -301,7 +301,7 @@ impl MachineCapabilitiesSet {
     pub fn from_hardware_info(
         hardware_info: &HardwareInfo,
         ib_status: Option<&MachineInfinibandStatusObservation>,
-        dpu_machine_ids: Vec<MachineId>,
+        dpu_machine_ids: Vec<DpuMachineId>,
         machine_interfaces: &[MachineInterfaceSnapshot],
     ) -> Self {
         //

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -20,7 +20,9 @@ use std::fmt::Display;
 use std::net::{IpAddr, Ipv6Addr, SocketAddr};
 
 use carbide_uuid::domain::DomainId;
-use carbide_uuid::machine::{MachineId, MachineInterfaceId};
+use carbide_uuid::machine::{
+    DpuMachineId, HostMachineId, InvalidMachineType, MachineId, MachineInterfaceId,
+};
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::power_shelf::PowerShelfId;
@@ -105,7 +107,10 @@ pub struct DpuInfo {
     pub observed_status: Option<DpuInfoStatusObservation>,
 }
 
-type DpuDeviceMappings = (HashMap<MachineId, String>, HashMap<String, Vec<MachineId>>);
+type DpuDeviceMappings = (
+    HashMap<DpuMachineId, String>,
+    HashMap<String, Vec<DpuMachineId>>,
+);
 
 pub fn get_display_ids(machines: &[Machine]) -> String {
     machines
@@ -247,11 +252,14 @@ pub enum NotAllocatableReason {
 
 #[derive(Debug, thiserror::Error)]
 pub enum ManagedHostStateSnapshotError {
+    #[error(transparent)]
+    InvalidMachineType(#[from] InvalidMachineType),
+
     #[error("missing primary interface. machine id: {0}")]
-    PrimaryInterfaceMissing(MachineId),
+    PrimaryInterfaceMissing(HostMachineId),
 
     #[error("missing dpu with primary dpu id. machine id: {0}, DPU ID: {1}")]
-    MissingPrimaryDpu(MachineId, MachineId),
+    MissingPrimaryDpu(HostMachineId, DpuMachineId),
 }
 
 impl From<ManagedHostStateSnapshotError> for sqlx::Error {
@@ -665,7 +673,7 @@ impl ManagedHostStateSnapshot {
             .all(|dpu_machine_id| {
                 self.dpu_snapshots
                     .iter()
-                    .find(|dpu_snapshot| dpu_snapshot.id == dpu_machine_id)
+                    .find(|dpu_snapshot| dpu_snapshot.id == dpu_machine_id.into())
                     .is_some_and(|dpu_snapshot| {
                         dpu_snapshot.managed_host_network_config_version_synced(host_version)
                     })
@@ -736,10 +744,10 @@ impl ManagedHostStateSnapshot {
             let index = self
                 .dpu_snapshots
                 .iter()
-                .position(|x| x.id == primary_dpu_id)
+                .position(|x| x.id == primary_dpu_id.into())
                 .ok_or({
                     ManagedHostStateSnapshotError::MissingPrimaryDpu(
-                        self.host_snapshot.id,
+                        self.host_snapshot.host_machine_id()?,
                         primary_dpu_id,
                     )
                 })?;
@@ -754,7 +762,7 @@ impl ManagedHostStateSnapshot {
             // ExpectedMachine can declare a non-DPU host admin NIC as primary, and in that case no
             // DPU should be promoted ahead of PCI order.
             return Err(ManagedHostStateSnapshotError::PrimaryInterfaceMissing(
-                self.host_snapshot.id,
+                self.host_snapshot.host_machine_id()?,
             ));
         };
 
@@ -974,6 +982,14 @@ impl Machine {
         self.id.machine_type().is_dpu()
     }
 
+    pub fn dpu_machine_id(&self) -> Result<DpuMachineId, InvalidMachineType> {
+        self.id.try_into()
+    }
+
+    pub fn host_machine_id(&self) -> Result<HostMachineId, InvalidMachineType> {
+        self.id.try_into()
+    }
+
     pub fn bmc_vendor(&self) -> bmc_vendor::BMCVendor {
         match self.status.hardware_info.as_ref() {
             Some(hw) => hw.bmc_vendor(),
@@ -1084,7 +1100,7 @@ impl Machine {
     }
 
     /// Returns all associated DPU Machine IDs if this is Host Machine
-    pub fn associated_dpu_machine_ids(&self) -> Vec<MachineId> {
+    pub fn associated_dpu_machine_ids(&self) -> Vec<DpuMachineId> {
         if self.is_dpu() {
             return Vec::new();
         }
@@ -1093,7 +1109,7 @@ impl Machine {
             .interfaces
             .iter()
             .filter_map(|i| i.attached_dpu_machine_id)
-            .collect::<Vec<MachineId>>()
+            .collect::<Vec<DpuMachineId>>()
     }
 
     pub fn bmc_addr(&self) -> Option<SocketAddr> {
@@ -1138,7 +1154,7 @@ impl Machine {
 
     pub fn get_device_locator_for_dpu_id(
         &self,
-        dpu_machine_id: &MachineId,
+        dpu_machine_id: &DpuMachineId,
     ) -> ModelResult<DeviceLocator> {
         let (id_to_device_map, device_to_id_map) = self.get_dpu_device_and_id_mappings()?;
 
@@ -1157,7 +1173,7 @@ impl Machine {
         )))
     }
 
-    pub fn primary_attached_dpu_machine_id(&self) -> Option<MachineId> {
+    pub fn primary_attached_dpu_machine_id(&self) -> Option<DpuMachineId> {
         self.status
             .interfaces
             .iter()
@@ -1181,8 +1197,8 @@ impl Machine {
                     self.id
                 )))?;
 
-        let mut id_to_device_map: HashMap<MachineId, String> = HashMap::default();
-        let mut device_to_id_map: HashMap<String, Vec<MachineId>> = HashMap::default();
+        let mut id_to_device_map: HashMap<DpuMachineId, String> = HashMap::default();
+        let mut device_to_id_map: HashMap<String, Vec<DpuMachineId>> = HashMap::default();
         // in order to ensure that the primary dpu is assigned a network config, it is configured first.
         // hardware_interfaces has the primary dpu as the first interface, self.status.interfaces may not.
         // iterate over hardware_interfaces and match it to self.status.interfaces using the mac address
@@ -1214,17 +1230,17 @@ impl Machine {
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DpuDiscoveringStates {
-    pub states: HashMap<MachineId, DpuDiscoveringState>,
+    pub states: HashMap<DpuMachineId, DpuDiscoveringState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DpuInitStates {
-    pub states: HashMap<MachineId, DpuInitState>,
+    pub states: HashMap<DpuMachineId, DpuInitState>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DpuReprovisionStates {
-    pub states: HashMap<MachineId, ReprovisionState>,
+    pub states: HashMap<DpuMachineId, ReprovisionState>,
 }
 
 /// Possible Machine state-machine implementation
@@ -1377,7 +1393,7 @@ pub enum ManagedHostState {
     /// backoff/quarantine is the rotation engine's `device_credential_rotation`
     /// bookkeeping keyed by that DPU's BMC MAC.
     RotatingDpuUefi {
-        dpu_machine_id: MachineId,
+        dpu_machine_id: DpuMachineId,
     },
 
     /// The host is rekeying its NIC lockdown keys to the staged
@@ -1668,7 +1684,7 @@ impl ManagedHostState {
         }
     }
 
-    pub fn as_reprovision_state(&self, dpu_id: &MachineId) -> Option<&ReprovisionState> {
+    pub fn as_reprovision_state(&self, dpu_id: &DpuMachineId) -> Option<&ReprovisionState> {
         self.dpu_reprovision_states()?.states.get(dpu_id)
     }
 
@@ -2901,7 +2917,7 @@ impl Display for ManagedHostState {
 }
 
 impl ManagedHostState {
-    pub fn dpu_state_string(&self, dpu_id: &MachineId) -> String {
+    pub fn dpu_state_string(&self, dpu_id: &DpuMachineId) -> String {
         match self {
             ManagedHostState::ConfigureAstra {
                 configure_astra_state,
@@ -3015,7 +3031,7 @@ pub struct MachineInterfaceSnapshot {
     /// [`MachineBootInterface`]; for the `primary_interface` row that pair is the
     /// host's boot device.
     pub boot_interface_id: Option<String>,
-    pub attached_dpu_machine_id: Option<MachineId>,
+    pub attached_dpu_machine_id: Option<DpuMachineId>,
     pub domain_id: Option<DomainId>,
     pub machine_id: Option<MachineId>,
     pub segment_id: NetworkSegmentId,
@@ -3915,6 +3931,8 @@ mod tests {
         };
         let dpu_id =
             MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
+                .unwrap()
+                .try_into()
                 .unwrap();
 
         assert_eq!(state.to_string(), "BootConfiguring/Failed");
@@ -4293,8 +4311,10 @@ mod tests {
     // both assertions ride along.
     #[test]
     fn test_json_deserialize_reprovisioning_states() {
-        let machine_id =
+        let machine_id: DpuMachineId =
             MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
+                .unwrap()
+                .try_into()
                 .unwrap();
         scenarios!(
             run = |s| {
@@ -4338,8 +4358,10 @@ mod tests {
     // variant; the parsed value (PartialEq) is the whole assertion.
     #[test]
     fn test_json_deserialize_managed_host_states() {
-        let machine_id =
+        let machine_id: DpuMachineId =
             MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
+                .unwrap()
+                .try_into()
                 .unwrap();
 
         scenarios!(
@@ -4620,11 +4642,15 @@ mod tests {
             aggregate_health: health_report::HealthReport,
         }
 
-        let machine_id =
+        let machine_id: DpuMachineId =
             MachineId::from_str("fm100ds7blqjsadm2uuh3qqbf1h7k8pmf47um6v9uckrg7l03po8mhqgvng")
+                .unwrap()
+                .try_into()
                 .unwrap();
-        let other_dpu_id =
+        let other_dpu_id: DpuMachineId =
             MachineId::from_str("fm100dtjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0")
+                .unwrap()
+                .try_into()
                 .unwrap();
         let validation_id = MachineValidationId::nil();
         let sla_config = slas::MachineSlaConfig::new(chrono::Duration::minutes(10));
@@ -4634,7 +4660,7 @@ mod tests {
                 failed_at: chrono::Utc::now(),
                 source: FailureSource::NoError,
             },
-            machine_id,
+            machine_id: machine_id.into(),
             retry_count: 1,
         };
         let excluded = || {

--- a/crates/api-model/src/network_devices.rs
+++ b/crates/api-model/src/network_devices.rs
@@ -19,7 +19,7 @@ use core::fmt;
 use std::fmt::Display;
 use std::net::IpAddr;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use sqlx::postgres::PgRow;
 use sqlx::{FromRow, Row};
 
@@ -120,7 +120,7 @@ impl<'r> FromRow<'r, PgRow> for NetworkDevice {
 // debugging.
 #[derive(Debug, Clone, FromRow)]
 pub struct DpuToNetworkDeviceMap {
-    pub dpu_id: MachineId,
+    pub dpu_id: DpuMachineId,
     pub local_port: DpuLocalPorts,
     pub remote_port: String,
     pub network_device_id: String,

--- a/crates/api-model/src/power_manager.rs
+++ b/crates/api-model/src/power_manager.rs
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use chrono::{DateTime, Utc};
 use config_version::ConfigVersion;
 use serde::{Deserialize, Serialize};
@@ -67,7 +67,7 @@ impl PowerHandlingOutcome {
 /// the handling and move to the state handler.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PowerOptions {
-    pub host_id: MachineId,
+    pub host_id: HostMachineId,
     pub last_fetched_updated_at: DateTime<Utc>,
     pub last_fetched_next_try_at: DateTime<Utc>,
     pub last_fetched_power_state: PowerState,
@@ -180,7 +180,7 @@ pub fn are_all_dpus_up_after_power_operation(
 
 impl<'r> FromRow<'r, PgRow> for PowerOptions {
     fn from_row(row: &'r PgRow) -> Result<Self, sqlx::Error> {
-        let host_id: MachineId = row.try_get("host_id")?;
+        let host_id: HostMachineId = row.try_get("host_id")?;
         let last_fetched_updated_at = row.try_get("last_fetched_updated_at")?;
         let last_fetched_next_try_at = row.try_get("last_fetched_next_try_at")?;
         let last_fetched_power_state = row.try_get("last_fetched_power_state")?;

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use carbide_network::BaseMac;
 use carbide_utils::arch::CpuArchitecture;
 use carbide_utils::none_if_empty::NoneIfEmpty;
-use carbide_uuid::machine::{MachineId, MachineType};
+use carbide_uuid::machine::{DpuMachineId, MachineId, MachineType};
 use carbide_uuid::power_shelf::{PowerShelfId, PowerShelfIdSource, PowerShelfType};
 use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
 use chrono::{DateTime, Utc};
@@ -600,8 +600,8 @@ pub struct ExploredDpu {
 }
 
 impl ExploredDpu {
-    pub fn machine_id_if_valid_report(&self) -> ModelResult<&MachineId> {
-        let Some(machine_id) = self.report.machine_id.as_ref() else {
+    pub fn machine_id_if_valid_report(&self) -> ModelResult<DpuMachineId> {
+        let Some(machine_id) = self.report.machine_id else {
             return Err(ModelError::MissingArgument("Missing Machine ID"));
         };
 
@@ -617,7 +617,7 @@ impl ExploredDpu {
             return Err(ModelError::MissingArgument("Missing Service Info"));
         }
 
-        Ok(machine_id)
+        Ok(machine_id.try_into()?)
     }
 
     pub fn bmc_firmware_version(&self) -> Option<String> {

--- a/crates/api-model/src/test_support/machine_snapshot.rs
+++ b/crates/api-model/src/test_support/machine_snapshot.rs
@@ -25,7 +25,9 @@
 use std::collections::{BTreeMap, HashMap};
 use std::net::IpAddr;
 
-use carbide_uuid::machine::{MachineId, MachineIdSource, MachineInterfaceId, MachineType};
+use carbide_uuid::machine::{
+    DpuMachineId, MachineId, MachineIdSource, MachineInterfaceId, MachineType,
+};
 use carbide_uuid::network::NetworkSegmentId;
 use chrono::{DateTime, TimeZone, Utc};
 use config_version::ConfigVersion;
@@ -62,7 +64,7 @@ pub fn host_machine_id() -> MachineId {
 }
 
 /// Deterministic machine ids for the fixture host's DPUs.
-pub fn dpu_machine_id(index: u8) -> MachineId {
+pub fn dpu_machine_id(index: u8) -> DpuMachineId {
     // Widen before adding: `0x20 + index` on a u8 overflows past index 223,
     // the same bound `fixture_dpu_index` documents. Fail with a clear message
     // instead of an overflow panic.
@@ -76,12 +78,14 @@ pub fn dpu_machine_id(index: u8) -> MachineId {
         [hash_byte as u8; 32],
         MachineType::Dpu,
     )
+    .try_into()
+    .unwrap()
 }
 
 /// Recovers the index a [`dpu_machine_id`] was created from, so id-keyed
 /// builders can give each fixture DPU its own hardware identity. `None` for
 /// ids that no fixture index produces.
-fn fixture_dpu_index(machine_id: MachineId) -> Option<u8> {
+fn fixture_dpu_index(machine_id: DpuMachineId) -> Option<u8> {
     // `dpu_machine_id` fills the id bytes with `0x20 + index`, so indexes
     // beyond `u8::MAX - 0x20` are not constructible.
     (0..=u8::MAX - 0x20).find(|&index| dpu_machine_id(index) == machine_id)
@@ -242,7 +246,7 @@ fn interface(
     machine_id: MachineId,
     interface_type: InterfaceType,
     primary: bool,
-    attached_dpu: Option<MachineId>,
+    attached_dpu: Option<carbide_uuid::machine::DpuMachineId>,
     segment_type: Option<NetworkSegmentType>,
 ) -> MachineInterfaceSnapshot {
     MachineInterfaceSnapshot {
@@ -332,11 +336,13 @@ fn health_reports(agent_source: &str) -> HealthReportSources {
 /// `machine_type` decides between the host shape (8 GPUs, 9 NICs) and the
 /// DPU shape (BlueField hardware info, small interface set).
 pub fn machine_snapshot_pg_json(machine_id: MachineId) -> MachineSnapshotPgJson {
-    let is_dpu = machine_id.machine_type().is_dpu();
-    let hardware_info = if is_dpu {
-        dpu_hardware_info(fixture_dpu_index(machine_id).unwrap_or(0))
+    let (hardware_info, is_dpu) = if let Ok(dpu_machine_id) = DpuMachineId::try_from(machine_id) {
+        (
+            dpu_hardware_info(fixture_dpu_index(dpu_machine_id).unwrap_or(0)),
+            true,
+        )
     } else {
-        host_hardware_info()
+        (host_hardware_info(), false)
     };
     let interfaces = if is_dpu {
         vec![interface(
@@ -517,7 +523,7 @@ pub fn host_machine() -> Machine {
 
 /// A fully-populated DPU [`Machine`], as loaded from the database.
 pub fn dpu_machine(index: u8) -> Machine {
-    machine_snapshot_pg_json(dpu_machine_id(index))
+    machine_snapshot_pg_json(dpu_machine_id(index).into())
         .try_into()
         .expect("fixture DPU snapshot converts to Machine")
 }

--- a/crates/api-model/src/test_support/managed_host.rs
+++ b/crates/api-model/src/test_support/managed_host.rs
@@ -20,7 +20,7 @@ use std::iter;
 use std::net::IpAddr;
 use std::str::FromStr;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use itertools::Itertools;
 use mac_address::MacAddress;
 
@@ -50,7 +50,7 @@ pub struct ManagedHostExplorationResults {
 }
 
 impl ManagedHostExplorationResults {
-    pub fn dpu_machine_ids(&self) -> HashMap<u8, MachineId> {
+    pub fn dpu_machine_ids(&self) -> HashMap<u8, DpuMachineId> {
         self.dpu_reports
             .iter()
             .map(|dpu_report| {
@@ -59,7 +59,9 @@ impl ManagedHostExplorationResults {
                     dpu_report
                         .report
                         .machine_id
-                        .expect("DPU exploration report should have a generated machine id"),
+                        .expect("DPU exploration report should have a generated machine id")
+                        .try_into()
+                        .expect("should be a valid DPU machine ID"),
                 )
             })
             .collect()

--- a/crates/api-model/src/vpc/mod.rs
+++ b/crates/api-model/src/vpc/mod.rs
@@ -26,7 +26,7 @@ pub use capability::{
 };
 use carbide_network::ip::IpAddressFamily;
 use carbide_network::virtualization::VpcVirtualizationType;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use carbide_uuid::network_security_group::NetworkSecurityGroupId;
 use carbide_uuid::nvlink::NvLinkLogicalPartitionId;
 use carbide_uuid::vpc::VpcId;
@@ -203,13 +203,13 @@ impl<'r> sqlx::FromRow<'r, PgRow> for Vpc {
 
 #[derive(Clone, Debug, FromRow)]
 pub struct VpcDpuLoopback {
-    pub dpu_id: MachineId,
+    pub dpu_id: DpuMachineId,
     pub vpc_id: VpcId,
     pub loopback_ip: IpAddr,
 }
 
 impl VpcDpuLoopback {
-    pub fn new(dpu_id: MachineId, vpc_id: VpcId, loopback_ip: IpAddr) -> Self {
+    pub fn new(dpu_id: DpuMachineId, vpc_id: VpcId, loopback_ip: IpAddr) -> Self {
         Self {
             dpu_id,
             vpc_id,

--- a/crates/api-web/src/tests/health.rs
+++ b/crates/api-web/src/tests/health.rs
@@ -60,7 +60,7 @@ async fn test_health_of_nonexisting_machine(pool: sqlx::PgPool) {
 
     assert!(
         env.test_harness
-            .find_machine(host_machine_id)
+            .find_machine(host_machine_id.into())
             .await
             .is_empty()
     );

--- a/crates/api-web/src/tests/managed_host.rs
+++ b/crates/api-web/src/tests/managed_host.rs
@@ -141,7 +141,7 @@ async fn machine_detail_manages_the_desired_boot_interface(pool: sqlx::PgPool) {
     let app = make_test_app(&env.test_harness);
     let host = env.create_ready_managed_host(2).await.0;
     let machine_id = host.host.id;
-    let interfaces = load_machine_interfaces(&env, machine_id).await;
+    let interfaces = load_machine_interfaces(&env, machine_id.into()).await;
     let default_interface = model::machine::pick_default_boot_interface(&interfaces)
         .expect("managed host should have a system-default interface")
         .clone();
@@ -221,7 +221,8 @@ async fn machine_detail_manages_the_desired_boot_interface(pool: sqlx::PgPool) {
     // Selecting an exact row moves primary + desired state atomically, while
     // the request path leaves the BMC untouched.
     let redfish_timepoint = env.redfish_sim.timepoint();
-    let response = post_desired_boot_interface(&app, machine_id, selected_interface.id).await;
+    let response =
+        post_desired_boot_interface(&app, machine_id.into(), selected_interface.id).await;
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
     assert!(
         env.redfish_sim
@@ -231,13 +232,11 @@ async fn machine_detail_manages_the_desired_boot_interface(pool: sqlx::PgPool) {
         "the web request should leave Redfish work to machine-controller",
     );
 
-    let selected_desired = db::machine_desired_boot_interface::get(
-        &env.api().database_connection,
-        &machine_id.try_into().unwrap(),
-    )
-    .await
-    .unwrap()
-    .expect("selecting an interface should persist a desired target");
+    let selected_desired =
+        db::machine_desired_boot_interface::get(&env.api().database_connection, &machine_id)
+            .await
+            .unwrap()
+            .expect("selecting an interface should persist a desired target");
     assert_eq!(
         selected_desired.value.mac_address(),
         selected_interface.mac_address
@@ -247,7 +246,7 @@ async fn machine_detail_manages_the_desired_boot_interface(pool: sqlx::PgPool) {
         selected_interface.boot_interface_id.as_deref()
     );
     assert!(
-        load_machine_interfaces(&env, machine_id)
+        load_machine_interfaces(&env, machine_id.into())
             .await
             .iter()
             .find(|interface| interface.id == selected_interface.id)
@@ -295,7 +294,7 @@ async fn machine_detail_manages_the_desired_boot_interface(pool: sqlx::PgPool) {
     // `Use system default` is the same exact-row write with the server's
     // current default mapped back to its managed UUID.
     let redfish_timepoint = env.redfish_sim.timepoint();
-    let response = post_desired_boot_interface(&app, machine_id, default_interface.id).await;
+    let response = post_desired_boot_interface(&app, machine_id.into(), default_interface.id).await;
     assert_eq!(response.status(), StatusCode::SEE_OTHER);
     assert!(
         env.redfish_sim
@@ -305,13 +304,11 @@ async fn machine_detail_manages_the_desired_boot_interface(pool: sqlx::PgPool) {
         "restoring the default should leave Redfish work to machine-controller",
     );
 
-    let default_desired = db::machine_desired_boot_interface::get(
-        &env.api().database_connection,
-        &machine_id.try_into().unwrap(),
-    )
-    .await
-    .unwrap()
-    .expect("restoring the system default should retain a desired target");
+    let default_desired =
+        db::machine_desired_boot_interface::get(&env.api().database_connection, &machine_id)
+            .await
+            .unwrap()
+            .expect("restoring the system default should retain a desired target");
     assert_eq!(
         default_desired.value.mac_address(),
         default_interface.mac_address
@@ -345,13 +342,11 @@ async fn machine_detail_manages_the_desired_boot_interface(pool: sqlx::PgPool) {
         "requesting reconciliation should leave Redfish work to machine-controller",
     );
 
-    let reconciled_desired = db::machine_desired_boot_interface::get(
-        &env.api().database_connection,
-        &machine_id.try_into().unwrap(),
-    )
-    .await
-    .unwrap()
-    .expect("requesting reconciliation should retain the desired target");
+    let reconciled_desired =
+        db::machine_desired_boot_interface::get(&env.api().database_connection, &machine_id)
+            .await
+            .unwrap()
+            .expect("requesting reconciliation should retain the desired target");
     assert_eq!(reconciled_desired.value, default_desired.value);
     assert_ne!(reconciled_desired.version, default_desired.version);
 }
@@ -417,13 +412,10 @@ async fn machine_detail_shows_an_uninitialized_desired_boot_interface(pool: sqlx
         "an uninitialized request should not touch Redfish",
     );
     assert!(
-        db::machine_desired_boot_interface::get(
-            &env.api().database_connection,
-            &machine_id.try_into().unwrap()
-        )
-        .await
-        .unwrap()
-        .is_none(),
+        db::machine_desired_boot_interface::get(&env.api().database_connection, &machine_id)
+            .await
+            .unwrap()
+            .is_none(),
         "reconciliation without a desired target should not initialize one",
     );
 }

--- a/crates/dpa-manager/src/lib.rs
+++ b/crates/dpa-manager/src/lib.rs
@@ -21,7 +21,7 @@ use std::time::Duration;
 
 use carbide_dpa::DpaInfo;
 use carbide_utils::periodic_timer::PeriodicTimer;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use chrono::TimeDelta;
 use db::db_read::PgPoolReader;
 use db::work_lock_manager::WorkLockManagerHandle;
@@ -367,7 +367,16 @@ impl DpaMonitor {
         // in the slice are harmless for `= ANY($1)`, and the non-consuming
         // `get` keeps the assignment correct even when two entries resolve to
         // the same host snapshot.
-        let machine_ids: Vec<MachineId> = res.values().map(|mh| mh.host_snapshot.id).collect();
+        let machine_ids: Vec<HostMachineId> = res
+            .values()
+            .map(|mh| {
+                mh.host_snapshot
+                    .host_machine_id()
+                    .map_err(|error| DpaManagerError::Internal {
+                        message: error.to_string(),
+                    })
+            })
+            .collect::<Result<_, _>>()?;
         let dpa_search_config = DpaSearchConfig {
             only_svpc: false,
             only_astra: false,
@@ -379,7 +388,11 @@ impl DpaMonitor {
 
         for mh in res.values_mut() {
             mh.dpa_interface_snapshots = dpa_snapshots_by_machine
-                .get(&mh.host_snapshot.id)
+                .get(&mh.host_snapshot.host_machine_id().map_err(|error| {
+                    DpaManagerError::Internal {
+                        message: error.to_string(),
+                    }
+                })?)
                 .cloned()
                 .unwrap_or_default();
         }

--- a/crates/machine-controller/src/dpf.rs
+++ b/crates/machine-controller/src/dpf.rs
@@ -30,7 +30,7 @@ use carbide_dpf::{
     DpuDeviceInfo, DpuNodeInfo, DpuPhase, DpuWatcher, KubeRepository, ResourceLabeler,
     node_id_from_dpu_node_cr_name,
 };
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 use model::dpa_interface::DpaInterface;
 use model::dpu_machine_update::OutdatedDpfDpu;
 use model::machine::{Machine, ManagedHostStateSnapshot};
@@ -528,7 +528,7 @@ impl DpfSdkOps {
 /// Records that a host owes `kind`, returning the stored action.
 async fn record_pending_action(
     db_pool: &PgPool,
-    host_machine_id: &MachineId,
+    host_machine_id: &HostMachineId,
     kind: MachinePendingActionKind,
 ) -> Result<MachinePendingAction, DpfError> {
     let mut conn = db_pool.acquire().await.map_err(|e| {
@@ -578,6 +578,9 @@ async fn enqueue_host(
         tracing::warn!(node = %node_name, bmc_mac_address = %bmc_mac, reason, "Could not find host for DPF node");
         return Ok(());
     };
+    let host_machine_id = HostMachineId::try_from(host_machine_id).map_err(|error| {
+        DpfError::InvalidState(format!("BMC MAC resolved to a non-host machine: {error}"))
+    })?;
 
     // Written before the enqueue so a processor cannot reach the host's handler
     // while the marker is still missing.
@@ -816,7 +819,7 @@ impl DpfOperations for DpfSdkOps {
                 );
                 continue;
             };
-            let dpu_machine_id: MachineId = match machine_id_str.parse() {
+            let dpu_machine_id: DpuMachineId = match machine_id_str.parse() {
                 Ok(id) => id,
                 Err(e) => {
                     tracing::warn!(

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -37,7 +37,7 @@ use carbide_redfish::libredfish::error::state_handler_redfish_error as redfish_e
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialReader, Credentials,
 };
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, HostMachineId, MachineId};
 use carbide_uuid::vpc::VpcId;
 use chrono::{DateTime, Duration, Utc};
 use config_version::{ConfigVersion, Versioned};
@@ -717,7 +717,8 @@ impl MachineStateHandler {
                     let since_last_seen = Utc::now().signed_duration_since(observed_at);
                     if since_last_seen > self.dpu_up_threshold {
                         let message = format!("Last seen over {} ago", self.dpu_up_threshold);
-                        let dpu_machine_id = &dpu_snapshot.id;
+                        let dpu_machine_id = dpu_snapshot.dpu_machine_id()?;
+                        let dpu_machine_id = &dpu_machine_id;
                         let health_report = health_report::HealthReport::heartbeat_timeout(
                             health_report::HealthReport::DPU_AGENT_SOURCE.to_string(),
                             health_report::HealthReport::DPU_AGENT_SOURCE.to_string(),
@@ -1171,7 +1172,10 @@ impl MachineStateHandler {
                     let next_state = reprov_state.next_state_with_all_dpus_updated(
                         &mh_state,
                         &mh_snapshot.dpu_snapshots,
-                        dpus_for_reprov.iter().map(|x| &x.id).collect_vec(),
+                        dpus_for_reprov
+                            .into_iter()
+                            .map(Machine::dpu_machine_id)
+                            .collect::<Result<Vec<_>, _>>()?,
                     )?;
 
                     let health_override = create_host_update_health_report_dpufw();
@@ -1462,7 +1466,12 @@ impl MachineStateHandler {
             }
 
             ManagedHostState::RotatingDpuUefi { dpu_machine_id } => {
-                dpu_uefi_rotation::handle_rotating_dpu_uefi(ctx, mh_snapshot, *dpu_machine_id).await
+                dpu_uefi_rotation::handle_rotating_dpu_uefi(
+                    ctx,
+                    mh_snapshot,
+                    (*dpu_machine_id).into(),
+                )
+                .await
             }
 
             ManagedHostState::RotatingNicLockdown => {
@@ -2279,7 +2288,7 @@ impl MachineStateHandler {
         let mut txn = ctx.services.db_pool.begin().await?;
         let mut dpa_interface = db::dpa_interface::ensure(
             NewDpaInterface {
-                machine_id: mh_snapshot.host_snapshot.id,
+                machine_id: mh_snapshot.host_snapshot.host_machine_id()?,
                 mac_address,
                 device_type: "Network Adapter Ethernet Interface".to_string(),
                 pci_name: nic_model_and_name.name,
@@ -2501,11 +2510,16 @@ impl MachineStateHandler {
             state,
             ctx.services.site_config.dpf_enabled,
         );
-        Ok(Some(reprov_state.next_state_with_all_dpus_updated(
-            &state.managed_state,
-            &state.dpu_snapshots,
-            dpus_for_reprov.iter().map(|x| &x.id).collect_vec(),
-        )?))
+        Ok(Some(
+            reprov_state.next_state_with_all_dpus_updated(
+                &state.managed_state,
+                &state.dpu_snapshots,
+                dpus_for_reprov
+                    .iter()
+                    .map(|machine| machine.dpu_machine_id())
+                    .collect::<Result<Vec<_>, _>>()?,
+            )?,
+        ))
     }
 
     // If current BMC FW allows to install bfb via redfish - performs redfish install,
@@ -2561,7 +2575,10 @@ impl MachineStateHandler {
                     .next_state_with_all_dpus_updated(
                         &state.managed_state,
                         &state.dpu_snapshots,
-                        dpus_for_reprov.iter().map(|x| &x.id).collect_vec(),
+                        dpus_for_reprov
+                            .iter()
+                            .map(|m| m.dpu_machine_id())
+                            .collect::<Result<Vec<_>, _>>()?,
                     )?,
                 );
             }
@@ -2585,7 +2602,10 @@ impl MachineStateHandler {
                     .next_state_with_all_dpus_updated(
                         &ManagedHostState::Ready,
                         &state.dpu_snapshots,
-                        dpus_for_reprov.iter().map(|x| &x.id).collect_vec(),
+                        dpus_for_reprov
+                            .iter()
+                            .map(|m| m.dpu_machine_id())
+                            .collect::<Result<Vec<_>, _>>()?,
                     )?,
                 );
             }
@@ -3025,7 +3045,7 @@ async fn are_dpus_up_trigger_reboot_if_needed(
 impl StateHandler for MachineStateHandler {
     type State = ManagedHostStateSnapshot;
     type ControllerState = ManagedHostState;
-    type ObjectId = MachineId;
+    type ObjectId = HostMachineId;
     type ContextObjects = MachineStateHandlerContextObjects;
 
     // Note: extra_logfmt_logging_fields function to add additional
@@ -3034,7 +3054,7 @@ impl StateHandler for MachineStateHandler {
     #[instrument(skip_all, fields(object_id=%host_machine_id, state=%_mh_state))]
     async fn handle_object_state(
         &self,
-        host_machine_id: &MachineId,
+        host_machine_id: &HostMachineId,
         mh_snapshot: &mut ManagedHostStateSnapshot,
         _mh_state: &Self::ControllerState, // mh_snapshot above already contains it
         ctx: &mut StateHandlerContext<Self::ContextObjects>,
@@ -3251,7 +3271,8 @@ async fn handle_bfb_install_state(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     next_state_resolver: &impl NextState,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let dpu_machine_id = &dpu_snapshot.id.clone();
+    let dpu_machine_id = dpu_snapshot.dpu_machine_id()?;
+    let dpu_machine_id = &dpu_machine_id;
     let dpu_redfish_client_result = ctx
         .services
         .create_redfish_client_from_machine(dpu_snapshot)
@@ -3528,8 +3549,9 @@ fn update_reprovision_targets_to_reprovision_state(
     let reprovision_target_dpu_ids = state
         .dpu_snapshots
         .iter()
-        .filter_map(|dpu| dpu.reprovision_requested.as_ref().map(|_| &dpu.id))
-        .collect_vec();
+        .filter(|dpu| dpu.reprovision_requested.is_some())
+        .map(Machine::dpu_machine_id)
+        .collect::<Result<Vec<_>, _>>()?;
 
     reprovision_state.next_state_with_all_dpus_updated(
         &state.managed_state,
@@ -3549,7 +3571,8 @@ async fn handle_dpu_reprovision(
     hardware_models: &FirmwareConfigSnapshot,
     dpf_sdk: Option<&dyn DpfOperations>,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-    let dpu_machine_id = &dpu_snapshot.id;
+    let dpu_machine_id = dpu_snapshot.dpu_machine_id()?;
+    let dpu_machine_id = &dpu_machine_id;
     let reprovision_state = state
         .managed_state
         .as_reprovision_state(dpu_machine_id)
@@ -3613,13 +3636,14 @@ async fn handle_dpu_reprovision(
             let dpus_states_for_reprov = &state
                 .dpu_snapshots
                 .iter()
-                .filter_map(|x| {
-                    if x.reprovision_requested.is_some() {
-                        state.managed_state.as_reprovision_state(&x.id)
-                    } else {
-                        None
-                    }
+                .filter(|x| x.reprovision_requested.is_some())
+                .map(|x| {
+                    let id = x.dpu_machine_id()?;
+                    Ok::<_, StateHandlerError>(state.managed_state.as_reprovision_state(&id))
                 })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .flatten()
                 .collect_vec();
 
             if !all_equal(dpus_states_for_reprov)? {
@@ -3712,13 +3736,14 @@ async fn handle_dpu_reprovision(
             let dpus_states_for_reprov = &state
                 .dpu_snapshots
                 .iter()
-                .filter_map(|x| {
-                    if x.reprovision_requested.is_some() {
-                        state.managed_state.as_reprovision_state(&x.id)
-                    } else {
-                        None
-                    }
+                .filter(|x| x.reprovision_requested.is_some())
+                .map(|x| {
+                    let id = x.dpu_machine_id()?;
+                    Ok::<_, StateHandlerError>(state.managed_state.as_reprovision_state(&id))
                 })
+                .collect::<Result<Vec<_>, _>>()?
+                .into_iter()
+                .flatten()
                 .collect_vec();
 
             if !all_equal(dpus_states_for_reprov)? {
@@ -4662,7 +4687,8 @@ impl DpuMachineStateHandler {
         dpu_snapshot: &Machine,
         ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-        let dpu_machine_id = &dpu_snapshot.id.clone();
+        let dpu_machine_id = dpu_snapshot.dpu_machine_id()?;
+        let dpu_machine_id = &dpu_machine_id;
         let current_dpu_state = match &state.managed_state {
             ManagedHostState::DpuDiscoveringState { dpu_states } => dpu_states
                 .states
@@ -4833,7 +4859,8 @@ impl DpuMachineStateHandler {
         dpu_snapshot: &Machine,
         ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
-        let dpu_machine_id = &dpu_snapshot.id;
+        let dpu_machine_id = dpu_snapshot.dpu_machine_id()?;
+        let dpu_machine_id = &dpu_machine_id;
         let dpu_state = match &state.managed_state {
             ManagedHostState::DPUInit { dpu_states } => dpu_states
                 .states
@@ -5285,7 +5312,7 @@ impl DpuMachineStateHandler {
                     "Invalid State WaitingForNetworkInstall for dpu Machine"
                 );
                 Err(StateHandlerError::InvalidHostState(
-                    *dpu_machine_id,
+                    (*dpu_machine_id).into(),
                     Box::new(state.managed_state.clone()),
                 ))
             }
@@ -5302,7 +5329,8 @@ impl DpuMachineStateHandler {
         dpu_redfish_client: &dyn Redfish,
     ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
         let next_state: ManagedHostState;
-        let dpu_machine_id = &dpu_snapshot.id.clone();
+        let dpu_machine_id = dpu_snapshot.dpu_machine_id()?;
+        let dpu_machine_id = &dpu_machine_id;
 
         // Use the host snapshot instead of the DPU snapshot because
         // the state.host_snapshot.current.version might be a bit more correct:
@@ -6246,7 +6274,7 @@ fn primary_dpu_has_pxe_blocking_bgp_alert(state: &ManagedHostStateSnapshot) -> b
     let Some(primary_dpu) = state
         .dpu_snapshots
         .iter()
-        .find(|dpu| dpu.id == primary_dpu_id)
+        .find(|dpu| dpu.id == primary_dpu_id.into())
     else {
         return false;
     };
@@ -9023,7 +9051,10 @@ impl StateHandler for InstanceStateHandler {
                         .next_state_with_all_dpus_updated(
                             &mh_snapshot.managed_state,
                             &mh_snapshot.dpu_snapshots,
-                            dpus_for_reprov.iter().map(|x| &x.id).collect_vec(),
+                            dpus_for_reprov
+                                .into_iter()
+                                .map(Machine::dpu_machine_id)
+                                .collect::<Result<Vec<_>, _>>()?,
                         )?;
                         Ok(StateHandlerOutcome::transition(next_state))
                     } else if mh_snapshot
@@ -9489,13 +9520,14 @@ async fn process_dpu_use_admin_network_state_change(
         .and_then(|i| i.attached_dpu_machine_id);
 
     for dpu in &mh_snapshot.dpu_snapshots {
+        let dpu_id = dpu.dpu_machine_id()?;
         let dpu_has_tenant_interface_config = interface_configs.iter().any(|cfg| {
-            let is_primary = primary_dpu_id == Some(dpu.id);
+            let is_primary = primary_dpu_id == Some(dpu_id);
             (cfg.device_locator.is_none() && is_primary)
                 || (cfg.device_locator.is_some()
                     && mh_snapshot
                         .host_snapshot
-                        .get_device_locator_for_dpu_id(&dpu.id)
+                        .get_device_locator_for_dpu_id(&dpu_id)
                         .ok()
                         .as_ref()
                         == cfg.device_locator.as_ref())
@@ -9730,7 +9762,7 @@ fn check_instance_network_synced_and_dpu_healthy(
         || maps.0.is_empty()
         || maps.1.is_empty();
 
-    let dpu_machine_ids: Vec<MachineId> = if use_primary_dpu_only {
+    let dpu_machine_ids: Vec<DpuMachineId> = if use_primary_dpu_only {
         if legacy_physical_interface_count != 1 {
             return Err(StateHandlerError::GenericError(eyre!(
                 "more than one interface configured when only the primary dpu is allowed"
@@ -9814,7 +9846,11 @@ fn check_instance_network_synced_and_dpu_healthy(
                 missing_dpus.push(dpu_id);
             }
         }
-        return Ok(InstanceNetworkSyncStatus::InstanceNetworkObservationNotAvailable(missing_dpus));
+        return Ok(
+            InstanceNetworkSyncStatus::InstanceNetworkObservationNotAvailable(
+                missing_dpus.into_iter().map(Into::into).collect(),
+            ),
+        );
     }
     // Check instance network config has been applied
     let expected = &instance.network_config_version;
@@ -9828,7 +9864,7 @@ fn check_instance_network_synced_and_dpu_healthy(
 
     if !outdated_dpus.is_empty() {
         return Ok(InstanceNetworkSyncStatus::InstanceNetworkNotSynced(
-            outdated_dpus,
+            outdated_dpus.into_iter().map(Into::into).collect(),
         ));
     }
 
@@ -9843,7 +9879,8 @@ pub async fn release_vpc_dpu_loopback(
 ) -> Result<(), StateHandlerError> {
     for dpu_snapshot in &mh_snapshot.dpu_snapshots {
         if let Some(common_pools) = common_pools {
-            db::vpc_dpu_loopback::delete_and_deallocate(common_pools, &dpu_snapshot.id, txn, false)
+            let dpu_id = dpu_snapshot.dpu_machine_id()?;
+            db::vpc_dpu_loopback::delete_and_deallocate(common_pools, &dpu_id, txn, false)
                 .await
                 .map_err(|e| StateHandlerError::ResourceCleanupError {
                     resource: "VpcLoopbackIp",
@@ -9872,17 +9909,13 @@ async fn release_vpc_dpu_loopback_for_vpcs(
 
     // Release the removed VPC loopbacks from every DPU that may have rendered them.
     for dpu_snapshot in &mh_snapshot.dpu_snapshots {
-        db::vpc_dpu_loopback::delete_and_deallocate_for_vpcs(
-            common_pools,
-            &dpu_snapshot.id,
-            vpc_ids,
-            txn,
-        )
-        .await
-        .map_err(|e| StateHandlerError::ResourceCleanupError {
-            resource: "VpcLoopbackIp",
-            error: e.to_string(),
-        })?;
+        let dpu_id = dpu_snapshot.dpu_machine_id()?;
+        db::vpc_dpu_loopback::delete_and_deallocate_for_vpcs(common_pools, &dpu_id, vpc_ids, txn)
+            .await
+            .map_err(|e| StateHandlerError::ResourceCleanupError {
+                resource: "VpcLoopbackIp",
+                error: e.to_string(),
+            })?;
     }
 
     Ok(())

--- a/crates/machine-controller/src/handler/dpf.rs
+++ b/crates/machine-controller/src/handler/dpf.rs
@@ -25,7 +25,7 @@ use std::net::IpAddr;
 
 use carbide_dpf::{DpfError, DpuDeploymentType, DpuPhase, dpu_node_cr_name};
 use carbide_libmlx_model::nvconfig::DpuNvConfigProfile;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, MachineId};
 use libredfish::SystemPowerControl;
 use model::hardware_info::HardwareInfo;
 use model::machine::{
@@ -163,6 +163,15 @@ fn consistent_deployment_type(
     }
 }
 
+fn dpu_machine_id(machine: &Machine) -> Result<DpuMachineId, StateHandlerError> {
+    machine.dpu_machine_id().map_err(|error| {
+        StateHandlerError::GenericError(eyre::eyre!(
+            "invalid DPU snapshot ID {}: {error}",
+            machine.id
+        ))
+    })
+}
+
 /// Returns whether any attached DPU reprovision request has started.
 fn any_dpu_reprovision_request_has_started(state: &ManagedHostStateSnapshot) -> bool {
     state.dpu_snapshots.iter().any(|dpu| {
@@ -195,7 +204,7 @@ fn deployment_migration_has_complete_dpu_set(
     let snapshot_dpu_ids = state
         .dpu_snapshots
         .iter()
-        .map(|dpu| dpu.id)
+        .filter_map(|dpu| dpu.id.try_into().ok())
         .collect::<HashSet<_>>();
     let state_dpu_ids = dpu_states.states.keys().copied().collect::<HashSet<_>>();
 
@@ -281,7 +290,11 @@ fn transition_all_dpus_to_dpf_state(
         | ManagedHostState::Assigned {
             instance_state: InstanceState::DPUReprovision { .. },
         } => {
-            let all_dpu_ids = state.dpu_snapshots.iter().map(|x| &x.id).collect();
+            let all_dpu_ids = state
+                .dpu_snapshots
+                .iter()
+                .map(dpu_machine_id)
+                .collect::<Result<Vec<_>, _>>()?;
             ReprovisionState::DpfStates { substate: next_dpf }.next_state_with_all_dpus_updated(
                 &state.managed_state,
                 &state.dpu_snapshots,
@@ -298,7 +311,7 @@ fn transition_all_dpus_to_dpf_state(
 /// Use when persisting a phase change or moving one DPU to the next DpfState.
 fn set_one_dpu_dpf_state(
     state: &ManagedHostStateSnapshot,
-    dpu_id: &MachineId,
+    dpu_id: &DpuMachineId,
     next_dpf: DpfState,
 ) -> Result<ManagedHostState, StateHandlerError> {
     let mut next_state = state.managed_state.clone();
@@ -334,7 +347,7 @@ fn set_one_dpu_dpf_state(
 /// Otherwise return a `Wait` with the given reason.
 fn update_phase_detail_or_wait(
     state: &ManagedHostStateSnapshot,
-    dpu_id: &MachineId,
+    dpu_id: &DpuMachineId,
     stored_phase_detail: &Option<String>,
     current_phase: &carbide_dpf::DpuPhase,
     wait_reason: &str,
@@ -371,7 +384,11 @@ fn waiting_for_ready_exit_state(
         | ManagedHostState::Assigned {
             instance_state: InstanceState::DPUReprovision { .. },
         } => {
-            let all_dpu_ids = state.dpu_snapshots.iter().map(|x| &x.id).collect();
+            let all_dpu_ids = state
+                .dpu_snapshots
+                .iter()
+                .map(dpu_machine_id)
+                .collect::<Result<Vec<_>, _>>()?;
             ReprovisionState::WaitingForNetworkConfig.next_state_with_all_dpus_updated(
                 &state.managed_state,
                 &state.dpu_snapshots,
@@ -418,7 +435,7 @@ async fn create_and_register_dpudevices_and_dpunode(
     if !state
         .dpu_snapshots
         .iter()
-        .any(|dpu| dpu.id == primary_dpu_id)
+        .any(|dpu| dpu.id == primary_dpu_id.into())
     {
         return Err(StateHandlerError::MissingData {
             object_id: state.host_snapshot.id.to_string(),
@@ -447,7 +464,7 @@ async fn create_and_register_dpudevices_and_dpunode(
             host_bmc_ip: bmc_ip(&state.host_snapshot)?,
             serial_number: serial_number.to_string(),
             dpu_machine_id: dpu.id.to_string(),
-            is_primary: dpu.id == primary_dpu_id,
+            is_primary: dpu.id == primary_dpu_id.into(),
         };
         dpf_sdk
             .register_dpu_device(device_info, astra_underlay_nics.clone())
@@ -695,6 +712,7 @@ async fn handle_dpf_waiting_for_ready(
     dpf_sdk: &dyn DpfOperations,
     deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let dpu_machine_id = dpu_machine_id(dpu_snapshot)?;
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let dpu_device_name = dpf_id(dpu_snapshot)?;
     // During a deployment migration the source and target DPUSet reuse the
@@ -811,14 +829,14 @@ async fn handle_dpf_waiting_for_ready(
     if current_phase != carbide_dpf::DpuPhase::Ready {
         return update_phase_detail_or_wait(
             state,
-            &dpu_snapshot.id,
+            &dpu_machine_id,
             waiting_phase_detail,
             &current_phase,
             "Waiting for DPU to reach Ready phase",
         );
     }
 
-    let next = set_one_dpu_dpf_state(state, &dpu_snapshot.id, DpfState::DeviceReady)?;
+    let next = set_one_dpu_dpf_state(state, &dpu_machine_id, DpfState::DeviceReady)?;
     Ok(StateHandlerOutcome::transition(next))
 }
 
@@ -938,6 +956,7 @@ async fn handle_dpf_reprovisioning(
     dpf_sdk: &dyn DpfOperations,
     deployment_type: DpuDeploymentType,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let dpu_machine_id = dpu_machine_id(dpu_snapshot)?;
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
     let dpf_dpudevices_and_dpunode_crs_noexist =
         crate::dpf::dpf_dpudevices_and_dpunode_crs_noexist(state, dpf_sdk)
@@ -972,7 +991,7 @@ async fn handle_dpf_reprovisioning(
         .map_err(dpf_error)?;
     let next = set_one_dpu_dpf_state(
         state,
-        &dpu_snapshot.id,
+        &dpu_machine_id,
         DpfState::WaitingForReady { phase_detail: None },
     )?;
     Ok(StateHandlerOutcome::transition(next))
@@ -1059,6 +1078,7 @@ pub(super) async fn handle_dpf_state(
     dpf_sdk: &dyn DpfOperations,
     power_down_wait: chrono::Duration,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let dpu_machine_id = dpu_machine_id(dpu_snapshot)?;
     let node_name = dpu_node_cr_name(&dpf_id(&state.host_snapshot)?);
 
     let astra_nics = machine_has_astra_nics(state, ctx).await?;
@@ -1182,7 +1202,7 @@ pub(super) async fn handle_dpf_state(
         }
         DpfState::Unknown => {
             tracing::warn!(dpu_machine_id = %dpu_snapshot.id, "unknown DPF state in DB, transitioning to provisioning");
-            let next = set_one_dpu_dpf_state(state, &dpu_snapshot.id, DpfState::Provisioning)?;
+            let next = set_one_dpu_dpf_state(state, &dpu_machine_id, DpfState::Provisioning)?;
             Ok(StateHandlerOutcome::transition(next))
         }
     }
@@ -1225,7 +1245,12 @@ mod tests {
                 states: state
                     .dpu_snapshots
                     .iter()
-                    .map(|dpu| (dpu.id, ReprovisionState::NotUnderReprovision))
+                    .filter_map(|dpu| {
+                        Some((
+                            dpu.id.try_into().ok()?,
+                            ReprovisionState::NotUnderReprovision,
+                        ))
+                    })
                     .collect(),
             },
         };

--- a/crates/machine-controller/src/handler/dpu_uefi_rotation.rs
+++ b/crates/machine-controller/src/handler/dpu_uefi_rotation.rs
@@ -43,7 +43,7 @@
 use bmc_vendor::DpuModel;
 use carbide_redfish::libredfish::CredentialOpError;
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, MachineId};
 use eyre::eyre;
 use model::machine::{Machine, ManagedHostState, ManagedHostStateSnapshot};
 use state_controller::state_handler::{
@@ -97,10 +97,10 @@ async fn should_rotate_dpu_uefi(
 pub(crate) async fn select_dpu_for_uefi_rotation(
     services: &MachineStateHandlerServices,
     mh: &ManagedHostStateSnapshot,
-) -> Result<Option<MachineId>, StateHandlerError> {
+) -> Result<Option<DpuMachineId>, StateHandlerError> {
     for dpu in &mh.dpu_snapshots {
         if should_rotate_dpu_uefi(services, dpu).await? {
-            return Ok(Some(dpu.id));
+            return Ok(Some(dpu.dpu_machine_id()?));
         }
     }
     Ok(None)

--- a/crates/machine-controller/src/handler/extension_services.rs
+++ b/crates/machine-controller/src/handler/extension_services.rs
@@ -20,7 +20,7 @@
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use carbide_uuid::extension_service::ExtensionServiceId;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use chrono::{DateTime, Utc};
 use config_version::Versioned;
 use db::extension_service as db_extension_service;
@@ -121,8 +121,8 @@ pub(super) async fn get_extension_services_status(
     let all_dpus = mh_snapshot
         .dpu_snapshots
         .iter()
-        .map(|dpu| dpu.id)
-        .collect_vec();
+        .map(|dpu| dpu.dpu_machine_id())
+        .collect::<Result<Vec<_>, _>>()?;
     let dpf_helm_chart_dpus = if instance_deleted_at.is_some() {
         all_dpus
     } else {
@@ -196,11 +196,11 @@ pub(super) async fn reconcile_dpf_helm_chart_placement(
     mh_snapshot: &ManagedHostStateSnapshot,
     extension_services_config_version: config_version::ConfigVersion,
     dpf_service_configs: &[&InstanceExtensionServiceConfig],
-    target_dpu_ids: &HashSet<MachineId>,
+    target_dpu_ids: &HashSet<DpuMachineId>,
     instance_deleted_at: Option<&DateTime<Utc>>,
     dpf_sdk: &dyn DpfOperations,
     db_pool: &sqlx::PgPool,
-) -> Result<HashMap<MachineId, InstanceExtensionServiceStatusObservation>, StateHandlerError> {
+) -> Result<HashMap<DpuMachineId, InstanceExtensionServiceStatusObservation>, StateHandlerError> {
     if dpf_service_configs.is_empty() {
         return Ok(HashMap::new());
     }
@@ -213,7 +213,8 @@ pub(super) async fn reconcile_dpf_helm_chart_placement(
     let mut observations = HashMap::new();
     let mut ignored_non_target_failure_count = 0;
     for dpu in &mh_snapshot.dpu_snapshots {
-        let is_target = target_dpu_ids.contains(&dpu.id);
+        let dpu_id = dpu.dpu_machine_id()?;
+        let is_target = target_dpu_ids.contains(&dpu_id);
         let is_required = is_target || instance_deleted_at.is_some();
         let label_reconciliation = match dpu.dpf_id() {
             None => {
@@ -268,7 +269,7 @@ pub(super) async fn reconcile_dpf_helm_chart_placement(
         };
 
         let observation = persist_dpf_helm_chart_placement_observation(
-            dpu.id,
+            dpu_id,
             extension_services_config_version,
             dpf_service_configs,
             is_target,
@@ -277,7 +278,7 @@ pub(super) async fn reconcile_dpf_helm_chart_placement(
             db_pool,
         )
         .await?;
-        observations.insert(dpu.id, observation);
+        observations.insert(dpu_id, observation);
     }
 
     if ignored_non_target_failure_count > 0 {
@@ -312,7 +313,7 @@ enum PlacementEvidence<'a> {
 /// pass, so a failure on a later DPU cannot discard the verified results of
 /// DPUs this pass already reconciled.
 async fn persist_dpf_helm_chart_placement_observation(
-    dpu_id: MachineId,
+    dpu_id: DpuMachineId,
     config_version: config_version::ConfigVersion,
     dpf_service_configs: &[&InstanceExtensionServiceConfig],
     is_target: bool,
@@ -347,7 +348,7 @@ async fn persist_dpf_helm_chart_placement_observation(
 
 /// A rejected write means another writer stored a newer observation for this
 /// DPU, so the caller is racing a concurrent reconciliation of the same host.
-fn warn_if_superseded(applied: bool, dpu_id: MachineId, observed_at: chrono::DateTime<Utc>) {
+fn warn_if_superseded(applied: bool, dpu_id: DpuMachineId, observed_at: chrono::DateTime<Utc>) {
     if !applied {
         tracing::warn!(
             dpu_machine_id = %dpu_id,

--- a/crates/machine-controller/src/handler/helpers.rs
+++ b/crates/machine-controller/src/handler/helpers.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId as MachineId;
 use model::machine::{
     DpfState, DpuDiscoveringState, DpuDiscoveringStates, DpuInitNextStateResolver, DpuInitState,
     DpuInitStates, DpuReprovisionStates, HostReprovisionState, InstallDpuOsState,
@@ -46,18 +46,18 @@ pub(super) trait NextState {
         state: &ManagedHostStateSnapshot,
         current_reprovision_state: &ReprovisionState,
     ) -> Result<ManagedHostState, StateHandlerError> {
-        let dpu_ids_for_reprov =
-            // EnumIter conflicts with Itertool, don't know why?
-            itertools::Itertools::collect_vec(state.dpu_snapshots.iter().filter_map(|x| {
-                if x.reprovision_requested.is_some() {
-                    Some(&x.id)
-                } else {
-                    None
-                }
-            }));
+        let dpu_ids_for_reprov = state
+            .dpu_snapshots
+            .iter()
+            .filter(|machine| machine.reprovision_requested.is_some())
+            .map(Machine::dpu_machine_id)
+            .collect::<Result<Vec<_>, _>>()?;
 
-        let all_machine_ids =
-            itertools::Itertools::collect_vec(state.dpu_snapshots.iter().map(|x| &x.id));
+        let all_machine_ids = state
+            .dpu_snapshots
+            .iter()
+            .map(Machine::dpu_machine_id)
+            .collect::<Result<Vec<_>, _>>()?;
 
         match current_reprovision_state {
             ReprovisionState::BmcFirmwareUpgrade { .. } => ReprovisionState::FirmwareUpgrade
@@ -216,12 +216,6 @@ impl DpuInitStateHelper for DpuInitState {
         current_state: &ManagedHostState,
         dpu_id: &MachineId,
     ) -> Result<ManagedHostState, StateHandlerError> {
-        if !dpu_id.machine_type().is_dpu() {
-            return Err(StateHandlerError::InvalidState(format!(
-                "Invalid DPU ID passed to DpuInitState::next_state. DPU ID: {dpu_id}."
-            )));
-        }
-
         match current_state {
             ManagedHostState::DPUInit { dpu_states } => {
                 let mut states = dpu_states.states.clone();
@@ -492,7 +486,7 @@ pub(super) trait ReprovisionStateHelper {
         self,
         current_state: &ManagedHostState,
         dpu_snapshots: &[Machine],
-        dpu_ids_to_process: Vec<&MachineId>,
+        dpu_ids_to_process: Vec<MachineId>,
     ) -> Result<ManagedHostState, StateHandlerError>;
 }
 
@@ -504,23 +498,24 @@ impl ReprovisionStateHelper for ReprovisionState {
         self,
         current_state: &ManagedHostState,
         dpu_snapshots: &[Machine],
-        dpu_ids_to_process: Vec<&MachineId>,
+        dpu_ids_to_process: Vec<MachineId>,
     ) -> Result<ManagedHostState, StateHandlerError> {
         match current_state {
             ManagedHostState::Ready => {
                 let states = dpu_snapshots
                     .iter()
                     .map(|x| {
-                        (
-                            x.id,
-                            if dpu_ids_to_process.contains(&&x.id) {
+                        let dpu_id = x.dpu_machine_id()?;
+                        Ok::<_, StateHandlerError>((
+                            dpu_id,
+                            if dpu_ids_to_process.contains(&dpu_id) {
                                 self.clone()
                             } else {
                                 ReprovisionState::NotUnderReprovision
                             },
-                        )
+                        ))
                     })
-                    .collect::<HashMap<MachineId, ReprovisionState>>();
+                    .collect::<Result<HashMap<MachineId, ReprovisionState>, _>>()?;
 
                 Ok(ManagedHostState::DPUReprovision {
                     dpu_states: DpuReprovisionStates { states },
@@ -530,16 +525,17 @@ impl ReprovisionStateHelper for ReprovisionState {
                 let states = dpu_snapshots
                     .iter()
                     .map(|x| {
-                        (
-                            x.id,
-                            if dpu_ids_to_process.contains(&&x.id) {
+                        let dpu_id = x.dpu_machine_id()?;
+                        Ok::<_, StateHandlerError>((
+                            dpu_id,
+                            if dpu_ids_to_process.contains(&dpu_id) {
                                 self.clone()
                             } else {
                                 ReprovisionState::NotUnderReprovision
                             },
-                        )
+                        ))
                     })
-                    .collect::<HashMap<MachineId, ReprovisionState>>();
+                    .collect::<Result<HashMap<MachineId, ReprovisionState>, _>>()?;
                 Ok(ManagedHostState::DPUReprovision {
                     dpu_states: DpuReprovisionStates { states },
                 })
@@ -551,16 +547,17 @@ impl ReprovisionStateHelper for ReprovisionState {
                     let states = dpu_snapshots
                         .iter()
                         .map(|x| {
-                            (
-                                x.id,
-                                if dpu_ids_to_process.contains(&&x.id) {
+                            let dpu_id = x.dpu_machine_id()?;
+                            Ok::<_, StateHandlerError>((
+                                dpu_id,
+                                if dpu_ids_to_process.contains(&dpu_id) {
                                     self.clone()
                                 } else {
                                     ReprovisionState::NotUnderReprovision
                                 },
-                            )
+                            ))
                         })
-                        .collect::<HashMap<MachineId, ReprovisionState>>();
+                        .collect::<Result<HashMap<MachineId, ReprovisionState>, _>>()?;
 
                     Ok(ManagedHostState::Assigned {
                         instance_state: InstanceState::DPUReprovision {

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -17,13 +17,12 @@
 
 //! State Controller IO implementation for Machines
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use config_version::{ConfigVersion, Versioned};
 use db::{self, DatabaseError};
 use model::StateSla;
 use model::controller_outcome::PersistentStateHandlerOutcome;
 use model::dpa_interface::DpaSearchConfig;
-use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::slas::MachineSlaConfig;
 use model::machine::{
     self, AttestationMode, ConfigureAstraState, DecommissioningState, DpuDiscoveringState,
@@ -46,7 +45,7 @@ pub struct MachineStateControllerIO {
 
 #[async_trait::async_trait]
 impl StateControllerIO for MachineStateControllerIO {
-    type ObjectId = MachineId;
+    type ObjectId = HostMachineId;
     type State = ManagedHostStateSnapshot;
     type ControllerState = ManagedHostState;
     type MetricsEmitter = MachineMetricsEmitter;
@@ -61,14 +60,7 @@ impl StateControllerIO for MachineStateControllerIO {
         &self,
         txn: &mut PgConnection,
     ) -> Result<Vec<Self::ObjectId>, DatabaseError> {
-        Ok(db::machine::find_machine_ids(
-            txn,
-            MachineSearchConfig {
-                include_predicted_host: true,
-                ..Default::default()
-            },
-        )
-        .await?)
+        db::managed_host::load_host_ids(txn).await
     }
 
     /// Loads a state snapshot from the database
@@ -77,20 +69,7 @@ impl StateControllerIO for MachineStateControllerIO {
         txn: &mut PgConnection,
         machine_id: &Self::ObjectId,
     ) -> Result<Option<Self::State>, DatabaseError> {
-        // Never load state for DPUs
-        // The state machine is only supposed to execute for hosts
-        // If by any accidental chance a DPU ID was enqueued into the system,
-        // we filter it here.
-        if machine_id.machine_type().is_dpu() {
-            return Err(DatabaseError::new(
-                "MachineStateControllerIO::load_object_state",
-                sqlx::Error::InvalidArgument(
-                    "DPU state can not be loaded by state controller".to_string(),
-                ),
-            ));
-        }
-
-        let mut retstate = db::managed_host::load_snapshot(
+        let mut retstate = db::managed_host::load_host_snapshot(
             txn,
             machine_id,
             model::machine::LoadSnapshotOptions {

--- a/crates/machine-controller/tests/integration/dpu_uefi_rotation.rs
+++ b/crates/machine-controller/tests/integration/dpu_uefi_rotation.rs
@@ -270,7 +270,8 @@ async fn force_request_converges_quarantined_dpu_uefi_when_disabled(
             Utc::now() + Duration::seconds(3600),
         )
         .await?;
-        db::machine::set_uefi_credential_rotation_requested(&mut conn, dpu_machine_id).await?;
+        db::machine::set_uefi_credential_rotation_requested(&mut conn, dpu_machine_id.into())
+            .await?;
     }
 
     // Iteration 1: the force request drives entry into RotatingDpuUefi for the

--- a/crates/machine-controller/tests/integration/maintenance.rs
+++ b/crates/machine-controller/tests/integration/maintenance.rs
@@ -228,7 +228,7 @@ async fn enter_requested_state(
             .unwrap();
             ManagedHostState::Failed {
                 details,
-                machine_id: host.host.id,
+                machine_id: host.host.id.into(),
                 retry_count: 1,
             }
         }
@@ -236,7 +236,7 @@ async fn enter_requested_state(
 
     db::machine::set_machine_maintenance_requested(
         &mut txn,
-        host.host.id,
+        host.host.id.into(),
         "maintenance-test",
         operation,
     )

--- a/crates/machine-controller/tests/integration/power_management.rs
+++ b/crates/machine-controller/tests/integration/power_management.rs
@@ -348,7 +348,7 @@ async fn desired_on_limits_power_on_attempts(
         .test_harness
         .api()
         .get_power_options(Request::new(PowerOptionRequest {
-            machine_id: vec![mh.host.id],
+            machine_id: vec![mh.host.id.into()],
         }))
         .await?
         .into_inner();
@@ -375,7 +375,7 @@ async fn desired_off_persists_observed_off_state(
         .api()
         .set_maintenance(Request::new(MaintenanceRequest {
             operation: MaintenanceOperation::Enable as i32,
-            host_id: Some(mh.host.id),
+            host_id: Some(mh.host.id.into()),
             reference: Some("testing".to_string()),
         }))
         .await?;
@@ -384,7 +384,7 @@ async fn desired_off_persists_observed_off_state(
     env.test_harness
         .api()
         .update_power_option(Request::new(PowerOptionUpdateRequest {
-            machine_id: Some(mh.host.id),
+            machine_id: Some(mh.host.id.into()),
             power_state: rpc::forge::PowerState::Off as i32,
         }))
         .await?;
@@ -440,14 +440,14 @@ async fn queued_power_off_runs_when_power_manager_gates_desired_off(
         .api()
         .set_maintenance(Request::new(MaintenanceRequest {
             operation: MaintenanceOperation::Enable as i32,
-            host_id: Some(mh.host.id),
+            host_id: Some(mh.host.id.into()),
             reference: Some("testing".to_string()),
         }))
         .await?;
     env.test_harness
         .api()
         .update_power_option(Request::new(PowerOptionUpdateRequest {
-            machine_id: Some(mh.host.id),
+            machine_id: Some(mh.host.id.into()),
             power_state: rpc::forge::PowerState::Off as i32,
         }))
         .await?;
@@ -458,7 +458,7 @@ async fn queued_power_off_runs_when_power_manager_gates_desired_off(
         .api()
         .set_maintenance(Request::new(MaintenanceRequest {
             operation: MaintenanceOperation::Disable as i32,
-            host_id: Some(mh.host.id),
+            host_id: Some(mh.host.id.into()),
             reference: Some("testing".to_string()),
         }))
         .await?;
@@ -472,7 +472,7 @@ async fn queued_power_off_runs_when_power_manager_gates_desired_off(
     let mut txn = env.test_harness.db_txn().await;
     db::machine::set_machine_maintenance_requested(
         &mut txn,
-        mh.host.id,
+        mh.host.id.into(),
         "component-manager",
         MachineMaintenanceOperation::PowerOff,
     )

--- a/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
+++ b/crates/machine-controller/tests/integration/rack_firmware_upgrade.rs
@@ -79,7 +79,7 @@ async fn create_instance(env: &TestHarness, host: &TestManagedHost) -> InstanceI
     let instances = db::instance::batch_persist(
         vec![NewInstance {
             instance_id,
-            machine_id: host.host.id,
+            machine_id: host.host.id.into(),
             instance_type_id: None,
             config: &config,
             metadata: Metadata::default(),

--- a/crates/rack-controller/src/discovering.rs
+++ b/crates/rack-controller/src/discovering.rs
@@ -23,6 +23,7 @@
 //! rack transitions to Maintenance.
 
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
+use carbide_uuid::machine::MachineId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::{ObjectFilter, machine as db_machine, power_shelf as db_power_shelf, switch as db_switch};
 use model::machine::ManagedHostState;
@@ -54,7 +55,7 @@ pub async fn handle_discovering(
 
     let available_compute = db_machine::find(
         txn.as_mut(),
-        ObjectFilter::All,
+        ObjectFilter::<MachineId>::All,
         MachineSearchConfig {
             rack_id: Some(id.clone()),
             ..Default::default()

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -349,7 +349,7 @@ async fn desired_off_machine_ids(
         .await?
         .into_iter()
         .filter(|options| options.desired_power_state == model::power_manager::PowerState::Off)
-        .map(|options| options.host_id)
+        .map(|options| options.host_id.into())
         .collect::<Vec<_>>();
     machine_ids.sort_by_key(ToString::to_string);
     Ok(machine_ids)

--- a/crates/rpc/src/model/dpa_interface.rs
+++ b/crates/rpc/src/model/dpa_interface.rs
@@ -18,6 +18,7 @@
 use std::convert::TryFrom;
 use std::str::FromStr;
 
+use carbide_uuid::machine::HostMachineId;
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::dpa_interface::{DpaInterface, DpaInterfaceType, NewDpaInterface};
@@ -54,7 +55,9 @@ impl TryFrom<rpc::forge::DpaInterfaceCreationRequest> for NewDpaInterface {
         let mac_address = MacAddress::from_str(&value.mac_addr)
             .map_err(|_| RpcDataConversionError::InvalidMacAddress(value.mac_addr.to_string()))?;
         Ok(NewDpaInterface {
-            machine_id,
+            machine_id: HostMachineId::try_from(machine_id).map_err(|error| {
+                RpcDataConversionError::InvalidValue(machine_id.to_string(), error.to_string())
+            })?,
             mac_address,
             device_type: value.device_type,
             pci_name: value.pci_name,
@@ -112,7 +115,7 @@ impl From<DpaInterface> for rpc::forge::DpaInterface {
             deleted: src.deleted.map(|t| t.into()),
             last_hb_time: Some(src.last_hb_time.into()),
             mac_addr: src.mac_address.to_string(),
-            machine_id: Some(src.machine_id),
+            machine_id: Some(src.machine_id.into()),
             controller_state: controller_state.to_string(),
             controller_state_version: controller_state_version.to_string(),
             network_config: network_config.to_string(),

--- a/crates/rpc/src/model/dpu_remediation.rs
+++ b/crates/rpc/src/model/dpu_remediation.rs
@@ -116,7 +116,7 @@ impl From<AppliedRemediation> for rpc::forge::AppliedRemediation {
             name: String::new(),
         };
         Self {
-            dpu_machine_id: Some(value.dpu_machine_id),
+            dpu_machine_id: Some(value.dpu_machine_id.into()),
             remediation_id: Some(value.id),
             attempt: value.attempt,
             metadata: Some(metadata.into()),

--- a/crates/rpc/src/model/instance/snapshot.rs
+++ b/crates/rpc/src/model/instance/snapshot.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use config_version::Versioned;
 use model::health::HealthReportSources;
 use model::instance::snapshot::InstanceSnapshot;
@@ -35,8 +35,8 @@ use crate::model::instance::status::instance_status_from_config_and_observation;
 #[allow(clippy::too_many_arguments)]
 pub fn instance_snapshot_derive_status(
     snapshot: &InstanceSnapshot,
-    dpu_id_to_device_map: HashMap<String, Vec<MachineId>>,
-    primary_dpu_machine_id: Option<MachineId>,
+    dpu_id_to_device_map: HashMap<String, Vec<DpuMachineId>>,
+    primary_dpu_machine_id: Option<DpuMachineId>,
     managed_host_state: ManagedHostState,
     reprovision_request: Option<ReprovisionRequest>,
     ib_status: Option<&MachineInfinibandStatusObservation>,

--- a/crates/rpc/src/model/instance/status.rs
+++ b/crates/rpc/src/model/instance/status.rs
@@ -17,7 +17,7 @@
 
 use std::collections::HashMap;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::DpuMachineId;
 use config_version::Versioned;
 use model::instance::config::InstanceConfig;
 use model::instance::config::extension_services::InstanceExtensionServicesConfig;
@@ -70,8 +70,8 @@ impl TryFrom<InstanceStatus> for rpc::InstanceStatus {
 /// and the interfaces therefore won't match.
 #[allow(clippy::too_many_arguments)]
 pub fn instance_status_from_config_and_observation(
-    dpu_id_to_device_map: HashMap<String, Vec<MachineId>>,
-    primary_dpu_machine_id: Option<MachineId>,
+    dpu_id_to_device_map: HashMap<String, Vec<DpuMachineId>>,
+    primary_dpu_machine_id: Option<DpuMachineId>,
     instance_config: Versioned<&InstanceConfig>,
     network_config: Versioned<&InstanceNetworkConfig>,
     ib_config: Versioned<&InstanceInfinibandConfig>,
@@ -304,8 +304,8 @@ mod tests {
 
     #[test]
     fn test_tenant_state() {
-        let machine_id: MachineId =
-            MachineId::from_str("fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0")
+        let machine_id =
+            DpuMachineId::from_str("fm100dtjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0")
                 .unwrap();
 
         assert_eq!(

--- a/crates/rpc/src/model/instance/status/extension_service.rs
+++ b/crates/rpc/src/model/instance/status/extension_service.rs
@@ -105,7 +105,7 @@ impl TryFrom<MachineExtensionServiceStatus> for rpc::DpuExtensionServiceStatus {
 
     fn try_from(status: MachineExtensionServiceStatus) -> Result<Self, Self::Error> {
         Ok(Self {
-            dpu_machine_id: Some(status.machine_id),
+            dpu_machine_id: Some(status.machine_id.into()),
             status: rpc::DpuExtensionServiceDeploymentStatus::from(status.status).into(),
             error_message: status.error_message,
             components: status

--- a/crates/rpc/src/model/machine/machine_id.rs
+++ b/crates/rpc/src/model/machine/machine_id.rs
@@ -29,13 +29,17 @@ pub fn try_parse_machine_id(id: &str) -> Result<MachineId, RpcDataConversionErro
 
 #[cfg(test)]
 mod tests {
+    use carbide_uuid::machine::DpuMachineId;
+
     use super::*;
 
     #[test]
     fn validate_remote_id() {
-        let dpu_id =
+        let dpu_id = DpuMachineId::try_from(
             try_parse_machine_id("fm100dsg4ekcb4sdi6hkqn0iojhj18okrr8vct64luh8957lfe8e69vme20")
-                .unwrap();
+                .unwrap(),
+        )
+        .unwrap();
 
         assert_eq!(
             "d33nk2ne8p59qr988hssbc84gb2b0s34vcq5j7pm5jnrbnhc6880",

--- a/crates/rpc/src/model/machine/mod.rs
+++ b/crates/rpc/src/model/machine/mod.rs
@@ -18,7 +18,7 @@ use std::collections::HashSet;
 use std::ops::Deref;
 
 use base64::prelude::*;
-use carbide_uuid::machine::{MachineId, MachineType};
+use carbide_uuid::machine::{DpuMachineId, MachineId, MachineType};
 use health_report::HealthReport;
 use model::errors::{ModelError, ModelResult};
 use model::health::HealthReportSources;
@@ -202,6 +202,7 @@ impl From<Dpf> for rpc::forge::DpfMachineState {
 #[allow(deprecated)]
 impl From<Machine> for rpc::forge::Machine {
     fn from(mut machine: Machine) -> Self {
+        let dpu_machine_id = machine.dpu_machine_id().ok();
         // Capture source origins before the DPU arm below empties machine.health_reports via
         // std::mem::take, which would otherwise leave health_sources empty for DPU machines.
         let health_sources: Vec<rpc::forge::HealthSourceOrigin> = machine
@@ -213,8 +214,8 @@ impl From<Machine> for rpc::forge::Machine {
             })
             .collect();
 
-        let health = match machine.is_dpu() {
-            true => {
+        let health = match dpu_machine_id {
+            Some(_) => {
                 // Taking the reports moves the selected one into the RPC
                 // machine; hosts keep theirs for the maintenance fields below.
                 let HealthReportSources {
@@ -242,17 +243,15 @@ impl From<Machine> for rpc::forge::Machine {
                     }
                 }
             }
-            false => HealthReport::empty("aggregate-health".to_string()), // Health is written by ManagedHostStateSnapshot
+            None => HealthReport::empty("aggregate-health".to_string()), // Health is written by ManagedHostStateSnapshot
         };
 
         let maintenance_reference = machine.config.maintenance_reference.clone();
         let maintenance_start_time = machine.config.maintenance_start_time;
 
-        let dpf = if !machine.is_dpu() {
-            Some(machine.config.dpf.clone().into())
-        } else {
-            // Dpf state is stored in host.
-            None
+        let dpf = match &dpu_machine_id {
+            Some(_) => None, // DPF state is stored on the host.
+            None => Some(machine.config.dpf.clone().into()),
         };
 
         let associated_dpu_machine_ids = machine.associated_dpu_machine_ids();
@@ -282,10 +281,9 @@ impl From<Machine> for rpc::forge::Machine {
 
         // Pre-compute lifecycle state fields shared between status.lifecycle and the flat
         // Machine aliases (state, state_version, state_reason, state_sla).
-        let rpc_state = if machine.is_dpu() {
-            machine.state.value.dpu_state_string(&machine.id)
-        } else {
-            machine.state.value.to_string()
+        let rpc_state = match dpu_machine_id {
+            Some(dpu_machine_id) => machine.state.value.dpu_state_string(&dpu_machine_id),
+            None => machine.state.value.to_string(),
         };
         let rpc_state_version = machine.state.version.version_string();
         let rpc_state_reason: Option<rpc::forge::ControllerStateReason> =
@@ -350,7 +348,11 @@ impl From<Machine> for rpc::forge::Machine {
             last_reboot_time: machine.status.last_reboot_time.map(|t| t.into()),
             last_observation_time,
             associated_host_machine_id: None, // Gets filled in the `ManagedHostStateSnapshot` conversion
-            associated_dpu_machine_ids: associated_dpu_machine_ids.clone(),
+            associated_dpu_machine_ids: associated_dpu_machine_ids
+                .iter()
+                .copied()
+                .map(Into::into)
+                .collect(),
             last_reboot_requested_time: machine
                 .status
                 .last_reboot_requested
@@ -418,7 +420,10 @@ impl From<Machine> for rpc::forge::Machine {
             maintenance_reference,
             maintenance_start_time: maintenance_start_time.map(rpc::Timestamp::from),
             associated_host_machine_id: None, // Gets filled in the `ManagedHostStateSnapshot` conversion
-            associated_dpu_machine_ids,
+            associated_dpu_machine_ids: associated_dpu_machine_ids
+                .into_iter()
+                .map(Into::into)
+                .collect(),
             inventory: Some(machine.status.inventory.unwrap_or_default().into()),
             last_reboot_requested_time: machine
                 .status
@@ -497,7 +502,7 @@ impl From<MachineValidationFilter> for fac::MachineValidationFilter {
 
 pub fn get_action_for_dpu_state(
     state: &ManagedHostState,
-    dpu_machine_id: &MachineId,
+    dpu_machine_id: &DpuMachineId,
 ) -> ModelResult<fac::Action> {
     Ok(match state {
         ManagedHostState::DPUReprovision { .. }
@@ -506,7 +511,7 @@ pub fn get_action_for_dpu_state(
         } => {
             let dpu_state = state
                 .as_reprovision_state(dpu_machine_id)
-                .ok_or(ModelError::MissingDpu(*dpu_machine_id))?;
+                .ok_or(ModelError::MissingDpu((*dpu_machine_id).into()))?;
             match dpu_state {
                 ReprovisionState::BufferTime => fac::Action::retry(),
                 ReprovisionState::WaitingForNetworkInstall
@@ -528,7 +533,7 @@ pub fn get_action_for_dpu_state(
             let dpu_state = dpu_states
                 .states
                 .get(dpu_machine_id)
-                .ok_or(ModelError::MissingDpu(*dpu_machine_id))?;
+                .ok_or(ModelError::MissingDpu((*dpu_machine_id).into()))?;
 
             match dpu_state {
                 DpuInitState::Init
@@ -566,7 +571,7 @@ impl From<MachineInterfaceSnapshot> for rpc::MachineInterface {
 
         rpc::MachineInterface {
             id: Some(machine_interface.id),
-            attached_dpu_machine_id: machine_interface.attached_dpu_machine_id,
+            attached_dpu_machine_id: machine_interface.attached_dpu_machine_id.map(Into::into),
             machine_id: machine_interface.machine_id,
             segment_id: Some(machine_interface.segment_id),
             hostname: machine_interface.hostname,

--- a/crates/rpc/src/model/network_devices.rs
+++ b/crates/rpc/src/model/network_devices.rs
@@ -49,7 +49,7 @@ impl From<NetworkTopologyData> for rpc::forge::NetworkTopologyData {
 impl From<DpuToNetworkDeviceMap> for rpc::forge::ConnectedDevice {
     fn from(value: DpuToNetworkDeviceMap) -> Self {
         Self {
-            id: value.dpu_id.into(),
+            id: Some(value.dpu_id.into()),
             local_port: value.local_port.to_string(),
             remote_port: value.remote_port.clone(),
             network_device_id: Some(value.network_device_id),

--- a/crates/rpc/src/model/power_manager.rs
+++ b/crates/rpc/src/model/power_manager.rs
@@ -46,7 +46,7 @@ impl From<PowerOptions> for rpc::forge::PowerOptions {
             desired_state_updated_at: Some(value.desired_power_state_version.timestamp().into()),
             actual_state: rpc::forge::PowerState::from(value.last_fetched_power_state) as i32,
             actual_state_updated_at: Some(value.last_fetched_updated_at.into()),
-            host_id: Some(value.host_id),
+            host_id: Some(value.host_id.into()),
             desired_power_state_version: value.desired_power_state_version.to_string(),
             next_power_state_fetch_at: Some(value.last_fetched_next_try_at.into()),
             off_counter: value.last_fetched_off_counter,

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -287,7 +287,7 @@ impl MachineCreator {
             // machine_id_if_valid_report makes sure that all optional fields on dpu_report are
             // actually set (like the machine-id etc) and returns the machine_id if everything
             // is valid.
-            let dpu_machine_id = *dpu_report.machine_id_if_valid_report()?;
+            let dpu_machine_id = dpu_report.machine_id_if_valid_report()?;
             dpu_ids.push(dpu_machine_id);
         }
 
@@ -344,7 +344,7 @@ impl MachineCreator {
                 self.configure_dpu_interface(&mut txn, dpu_report).await?;
             }
 
-            self.reconcile_host_admin_addresses(&mut txn, host_machine_id.as_machine_id())
+            self.reconcile_host_admin_addresses(&mut txn, &host_machine_id)
                 .await?;
             // The primary on an existing host may predate source
             // tracking. Do not infer its historical selector from today's
@@ -431,7 +431,7 @@ impl MachineCreator {
             &mut txn,
             // TODO: ManagedHost will eventually have a HostMachineId as its machine_id and
             // conversion will become unnecessary.
-            &HostMachineId::try_from(host_machine_id)?,
+            &host_machine_id,
             primary_interface_selection,
             machine_data.and_then(ExpectedMachineData::declared_primary_mac),
         )
@@ -528,7 +528,7 @@ impl MachineCreator {
         report: &mut EndpointExplorationReport,
         bmc_mac_address: MacAddress,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> SiteExplorerResult<Option<MachineId>> {
+    ) -> SiteExplorerResult<Option<HostMachineId>> {
         // If there's already a machine with the same MAC address as this endpoint, return false. We
         // can't rely on matching the machine_id, as it may have migrated to a stable MachineID
         // already.
@@ -555,19 +555,12 @@ impl MachineCreator {
                     MachineIdSubtype::StableHost(stable_machine_id) => {
                         // ExpectedMachine is ingestion policy, not a way to
                         // rewrite interfaces on an already managed host.
-                        reconcile_desired_boot_interface(
-                            txn,
-                            stable_machine_id.as_ref(),
-                            None,
-                            None,
-                        )
-                        .await?;
+                        reconcile_desired_boot_interface(txn, &stable_machine_id, None, None)
+                            .await?;
                         return Ok(None);
                     }
                     MachineIdSubtype::PredictedHost(predicted_machine_id) => {
-                        if endpoint_machine_id.as_ref()
-                            != Some(predicted_machine_id.as_machine_id())
-                        {
+                        if endpoint_machine_id.as_ref() != Some(&predicted_machine_id) {
                             tracing::warn!(
                                 %mac_address,
                                 predicted_machine_id = %machine.id,
@@ -607,9 +600,7 @@ impl MachineCreator {
                         return Ok(None);
                     }
                     MachineIdSubtype::PredictedHost(predicted_machine_id) => {
-                        if endpoint_machine_id.as_ref()
-                            != Some(predicted_machine_id.as_machine_id())
-                        {
+                        if endpoint_machine_id.as_ref() != Some(&predicted_machine_id) {
                             tracing::warn!(
                                 %mac_address,
                                 predicted_machine_id = %prediction.machine_id,
@@ -635,18 +626,11 @@ impl MachineCreator {
         let has_existing_primary = if declared_primary.is_none()
             && let Some(machine_id) = existing_predicted_host_machine_id
         {
-            db::machine_interface::machine_has_primary_interface(
-                machine_id.as_machine_id(),
-                &mut *txn,
-            )
-            .await?
-                || db::predicted_machine_interface::find_by_machine_id(
-                    &mut *txn,
-                    machine_id.as_machine_id(),
-                )
-                .await?
-                .iter()
-                .any(|prediction| prediction.primary_interface)
+            db::machine_interface::machine_has_primary_interface(&machine_id, &mut *txn).await?
+                || db::predicted_machine_interface::find_by_machine_id(&mut *txn, &machine_id)
+                    .await?
+                    .iter()
+                    .any(|prediction| prediction.primary_interface)
         } else {
             false
         };
@@ -675,7 +659,7 @@ impl MachineCreator {
         if let Some(machine_id) = existing_predicted_host_machine_id {
             Self::reconcile_zero_dpu_host_interfaces(
                 txn,
-                machine_id.as_machine_id(),
+                &machine_id,
                 &mac_addresses,
                 &report_boot_interface_ids,
                 primary_mac,
@@ -692,10 +676,11 @@ impl MachineCreator {
         }
 
         let machine_id = match managed_host.machine_id.as_ref() {
-            Some(machine_id) => machine_id,
+            Some(machine_id) => *machine_id,
             None => {
                 // Mint a predicted-host machine_id from the exploration report
-                report.generate_machine_id(true)?.unwrap()
+                PredictedHostMachineId::try_from(*report.generate_machine_id(true)?.unwrap())?
+                    .into()
             }
         };
 
@@ -703,7 +688,7 @@ impl MachineCreator {
 
         let existing_machine = db::machine::find_one(
             &mut *txn,
-            machine_id,
+            &machine_id,
             MachineSearchConfig {
                 include_predicted_host: true,
                 ..Default::default()
@@ -732,19 +717,24 @@ impl MachineCreator {
             return Ok(None);
         }
 
-        self.create_machine_from_explored_managed_host(txn, managed_host, machine_id, machine_data)
-            .await?;
+        self.create_machine_from_explored_managed_host(
+            txn,
+            managed_host,
+            &machine_id,
+            machine_data,
+        )
+        .await?;
 
         Self::reconcile_zero_dpu_host_interfaces(
             txn,
-            machine_id,
+            &machine_id,
             &mac_addresses,
             &report_boot_interface_ids,
             primary_mac,
         )
         .await?;
 
-        Ok(Some(*machine_id))
+        Ok(Some(machine_id))
     }
 
     /// Reconciles every discovered Host candidate with a zero-DPU host.
@@ -947,7 +937,7 @@ impl MachineCreator {
     async fn own_declared_host_boot_nic(
         &self,
         txn: &mut PgConnection,
-        host_machine_id: &MachineId,
+        host_machine_id: &HostMachineId,
         report: &EndpointExplorationReport,
         machine_data: Option<&ExpectedMachineData>,
     ) -> SiteExplorerResult<()> {
@@ -966,7 +956,7 @@ impl MachineCreator {
                 // Owned by a DIFFERENT machine: the declaration names a MAC that
                 // already belongs elsewhere -- surface it rather than silently
                 // dropping the declared boot NIC (mirrors create_zero_dpu_machine).
-                if existing_machine_id != *host_machine_id {
+                if existing_machine_id != host_machine_id.into() {
                     return Err(SiteExplorerError::AlreadyFoundError {
                         kind: "MachineInterface",
                         id: declared_mac.to_string(),
@@ -984,7 +974,7 @@ impl MachineCreator {
             }
             db::machine_interface::associate_interface_with_machine(
                 &existing.id,
-                MachineInterfaceAssociation::Machine(*host_machine_id),
+                MachineInterfaceAssociation::Machine((*host_machine_id).into()),
                 txn,
             )
             .await?;
@@ -1002,7 +992,7 @@ impl MachineCreator {
         if let Some(existing_prediction) =
             db::predicted_machine_interface::find_by_mac_address(&mut *txn, declared_mac).await?
         {
-            if existing_prediction.machine_id != *host_machine_id {
+            if existing_prediction.machine_id != (*host_machine_id).into() {
                 return Err(SiteExplorerError::AlreadyFoundError {
                     kind: "PredictedMachineInterface",
                     id: declared_mac.to_string(),
@@ -1219,7 +1209,7 @@ impl MachineCreator {
         explored_host: &ManagedHost<'_>,
         explored_dpu: &ExploredDpu,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> SiteExplorerResult<MachineId> {
+    ) -> SiteExplorerResult<HostMachineId> {
         let dpu_hw_info = explored_dpu.hardware_info()?;
         // Create Host proactively.
         // In case host interface is created, this method will return existing one, instead
@@ -1253,7 +1243,7 @@ impl MachineCreator {
 
         db::machine_interface::associate_interface_with_machine(
             &host_machine_interface.id,
-            MachineInterfaceAssociation::Machine(host_machine_id),
+            MachineInterfaceAssociation::Machine(host_machine_id.into()),
             txn,
         )
         .await?;
@@ -1340,7 +1330,7 @@ impl MachineCreator {
     async fn reconcile_host_admin_addresses(
         &self,
         txn: &mut PgConnection,
-        host_machine_id: &MachineId,
+        host_machine_id: &HostMachineId,
     ) -> SiteExplorerResult<bool> {
         let active_config_changed =
             db::machine_interface::reconcile_admin_addresses_for_host(txn, host_machine_id).await?;
@@ -1381,7 +1371,7 @@ impl MachineCreator {
         host_machine_interface: &MachineInterfaceSnapshot,
         explored_dpu: &ExploredDpu,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> SiteExplorerResult<MachineId> {
+    ) -> SiteExplorerResult<HostMachineId> {
         match &explored_host.machine_id {
             Some(host_machine_id) => {
                 // This is not the primary interface for this host
@@ -1415,7 +1405,7 @@ impl MachineCreator {
 
                 db::machine_interface::set_primary_interface(&host_machine_interface.id, true, txn)
                     .await?;
-                Ok(host_machine_id)
+                Ok(host_machine_id.into())
             }
         }
     }
@@ -1429,7 +1419,7 @@ impl MachineCreator {
         explored_host: &ExploredManagedHost,
         explored_dpu: &ExploredDpu,
         machine_data: Option<&ExpectedMachineData>,
-    ) -> SiteExplorerResult<MachineId> {
+    ) -> SiteExplorerResult<PredictedHostMachineId> {
         let dpu_hw_info = explored_dpu.hardware_info()?;
         let predicted_machine_id = host_id_from_dpu_hardware_info(&dpu_hw_info).map_err(|e| {
             SiteExplorerError::InvalidArgument(format!("hardware info missing: {e}"))
@@ -1455,7 +1445,7 @@ impl MachineCreator {
         )
         .await?;
 
-        Ok(predicted_machine_id)
+        Ok(PredictedHostMachineId::try_from(predicted_machine_id)?)
     }
 }
 
@@ -1485,13 +1475,9 @@ async fn reconcile_desired_boot_interface(
     // `find_by_machine_ids` removes BMC rows. Keeping that boundary in the
     // database query also lets `pick_boot_interface` borrow this list directly.
     let mut interfaces_by_machine =
-        db::machine_interface::find_by_machine_ids(txn, &[*machine_id.as_machine_id()]).await?;
-    let interfaces = interfaces_by_machine
-        .remove(machine_id.as_machine_id())
-        .unwrap_or_default();
-    let predictions =
-        db::predicted_machine_interface::find_by_machine_id(txn, machine_id.as_machine_id())
-            .await?;
+        db::machine_interface::find_by_machine_ids(txn, &[*machine_id]).await?;
+    let interfaces = interfaces_by_machine.remove(machine_id).unwrap_or_default();
+    let predictions = db::predicted_machine_interface::find_by_machine_id(txn, machine_id).await?;
     let update = desired_boot_interface_update(
         desired.as_ref().map(|desired| &desired.value),
         &interfaces,

--- a/crates/site-explorer/src/managed_host.rs
+++ b/crates/site-explorer/src/managed_host.rs
@@ -16,7 +16,7 @@
  */
 use std::net::IpAddr;
 
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::HostMachineId;
 use db::DatabaseError;
 use db::db_read::DbReader;
 use model::site_explorer::ExploredManagedHost;
@@ -34,7 +34,7 @@ pub(super) struct ManagedHost<'a> {
     pub(super) explored_host: &'a ExploredManagedHost,
     /// The site explorer uses the machine_id as the host's machine ID when attaching a DPU to a host.
     /// The site explorer sets this field as part of attaching the first DPU to a host in the create_managed_host function.
-    pub(super) machine_id: Option<MachineId>,
+    pub(super) machine_id: Option<HostMachineId>,
 }
 
 impl<'a> ManagedHost<'a> {

--- a/crates/site-explorer/tests/integration/health_report.rs
+++ b/crates/site-explorer/tests/integration/health_report.rs
@@ -121,7 +121,7 @@ async fn test_site_explorer_health_report(pool: PgPool) -> Result<(), Box<dyn st
         .await;
     let host_bmc_ip = build_data.host_bmc_ip();
 
-    let host_machine = find_machine(test_harness.api(), created_host.host.id).await?;
+    let host_machine = find_machine(test_harness.api(), created_host.host.id.into()).await?;
     let alerts = &host_machine.health.as_ref().unwrap().alerts;
     assert!(
         alerts.is_empty(),
@@ -136,7 +136,7 @@ async fn test_site_explorer_health_report(pool: PgPool) -> Result<(), Box<dyn st
 
     explorer.run_single_iteration().await?;
 
-    let host_machine = find_machine(test_harness.api(), created_host.host.id).await?;
+    let host_machine = find_machine(test_harness.api(), created_host.host.id.into()).await?;
 
     let mut alerts = host_machine.health.as_ref().unwrap().alerts.clone();
     assert_eq!(
@@ -302,7 +302,7 @@ async fn test_orphan_managed_host_alert_emitted(
 
     // Run an iteration: audit_exploration_results should emit the orphan alert.
     explorer.run_single_iteration().await?;
-    let alerts = find_machine(test_harness.api(), created_host.host.id)
+    let alerts = find_machine(test_harness.api(), created_host.host.id.into())
         .await?
         .health
         .unwrap()
@@ -329,7 +329,7 @@ async fn test_orphan_managed_host_alert_emitted(
     txn.commit().await?;
 
     explorer.run_single_iteration().await?;
-    let alerts = find_machine(test_harness.api(), created_host.host.id)
+    let alerts = find_machine(test_harness.api(), created_host.host.id.into())
         .await?
         .health
         .unwrap()

--- a/crates/site-explorer/tests/integration/machine_creator.rs
+++ b/crates/site-explorer/tests/integration/machine_creator.rs
@@ -28,7 +28,7 @@ use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::{
     DpuConfigExt as _, FixtureDefault as _, ManagedHostConfigExt as _,
 };
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, MachineId};
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::ObjectFilter;
 use librms::protos::rack_manager as rms;
@@ -55,7 +55,7 @@ const ROLE_COMPUTE: &str = "compute";
 struct ExploredHostFixture {
     host: ExploredManagedHost,
     host_report: EndpointExplorationReport,
-    dpu_machine_ids: HashMap<u8, MachineId>,
+    dpu_machine_ids: HashMap<u8, DpuMachineId>,
 }
 
 struct Env {
@@ -176,7 +176,7 @@ fn expected_machine(managed_host: &ManagedHostConfig) -> ExpectedMachine {
 async fn assert_no_machines_created(pool: &PgPool) -> Result<(), Box<dyn std::error::Error>> {
     let machines = db::machine::find(
         pool,
-        ObjectFilter::All,
+        ObjectFilter::<MachineId>::All,
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()
@@ -563,7 +563,7 @@ async fn test_dpu_interface_predictions_apply_when_dhcp_follows_machine_creation
         db::predicted_machine_interface::find_by_mac_address(&mut txn, mock_dpu.oob_mac_address)
             .await?
             .expect("DPU OOB prediction should exist");
-    assert_eq!(prediction.machine_id, dpu_machine_id);
+    assert_eq!(prediction.machine_id, dpu_machine_id.into());
     assert_eq!(
         prediction.expected_network_segment_type,
         model::network_segment::NetworkSegmentType::Underlay
@@ -580,7 +580,7 @@ async fn test_dpu_interface_predictions_apply_when_dhcp_follows_machine_creation
     let [interface] = interfaces.as_slice() else {
         panic!("expected one promoted DPU OOB interface, got {interfaces:#?}");
     };
-    assert_eq!(interface.machine_id, Some(dpu_machine_id));
+    assert_eq!(interface.machine_id, Some(dpu_machine_id.into()));
     assert_eq!(interface.attached_dpu_machine_id, Some(dpu_machine_id));
     assert!(interface.primary_interface);
     assert!(
@@ -605,7 +605,7 @@ async fn test_dpu_interface_predictions_apply_when_dhcp_follows_machine_creation
         }))
         .await?
         .into_inner();
-    assert_eq!(response.machine_id, Some(dpu_machine_id));
+    assert_eq!(response.machine_id, Some(dpu_machine_id.into()));
 
     Ok(())
 }
@@ -644,7 +644,7 @@ async fn test_dpu_interface_predictions_apply_when_dhcp_follows_multi_dpu_machin
         assert_eq!(interfaces.len(), 1);
         assert_eq!(
             interfaces[0].machine_id,
-            Some(fixture.dpu_machine_ids[&dpu_index])
+            Some(fixture.dpu_machine_ids[&dpu_index].into())
         );
         assert_eq!(
             interfaces[0].attached_dpu_machine_id,
@@ -740,7 +740,7 @@ async fn test_machine_creator_creates_managed_host_with_dpf_disabled(
 
     let machines = db::machine::find(
         &env.pool,
-        ObjectFilter::All,
+        ObjectFilter::<MachineId>::All,
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()
@@ -792,7 +792,7 @@ async fn test_machine_creator_creates_managed_host_with_dpf_enabled(
 
     let machines = db::machine::find(
         &env.pool,
-        ObjectFilter::All,
+        ObjectFilter::<MachineId>::All,
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()
@@ -828,7 +828,7 @@ async fn test_machine_creator_rejects_unexpected_host(
 
     let machines = db::machine::find(
         &env.pool,
-        ObjectFilter::All,
+        ObjectFilter::<MachineId>::All,
         MachineSearchConfig {
             include_predicted_host: true,
             ..Default::default()

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -29,6 +29,7 @@ use carbide_test_harness::prelude::*;
 use carbide_test_harness::test_support::fixture_config::{
     DpuConfigExt as _, FixtureDefault as _, ManagedHostConfigExt as _,
 };
+use carbide_uuid::machine::MachineId;
 use db::ObjectFilter;
 use db::sku::CURRENT_SKU_VERSION;
 use itertools::Itertools;
@@ -2662,9 +2663,13 @@ async fn test_fallback_dpu_serial(pool: PgPool) -> Result<(), Box<dyn std::error
     assert_eq!(explored_endpoints.len(), 2);
 
     let mut explored_managed_hosts = db::explored_managed_host::find_all(&pool).await?;
-    let mut machines = db::machine::find(&pool, ObjectFilter::All, MachineSearchConfig::default())
-        .await
-        .unwrap();
+    let mut machines = db::machine::find(
+        &pool,
+        ObjectFilter::<MachineId>::All,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap();
 
     // There should be no managed host
     assert_eq!(explored_managed_hosts.len(), 0);
@@ -2698,9 +2703,13 @@ async fn test_fallback_dpu_serial(pool: PgPool) -> Result<(), Box<dyn std::error
 
     explorer.run_single_iteration().await.unwrap();
     explored_managed_hosts = db::explored_managed_host::find_all(&pool).await?;
-    machines = db::machine::find(&pool, ObjectFilter::All, MachineSearchConfig::default())
-        .await
-        .unwrap();
+    machines = db::machine::find(
+        &pool,
+        ObjectFilter::<MachineId>::All,
+        MachineSearchConfig::default(),
+    )
+    .await
+    .unwrap();
 
     // We should see one explored_managed host && 2 machines
     assert_eq!(

--- a/crates/test-harness/src/db_machine.rs
+++ b/crates/test-harness/src/db_machine.rs
@@ -42,7 +42,8 @@ impl DbMachineExt for Machine {
     }
 
     async fn update_state<'txn>(&self, txn: &mut PgTransaction<'txn>, state: ManagedHostState) {
-        db::machine::update_state(txn.as_mut(), &self.id, &state)
+        let host_machine_id = self.id.try_into().expect("machine should be a host");
+        db::machine::update_state(txn.as_mut(), &host_machine_id, &state)
             .await
             .expect("machine state should be updated");
     }

--- a/crates/test-harness/src/machine_dpu.rs
+++ b/crates/test-harness/src/machine_dpu.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use carbide_api_core::test_support::Api;
 use carbide_network::virtualization::build_dual_stack_list;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{DpuMachineId, MachineId};
 use mac_address::MacAddress;
 use model::hardware_info::HardwareInfo;
 use model::test_support::DpuConfig;
@@ -31,7 +31,7 @@ use crate::rpc::forge::{DhcpDiscovery, DhcpRecord, ManagedHostNetworkConfigReque
 
 #[derive(Clone)]
 pub struct TestDpuMachine {
-    pub id: MachineId,
+    pub id: DpuMachineId,
     pub bmc_mac: MacAddress,
     pub api: Arc<Api>,
     hardware_info: HardwareInfo,
@@ -39,7 +39,7 @@ pub struct TestDpuMachine {
 }
 
 impl TestDpuMachine {
-    pub(crate) fn new(id: MachineId, api: Arc<Api>, config: &DpuConfig) -> Self {
+    pub(crate) fn new(id: DpuMachineId, api: Arc<Api>, config: &DpuConfig) -> Self {
         Self {
             id,
             bmc_mac: config.bmc_mac_address,
@@ -73,7 +73,8 @@ impl TestDpuMachine {
             .machine_id
             .expect("DPU discovery should return a machine id");
         assert_eq!(
-            discovered_id, self.id,
+            discovered_id,
+            self.id.into(),
             "DPU discovery should resolve to the expected test machine"
         );
     }
@@ -86,7 +87,7 @@ impl TestDpuMachine {
 
 impl TestMachine for TestDpuMachine {
     fn id(&self) -> MachineId {
-        self.id
+        self.id.into()
     }
 
     fn api(&self) -> &Api {
@@ -98,10 +99,10 @@ impl TestMachinePrivate for TestDpuMachine {}
 
 // This harness models the compatibility fields consumed by older agents.
 #[allow(deprecated)]
-async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {
+async fn record_dpu_network_status(api: &Api, dpu_machine_id: DpuMachineId) {
     let network_config = api
         .get_managed_host_network_config(tonic::Request::new(ManagedHostNetworkConfigRequest {
-            dpu_machine_id: Some(dpu_machine_id),
+            dpu_machine_id: Some(dpu_machine_id.into()),
         }))
         .await
         .expect("managed host network config should be available")
@@ -114,7 +115,7 @@ async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {
             Some(network_config.instance_network_config_version.clone())
         };
     let instance_config_version = api
-        .find_instance_by_machine_id(tonic::Request::new(dpu_machine_id))
+        .find_instance_by_machine_id(tonic::Request::new(dpu_machine_id.into()))
         .await
         .expect("instance lookup by machine id should succeed")
         .into_inner()
@@ -205,7 +206,7 @@ async fn record_dpu_network_status(api: &Api, dpu_machine_id: MachineId) {
         .collect();
 
     api.record_dpu_network_status(tonic::Request::new(crate::rpc::forge::DpuNetworkStatus {
-        dpu_machine_id: Some(dpu_machine_id),
+        dpu_machine_id: Some(dpu_machine_id.into()),
         dpu_agent_version: Some("test-dpu-agent-version".to_string()),
         observed_at: None,
         dpu_health: Some(crate::rpc::health::HealthReport {

--- a/crates/test-harness/src/machine_host.rs
+++ b/crates/test-harness/src/machine_host.rs
@@ -18,7 +18,7 @@
 use std::sync::Arc;
 
 use carbide_api_core::test_support::Api;
-use carbide_uuid::machine::MachineId;
+use carbide_uuid::machine::{HostMachineId, MachineId};
 use mac_address::MacAddress;
 use model::hardware_info::HardwareInfo;
 use model::machine::machine_id::from_hardware_info;
@@ -34,7 +34,7 @@ use crate::rpc::forge::{
 
 #[derive(Clone)]
 pub struct TestHostMachine {
-    pub id: MachineId,
+    pub id: HostMachineId,
     pub bmc_mac: MacAddress,
     pub api: Arc<Api>,
     hardware_info: HardwareInfo,
@@ -42,7 +42,7 @@ pub struct TestHostMachine {
 }
 
 impl TestHostMachine {
-    pub(crate) fn new(id: MachineId, api: Arc<Api>, config: &ManagedHostConfig) -> Self {
+    pub(crate) fn new(id: HostMachineId, api: Arc<Api>, config: &ManagedHostConfig) -> Self {
         Self {
             id,
             bmc_mac: config.bmc_mac_address,
@@ -98,13 +98,15 @@ impl TestHostMachine {
             discovered_id, expected_id,
             "host discovery should resolve to the stable test machine"
         );
-        self.id = discovered_id;
+        self.id = discovered_id
+            .try_into()
+            .expect("host discovery should yield a valid HostMachineId");
     }
 
     pub async fn reboot_completed(&self) {
         self.api
             .reboot_completed(tonic::Request::new(MachineRebootCompletedRequest {
-                machine_id: Some(self.id),
+                machine_id: Some(self.id.into()),
             }))
             .await
             .unwrap();
@@ -113,7 +115,7 @@ impl TestHostMachine {
     pub async fn forge_agent_control(&self) -> ForgeAgentControlResponse {
         self.api
             .forge_agent_control(tonic::Request::new(ForgeAgentControlRequest {
-                machine_id: Some(self.id),
+                machine_id: Some(self.id.into()),
             }))
             .await
             .unwrap()
@@ -123,7 +125,7 @@ impl TestHostMachine {
 
 impl TestMachine for TestHostMachine {
     fn id(&self) -> MachineId {
-        self.id
+        self.id.into()
     }
 
     fn api(&self) -> &Api {

--- a/crates/test-harness/src/managed_host.rs
+++ b/crates/test-harness/src/managed_host.rs
@@ -71,7 +71,7 @@ impl TestManagedHost {
                     }),
                     ..Default::default()
                 }),
-                machine_id: Some(self.host.id),
+                machine_id: Some(self.host.id.into()),
             }))
             .await
             .expect("empty host health report should be inserted");
@@ -114,7 +114,7 @@ impl TestManagedHost {
         assert!(
             db::machine_desired_boot_interface::mark_verified(
                 txn.as_mut(),
-                &self.host.id.try_into().unwrap(),
+                &self.host.id,
                 desired_version,
                 Utc::now(),
             )
@@ -290,7 +290,7 @@ impl<'a> TestManagedHostBuilder<'a> {
             })
             .collect();
         let managed_host = TestManagedHost {
-            host: TestHostMachine::new(host_machine_id(&config).into(), api.clone(), &config),
+            host: TestHostMachine::new(host_machine_id(&config), api.clone(), &config),
             dpus,
             api,
         };

--- a/crates/uuid/src/machine/dpu.rs
+++ b/crates/uuid/src/machine/dpu.rs
@@ -16,9 +16,13 @@
  */
 
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 use std::str::FromStr;
 
-use super::{InvalidMachineType, MachineId, MachineType};
+use data_encoding::BASE32_DNSSEC;
+use sha2::{Digest, Sha256};
+
+use super::{InvalidMachineType, MachineId, MachineIdSubtype, MachineIdSubtypeTrait, MachineType};
 
 /// A machine ID that identifies a DPU.
 #[repr(transparent)]
@@ -26,15 +30,41 @@ use super::{InvalidMachineType, MachineId, MachineType};
 #[serde(transparent)]
 pub struct DpuMachineId(pub(super) MachineId);
 
+impl_prost_message_for_machine_id!(DpuMachineId, MachineType::Dpu);
+
+impl MachineIdSubtypeTrait for DpuMachineId {
+    fn machine_type(&self) -> MachineType {
+        MachineType::Dpu
+    }
+
+    fn as_machine_id(&self) -> &MachineId {
+        DpuMachineId::as_machine_id(self)
+    }
+
+    fn machine_id_subtype(&self) -> MachineIdSubtype {
+        MachineIdSubtype::Dpu(*self)
+    }
+}
+
 impl DpuMachineId {
     /// Returns the underlying machine ID.
     pub fn as_machine_id(&self) -> &MachineId {
         &self.0
     }
+
+    /// Generate Remote ID based on machineID.
+    /// Remote Id is inserted by dhcrelay on DPU in each DHCP request sent by host.
+    pub fn remote_id(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.to_string().as_bytes());
+        let hash: [u8; 32] = hasher.finalize().into();
+        BASE32_DNSSEC.encode(&hash)
+    }
 }
 
-impl AsRef<MachineId> for DpuMachineId {
-    fn as_ref(&self) -> &MachineId {
+impl Deref for DpuMachineId {
+    type Target = MachineId;
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
@@ -53,6 +83,14 @@ impl TryFrom<MachineId> for DpuMachineId {
     }
 }
 
+impl TryFrom<&MachineId> for DpuMachineId {
+    type Error = InvalidMachineType;
+
+    fn try_from(id: &MachineId) -> Result<Self, Self::Error> {
+        Self::try_from(*id)
+    }
+}
+
 impl FromStr for DpuMachineId {
     type Err = crate::machine::MachineIdSubtypeParseError;
 
@@ -64,6 +102,12 @@ impl FromStr for DpuMachineId {
 
 impl From<DpuMachineId> for MachineId {
     fn from(id: DpuMachineId) -> Self {
+        id.0
+    }
+}
+
+impl From<&DpuMachineId> for MachineId {
+    fn from(id: &DpuMachineId) -> Self {
         id.0
     }
 }

--- a/crates/uuid/src/machine/host.rs
+++ b/crates/uuid/src/machine/host.rs
@@ -16,10 +16,12 @@
  */
 
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 use std::str::FromStr;
 
 use super::{
-    InvalidMachineType, MachineId, MachineType, PredictedHostMachineId, StableHostMachineId,
+    InvalidMachineType, MachineId, MachineIdSubtype, MachineIdSubtypeTrait, MachineType,
+    PredictedHostMachineId, StableHostMachineId,
 };
 
 /// A machine ID that identifies either a stable or predicted host.
@@ -27,6 +29,28 @@ use super::{
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash, serde::Serialize, PartialOrd, Ord)]
 #[serde(transparent)]
 pub struct HostMachineId(pub(super) MachineId);
+
+impl_prost_message_for_machine_id!(HostMachineId, MachineType::Host);
+
+impl MachineIdSubtypeTrait for HostMachineId {
+    fn machine_type(&self) -> MachineType {
+        match self.host_machine_id_subtype() {
+            HostMachineIdSubtype::Stable(_) => MachineType::Host,
+            HostMachineIdSubtype::Predicted(_) => MachineType::PredictedHost,
+        }
+    }
+
+    fn as_machine_id(&self) -> &MachineId {
+        HostMachineId::as_machine_id(self)
+    }
+
+    fn machine_id_subtype(&self) -> MachineIdSubtype {
+        match Self::host_machine_id_subtype(self) {
+            HostMachineIdSubtype::Stable(id) => MachineIdSubtype::StableHost(id),
+            HostMachineIdSubtype::Predicted(id) => MachineIdSubtype::PredictedHost(id),
+        }
+    }
+}
 
 /// Actual type-safe variants of a host machine ID, stable (fm100h) or predicted (fm100p)
 pub enum HostMachineIdSubtype {
@@ -63,8 +87,9 @@ impl HostMachineId {
     }
 }
 
-impl AsRef<MachineId> for HostMachineId {
-    fn as_ref(&self) -> &MachineId {
+impl Deref for HostMachineId {
+    type Target = MachineId;
+    fn deref(&self) -> &MachineId {
         &self.0
     }
 }
@@ -83,6 +108,14 @@ impl TryFrom<MachineId> for HostMachineId {
     }
 }
 
+impl TryFrom<&MachineId> for HostMachineId {
+    type Error = InvalidMachineType;
+
+    fn try_from(id: &MachineId) -> Result<Self, Self::Error> {
+        Self::try_from(*id)
+    }
+}
+
 impl FromStr for HostMachineId {
     type Err = crate::machine::MachineIdSubtypeParseError;
 
@@ -94,6 +127,12 @@ impl FromStr for HostMachineId {
 
 impl From<HostMachineId> for MachineId {
     fn from(id: HostMachineId) -> Self {
+        id.0
+    }
+}
+
+impl From<&HostMachineId> for MachineId {
+    fn from(id: &HostMachineId) -> Self {
         id.0
     }
 }

--- a/crates/uuid/src/machine/mod.rs
+++ b/crates/uuid/src/machine/mod.rs
@@ -16,8 +16,10 @@
  */
 
 use std::cmp::Ordering;
+use std::convert::Infallible;
 use std::fmt;
 use std::fmt::{Debug, Display, Formatter, Write};
+use std::hash::Hash;
 use std::str::FromStr;
 
 use data_encoding::BASE32_DNSSEC;
@@ -25,13 +27,63 @@ use prost::DecodeError;
 use prost::bytes::{Buf, BufMut};
 use prost::encoding::{DecodeContext, WireType};
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 
 use super::DbPrimaryUuid;
 
 static MACHINE_ID_PREFIX: &str = "fm100";
 
 use crate::typed_uuids::{TypedUuid, UuidSubtype};
+
+macro_rules! impl_prost_message_for_machine_id {
+    ($newtype:ty, $default_type:expr) => {
+        impl prost::Message for $newtype {
+            fn encode_raw(&self, buf: &mut impl prost::bytes::BufMut)
+            where
+                Self: Sized,
+            {
+                super::encode_machine_id(self.as_machine_id(), buf);
+            }
+
+            fn merge_field(
+                &mut self,
+                tag: u32,
+                wire_type: prost::encoding::WireType,
+                buf: &mut impl prost::bytes::Buf,
+                ctx: prost::encoding::DecodeContext,
+            ) -> Result<(), prost::DecodeError>
+            where
+                Self: Sized,
+            {
+                let mut id = *self.as_machine_id();
+                super::merge_machine_id(&mut id, tag, wire_type, buf, ctx)?;
+                *self = Self::try_from(id).map_err(|error| {
+                    #[allow(deprecated)]
+                    prost::DecodeError::new(error.to_string())
+                })?;
+                Ok(())
+            }
+
+            fn encoded_len(&self) -> usize {
+                super::encoded_machine_id_len(self.as_machine_id())
+            }
+
+            #[allow(deprecated)]
+            fn clear(&mut self) {
+                *self = Self::default();
+            }
+        }
+
+        impl Default for $newtype {
+            /// Returns a synthetic value required for prost message decoding.
+            ///
+            /// This is an interoperability value, not an application machine ID.
+            fn default() -> Self {
+                Self::try_from(super::prost_default_machine_id($default_type))
+                    .expect("the prost default machine type matches the subtype")
+            }
+        }
+    };
+}
 
 // Macro used by below modules (`mod dpu;`, etc): needs to be declared before we declare them.
 #[cfg(feature = "sqlx")]
@@ -167,14 +219,13 @@ impl PartialOrd for MachineId {
 }
 
 // Implement [`prost::Message`] manually so that we can be wire-compatible with the
-// `.common.MachineId` protobuf message, which is what we actually serialize. Do this by
-// constructing a `legacy_rpc::MachineId` and delegate all  [`prost::Message`] methods to it.
+// `.common.MachineId` protobuf message, which is what we actually serialize.
 impl prost::Message for MachineId {
     fn encode_raw(&self, buf: &mut impl BufMut)
     where
         Self: Sized,
     {
-        legacy_rpc::MachineId::from(*self).encode_raw(buf);
+        encode_machine_id(self, buf);
     }
 
     fn merge_field(
@@ -187,25 +238,41 @@ impl prost::Message for MachineId {
     where
         Self: Sized,
     {
-        let mut legacy_message = legacy_rpc::MachineId::from(*self);
-        legacy_message.merge_field(tag, wire_type, buf, ctx)?;
-        *self = MachineId::from_str(&legacy_message.id).map_err(|_| {
-            // Deprecation: if they remove DecodeError::new, they hopefully will provide some other way
-            // to impl prost::Message.
-            #[allow(deprecated)]
-            DecodeError::new(format!("Invalid machine id: {}", legacy_message.id))
-        })?;
-        Ok(())
+        merge_machine_id(self, tag, wire_type, buf, ctx)
     }
 
     fn encoded_len(&self) -> usize {
-        legacy_rpc::MachineId::from(*self).encoded_len()
+        encoded_machine_id_len(self)
     }
 
     #[allow(deprecated)]
     fn clear(&mut self) {
         *self = MachineId::default();
     }
+}
+
+fn encode_machine_id(id: &MachineId, buf: &mut impl BufMut) {
+    prost::Message::encode_raw(&legacy_rpc::MachineId::from(*id), buf);
+}
+
+fn merge_machine_id(
+    id: &mut MachineId,
+    tag: u32,
+    wire_type: WireType,
+    buf: &mut impl Buf,
+    ctx: DecodeContext,
+) -> Result<(), DecodeError> {
+    let mut legacy_message = legacy_rpc::MachineId::from(*id);
+    prost::Message::merge_field(&mut legacy_message, tag, wire_type, buf, ctx)?;
+    *id = MachineId::from_str(&legacy_message.id).map_err(|_| {
+        #[allow(deprecated)]
+        DecodeError::new(format!("Invalid machine id: {}", legacy_message.id))
+    })?;
+    Ok(())
+}
+
+fn encoded_machine_id_len(id: &MachineId) -> usize {
+    prost::Message::encoded_len(&legacy_rpc::MachineId::from(*id))
 }
 
 mod legacy_rpc {
@@ -311,6 +378,65 @@ impl PgHasArrayType for MachineId {
     }
 }
 
+pub trait MachineIdSubtypeTrait:
+    Display
+    + Copy
+    + Clone
+    + Send
+    + Sync
+    + Eq
+    + PartialEq
+    + Hash
+    + Into<MachineId>
+    + TryFrom<MachineId, Error: Into<InvalidMachineType>>
+{
+    fn machine_type(&self) -> MachineType;
+    fn as_machine_id(&self) -> &MachineId;
+    fn machine_id_subtype(&self) -> MachineIdSubtype;
+
+    fn to_machine_id(&self) -> MachineId {
+        *Self::as_machine_id(self)
+    }
+
+    fn host_or_dpu_id(&self) -> HostOrDpuId {
+        HostOrDpuId::from(self.machine_id_subtype())
+    }
+
+    fn is_dpu(&self) -> bool {
+        matches!(self.machine_type(), MachineType::Dpu)
+    }
+}
+
+pub trait AsMachineId: Send + Sync {
+    fn as_machine_id(&self) -> &MachineId;
+}
+
+impl<T: MachineIdSubtypeTrait> AsMachineId for T {
+    fn as_machine_id(&self) -> &MachineId {
+        <Self as MachineIdSubtypeTrait>::as_machine_id(self)
+    }
+}
+
+impl MachineIdSubtypeTrait for MachineId {
+    fn machine_type(&self) -> MachineType {
+        Self::machine_type(self)
+    }
+
+    fn as_machine_id(&self) -> &MachineId {
+        self
+    }
+
+    fn machine_id_subtype(&self) -> MachineIdSubtype {
+        MachineId::machine_id_subtype(self)
+    }
+}
+
+impl From<&MachineId> for MachineId {
+    fn from(id: &MachineId) -> Self {
+        *id
+    }
+}
+
 /// Equivalent to [`MachineType`] but carries the strongly-typed subtype with each variant
 pub enum MachineIdSubtype {
     Dpu(DpuMachineId),
@@ -323,6 +449,16 @@ pub enum MachineIdSubtype {
 pub enum HostOrDpuId {
     Host(HostMachineId),
     Dpu(DpuMachineId),
+}
+
+impl From<MachineIdSubtype> for HostOrDpuId {
+    fn from(value: MachineIdSubtype) -> Self {
+        match value {
+            MachineIdSubtype::Dpu(id) => HostOrDpuId::Dpu(id),
+            MachineIdSubtype::StableHost(id) => HostOrDpuId::Host(id.into()),
+            MachineIdSubtype::PredictedHost(id) => HostOrDpuId::Host(id.into()),
+        }
+    }
 }
 
 impl MachineId {
@@ -349,16 +485,6 @@ impl MachineId {
         self.ty
     }
 
-    /// Generate Remote ID based on machineID.
-    /// Remote Id is inserted by dhcrelay on DPU in each DHCP request sent by host.
-    /// This field is used only for DPU.
-    pub fn remote_id(&self) -> String {
-        let mut hasher = Sha256::new();
-        hasher.update(self.to_string().as_bytes());
-        let hash: [u8; 32] = hasher.finalize().into();
-        BASE32_DNSSEC.encode(&hash)
-    }
-
     /// Note: Never use this! Tonic's codegen requires all types to implement Default, but there is
     /// no logical reason to construct a "default" MachineId in real code, so we simply construct a
     /// bogus one here.
@@ -367,11 +493,7 @@ impl MachineId {
         note = "Do not use `MachineId::default()` directly; only implemented for prost interop"
     )]
     pub fn default() -> Self {
-        Self::new(
-            MachineIdSource::ProductBoardChassisSerial,
-            [0; 32],
-            MachineType::Host,
-        )
+        prost_default_machine_id(MachineType::Host)
     }
 
     pub(crate) fn is_matching_prefix(s: &str) -> bool {
@@ -381,14 +503,13 @@ impl MachineId {
     /// Equivalent to [`Self::machine_type`] but returns a [`MachineIdSubtype`], which carries the
     /// strongly-typed subtype with each variant
     pub fn machine_id_subtype(&self) -> MachineIdSubtype {
-        // SAFETY: subtypes must convert if the type matches
         match self.ty {
-            MachineType::Dpu => MachineIdSubtype::Dpu(DpuMachineId::try_from(*self).unwrap()),
+            MachineType::Dpu => MachineIdSubtype::Dpu(DpuMachineId(*self)),
             MachineType::Host => {
-                MachineIdSubtype::StableHost(StableHostMachineId::try_from(*self).unwrap())
+                MachineIdSubtype::StableHost(StableHostMachineId(HostMachineId(*self)))
             }
             MachineType::PredictedHost => {
-                MachineIdSubtype::PredictedHost(PredictedHostMachineId::try_from(*self).unwrap())
+                MachineIdSubtype::PredictedHost(PredictedHostMachineId(HostMachineId(*self)))
             }
         }
     }
@@ -396,14 +517,17 @@ impl MachineId {
     /// Similar to [`Self::machine_id_subtype`] but for cases where stable and predicted host ID's
     /// should be combined into a single [`HostMachineId`] variant.
     pub fn host_or_dpu_id(&self) -> HostOrDpuId {
-        // SAFETY: subtypes must convert if the type matches
         match self.ty {
-            MachineType::Dpu => HostOrDpuId::Dpu(DpuMachineId::try_from(*self).unwrap()),
+            MachineType::Dpu => HostOrDpuId::Dpu(DpuMachineId(*self)),
             MachineType::Host | MachineType::PredictedHost => {
-                HostOrDpuId::Host(HostMachineId::try_from(*self).unwrap())
+                HostOrDpuId::Host(HostMachineId(*self))
             }
         }
     }
+}
+
+fn prost_default_machine_id(ty: MachineType) -> MachineId {
+    MachineId::new(MachineIdSource::ProductBoardChassisSerial, [0; 32], ty)
 }
 
 impl DbPrimaryUuid for MachineId {
@@ -648,6 +772,12 @@ impl<'de> Deserialize<'de> for MachineId {
 pub struct InvalidMachineType {
     expected: &'static str,
     actual: MachineId,
+}
+
+impl From<Infallible> for InvalidMachineType {
+    fn from(_: Infallible) -> Self {
+        unreachable!()
+    }
 }
 
 #[cfg(test)]

--- a/crates/uuid/src/machine/predicted_host.rs
+++ b/crates/uuid/src/machine/predicted_host.rs
@@ -16,9 +16,13 @@
  */
 
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 use std::str::FromStr;
 
-use super::{HostMachineId, InvalidMachineType, MachineId, MachineType};
+use super::{
+    HostMachineId, InvalidMachineType, MachineId, MachineIdSubtype, MachineIdSubtypeTrait,
+    MachineType,
+};
 
 /// A machine ID that identifies a predicted host.
 #[repr(transparent)]
@@ -26,10 +30,26 @@ use super::{HostMachineId, InvalidMachineType, MachineId, MachineType};
 #[serde(transparent)]
 pub struct PredictedHostMachineId(pub(super) HostMachineId);
 
+impl_prost_message_for_machine_id!(PredictedHostMachineId, MachineType::PredictedHost);
+
+impl MachineIdSubtypeTrait for PredictedHostMachineId {
+    fn machine_type(&self) -> MachineType {
+        MachineType::PredictedHost
+    }
+
+    fn as_machine_id(&self) -> &MachineId {
+        PredictedHostMachineId::as_machine_id(self)
+    }
+
+    fn machine_id_subtype(&self) -> MachineIdSubtype {
+        MachineIdSubtype::PredictedHost(*self)
+    }
+}
+
 impl PredictedHostMachineId {
     /// Returns the underlying machine ID.
     pub fn as_machine_id(&self) -> &MachineId {
-        self.0.as_machine_id()
+        &self.0.0
     }
 
     /// Returns the underlying HostMachineId (which is allowed to be either a predicted or stable
@@ -39,9 +59,10 @@ impl PredictedHostMachineId {
     }
 }
 
-impl AsRef<MachineId> for PredictedHostMachineId {
-    fn as_ref(&self) -> &MachineId {
-        self.as_machine_id()
+impl Deref for PredictedHostMachineId {
+    type Target = HostMachineId;
+    fn deref(&self) -> &Self::Target {
+        &self.0
     }
 }
 
@@ -79,6 +100,22 @@ impl TryFrom<HostMachineId> for PredictedHostMachineId {
     }
 }
 
+impl TryFrom<&MachineId> for PredictedHostMachineId {
+    type Error = InvalidMachineType;
+
+    fn try_from(id: &MachineId) -> Result<Self, Self::Error> {
+        Self::try_from(*id)
+    }
+}
+
+impl TryFrom<&HostMachineId> for PredictedHostMachineId {
+    type Error = InvalidMachineType;
+
+    fn try_from(id: &HostMachineId) -> Result<Self, Self::Error> {
+        Self::try_from(*id)
+    }
+}
+
 impl FromStr for PredictedHostMachineId {
     type Err = crate::machine::MachineIdSubtypeParseError;
 
@@ -96,6 +133,18 @@ impl From<PredictedHostMachineId> for HostMachineId {
 
 impl From<PredictedHostMachineId> for MachineId {
     fn from(id: PredictedHostMachineId) -> Self {
+        id.0.into()
+    }
+}
+
+impl From<&PredictedHostMachineId> for HostMachineId {
+    fn from(id: &PredictedHostMachineId) -> Self {
+        id.0
+    }
+}
+
+impl From<&PredictedHostMachineId> for MachineId {
+    fn from(id: &PredictedHostMachineId) -> Self {
         id.0.into()
     }
 }

--- a/crates/uuid/src/machine/stable_host.rs
+++ b/crates/uuid/src/machine/stable_host.rs
@@ -16,9 +16,13 @@
  */
 
 use std::fmt::{Display, Formatter};
+use std::ops::Deref;
 use std::str::FromStr;
 
-use super::{HostMachineId, InvalidMachineType, MachineId, MachineType};
+use super::{
+    HostMachineId, InvalidMachineType, MachineId, MachineIdSubtype, MachineIdSubtypeTrait,
+    MachineType,
+};
 
 /// A stable machine ID that identifies an ingested host (not a predicted host).
 #[repr(transparent)]
@@ -26,10 +30,26 @@ use super::{HostMachineId, InvalidMachineType, MachineId, MachineType};
 #[serde(transparent)]
 pub struct StableHostMachineId(pub(super) HostMachineId);
 
+impl_prost_message_for_machine_id!(StableHostMachineId, MachineType::Host);
+
+impl MachineIdSubtypeTrait for StableHostMachineId {
+    fn machine_type(&self) -> MachineType {
+        MachineType::Host
+    }
+
+    fn as_machine_id(&self) -> &MachineId {
+        StableHostMachineId::as_machine_id(self)
+    }
+
+    fn machine_id_subtype(&self) -> MachineIdSubtype {
+        MachineIdSubtype::StableHost(*self)
+    }
+}
+
 impl StableHostMachineId {
     /// Returns the underlying machine ID.
     pub fn as_machine_id(&self) -> &MachineId {
-        self.0.as_machine_id()
+        &self.0.0
     }
 
     /// Returns the underlying HostMachineId (which is allowed to be either a predicted or stable
@@ -39,14 +59,9 @@ impl StableHostMachineId {
     }
 }
 
-impl AsRef<MachineId> for StableHostMachineId {
-    fn as_ref(&self) -> &MachineId {
-        self.0.as_machine_id()
-    }
-}
-
-impl AsRef<HostMachineId> for StableHostMachineId {
-    fn as_ref(&self) -> &HostMachineId {
+impl Deref for StableHostMachineId {
+    type Target = HostMachineId;
+    fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
@@ -79,12 +94,40 @@ impl TryFrom<HostMachineId> for StableHostMachineId {
     }
 }
 
+impl TryFrom<&MachineId> for StableHostMachineId {
+    type Error = InvalidMachineType;
+
+    fn try_from(id: &MachineId) -> Result<Self, Self::Error> {
+        Self::try_from(*id)
+    }
+}
+
+impl TryFrom<&HostMachineId> for StableHostMachineId {
+    type Error = InvalidMachineType;
+
+    fn try_from(id: &HostMachineId) -> Result<Self, Self::Error> {
+        Self::try_from(*id)
+    }
+}
+
 impl FromStr for StableHostMachineId {
     type Err = crate::machine::MachineIdSubtypeParseError;
 
     fn from_str(value: &str) -> Result<Self, Self::Err> {
         let id = MachineId::from_str(value)?;
         Ok(Self::try_from(id)?)
+    }
+}
+
+impl From<&StableHostMachineId> for HostMachineId {
+    fn from(id: &StableHostMachineId) -> Self {
+        id.0
+    }
+}
+
+impl From<&StableHostMachineId> for MachineId {
+    fn from(id: &StableHostMachineId) -> Self {
+        id.0.into()
     }
 }
 


### PR DESCRIPTION
As a continuation of #5341, adopt the MachineId subtypes in places that are "obvious" that they need a particular subtype of a MachineId instead of the base MachineId type.

To limit the scope, this change does not touch the gRPC types, or the admin-CLI, and limits to things inside the nico-api process, including api-core, site-explorer and the machine controller. It also doesn't touch the Machine or InstanceSnapshot types yet, because the surface of those changes is large.

- Implement a new trait, MachineIdSubtypeTrait, which can be used by generic functions that can take any type of MachineId.
- Migrate several functions to accept any MachineId subtype, and where feasible, have them return ID's of the same type, for example db::managed_host::load_by_machine_ids, which returns a HashMap with the same ID type you give it.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [X] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [X] No testing required (docs, internal refactor, etc.)

## Additional Notes