### PR TITLE
fix(machine-controller): recover paused BlueField-3 DPUs

### DIFF
--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -12733,7 +12733,7 @@ async fn restart_dpu(
         tracing::warn!(
             machine_id = %machine.id,
             %power_state,
-            "DPU is powered off; powering it on instead of restarting it"
+            "DPU is not running; powering it on instead of restarting it"
         );
     }
 
@@ -12749,11 +12749,12 @@ fn dpu_restart_power_action(
     power_state: libredfish::PowerState,
 ) -> Result<SystemPowerControl, StateHandlerError> {
     match power_state {
-        libredfish::PowerState::Off => Ok(SystemPowerControl::On),
+        // BlueField-3 reports its stable StandbyOffline state as Paused after
+        // the Arm OS shuts down, so it needs the same recovery as Off.
+        libredfish::PowerState::Off | libredfish::PowerState::Paused => Ok(SystemPowerControl::On),
         libredfish::PowerState::On => Ok(SystemPowerControl::ForceRestart),
         libredfish::PowerState::PoweringOff
         | libredfish::PowerState::PoweringOn
-        | libredfish::PowerState::Paused
         | libredfish::PowerState::Reset
         | libredfish::PowerState::Unknown => Err(StateHandlerError::GenericError(eyre!(
             "cannot restart DPU while its power state is {power_state}; retrying"
@@ -14219,9 +14220,9 @@ mod tests {
                     expect: Err(()),
                 },
                 Check {
-                    scenario: "paused DPU is retried",
+                    scenario: "paused DPU is powered on",
                     input: libredfish::PowerState::Paused,
-                    expect: Err(()),
+                    expect: Ok(SystemPowerControl::On),
                 },
                 Check {
                     scenario: "resetting DPU is retried",


### PR DESCRIPTION
## Summary

BlueField-3 DPUs can report the Redfish `Paused` power state after the Arm OS shuts down. On this platform, that value represents the stable `StandbyOffline` state: the DPU is not running and must be powered on before initialization can continue.

The DPU restart path previously handled only `Off` as a stable non-running state. It treated `Paused` like a transitional or unknown state and returned a retryable error. Because `Paused` remains stable until an explicit power action is issued, every controller iteration selected the same retry path and a machine could remain in DPU initialization indefinitely.

This change makes the restart action selection reflect the platform's power-state semantics:

- `Off` and `Paused` select `SystemPowerControl::On`.
- `On` continues to select `SystemPowerControl::ForceRestart`.
- Transitional and unknown states continue to return a retryable error.

The warning emitted before the recovery action now says that the DPU is not running instead of claiming it is specifically powered off.

## Scope and behavior

This is intentionally limited to choosing the recovery action for a DPU whose current Redfish state is already known. It does not change controller persistence, retry timing, or restart-verification behavior. A stable `Paused` DPU now takes the same existing recovery path as an `Off` DPU, while genuinely transitional states retain their current retry behavior.

The existing table-driven unit test was updated with a regression case that requires `Paused` to produce a power-on action. The test was changed first and observed to fail because the helper returned a retry error; it passed after the implementation change.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validation completed locally:

- Focused regression test: failed before the fix and passed afterward.
- `cargo clippy -p carbide-machine-controller --lib -- -D warnings`
- `cargo +nightly-2026-06-16 fmt --all -- --check`
- `git diff --check`

Validation completed on an x86_64 Linux VM against its dedicated PostgreSQL test instance:

- Focused `dpu_restart_requires_a_stable_power_state` regression test: 1 passed, 0 failed.
- `cargo test -p carbide-machine-controller`: 86 library tests and 34 integration tests passed; doc tests passed with no failures.

## Additional Notes

No schema, API, configuration, or externally visible state-machine contract changes are included.
