### PR TITLE
fix(rack): preserve token for NVOS image submission retries

### DIFF
--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -3117,11 +3117,10 @@ async fn test_firmware_upgrade_wait_for_complete_retries_on_transient_poll_error
     Ok(())
 }
 
-/// test_nvos_update_start_transitions_to_wait_for_complete verifies that
-/// Maintenance::NVOSUpdate(Start) transitions to WaitForComplete when a
-/// NVOS SOT JSON is available for RMS ApplySwitchSystemImage.
+/// A retryable RMS rejection preserves the access token so the next
+/// `NVOSUpdate(Start)` iteration can resubmit the request.
 #[crate::sqlx_test]
-async fn test_nvos_update_start_transitions_to_wait_for_complete(
+async fn test_nvos_update_start_retries_rejection_with_access_token(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env_with_overrides(
@@ -3157,6 +3156,18 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
     };
     let mut txn = pool.acquire().await?;
     db_rack::update(&mut txn, &rack_id, &config).await?;
+
+    crate::tests::rack_state_controller::fixtures::rack::set_rack_controller_state(
+        &mut txn,
+        &rack_id,
+        RackState::Maintenance {
+            maintenance_state: RackMaintenanceState::NVOSUpdate {
+                nvos_update: NvosUpdateState::Start,
+            },
+        },
+    )
+    .await?;
+
     drop(txn);
 
     env.api
@@ -3177,6 +3188,19 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
         .queue_apply_switch_system_image_response(
             librms::protos::rack_manager::ApplySwitchSystemImageResponse {
                 response: Some(librms::protos::rack_manager::NodeBatchResponse {
+                    status: librms::protos::rack_manager::ReturnCode::Failure as i32,
+                    message: "RMS temporarily rejected the NVOS update".to_string(),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            },
+        )
+        .await;
+
+    env.rms_sim
+        .queue_apply_switch_system_image_response(
+            librms::protos::rack_manager::ApplySwitchSystemImageResponse {
+                response: Some(librms::protos::rack_manager::NodeBatchResponse {
                     status: librms::protos::rack_manager::ReturnCode::Success as i32,
                     job_id: "nvos-job-1".to_string(),
                     ..Default::default()
@@ -3186,67 +3210,93 @@ async fn test_nvos_update_start_transitions_to_wait_for_complete(
         )
         .await;
 
-    let mut rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+    env.run_rack_controller_iteration().await;
 
-    let handler_instance = RackStateHandler::default();
-    let mut services = env.rack_state_handler_services();
-    let mut metrics = RackMetrics::default();
-    let mut db_writes = DbWriteBatch::default();
-    let mut ctx = StateHandlerContext::<RackStateHandlerContextObjects> {
-        services: &mut services,
-        metrics: &mut metrics,
-        pending_db_writes: &mut db_writes,
-    };
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
 
-    let nvos_state = RackState::Maintenance {
-        maintenance_state: RackMaintenanceState::NVOSUpdate {
-            nvos_update: NvosUpdateState::Start,
-        },
-    };
-    let outcome = handler_instance
-        .handle_object_state(&rack_id, &mut rack, &nvos_state, &mut ctx)
-        .await?;
+    assert!(matches!(
+        rack.controller_state.value,
+        RackState::Maintenance {
+            maintenance_state: RackMaintenanceState::NVOSUpdate {
+                nvos_update: NvosUpdateState::Start,
+            },
+        }
+    ));
 
-    assert!(
-        rack.nvos_update_job.is_some(),
-        "NVOSUpdate(Start) should populate rack.nvos_update_job"
+    assert!(rack.nvos_update_job.is_none());
+
+    let token = env
+        .api
+        .credential_manager
+        .get_credentials(&CredentialKey::RackMaintenanceAccessToken {
+            rack_id: rack_id.clone(),
+        })
+        .await
+        .map_err(|error| eyre::eyre!("failed to get maintenance access token: {}", error))?
+        .expect("retryable submission should preserve the access token");
+
+    assert_eq!(
+        token,
+        Credentials::UsernamePassword {
+            username: "access_token".to_string(),
+            password: "token".to_string(),
+        }
     );
+
     let requests = env
         .rms_sim
         .submitted_apply_switch_system_image_requests()
         .await;
-    assert!(
-        !requests.is_empty(),
-        "NVOSUpdate(Start) should submit ApplySwitchSystemImage"
-    );
+
+    assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].config_json, r#"{"Id":"fw-nvos-default"}"#);
     assert_eq!(requests[0].access_token.as_deref(), Some("token"));
+
+    env.run_rack_controller_iteration().await;
+
+    let rack = get_db_rack(env.db_reader().as_mut(), &rack_id).await;
+
+    assert!(rack.nvos_update_job.is_some());
+
+    assert!(matches!(
+        rack.controller_state.value,
+        RackState::Maintenance {
+            maintenance_state: RackMaintenanceState::NVOSUpdate {
+                nvos_update: NvosUpdateState::WaitForComplete,
+            },
+        }
+    ));
+
+    assert!(
+        env.api
+            .credential_manager
+            .get_credentials(&CredentialKey::RackMaintenanceAccessToken {
+                rack_id: rack_id.clone(),
+            })
+            .await
+            .map_err(|error| eyre::eyre!("failed to get maintenance access token: {}", error))?
+            .is_none()
+    );
+
+    let requests = env
+        .rms_sim
+        .submitted_apply_switch_system_image_requests()
+        .await;
+
+    assert_eq!(requests.len(), 2);
+
+    assert!(
+        requests
+            .iter()
+            .all(|request| request.access_token.as_deref() == Some("token"))
+    );
+
     let mut txn = pool.acquire().await?;
     let switch = db_switch::find_by_id(&mut txn, &switch_id)
         .await?
         .expect("switch should exist");
-    assert!(switch.switch_reprovisioning_requested.is_none());
 
-    match outcome {
-        StateHandlerOutcome::Transition { next_state, .. } => {
-            assert!(
-                matches!(
-                    next_state,
-                    RackState::Maintenance {
-                        maintenance_state: RackMaintenanceState::NVOSUpdate {
-                            nvos_update: NvosUpdateState::WaitForComplete,
-                        },
-                    }
-                ),
-                "NVOSUpdate(Start) should transition to WaitForComplete, got {:?}",
-                next_state
-            );
-        }
-        other => panic!(
-            "Expected Transition, got {:?}",
-            std::mem::discriminant(&other)
-        ),
-    }
+    assert!(switch.switch_reprovisioning_requested.is_none());
 
     Ok(())
 }

--- a/crates/component-manager/src/nvos_update_manager.rs
+++ b/crates/component-manager/src/nvos_update_manager.rs
@@ -43,10 +43,10 @@ pub trait NvosUpdateManager: sealed::Sealed + Send + Sync {
     /// # Errors
     ///
     /// Returns [`ComponentManagerError::InvalidArgument`] when the request cannot
-    /// be translated for the backend. An explicit backend rejection without a
-    /// durable job handle returns [`ComponentManagerError::RejectedBeforeDispatch`].
-    /// The current RMS backend reports RPC invocation failures as
-    /// [`ComponentManagerError::Internal`].
+    /// be translated for the backend or the backend rejects it as invalid before
+    /// accepting work. An explicit backend rejection without a durable job handle
+    /// returns [`ComponentManagerError::RejectedBeforeDispatch`]. Other submission
+    /// failures return [`ComponentManagerError::Internal`].
     async fn start_nvos_update(
         &self,
         request: NvosUpdateRequest<'_>,

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -231,15 +231,22 @@ impl NvosUpdateManager for RmsNvosUpdateManager {
                 nodes: Some(rms::NodeSet { nodes }),
             })
             .await
-            .map_err(|error| {
-                let cause = match error {
-                    RackManagerError::ApiInvocationError(status) => status.to_string(),
-                    error => error.to_string(),
-                };
-
-                ComponentManagerError::Internal(format!(
-                    "failed to submit NVOS update to RMS: {cause}"
-                ))
+            .map_err(|error| match error {
+                // RMS validates node descriptor support before creating a job,
+                // so InvalidArgument is terminal for the submitted request.
+                RackManagerError::ApiInvocationError(status)
+                    if status.code() == tonic::Code::InvalidArgument =>
+                {
+                    ComponentManagerError::InvalidArgument(format!(
+                        "failed to submit NVOS update to RMS: {status}"
+                    ))
+                }
+                RackManagerError::ApiInvocationError(status) => ComponentManagerError::Internal(
+                    format!("failed to submit NVOS update to RMS: {status}"),
+                ),
+                error => ComponentManagerError::Internal(format!(
+                    "failed to submit NVOS update to RMS: {error}"
+                )),
             })?;
 
         let batch_response = response.response.as_ref();
@@ -3582,6 +3589,71 @@ mod tests {
                 if credentials.username == "nvos-admin"
                     && credentials.password == "nvos-password"
         ));
+    }
+
+    #[tokio::test]
+    async fn rack_nvos_submission_preserves_rms_rpc_error_classification() {
+        let mock = Arc::new(MockRmsApi::new());
+        let rack_id = RackId::new("rack-1");
+
+        let switch = FirmwareUpgradeDeviceInfo {
+            node_id: "switch-1".to_string(),
+            mac: SW_MAC_1.to_string(),
+            bmc_ip: "192.0.2.10".to_string(),
+            bmc_username: "admin".to_string(),
+            bmc_password: "password".to_string(),
+            os_mac: Some("11:22:33:44:55:66".to_string()),
+            os_ip: Some("192.0.2.20".to_string()),
+            os_username: Some("nvos-admin".to_string()),
+            os_password: Some("nvos-password".to_string()),
+            os_hostname: None,
+        };
+
+        mock.enqueue_apply_switch_system_image(Err(RackManagerError::ApiInvocationError(
+            tonic::Status::invalid_argument("unsupported node descriptor"),
+        )))
+        .await;
+
+        let manager = RmsNvosUpdateManager {
+            client: mock.clone(),
+        };
+
+        let result = manager
+            .start_nvos_update(NvosUpdateRequest {
+                rack_id: &rack_id,
+                profile: &test_rms_profile(),
+                config_json: r#"{"Id":"fw-nvos-default"}"#,
+                access_token: "token",
+                switches: vec![switch.clone()],
+            })
+            .await;
+
+        let Err(ComponentManagerError::InvalidArgument(cause)) = result else {
+            panic!("expected RMS InvalidArgument to remain InvalidArgument");
+        };
+
+        assert!(cause.contains("unsupported node descriptor"));
+
+        mock.enqueue_apply_switch_system_image(Err(RackManagerError::ApiInvocationError(
+            tonic::Status::unavailable("RMS unavailable"),
+        )))
+        .await;
+
+        let result = manager
+            .start_nvos_update(NvosUpdateRequest {
+                rack_id: &rack_id,
+                profile: &test_rms_profile(),
+                config_json: r#"{"Id":"fw-nvos-default"}"#,
+                access_token: "token",
+                switches: vec![switch],
+            })
+            .await;
+
+        let Err(ComponentManagerError::Internal(cause)) = result else {
+            panic!("expected RMS Unavailable to remain Internal");
+        };
+
+        assert!(cause.contains("RMS unavailable"));
     }
 
     #[test]

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -2757,14 +2757,18 @@ pub async fn handle_maintenance(
                     })
                     .await;
 
-                delete_rack_maintenance_access_token(ctx.services.credential_manager.as_ref(), id)
-                    .await;
-
                 // Invalid requests cannot succeed on retry. Backend submission
-                // failures remain handler errors so the Start state is retried.
+                // failures remain handler errors, with the token retained so
+                // the Start state can resubmit the request.
                 let job = match submit_result {
                     Ok(job) => job,
                     Err(ComponentManagerError::InvalidArgument(cause)) => {
+                        delete_rack_maintenance_access_token(
+                            ctx.services.credential_manager.as_ref(),
+                            id,
+                        )
+                        .await;
+
                         return transition_to_rack_error(id, state, &cause, ctx).await;
                     }
                     Err(ComponentManagerError::Internal(cause))
@@ -2773,6 +2777,9 @@ pub async fn handle_maintenance(
                     }
                     Err(error) => return Err(StateHandlerError::GenericError(eyre::eyre!(error))),
                 };
+
+                delete_rack_maintenance_access_token(ctx.services.credential_manager.as_ref(), id)
+                    .await;
 
                 let mut txn = ctx.services.db_pool.begin().await?;
                 clear_nvos_update_statuses(txn.as_mut(), &switch_inventory.switch_ids).await?;


### PR DESCRIPTION
Preserve the rack maintenance access token when an NVOS system-image update submission returns a retryable `Internal` or `RejectedBeforeDispatch` error. The next `NVOSUpdate(Start)` iteration can reload the token and resubmit the `ApplySwitchSystemImage` request.

The token is deleted after successful submission, before transitioning to `NVOSUpdate(WaitForComplete)`. A non-retryable `InvalidArgument` error deletes the token before transitioning the rack to `RackState::Error`.

## Related issues

Resolves #5616

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

### Simulation Testing

Method:

- Built the PR revision and deployed it to a simulation cluster with RMS.
- Submitted NVOS system-image updates using `nico-admin-cli`.
- Inspected rack state history, NICo logs, RMS jobs, artifact transfer, and final rack state.

Coverage:

- One simulated GB200 rack and two NVSwitches.
- NVOS image submission retry after an RMS transport failure.
- Successful submission, artifact download, SFTP transfer, installation, polling, and rack state recovery.

Steps:

1. Scaled RMS to zero and submitted an NVOS image update for one switch. NICo logged repeated `ApplySwitchSystemImage` submission failures while the rack remained in `NVOSUpdate(Start)`.
2. Restored RMS. A later controller iteration resubmitted the request and transitioned the rack to `NVOSUpdate(WaitForComplete)` without a missing-token error.
3. Submitted the image update to another switch. RMS completed the parent and child jobs.
4. Confirmed the successful update transitioned through:

   ```text
   Maintenance(NVOSUpdate(Start))
   Maintenance(NVOSUpdate(WaitForComplete))
   Maintenance(Completed)
   Validating(Pending)
   Ready
   ```

Results:

- The NVOS image submission was retried successfully after RMS recovery, confirming that the access token remained available.
- The baseline test with a separate switch completed the NVOS image update workflow.