### PR TITLE
cherry-pick(v2.1): clamp the nico-pxe file-descriptor soft limit to the runtime hard limit

### DIFF
--- a/helm/charts/nico-pxe/templates/deployment.yaml
+++ b/helm/charts/nico-pxe/templates/deployment.yaml
@@ -69,7 +69,21 @@ spec:
             - /bin/sh
             - -c
             - |
-              ulimit -Sn {{ .Values.fileDescriptorLimit | int }} || exit 1
+              {{- $fdLimit := 65536 }}
+              {{- if not (kindIs "invalid" .Values.fileDescriptorLimit) }}
+              {{- $fdLimit = .Values.fileDescriptorLimit | int }}
+              {{- end }}
+              {{- if le $fdLimit 0 }}
+              {{- fail "fileDescriptorLimit must be a positive integer" }}
+              {{- end }}
+              FD_LIMIT={{ $fdLimit }}
+              FD_REQUESTED="$FD_LIMIT"
+              FD_HARD="$(ulimit -Hn)"
+              if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
+                echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
+                FD_LIMIT="$FD_HARD"
+              fi
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (requested ${FD_REQUESTED}, hard limit ${FD_HARD})" >&2; exit 1; }
               if [ -x /opt/nico/nico ]; then BIN=/opt/nico/nico; else BIN=/opt/carbide/carbide; fi
               exec "$BIN" -s {{ .Values.bootArtifacts.servePath }}
           env:

--- a/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-pxe/tests/file_descriptor_limit_test.yaml
@@ -2,15 +2,46 @@ suite: pxe file descriptor limit
 templates:
   - templates/deployment.yaml
 tests:
-  - it: uses the default soft limit
+  - it: uses the default soft limit with a hard-limit clamp
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 65536 \|\| exit 1'
+          pattern: 'FD_LIMIT=65536'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_HARD="\$\(ulimit -Hn\)"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn "\$FD_LIMIT"'
   - it: allows an override
     set:
       fileDescriptorLimit: 32768
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn 32768 \|\| exit 1'
+          pattern: 'FD_LIMIT=32768'
+  - it: falls back to the default when the value is nulled out
+    set:
+      fileDescriptorLimit: null
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=65536'
+  - it: rejects a non-numeric value at render time
+    set:
+      fileDescriptorLimit: unlimited
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects a negative value at render time
+    set:
+      fileDescriptorLimit: -1
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects zero at render time instead of falling back to the default
+    set:
+      fileDescriptorLimit: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-pxe/values.yaml
+++ b/helm/charts/nico-pxe/values.yaml
@@ -45,7 +45,9 @@ legacyAlias:
 
 replicas: 1
 
-## Soft open-file limit applied before startup. Must not exceed the runtime hard limit.
+## Soft open-file limit applied before startup. Clamped to the runtime hard
+## limit when it exceeds it. null falls back to 65536; non-null values must be
+## a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 ## Optional init containers (general-purpose pass-through)


### PR DESCRIPTION
This PR backports the file-descriptor limit hardening (#5583) into `v2.1`, scoped to nico-pxe - the only chart on this line that carries the `ulimit` fail-fast entrypoint:

- The requested soft limit is clamped to the runtime hard limit with a logged notice (reproduced failure: a hard limit of 65535 crashloops the pod against the 65536 default, with only dash's terse EINVAL as diagnostic).
- A nulled or non-numeric `fileDescriptorLimit` no longer renders `ulimit -Sn 0` (a silent zero-fd start): null falls back to the 65536 default, invalid values fail the render.
- The hardware-health and ssh-console hunks from the original commit are dropped: those charts do not have the FD-limit entrypoint on `release/v2.1`.

Cherry-pick of 00a7a45d5 (#5583), conflicts resolved by scoping to nico-pxe.

## Related issues

Backport of #5583 (fixes #5535 for the v2.1 line).

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

helm unittest on the v2.1 tree: the FD-limit suite passes (5 cases: default+clamp shape, override, null fallback, non-numeric and negative render failures); render checks confirm null falls back to 65536 and invalid values fail with the guard message. The clamp behavior was verified live on dev6 (hard limit 65535) during #5583.
