### PR TITLE
Remove option go gitlab reference from weave vpc proto

### DIFF
--- a/crates/agent/proto/weave_ew_vpc.proto
+++ b/crates/agent/proto/weave_ew_vpc.proto
@@ -21,9 +21,6 @@ package nvidia.weave.controller.v1;
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 
-// TODO(Ashok): Replace this with the canonical public Go import path.
-option go_package = "gitlab-master.nvidia.com/doca-platform-foundation/dpf-vpc/api/grpc/nvidia/weave/controller/v1;controllerv1";
-
 // The NetworkIsolationService service provides APIs to manage virtual networks.
 service NetworkIsolationService {
   // CreateVirtualNetwork creates a new virtual network.


### PR DESCRIPTION
Remove option_go reference from weave_ew_vpc.proto

This is in line with what weave team wants to do
- We don't need it in the file, our own build sets it through buf managed mode, and it only ever pointed at an internal gitlab path you can't resolve.
- It's a Go-codegen hint only, so nothing changes on the wire, and non-Go clients (Java, Python, C++, ...) are unaffected either way, they derive their packages from package nvidia.weave.controller.v1

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes

Closes https://github.com/NVIDIA/infra-controller/issues/5385
