### PR TITLE
refactor(redfish): split credential-lifecycle ops off RedfishClientPool

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -34,7 +34,7 @@ use carbide_ib_fabric::ib::IBFabricManager;
 use carbide_machine_controller::dpf::DpfOperations;
 use carbide_machine_controller::io::MachineStateControllerIO;
 use carbide_rack::bms_client::BmsDsxExchangeHandle;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, CredentialType, Credentials,
@@ -69,6 +69,11 @@ pub struct Api {
     pub(crate) credential_manager: Arc<dyn CredentialManager>,
     pub(crate) certificate_provider: Arc<dyn CertificateProvider>,
     pub(crate) redfish_pool: Arc<dyn RedfishClientPool>,
+    /// Credential-lifecycle operations (password set/rotate/clear, candidate
+    /// validation). A sealed trait implemented only by the direct pool, so
+    /// handing these to a wrapper pool is a compile error (a wrong-pool
+    /// guard, not a wire-path guarantee -- see [`BmcCredentialOps`]).
+    pub(crate) bmc_credential_ops: Arc<dyn BmcCredentialOps>,
     pub(crate) bmc_session_manager: Arc<crate::credentials::BmcSessionManager>,
     pub(crate) eth_data: EthVirtData,
     pub(crate) common_pools: Arc<CommonPools>,

--- a/crates/api-core/src/handlers/machine.rs
+++ b/crates/api-core/src/handlers/machine.rs
@@ -61,9 +61,12 @@ async fn resolve_host_uefi_clear_credentials(
         return None;
     }
     let clear_key = key.ok()?;
-    crate::handlers::uefi::read_uefi_credentials(api.redfish_pool.credential_reader(), &clear_key)
-        .await
-        .ok()
+    crate::handlers::uefi::read_uefi_credentials(
+        api.bmc_credential_ops.credential_reader(),
+        &clear_key,
+    )
+    .await
+    .ok()
 }
 
 pub(crate) async fn find_machine_ids(
@@ -776,9 +779,14 @@ pub(crate) async fn admin_force_delete_machine(
                             let clear_credentials =
                                 resolve_host_uefi_clear_credentials(api, bmc_mac_address).await;
                             if let Some(clear_credentials) = clear_credentials {
+                                let access = carbide_utils::redfish::BmcAccessInfo {
+                                    host: ip_address.clone(),
+                                    port: machine.status.bmc_info.port,
+                                    mac_address: bmc_mac_address,
+                                };
                                 match api
-                                    .redfish_pool
-                                    .clear_host_uefi_password(client.as_ref(), clear_credentials)
+                                    .bmc_credential_ops
+                                    .clear_host_uefi_password(&access, clear_credentials)
                                     .await
                                 {
                                     Ok(_) => {

--- a/crates/api-core/src/handlers/uefi.rs
+++ b/crates/api-core/src/handlers/uefi.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use ::rpc::forge as rpc;
+use carbide_redfish::libredfish::CredentialOpError;
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use db::WithTransaction;
 use futures_util::FutureExt;
@@ -283,27 +284,11 @@ pub(crate) async fn clear_host_uefi_password(
     // held across it, then read the actual secret.
     txn.commit().await?;
     let clear_credentials =
-        read_uefi_credentials(api.redfish_pool.credential_reader(), &clear_key).await?;
-
-    let redfish_client = api
-        .redfish_pool
-        .client_by_info(&bmc_access_info)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                error = %e,
-                "unable to create redfish client",
-            );
-            CarbideError::Internal {
-                message: format!(
-                    "Could not create connection to Redfish API to {machine_id}, check logs"
-                ),
-            }
-        })?;
+        read_uefi_credentials(api.bmc_credential_ops.credential_reader(), &clear_key).await?;
 
     let job_id: Option<String> = api
-        .redfish_pool
-        .clear_host_uefi_password(redfish_client.as_ref(), clear_credentials)
+        .bmc_credential_ops
+        .clear_host_uefi_password(&bmc_access_info, clear_credentials)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to run clear_host_uefi_password call");
@@ -398,30 +383,23 @@ pub(crate) async fn set_host_uefi_password(
     // connection is not held across them, then read the actual secret.
     txn.commit().await?;
     let host_uefi_credentials =
-        read_uefi_credentials(api.redfish_pool.credential_reader(), &host_uefi_key).await?;
-
-    let redfish_client = api
-        .redfish_pool
-        .client_by_info(&bmc_access_info)
-        .await
-        .map_err(|e| {
-            tracing::error!(
-                error = %e,
-                "unable to create redfish client",
-            );
-            CarbideError::RedfishClientCreation {
-                inner: e.into(),
-                machine_id,
-            }
-        })?;
+        read_uefi_credentials(api.bmc_credential_ops.credential_reader(), &host_uefi_key).await?;
 
     let job_id = api
-        .redfish_pool
-        .uefi_setup(redfish_client.as_ref(), false, host_uefi_credentials)
+        .bmc_credential_ops
+        .uefi_setup(&bmc_access_info, false, host_uefi_credentials)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to run uefi_setup call");
-            CarbideError::internal(format!("failed redfish uefi_setup subtask: {e}"))
+            match e {
+                // Keep the Redfish-classified error code (and its operator
+                // mitigation text) for client-creation failures.
+                CredentialOpError::ClientCreation(inner) => CarbideError::RedfishClientCreation {
+                    inner: inner.into(),
+                    machine_id,
+                },
+                e => CarbideError::internal(format!("failed redfish uefi_setup subtask: {e}")),
+            }
         })?;
     // uefi_setup returns a BMC job_id; the password change completes
     // asynchronously on the device and we do not poll it here. We optimistically
@@ -554,28 +532,24 @@ pub(crate) async fn set_dpu_uefi_password(
     // connection is not held across them, then read the actual secret.
     txn.commit().await?;
     let dpu_uefi_credentials =
-        read_uefi_credentials(api.redfish_pool.credential_reader(), &dpu_uefi_key).await?;
-
-    let redfish_client = api
-        .redfish_pool
-        .client_by_info(&bmc_access_info)
-        .await
-        .map_err(|e| {
-            tracing::error!(error = %e, "unable to create redfish client");
-            CarbideError::RedfishClientCreation {
-                inner: e.into(),
-                machine_id,
-            }
-        })?;
+        read_uefi_credentials(api.bmc_credential_ops.credential_reader(), &dpu_uefi_key).await?;
 
     // A DPU stages the UEFI change through Redfish BIOS settings and schedules no
     // job (it commits on the next DPU restart), so there is no job id to return.
-    api.redfish_pool
-        .uefi_setup(redfish_client.as_ref(), true, dpu_uefi_credentials)
+    api.bmc_credential_ops
+        .uefi_setup(&bmc_access_info, true, dpu_uefi_credentials)
         .await
         .map_err(|e| {
             tracing::error!(error = %e, "Failed to run uefi_setup call for DPU");
-            CarbideError::internal(format!("failed redfish uefi_setup subtask: {e}"))
+            match e {
+                // Keep the Redfish-classified error code (and its operator
+                // mitigation text) for client-creation failures.
+                CredentialOpError::ClientCreation(inner) => CarbideError::RedfishClientCreation {
+                    inner: inner.into(),
+                    machine_id,
+                },
+                e => CarbideError::internal(format!("failed redfish uefi_setup subtask: {e}")),
+            }
         })?;
 
     // Mirror the host path's optimistic convergence record: the change is staged

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -55,7 +55,7 @@ use carbide_rack_controller::config::RackConfig;
 use carbide_rack_controller::context::RackStateHandlerServices;
 use carbide_rack_controller::handler::RackStateHandler;
 use carbide_rack_controller::io::RackStateControllerIO;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::{CredentialManager, CredentialReader};
 use carbide_site_explorer::{EndpointExplorationService, SiteExplorer};
@@ -140,7 +140,7 @@ fn create_ipmi_tool(
 fn create_redfish_pool(
     carbide_config: &CarbideConfig,
     credential_manager: Arc<dyn CredentialManager>,
-) -> eyre::Result<Arc<dyn RedfishClientPool>> {
+) -> eyre::Result<(Arc<dyn RedfishClientPool>, Arc<dyn BmcCredentialOps>)> {
     let pool = libredfish::RedfishClientPool::builder()
         .danger_accept_invalid_certs()
         .build()
@@ -184,7 +184,7 @@ fn create_redfish_pool(
         (None, None, _) => {} // leave bmc_proxy untouched
     }
 
-    Ok(carbide_redfish::libredfish::new_pool(
+    Ok(carbide_redfish::libredfish::new_pool_with_credential_ops(
         credential_manager,
         pool,
         carbide_config.site_explorer.bmc_proxy.clone(),
@@ -208,7 +208,8 @@ pub(crate) async fn start_runtime(
     admin_ui_routes_builder: Option<AdminUiRoutesBuilder>,
     cancel_token: CancellationToken,
 ) -> eyre::Result<SocketAddr> {
-    let shared_redfish_pool = create_redfish_pool(&carbide_config, credential_manager.clone())?;
+    let (shared_redfish_pool, bmc_credential_ops) =
+        create_redfish_pool(&carbide_config, credential_manager.clone())?;
     let shared_nv_redfish_pool =
         carbide_redfish::nv_redfish::new_pool(carbide_config.site_explorer.bmc_proxy.clone());
 
@@ -399,7 +400,7 @@ pub(crate) async fn start_runtime(
     ));
 
     let bmc_explorer = carbide_site_explorer::new_bmc_explorer(
-        shared_redfish_pool.clone(),
+        bmc_credential_ops.clone(),
         shared_nv_redfish_pool,
         ipmi_tool.clone(),
         credential_manager.clone(),
@@ -525,6 +526,7 @@ pub(crate) async fn start_runtime(
         eth_data,
         ib_fabric_manager,
         redfish_pool: shared_redfish_pool,
+        bmc_credential_ops: bmc_credential_ops.clone(),
         bmc_session_manager,
         runtime_config: carbide_config.clone(),
         scout_stream_registry: ConnectionRegistry::new(),
@@ -1083,6 +1085,7 @@ async fn initialize_and_start_controllers<'a>(
         database_connection: db_pool,
         ib_fabric_manager,
         redfish_pool: shared_redfish_pool,
+        bmc_credential_ops,
         work_lock_manager_handle,
         rms_client,
         component_manager,
@@ -1473,6 +1476,7 @@ async fn initialize_and_start_controllers<'a>(
                 db_pool: db_pool.clone(),
                 db_reader: db_pool.clone().into(),
                 redfish_client_pool: shared_redfish_pool.clone(),
+                bmc_credential_ops: bmc_credential_ops.clone(),
                 ipmi_tool: ipmi_tool.clone(),
                 site_config: carbide_config.machine_state_handler_site_config().into(),
                 component_manager: component_manager.clone().map(Arc::new),
@@ -1692,6 +1696,7 @@ async fn initialize_and_start_controllers<'a>(
                     .power_shelf_state_controller
                     .rack_firmware_reprovisioning_enabled,
                 redfish_client_pool: shared_redfish_pool.clone(),
+                bmc_credential_ops: bmc_credential_ops.clone(),
                 bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                     db::credential_rotation::CredentialRotationType::Bmc,
                 ),
@@ -1765,6 +1770,7 @@ async fn initialize_and_start_controllers<'a>(
                     .effective_switch_mtls_services_as_i32(),
                 per_object_metrics_registry: per_object_metrics_registry.clone(),
                 redfish_client_pool: shared_redfish_pool.clone(),
+                bmc_credential_ops: bmc_credential_ops.clone(),
                 bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                     db::credential_rotation::CredentialRotationType::Bmc,
                 ),

--- a/crates/api-core/src/test_support/builder.rs
+++ b/crates/api-core/src/test_support/builder.rs
@@ -21,7 +21,7 @@ use arc_swap::ArcSwap;
 use carbide_ib_fabric::ib::IBFabricManager;
 use carbide_machine_controller::dpf::DpfOperations;
 use carbide_nvlink_manager::nvlink::test_support::NmxcSimClient;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::BmcCredentialOps;
 use carbide_redfish::libredfish::test_support::RedfishSim;
 use carbide_secrets::credentials::CredentialManager;
 use carbide_secrets::test_support::certificates::TestCertificateProvider;
@@ -56,7 +56,7 @@ pub struct TestApiBuilder {
     work_lock_manager: WorkLockManagerHandle,
     runtime_config: Option<Arc<CarbideConfig>>,
     credential_manager: Option<Arc<dyn CredentialManager>>,
-    redfish_pool: Option<Arc<dyn RedfishClientPool>>,
+    redfish_pool: Option<Arc<dyn BmcCredentialOps>>,
     rms_client: Option<Arc<dyn RmsApi>>,
     nmxc_client_pool: Option<Arc<dyn NmxcPool>>,
     eth_data: Option<EthVirtData>,
@@ -107,7 +107,10 @@ impl TestApiBuilder {
         }
     }
 
-    pub fn with_redfish_pool(self, redfish_pool: Arc<dyn RedfishClientPool>) -> Self {
+    /// Installs the Redfish pool the API under test uses. Takes the
+    /// credential-operations handle because tests hand one sim in as both
+    /// the general pool and the ops handle.
+    pub fn with_redfish_pool(self, redfish_pool: Arc<dyn BmcCredentialOps>) -> Self {
         Self {
             redfish_pool: Some(redfish_pool),
             ..self
@@ -199,7 +202,7 @@ impl TestApiBuilder {
         let machine_state_handler_enqueuer = Enqueuer::new(self.db_pool.clone());
         let dpu_health_log_limiter = LogLimiter::default();
 
-        let redfish_pool = self
+        let redfish_pool: Arc<dyn BmcCredentialOps> = self
             .redfish_pool
             .unwrap_or_else(|| Arc::new(RedfishSim::default()));
 
@@ -273,7 +276,9 @@ impl TestApiBuilder {
             credential_manager,
             certificate_provider,
             database_connection: self.db_pool,
-            redfish_pool,
+            // dyn upcast: the ops handle is also the general pool in tests.
+            redfish_pool: redfish_pool.clone(),
+            bmc_credential_ops: redfish_pool,
             eth_data,
             common_pools: self.common_pools,
             ib_fabric_manager,

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -325,6 +325,7 @@ impl TestEnv {
             db_pool: self.pool.clone(),
             db_reader: self.pool.clone().into(),
             redfish_client_pool: self.redfish_sim.clone(),
+            bmc_credential_ops: self.redfish_sim.clone(),
             ipmi_tool: self.ipmi_tool.clone(),
             site_config: self.config.machine_state_handler_site_config().into(),
             component_manager: self.test_component_manager.clone(),
@@ -1505,6 +1506,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
                 db_pool: db_pool.clone(),
                 db_reader: db_pool.clone().into(),
                 redfish_client_pool: redfish_sim.clone(),
+                bmc_credential_ops: redfish_sim.clone(),
                 ipmi_tool: ipmi_tool.clone(),
                 site_config: config.machine_state_handler_site_config().into(),
                 component_manager: test_component_manager.clone(),
@@ -1652,6 +1654,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
                 ),
                 per_object_metrics_registry: per_object_metrics_registry.clone(),
                 redfish_client_pool: redfish_sim.clone(),
+                bmc_credential_ops: redfish_sim.clone(),
                 bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                     db::credential_rotation::CredentialRotationType::Bmc,
                 ),

--- a/crates/api-core/src/tests/switch_state_controller/bmc_rotation.rs
+++ b/crates/api-core/src/tests/switch_state_controller/bmc_rotation.rs
@@ -104,6 +104,7 @@ fn switch_services(
         switch_mtls_services: default_switch_mtls_services(),
         per_object_metrics_registry: env.per_object_metrics_registry(),
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: RotationGate::new_for_family(CredentialRotationType::Bmc),
         bmc_rotation_enabled,
     }

--- a/crates/api-core/src/tests/switch_state_controller/maintenance.rs
+++ b/crates/api-core/src/tests/switch_state_controller/maintenance.rs
@@ -127,6 +127,7 @@ fn services_without_component_manager(env: &TestEnv) -> SwitchStateHandlerServic
         switch_mtls_services: super::default_switch_mtls_services(),
         per_object_metrics_registry: env.per_object_metrics_registry(),
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),
@@ -143,6 +144,7 @@ async fn services_with_component_manager(env: &TestEnv) -> SwitchStateHandlerSer
         switch_mtls_services: super::default_switch_mtls_services(),
         per_object_metrics_registry: env.per_object_metrics_registry(),
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),

--- a/crates/api-core/src/tests/switch_state_controller/mod.rs
+++ b/crates/api-core/src/tests/switch_state_controller/mod.rs
@@ -330,6 +330,7 @@ async fn test_configure_certificate_start_skips_without_component_manager(
                 std::time::Duration::from_secs(60),
             ),
             redfish_client_pool: env.redfish_sim.clone(),
+            bmc_credential_ops: env.redfish_sim.clone(),
             bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                 db::credential_rotation::CredentialRotationType::Bmc,
             ),
@@ -405,6 +406,7 @@ async fn test_configure_certificate_start_transitions_to_wait_for_complete_with_
                 std::time::Duration::from_secs(60),
             ),
             redfish_client_pool: env.redfish_sim.clone(),
+            bmc_credential_ops: env.redfish_sim.clone(),
             bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                 db::credential_rotation::CredentialRotationType::Bmc,
             ),
@@ -494,6 +496,7 @@ async fn test_configure_certificate_start_seeds_expected_switch_credentials(
                 std::time::Duration::from_secs(60),
             ),
             redfish_client_pool: env.redfish_sim.clone(),
+            bmc_credential_ops: env.redfish_sim.clone(),
             bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                 db::credential_rotation::CredentialRotationType::Bmc,
             ),
@@ -570,6 +573,7 @@ async fn test_configure_certificate_start_retries_after_credential_import(
             std::time::Duration::from_secs(60),
         ),
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),
@@ -669,6 +673,7 @@ async fn test_configure_certificate_wait_for_complete_transitions_to_rotate_os_p
                 std::time::Duration::from_secs(60),
             ),
             redfish_client_pool: env.redfish_sim.clone(),
+            bmc_credential_ops: env.redfish_sim.clone(),
             bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                 db::credential_rotation::CredentialRotationType::Bmc,
             ),
@@ -726,6 +731,7 @@ async fn test_configure_certificate_wait_for_complete_transitions_to_error_on_fa
                 std::time::Duration::from_secs(60),
             ),
             redfish_client_pool: env.redfish_sim.clone(),
+            bmc_credential_ops: env.redfish_sim.clone(),
             bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                 db::credential_rotation::CredentialRotationType::Bmc,
             ),
@@ -806,6 +812,7 @@ async fn test_switch_deletion_with_state_controller(
             std::time::Duration::from_secs(60),
         ),
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),
@@ -918,6 +925,7 @@ async fn test_switch_entire_state_transition_flow(
                 switch_mtls_services: default_switch_mtls_services(),
                 per_object_metrics_registry: env.per_object_metrics_registry(),
                 redfish_client_pool: env.redfish_sim.clone(),
+                bmc_credential_ops: env.redfish_sim.clone(),
                 bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                     db::credential_rotation::CredentialRotationType::Bmc,
                 ),

--- a/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
+++ b/crates/api-core/src/tests/switch_state_controller/nvos_password_rotation.rs
@@ -235,6 +235,7 @@ fn switch_services(
         switch_mtls_services: default_switch_mtls_services(),
         per_object_metrics_registry: env.per_object_metrics_registry(),
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -87,7 +87,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let proxy_address = Arc::new(ArcSwap::new(None.into()));
     let credential_provider = Arc::new(TestCredentialManager::new(fallback_credentials.clone()));
 
-    let redfish_client_pool = carbide_redfish::libredfish::new_pool(
+    // The explorer performs credential-lifecycle work, so it takes the
+    // credential-operations handle of the direct pool.
+    let (_, redfish_client_pool) = carbide_redfish::libredfish::new_pool_with_credential_ops(
         credential_provider.clone(),
         rf_pool,
         proxy_address.clone(),

--- a/crates/credential-rotation/src/lib.rs
+++ b/crates/credential-rotation/src/lib.rs
@@ -32,7 +32,7 @@
 //! # BMC flow (single synchronous step + crash marker)
 //!
 //! The BMC password primitive
-//! ([`carbide_redfish::libredfish::RedfishClientPool::set_bmc_root_password`])
+//! ([`carbide_redfish::libredfish::BmcCredentialOps::set_bmc_root_password`])
 //! is synchronous (no BIOS job to poll), so BMC rotation is one step guarded by
 //! the `rotating_to_version` crash marker:
 //!
@@ -42,7 +42,7 @@
 //! 3. Change the password with **change-then-verify recovery**: authenticate
 //!    with the current per-device secret and change to the rotate-TO value. On
 //!    failure, ask the BMC whether the rotate-TO value *already* authenticates
-//!    ([`RedfishClientPool::bmc_credentials_valid`]) -- if so, a prior attempt
+//!    ([`BmcCredentialOps::bmc_credentials_valid`]) -- if so, a prior attempt
 //!    changed the hardware before crashing and the device is already at target.
 //!    This never re-issues a same-value (`new -> new`) change, which some BMCs
 //!    reject under a password-reuse policy, and costs at most one extra failed
@@ -62,7 +62,7 @@
 //! every tick.
 //!
 //! The recovery path intentionally does not re-apply the vendor password policy
-//! ([`carbide_redfish::libredfish::RedfishClientPool::set_bmc_root_password`]
+//! ([`carbide_redfish::libredfish::BmcCredentialOps::set_bmc_root_password`]
 //! applies it on every change). That policy is a *static* per-vendor setting,
 //! and every password the device has ever carried -- including its initial
 //! provisioning value -- was set through `set_bmc_root_password`, so a device
@@ -84,7 +84,7 @@ use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use carbide_instrument::{Event, LabelValue, MetricFamily, emit};
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::BmcCredentialOps;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, Credentials,
 };
@@ -364,7 +364,7 @@ pub enum DispatchVendor {
     /// it -- `Fixed` only means "resolved by the caller, not the engine".
     Fixed(RedfishVendor),
     /// Resolve the vendor at rotation time by probing the BMC's Chassis
-    /// manufacturer ([`RedfishClientPool::probe_bmc_vendor`]) -- power-shelf
+    /// manufacturer ([`BmcCredentialOps::probe_bmc_vendor`]) -- power-shelf
     /// PMCs (Lite-On/Delta), which do *not* expose a recognized vendor in their
     /// Redfish service root. The probe runs *inside* the engine's
     /// quarantine-on-failure envelope and reuses the same credential candidates
@@ -936,10 +936,14 @@ async fn enter_device_rotation(
 /// (no rotation row) or [`RotateOutcome::Converged`] (already at target) -- there
 /// is nothing to force in those cases -- and a forced attempt that fails
 /// re-quarantines through the normal backoff bookkeeping.
+///
+/// `redfish_pool` is the direct pool's credential-operations handle
+/// ([`BmcCredentialOps`]): rotation authenticates to the BMC itself to
+/// change and verify passwords.
 pub async fn rotate_bmc(
     db_pool: &PgPool,
     credential_manager: &dyn CredentialManager,
-    redfish_pool: &dyn RedfishClientPool,
+    redfish_pool: &dyn BmcCredentialOps,
     bmc: &BmcRotationTarget,
     force: bool,
 ) -> Result<RotateOutcome, RotationEngineError> {
@@ -1013,10 +1017,14 @@ pub async fn rotate_bmc(
 
 /// Converge one BF4 DPU BMC's `service` account password to the staged
 /// site-wide target.
+///
+/// `redfish_pool` is the direct pool's credential-operations handle
+/// ([`BmcCredentialOps`]): rotation authenticates to the BMC itself to
+/// change and verify passwords.
 pub async fn rotate_dpu_bmc_service(
     db_pool: &PgPool,
     credential_manager: &dyn CredentialManager,
-    redfish_pool: &dyn RedfishClientPool,
+    redfish_pool: &dyn BmcCredentialOps,
     endpoint: &BmcEndpoint,
     force: bool,
 ) -> Result<RotateOutcome, RotationEngineError> {
@@ -1085,7 +1093,7 @@ pub async fn rotate_dpu_bmc_service(
 /// secret is written: the site-wide versioned secret is the only copy.
 async fn converge_dpu_bmc_service_password(
     credential_manager: &dyn CredentialManager,
-    redfish_pool: &dyn RedfishClientPool,
+    redfish_pool: &dyn BmcCredentialOps,
     endpoint: &BmcEndpoint,
     rotate_to_version: u32,
 ) -> Result<CredentialConvergence, String> {
@@ -1214,7 +1222,7 @@ impl CredentialConvergence {
 /// returns a secret-bearing string.
 async fn converge_bmc_password(
     credential_manager: &dyn CredentialManager,
-    redfish_pool: &dyn RedfishClientPool,
+    redfish_pool: &dyn BmcCredentialOps,
     bmc: &BmcRotationTarget,
     rotate_to_version: u32,
 ) -> Result<CredentialConvergence, ConvergeError> {
@@ -1300,7 +1308,7 @@ async fn converge_bmc_password(
 /// The normal path authenticates with `rotate_from` (the current per-device
 /// secret) and changes the password to `rotate_to`. When that fails, the
 /// hardware may already be at `rotate_to` because a prior attempt changed it and
-/// crashed before recording success; [`RedfishClientPool::bmc_credentials_valid`]
+/// crashed before recording success; [`BmcCredentialOps::bmc_credentials_valid`]
 /// confirms that without re-issuing a same-value (`new -> new`) change some BMCs
 /// reject. Only when the rotate-TO value does *not* already authenticate is the
 /// change treated as a genuine failure.
@@ -1309,7 +1317,7 @@ async fn converge_bmc_password(
 /// on a genuine device-level failure. Bounded to at most one failed login on the
 /// recovery path, so it cannot trip BMC lockout.
 async fn change_or_recover(
-    redfish_pool: &dyn RedfishClientPool,
+    redfish_pool: &dyn BmcCredentialOps,
     bmc: &BmcRotationTarget,
     vendor: RedfishVendor,
     rotate_from: Credentials,
@@ -1364,7 +1372,7 @@ async fn change_or_recover(
 /// quarantine with backoff. Returns an already-`to_string`-ed error (still to be
 /// redacted by the caller); never returns a secret-bearing string itself.
 async fn resolve_dispatch_vendor(
-    redfish_pool: &dyn RedfishClientPool,
+    redfish_pool: &dyn BmcCredentialOps,
     bmc: &BmcRotationTarget,
     rotate_from: &Credentials,
     rotate_to: &Credentials,
@@ -1409,7 +1417,7 @@ mod tests {
 
     use carbide_instrument::emit;
     use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
-    use carbide_redfish::libredfish::RedfishClientPool;
+    use carbide_redfish::libredfish::BmcCredentialOps;
     use carbide_redfish::libredfish::test_support::RedfishSim;
     use carbide_secrets::credentials::{
         BmcCredentialType, CredentialKey, CredentialReader, CredentialWriter, Credentials,

--- a/crates/machine-controller/src/context.rs
+++ b/crates/machine-controller/src/context.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 use carbide_credential_rotation::RotationGate;
 use carbide_health_metrics::PerObjectMetricsRegistry;
 use carbide_ipmi::IPMITool;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::credentials::CredentialManager;
 use component_manager::component_manager::ComponentManager;
 use db::db_read::PgPoolReader;
@@ -48,6 +48,12 @@ pub struct MachineStateHandlerServices {
     pub db_reader: PgPoolReader,
     /// API for interaction with Libredfish
     pub redfish_client_pool: Arc<dyn RedfishClientPool>,
+    /// Credential-lifecycle operations (password set/rotate/clear,
+    /// candidate validation). A sealed trait implemented only by the direct
+    /// pool, so handing these to a wrapper pool is a compile error (a
+    /// wrong-pool guard, not a wire-path guarantee -- see
+    /// [`BmcCredentialOps`]).
+    pub bmc_credential_ops: Arc<dyn BmcCredentialOps>,
     /// An implementation of the IPMITool that understands how to reboot a machine
     pub ipmi_tool: Arc<dyn IPMITool>,
     /// Configuration used by MachineStateHandler.
@@ -91,21 +97,30 @@ impl MachineStateHandlerServices {
         &self,
         machine: &Machine,
     ) -> Result<Box<dyn Redfish>, StateHandlerError> {
+        let bmc_access_info = self.bmc_access_info_for_machine(machine).await?;
+        self.redfish_client_pool
+            .client_by_info(&bmc_access_info)
+            .await
+            .map_err(StateHandlerError::from)
+    }
+
+    /// Resolves a machine's BMC access info; credential-lifecycle call sites
+    /// hand this to [`BmcCredentialOps`], which builds its own direct client.
+    pub(crate) async fn bmc_access_info_for_machine(
+        &self,
+        machine: &Machine,
+    ) -> Result<carbide_utils::redfish::BmcAccessInfo, StateHandlerError> {
         let addr = machine
             .bmc_addr()
             .ok_or_else(|| StateHandlerError::MissingData {
                 object_id: machine.id.to_string(),
                 missing: "BMC Endpoint Information (bmc_info.ip)",
             })?;
-        let bmc_access_info = db::machine_interface::lookup_bmc_access_info(
+        Ok(db::machine_interface::lookup_bmc_access_info(
             &self.db_pool,
             addr.ip(),
             Some(addr.port()),
         )
-        .await?;
-        self.redfish_client_pool
-            .client_by_info(&bmc_access_info)
-            .await
-            .map_err(StateHandlerError::from)
+        .await?)
     }
 }

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -4973,12 +4973,24 @@ impl DpuMachineStateHandler {
 
                 let dpf_managed_bf4 = is_dpf_managed_bf4(state, dpu_snapshot)?;
 
-                let dpu_redfish_client = match ctx
-                    .services
-                    .create_redfish_client_from_machine(dpu_snapshot)
-                    .await
-                {
-                    Ok(client) => client,
+                // One access-info lookup serves both the general client
+                // and the credential op below.
+                let client_result = async {
+                    let access = ctx
+                        .services
+                        .bmc_access_info_for_machine(dpu_snapshot)
+                        .await?;
+                    let client = ctx
+                        .services
+                        .redfish_client_pool
+                        .client_by_info(&access)
+                        .await
+                        .map_err(StateHandlerError::from)?;
+                    Ok::<_, StateHandlerError>((access, client))
+                }
+                .await;
+                let (dpu_bmc_access, dpu_redfish_client) = match client_result {
+                    Ok(v) => v,
                     Err(e) => {
                         let msg = format!(
                             "failed to create redfish client for DPU {}, potentially because we turned the host off as part of error handling in this state. err: {}",
@@ -5063,14 +5075,14 @@ impl DpuMachineStateHandler {
 
                 let dpu_uefi_credentials = resolve_site_uefi_credentials(
                     &ctx.services.db_pool,
-                    ctx.services.redfish_client_pool.credential_reader(),
+                    ctx.services.bmc_credential_ops.credential_reader(),
                     db::credential_rotation::CredentialRotationType::DpuUefi,
                 )
                 .await?;
                 let credentials_updated = match ctx
                     .services
-                    .redfish_client_pool
-                    .uefi_setup(dpu_redfish_client.as_ref(), true, dpu_uefi_credentials)
+                    .bmc_credential_ops
+                    .uefi_setup(&dpu_bmc_access, true, dpu_uefi_credentials)
                     .await
                 {
                     Err(e) => {
@@ -7443,14 +7455,13 @@ async fn handle_host_uefi_setup(
                 missing: "bmc_mac",
             })?;
 
-    let redfish_client = ctx
-        .services
-        .create_redfish_client_from_machine(&state.host_snapshot)
-        .await?;
-
     match uefi_setup_info.uefi_setup_state.clone() {
         UefiSetupState::UnlockHost => {
             if state.host_snapshot.needs_bmc_unlock_for_uefi_setup() {
+                let redfish_client = ctx
+                    .services
+                    .create_redfish_client_from_machine(&state.host_snapshot)
+                    .await?;
                 redfish_client
                     .lockdown_bmc(libredfish::EnabledDisabled::Disabled)
                     .await
@@ -7471,14 +7482,18 @@ async fn handle_host_uefi_setup(
         UefiSetupState::SetUefiPassword => {
             let host_uefi_credentials = resolve_site_uefi_credentials(
                 &ctx.services.db_pool,
-                ctx.services.redfish_client_pool.credential_reader(),
+                ctx.services.bmc_credential_ops.credential_reader(),
                 db::credential_rotation::CredentialRotationType::HostUefi,
             )
             .await?;
+            let host_bmc_access = ctx
+                .services
+                .bmc_access_info_for_machine(&state.host_snapshot)
+                .await?;
             match ctx
                 .services
-                .redfish_client_pool
-                .uefi_setup(redfish_client.as_ref(), false, host_uefi_credentials)
+                .bmc_credential_ops
+                .uefi_setup(&host_bmc_access, false, host_uefi_credentials)
                 .await
             {
                 Ok(job_id) => Ok(StateHandlerOutcome::transition(
@@ -7491,6 +7506,13 @@ async fn handle_host_uefi_setup(
                         },
                     },
                 )),
+                // Client creation failed (credential store, TCP, or the
+                // vendor probe): return Err so the framework retries.
+                // Falling through to the untested-vendor arm below would
+                // permanently skip setting the BIOS password over a blip.
+                Err(carbide_redfish::libredfish::CredentialOpError::ClientCreation(e)) => {
+                    Err(e.into())
+                }
                 Err(e) => {
                     let msg = format!(
                         "failed to set the BIOS password on {} ({}): {}",
@@ -7526,6 +7548,10 @@ async fn handle_host_uefi_setup(
         }
         UefiSetupState::WaitForPasswordJobScheduled => {
             if let Some(job_id) = uefi_setup_info.uefi_password_jid.as_ref() {
+                let redfish_client = ctx
+                    .services
+                    .create_redfish_client_from_machine(&state.host_snapshot)
+                    .await?;
                 let job_state = redfish_client
                     .get_job_state(job_id)
                     .await

--- a/crates/machine-controller/src/handler/decommissioning.rs
+++ b/crates/machine-controller/src/handler/decommissioning.rs
@@ -181,10 +181,7 @@ pub(super) async fn handle_deconfiguring_host(
                 ));
             }
 
-            let redfish_client = ctx
-                .services
-                .create_redfish_client_from_machine(machine)
-                .await?;
+            let bmc_access_info = ctx.services.bmc_access_info_for_machine(machine).await?;
 
             let bmc_mac =
                 machine
@@ -222,7 +219,7 @@ pub(super) async fn handle_deconfiguring_host(
             let key = CredentialKey::host_uefi_site_default(version);
             let credentials = ctx
                 .services
-                .redfish_client_pool
+                .bmc_credential_ops
                 .credential_reader()
                 .get_credentials(&key)
                 .await
@@ -239,13 +236,17 @@ pub(super) async fn handle_deconfiguring_host(
 
             let job_id = ctx
                 .services
-                .redfish_client_pool
-                .clear_host_uefi_password(redfish_client.as_ref(), credentials)
+                .bmc_credential_ops
+                .clear_host_uefi_password(&bmc_access_info, credentials)
                 .await
-                .map_err(|error| {
-                    StateHandlerError::GenericError(eyre::eyre!(
+                .map_err(|error| match error {
+                    // Client creation failed (credential store, TCP, or the
+                    // vendor probe): propagate as-is so the framework
+                    // retries normally.
+                    carbide_redfish::libredfish::CredentialOpError::ClientCreation(e) => e.into(),
+                    error => StateHandlerError::GenericError(eyre::eyre!(
                         "failed to clear host UEFI password: {error}"
-                    ))
+                    )),
                 })?;
 
             let next = match job_id {

--- a/crates/machine-controller/src/handler/dpu_uefi_rotation.rs
+++ b/crates/machine-controller/src/handler/dpu_uefi_rotation.rs
@@ -41,6 +41,7 @@
 //! [`RotationGate::rotation_needed`]: carbide_credential_rotation::RotationGate::rotation_needed
 
 use bmc_vendor::DpuModel;
+use carbide_redfish::libredfish::CredentialOpError;
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
 use carbide_uuid::machine::MachineId;
 use eyre::eyre;
@@ -248,7 +249,7 @@ pub(crate) async fn handle_rotating_dpu_uefi(
     // password before touching the device; scope the credential reader so it is
     // not held across the mutable-context DPU restart below.
     let (candidates, new_password) = {
-        let reader = ctx.services.redfish_client_pool.credential_reader();
+        let reader = ctx.services.bmc_credential_ops.credential_reader();
         let candidates = dpu_uefi_current_candidates(reader, current_version, target).await?;
         let Credentials::UsernamePassword {
             password: new_password,
@@ -256,8 +257,6 @@ pub(crate) async fn handle_rotating_dpu_uefi(
         } = resolve_site_uefi_credentials(&db_pool, reader, DpuUefi).await?;
         (candidates, new_password)
     };
-
-    let dpu_redfish_client = ctx.services.create_redfish_client_from_machine(dpu).await?;
 
     // Stage the target before dispatch (crash-safe), in its own short
     // transaction so no lock is held across the Redfish round-trip.
@@ -275,10 +274,11 @@ pub(crate) async fn handle_rotating_dpu_uefi(
         })?;
     }
 
+    let access = ctx.services.bmc_access_info_for_machine(dpu).await?;
     match ctx
         .services
-        .redfish_client_pool
-        .rotate_uefi_password(dpu_redfish_client.as_ref(), &candidates, new_password)
+        .bmc_credential_ops
+        .rotate_uefi_password(&access, &candidates, new_password)
         .await
     {
         // The DPU stages the change through Bios/Settings and schedules no job
@@ -312,7 +312,11 @@ pub(crate) async fn handle_rotating_dpu_uefi(
             }
             Ok(StateHandlerOutcome::transition(ManagedHostState::Ready).with_txn(txn))
         }
-        Err(e) => {
+        // Client creation failed (credential store, TCP, or the vendor
+        // probe): return Err so the state framework retries; quarantine is
+        // reserved for the operation itself failing on the device.
+        Err(CredentialOpError::ClientCreation(e)) => Err(e.into()),
+        Err(CredentialOpError::Operation(e)) => {
             // Device-level failure (all current-password candidates rejected, or
             // the DPU refused the change). The pool already redacted the password
             // out of the error. Quarantine with backoff and return to Ready so

--- a/crates/machine-controller/src/handler/factory_reset.rs
+++ b/crates/machine-controller/src/handler/factory_reset.rs
@@ -496,7 +496,7 @@ async fn wait_for_bmc(
     // Readiness = a successful anonymous service-root read. The `Unknown` path
     // does no I/O at client creation and works against a just-reset BMC on its
     // factory password without consuming an authenticated login attempt.
-    let redfish = ctx.services.redfish_client_pool.clone();
+    let redfish = ctx.services.bmc_credential_ops.clone();
     let ready = match redfish
         .create_client(
             &host,
@@ -568,7 +568,7 @@ async fn restore_credentials(
     }
 
     let (host, port) = bmc_host_port(mh_snapshot)?;
-    let redfish = ctx.services.redfish_client_pool.clone();
+    let redfish = ctx.services.bmc_credential_ops.clone();
 
     // Step 1: verify the factory credentials. Until they authenticate we never
     // mutate and never park.

--- a/crates/machine-controller/src/handler/host_boot_config.rs
+++ b/crates/machine-controller/src/handler/host_boot_config.rs
@@ -546,6 +546,7 @@ mod tests {
             db_pool: db_pool.clone(),
             db_reader: db_pool.into(),
             redfish_client_pool: redfish_sim.clone(),
+            bmc_credential_ops: redfish_sim.clone(),
             ipmi_tool: carbide_ipmi::test_support(),
             site_config: Arc::new(MachineStateHandlerSiteConfig::test_default()),
             component_manager: None,

--- a/crates/machine-controller/src/handler/host_uefi_rotation.rs
+++ b/crates/machine-controller/src/handler/host_uefi_rotation.rs
@@ -45,6 +45,7 @@
 //! several DPUs -- distinct enough from the host flow to keep the two states
 //! separate rather than overloading this one.
 
+use carbide_redfish::libredfish::CredentialOpError;
 use carbide_redfish::libredfish::error::state_handler_redfish_error as redfish_error;
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, Credentials};
 use eyre::eyre;
@@ -205,14 +206,13 @@ pub(crate) async fn handle_rotating_host_uefi(
                 missing: "bmc_mac",
             })?;
 
-    let redfish_client = ctx
-        .services
-        .create_redfish_client_from_machine(&state.host_snapshot)
-        .await?;
-
     match &uefi_setup_info.uefi_setup_state {
         UefiSetupState::UnlockHost => {
             if state.host_snapshot.needs_bmc_unlock_for_uefi_setup() {
+                let redfish_client = ctx
+                    .services
+                    .create_redfish_client_from_machine(&state.host_snapshot)
+                    .await?;
                 redfish_client
                     .lockdown_bmc(libredfish::EnabledDisabled::Disabled)
                     .await
@@ -224,10 +224,14 @@ pub(crate) async fn handle_rotating_host_uefi(
             ))
         }
         UefiSetupState::SetUefiPassword => {
-            set_rotating_host_uefi_password(ctx, state, host_bmc_mac, redfish_client.as_ref()).await
+            set_rotating_host_uefi_password(ctx, state, host_bmc_mac).await
         }
         UefiSetupState::WaitForPasswordJobScheduled => {
             if let Some(job_id) = uefi_setup_info.uefi_password_jid.as_ref() {
+                let redfish_client = ctx
+                    .services
+                    .create_redfish_client_from_machine(&state.host_snapshot)
+                    .await?;
                 let job_state = redfish_client
                     .get_job_state(job_id)
                     .await
@@ -251,6 +255,10 @@ pub(crate) async fn handle_rotating_host_uefi(
             ))
         }
         UefiSetupState::WaitForPasswordJobCompletion => {
+            let redfish_client = ctx
+                .services
+                .create_redfish_client_from_machine(&state.host_snapshot)
+                .await?;
             if let Some(job_id) = uefi_setup_info.uefi_password_jid.as_ref() {
                 let job_state = redfish_client
                     .get_job_state(job_id)
@@ -268,6 +276,10 @@ pub(crate) async fn handle_rotating_host_uefi(
         // BMC lockdown that `UnlockHost` disabled, so treat this as completion
         // for any host that somehow carries it.
         UefiSetupState::LockdownHost => {
+            let redfish_client = ctx
+                .services
+                .create_redfish_client_from_machine(&state.host_snapshot)
+                .await?;
             finish_rotating_host_uefi(ctx, state, host_bmc_mac, redfish_client.as_ref()).await
         }
     }
@@ -280,12 +292,11 @@ async fn set_rotating_host_uefi_password(
     ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
     state: &ManagedHostStateSnapshot,
     host_bmc_mac: mac_address::MacAddress,
-    redfish_client: &dyn Redfish,
 ) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
     use db::credential_rotation::CredentialRotationType::HostUefi;
 
     let db_pool = &ctx.services.db_pool;
-    let reader = ctx.services.redfish_client_pool.credential_reader();
+    let reader = ctx.services.bmc_credential_ops.credential_reader();
 
     let target = current_site_uefi_target(db_pool, HostUefi).await?;
 
@@ -328,17 +339,25 @@ async fn set_rotating_host_uefi_password(
         })?;
     }
 
+    let access = ctx
+        .services
+        .bmc_access_info_for_machine(&state.host_snapshot)
+        .await?;
     match ctx
         .services
-        .redfish_client_pool
-        .rotate_uefi_password(redfish_client, &candidates, new_password)
+        .bmc_credential_ops
+        .rotate_uefi_password(&access, &candidates, new_password)
         .await
     {
         Ok(job_id) => Ok(rotating_host_uefi_step(
             job_id,
             UefiSetupState::WaitForPasswordJobScheduled,
         )),
-        Err(e) => {
+        // Client creation failed (credential store, TCP, or the vendor
+        // probe): return Err so the state framework retries; quarantine is
+        // reserved for the operation itself failing on the device.
+        Err(CredentialOpError::ClientCreation(e)) => Err(e.into()),
+        Err(CredentialOpError::Operation(e)) => {
             // Device-level failure (all current-password candidates rejected, or
             // the vendor refused the change). The pool already redacted the
             // password out of the error. Quarantine with backoff and return to
@@ -352,9 +371,16 @@ async fn set_rotating_host_uefi_password(
             // re-lock failure must neither hold a lock across a Redfish call nor
             // mask the quarantine record (which would tighten the retry loop), so
             // we log and continue.
-            if let Err(relock_err) =
-                reenable_host_bmc_lockdown_after_rotation(state, redfish_client).await
-            {
+            let relock = async {
+                let client = ctx
+                    .services
+                    .redfish_client_pool
+                    .client_by_info(&access)
+                    .await
+                    .map_err(StateHandlerError::from)?;
+                reenable_host_bmc_lockdown_after_rotation(state, client.as_ref()).await
+            };
+            if let Err(relock_err) = relock.await {
                 tracing::warn!(
                     mac = %host_bmc_mac,
                     error = %relock_err,

--- a/crates/machine-controller/src/handler/rotation.rs
+++ b/crates/machine-controller/src/handler/rotation.rs
@@ -244,7 +244,7 @@ async fn rotate_endpoint(
     match rotate_bmc(
         &services.db_pool,
         services.credential_manager.as_ref(),
-        services.redfish_client_pool.as_ref(),
+        services.bmc_credential_ops.as_ref(),
         &target,
         force,
     )
@@ -298,7 +298,7 @@ async fn rotate_dpu_service_endpoint(
     match rotate_dpu_bmc_service(
         &services.db_pool,
         services.credential_manager.as_ref(),
-        services.redfish_client_pool.as_ref(),
+        services.bmc_credential_ops.as_ref(),
         &endpoint,
         force,
     )

--- a/crates/machine-controller/tests/integration/dpu_uefi_rotation.rs
+++ b/crates/machine-controller/tests/integration/dpu_uefi_rotation.rs
@@ -378,3 +378,76 @@ async fn dpu_uefi_change_failure_quarantines_and_returns_to_ready(
 
     Ok(())
 }
+
+/// A client-creation failure during the DPU UEFI change (credential store,
+/// TCP, or the vendor probe) is transient: the state must hold in place with
+/// no quarantine or counted attempt, and a later tick must complete the
+/// rotation once creation succeeds again.
+#[sqlx_test]
+async fn dpu_uefi_client_creation_failure_retries_without_quarantine(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cm = Arc::new(TestCredentialManager::default());
+    let mut env = Env::builder(pool.clone())
+        .with_credential_manager(cm.clone())
+        .configure_runtime(|c| c.uefi_rotation_enabled = true)
+        .build()
+        .await;
+
+    let (mh, dpu_mac) = ready_host_with_dpu(&env).await;
+    stage_lagging_dpu_uefi(&env, &pool, dpu_mac).await?;
+
+    // Iteration 1: Ready observes the lag and enters RotatingDpuUefi.
+    env.run_single_iteration().await;
+    assert!(
+        matches!(
+            mh.host.machine().await.state.value,
+            ManagedHostState::RotatingDpuUefi { .. }
+        ),
+        "expected RotatingDpuUefi after the entry guard fires, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+
+    // A tick with client creation failing must hold in place: same state, no
+    // quarantine, no counted attempt.
+    env.redfish_sim
+        .set_create_client_error("dpu bmc unreachable");
+    env.run_single_iteration().await;
+    assert!(
+        matches!(
+            mh.host.machine().await.state.value,
+            ManagedHostState::RotatingDpuUefi { .. }
+        ),
+        "a transient creation failure must not advance or abort the rotation, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, DPU_UEFI, dpu_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            !status.quarantined,
+            "a transient creation failure must not quarantine the DPU"
+        );
+        assert_eq!(
+            status.rotate_attempts, 0,
+            "a transient creation failure must not count a rotation attempt"
+        );
+    }
+
+    // Once creation succeeds again, a later iteration retries and the
+    // rotation converges normally.
+    env.redfish_sim.clear_create_client_error();
+    run_until_ready(&mut env, &mh).await;
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, DPU_UEFI, dpu_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(status.converged, "the retried rotation should converge");
+        assert_eq!(status.current_version, Some(1));
+    }
+
+    Ok(())
+}

--- a/crates/machine-controller/tests/integration/env.rs
+++ b/crates/machine-controller/tests/integration/env.rs
@@ -160,7 +160,8 @@ impl EnvBuilder {
         let services = MachineStateHandlerServices {
             db_pool: pool.clone(),
             db_reader: pool.clone().into(),
-            redfish_client_pool: controller_redfish_sim,
+            redfish_client_pool: controller_redfish_sim.clone(),
+            bmc_credential_ops: controller_redfish_sim,
             ipmi_tool: carbide_ipmi::test_support(),
             site_config: runtime_config.machine_state_handler_site_config().into(),
             component_manager,

--- a/crates/machine-controller/tests/integration/host_uefi_rotation.rs
+++ b/crates/machine-controller/tests/integration/host_uefi_rotation.rs
@@ -36,7 +36,7 @@ use db::credential_rotation::{
     record_device_converged, set_next_target_version,
 };
 use mac_address::MacAddress;
-use model::machine::ManagedHostState;
+use model::machine::{ManagedHostState, UefiSetupState};
 use model::test_support::ManagedHostConfig;
 
 use crate::env::Env;
@@ -379,6 +379,85 @@ async fn uefi_change_failure_quarantines_and_returns_to_ready(
             !recorded.contains("uefi-v1"),
             "the recorded rotation error must be password-redacted, got {recorded:?}"
         );
+    }
+
+    Ok(())
+}
+
+/// A client-creation failure during the SET step (credential store, TCP, or
+/// the vendor probe) is transient: the FSM must hold in place with no
+/// quarantine or counted attempt, and a later tick must complete the rotation
+/// once creation succeeds again.
+#[sqlx_test]
+async fn uefi_client_creation_failure_retries_without_quarantine(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let cm = Arc::new(TestCredentialManager::default());
+    let mut env = Env::builder(pool.clone())
+        .with_credential_manager(cm.clone())
+        .configure_runtime(|c| c.uefi_rotation_enabled = true)
+        .build()
+        .await;
+
+    let (mh, host_mac) = ready_host(&env, &pool).await;
+    stage_lagging_host_uefi(&env, &pool, host_mac).await?;
+
+    // Drive the FSM to the SET step with a healthy sim, so the injected
+    // failure lands in the dispatch itself rather than an earlier step.
+    let at_set_step = |state: &ManagedHostState| {
+        matches!(
+            state,
+            ManagedHostState::RotatingHostUefi { uefi_setup_info }
+                if uefi_setup_info.uefi_setup_state == UefiSetupState::SetUefiPassword
+        )
+    };
+    for _ in 0..4 {
+        if at_set_step(&mh.host.machine().await.state.value) {
+            break;
+        }
+        env.run_single_iteration().await;
+    }
+    assert!(
+        at_set_step(&mh.host.machine().await.state.value),
+        "FSM should reach the SET step, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+
+    // A tick with client creation failing must hold in place: same step, no
+    // quarantine, no counted attempt.
+    env.redfish_sim.set_create_client_error("bmc unreachable");
+    env.run_single_iteration().await;
+    assert!(
+        at_set_step(&mh.host.machine().await.state.value),
+        "a transient creation failure must not advance or abort the SET step, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, HOST_UEFI, host_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(
+            !status.quarantined,
+            "a transient creation failure must not quarantine the device"
+        );
+        assert_eq!(
+            status.rotate_attempts, 0,
+            "a transient creation failure must not count a rotation attempt"
+        );
+    }
+
+    // Once creation succeeds again, a later iteration retries and the
+    // rotation converges normally.
+    env.redfish_sim.clear_create_client_error();
+    run_until_ready(&mut env, &mh).await;
+    {
+        let mut conn = pool.acquire().await?;
+        let status = device_rotation_status(&mut conn, HOST_UEFI, host_mac)
+            .await?
+            .expect("device rotation row should exist");
+        assert!(status.converged, "the retried rotation should converge");
+        assert_eq!(status.current_version, Some(1));
     }
 
     Ok(())

--- a/crates/machine-controller/tests/integration/host_uefi_setup.rs
+++ b/crates/machine-controller/tests/integration/host_uefi_setup.rs
@@ -1,0 +1,124 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Coverage for the ingestion `UefiSetupState::SetUefiPassword` step's error
+//! split: a client-creation failure is transient and must retry in place. On
+//! a vendor outside the tested set (Dell/Lenovo/NVIDIA) the device-level
+//! error path deliberately skips ahead and ingests the host without a BIOS
+//! password, so a transient blip taking that path would be permanent -- this
+//! pins the retry.
+
+use carbide_secrets::credentials::{CredentialKey, Credentials};
+use carbide_test_harness::prelude::*;
+use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
+use model::machine::{MachineState, ManagedHostState, UefiSetupInfo, UefiSetupState};
+use model::test_support::ManagedHostConfig;
+
+use crate::env::Env;
+
+fn uefi_setup_state(state: UefiSetupState) -> ManagedHostState {
+    ManagedHostState::HostInit {
+        machine_state: MachineState::UefiSetup {
+            uefi_setup_info: UefiSetupInfo {
+                uefi_password_jid: None,
+                uefi_setup_state: state,
+            },
+        },
+    }
+}
+
+fn at_uefi_step(state: &ManagedHostState, step: UefiSetupState) -> bool {
+    matches!(
+        state,
+        ManagedHostState::HostInit {
+            machine_state: MachineState::UefiSetup { uefi_setup_info },
+        } if uefi_setup_info.uefi_setup_state == step
+    )
+}
+
+/// A client-creation failure while setting the ingestion BIOS password is
+/// transient: the step must hold in place (not skip ahead to lockdown, which
+/// on an untested vendor would permanently ingest the host without a BIOS
+/// password), and a later tick must proceed once creation succeeds again.
+#[sqlx_test]
+async fn set_uefi_password_client_creation_failure_retries_in_place(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut env = Env::builder(pool.clone()).build().await;
+
+    // A vendor outside the tested set: its device-level error path skips the
+    // password rather than retrying, so this fixture can tell the two error
+    // classes apart.
+    let domain = env.test_harness.test_domain().await;
+    let network_controller = env.test_harness.network_controller();
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    network_controller.create_admin_segment(&domain).await;
+    let site_explorer = env.test_harness.default_test_site_explorer();
+    let mh = env
+        .test_harness
+        .managed_host_builder(&site_explorer, underlay_segment)
+        .with_config(ManagedHostConfig {
+            vendor: Some(bmc_vendor::BMCVendor::Supermicro),
+            ..ManagedHostConfig::default()
+        })
+        .build()
+        .await
+        .0;
+
+    // The SET step resolves the site-wide host UEFI credential (version 0 on
+    // a fresh site) before dispatching.
+    env.redfish_sim
+        .seed_credential(
+            &CredentialKey::host_uefi_site_default(0),
+            &Credentials::UsernamePassword {
+                username: String::new(),
+                password: "uefi-v0".to_string(),
+            },
+        )
+        .await;
+
+    mh.advance_state(uefi_setup_state(UefiSetupState::SetUefiPassword))
+        .await;
+
+    // A tick with the credential op failing on client creation must hold in
+    // place rather than fall through to the vendor skip.
+    env.redfish_sim
+        .set_uefi_setup_client_creation_error("bmc unreachable");
+    env.run_single_iteration().await;
+    assert!(
+        at_uefi_step(
+            &mh.host.machine().await.state.value,
+            UefiSetupState::SetUefiPassword
+        ),
+        "a transient creation failure must retry the SET step in place, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+
+    // Once creation succeeds again, the step proceeds normally.
+    env.redfish_sim.clear_uefi_setup_client_creation_error();
+    env.run_single_iteration().await;
+    assert!(
+        at_uefi_step(
+            &mh.host.machine().await.state.value,
+            UefiSetupState::WaitForPasswordJobScheduled
+        ),
+        "the retried SET step should dispatch and advance, got {:?}",
+        mh.host.machine().await.state.value,
+    );
+
+    Ok(())
+}

--- a/crates/machine-controller/tests/integration/main.rs
+++ b/crates/machine-controller/tests/integration/main.rs
@@ -21,6 +21,7 @@ mod dpu_uefi_rotation;
 mod env;
 mod firmware_upgrade_completion;
 mod host_uefi_rotation;
+mod host_uefi_setup;
 mod maintenance;
 mod power_management;
 mod rack_firmware_upgrade;

--- a/crates/power-shelf-controller/src/context.rs
+++ b/crates/power-shelf-controller/src/context.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use carbide_credential_rotation::RotationGate;
 use carbide_health_metrics::PerObjectMetricsRegistry;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::credentials::CredentialManager;
 use component_manager::component_manager::ComponentManager;
 use sqlx::PgPool;
@@ -44,6 +44,12 @@ pub struct PowerShelfStateHandlerServices {
     /// Libredfish pool used to converge the power shelf BMC (PMC) credential
     /// The same shared instance the machine- and switch-controllers use.
     pub redfish_client_pool: Arc<dyn RedfishClientPool>,
+    /// Credential-lifecycle operations (password set/rotate/clear,
+    /// candidate validation). A sealed trait implemented only by the direct
+    /// pool, so handing these to a wrapper pool is a compile error (a
+    /// wrong-pool guard, not a wire-path guarantee -- see
+    /// [`BmcCredentialOps`]).
+    pub bmc_credential_ops: Arc<dyn BmcCredentialOps>,
     /// Short-TTL cache of the site-wide BMC rotation aggregate, shared across
     /// this replica's per-object ticks so the steady state costs one aggregate
     /// query per TTL window rather than a per-device query every sweep.

--- a/crates/power-shelf-controller/src/rotating_bmc.rs
+++ b/crates/power-shelf-controller/src/rotating_bmc.rs
@@ -205,7 +205,7 @@ async fn rotate_power_shelf_bmc(
     match rotate_bmc(
         &services.db_pool,
         services.credential_manager.as_ref(),
-        services.redfish_client_pool.as_ref(),
+        services.bmc_credential_ops.as_ref(),
         &target,
         force,
     )

--- a/crates/power-shelf-controller/tests/integration/bmc_rotation.rs
+++ b/crates/power-shelf-controller/tests/integration/bmc_rotation.rs
@@ -118,6 +118,7 @@ fn power_shelf_services(
         per_object_metrics_registry: env.per_object_metrics_registry.clone(),
         rack_firmware_reprovisioning_enabled: false,
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: RotationGate::new_for_family(CredentialRotationType::Bmc),
         bmc_rotation_enabled,
     }

--- a/crates/power-shelf-controller/tests/integration/common.rs
+++ b/crates/power-shelf-controller/tests/integration/common.rs
@@ -119,6 +119,7 @@ impl ControllerEnv {
                     per_object_metrics_registry: per_object_metrics_registry.clone(),
                     rack_firmware_reprovisioning_enabled: false,
                     redfish_client_pool: redfish_sim.clone(),
+                    bmc_credential_ops: redfish_sim.clone(),
                     bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
                         db::credential_rotation::CredentialRotationType::Bmc,
                     ),
@@ -151,6 +152,9 @@ pub(super) fn services_without_component_manager(
     pool: &PgPool,
     rack_firmware_reprovisioning_enabled: bool,
 ) -> PowerShelfStateHandlerServices {
+    // One shared sim so tests that queue expectations or read history see
+    // the same instance behind both handles.
+    let redfish_sim: Arc<RedfishSim> = Arc::new(RedfishSim::default());
     PowerShelfStateHandlerServices {
         db_pool: pool.clone(),
         component_manager: None,
@@ -160,7 +164,8 @@ pub(super) fn services_without_component_manager(
             Duration::from_secs(60),
         ),
         rack_firmware_reprovisioning_enabled,
-        redfish_client_pool: Arc::new(RedfishSim::default()),
+        redfish_client_pool: redfish_sim.clone(),
+        bmc_credential_ops: redfish_sim,
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),

--- a/crates/power-shelf-controller/tests/integration/error_state.rs
+++ b/crates/power-shelf-controller/tests/integration/error_state.rs
@@ -66,6 +66,7 @@ async fn services(env: &ControllerEnv) -> PowerShelfStateHandlerServices {
         per_object_metrics_registry: env.per_object_metrics_registry.clone(),
         rack_firmware_reprovisioning_enabled: false,
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),

--- a/crates/power-shelf-controller/tests/integration/maintenance.rs
+++ b/crates/power-shelf-controller/tests/integration/maintenance.rs
@@ -123,6 +123,7 @@ fn services_with_component_manager(
         per_object_metrics_registry: env.per_object_metrics_registry.clone(),
         rack_firmware_reprovisioning_enabled: false,
         redfish_client_pool: env.redfish_sim.clone(),
+        bmc_credential_ops: env.redfish_sim.clone(),
         bmc_rotation_gate: carbide_credential_rotation::RotationGate::new_for_family(
             db::credential_rotation::CredentialRotationType::Bmc,
         ),

--- a/crates/redfish/src/libredfish/error.rs
+++ b/crates/redfish/src/libredfish/error.rs
@@ -33,6 +33,31 @@ pub enum RedfishClientCreationError {
     MissingArgument(String),
 }
 
+/// Error from a credential-lifecycle operation ([`super::BmcCredentialOps`]),
+/// separating "could not build the Redfish client" from "the operation
+/// itself failed". Callers retry `ClientCreation` and treat `Operation` as
+/// device-level (quarantine, vendor fallback). Note that client creation is
+/// not purely local: besides the credential store and TCP it includes the
+/// vendor auto-detect HTTP probe of the BMC, so a persistently broken BMC
+/// can surface here too. The operations create their clients internally, so
+/// without this split both failure classes would surface identically.
+#[derive(thiserror::Error, Debug)]
+pub enum CredentialOpError {
+    /// The operation's Redfish client could not be built: the credential
+    /// store, TCP, or the vendor auto-detect probe failed before the
+    /// operation was attempted. Callers retry.
+    #[error("creating redfish client: {0}")]
+    ClientCreation(#[source] RedfishClientCreationError),
+    /// The operation itself failed after the client was built. Callers treat
+    /// it as device-level (quarantine, vendor fallback). Only the
+    /// [`RedfishClientCreationError::RedfishError`] payload variant is ever
+    /// constructed; the wider type is kept so the transparent `Display`
+    /// keeps the `failed redfish request` prefix call sites record (e.g. in
+    /// quarantine rows).
+    #[error(transparent)]
+    Operation(RedfishClientCreationError),
+}
+
 impl From<SecretsError> for RedfishClientCreationError {
     fn from(cause: SecretsError) -> Self {
         RedfishClientCreationError::SecretEngineError { cause }

--- a/crates/redfish/src/libredfish/implementation.rs
+++ b/crates/redfish/src/libredfish/implementation.rs
@@ -179,6 +179,11 @@ impl RedfishClientPool for RedfishClientPoolImpl {
     }
 }
 
+impl super::sealed::Sealed for RedfishClientPoolImpl {}
+
+#[async_trait]
+impl super::BmcCredentialOps for RedfishClientPoolImpl {}
+
 #[cfg(test)]
 mod tests {
     use carbide_test_support::value_scenarios;

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -35,7 +35,7 @@ use carbide_instrument::{Event, LabelValue, emit};
 use carbide_secrets::credentials::{CredentialKey, CredentialReader, CredentialType, Credentials};
 use carbide_utils::HostPortPair;
 use carbide_utils::redfish::BmcAccessInfo;
-pub use error::RedfishClientCreationError;
+pub use error::{CredentialOpError, RedfishClientCreationError};
 use libredfish::Redfish;
 use libredfish::model::service_root::RedfishVendor;
 
@@ -97,16 +97,21 @@ fn emit_dpu_uefi_password_setup_skipped_if_needed(
     true
 }
 
-pub fn new_pool(
+/// The direct pool and its credential-operations handle, backed by one
+/// object. Only this constructor yields a [`BmcCredentialOps`]: it is built
+/// from the raw `libredfish` pool, which an intermediary-routing pool does
+/// not have -- credential operations always authenticate to the BMC itself.
+pub fn new_pool_with_credential_ops(
     credential_reader: Arc<dyn CredentialReader>,
     pool: libredfish::RedfishClientPool,
     proxy_address: Arc<ArcSwap<Option<HostPortPair>>>,
-) -> Arc<dyn RedfishClientPool> {
-    Arc::new(implementation::RedfishClientPoolImpl::new(
+) -> (Arc<dyn RedfishClientPool>, Arc<dyn BmcCredentialOps>) {
+    let inner = Arc::new(implementation::RedfishClientPoolImpl::new(
         credential_reader,
         pool,
         proxy_address,
-    ))
+    ));
+    (inner.clone(), inner)
 }
 
 /// Create Redfish clients for a certain Redfish BMC endpoint
@@ -165,20 +170,54 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         )
         .await
     }
+}
 
-    // clear_host_uefi_password updates the UEFI password from Forge's sitewide password to an empty string
-    // The assumption is that this function will only be called on a machine that already updated the UEFI password to match the Forge sitewide password.
-    //
-    // `current_device_credentials` is the credential the device currently
-    // carries (the host UEFI password to authenticate the clear with). The
-    // caller resolves it -- this low-level crate intentionally knows nothing
-    // about credential versions or the rotation table; it just applies the
-    // password it is handed.
+// Seals `BmcCredentialOps`: implementations outside this crate would defeat
+// the wrong-pool guard the trait exists to provide.
+mod sealed {
+    pub trait Sealed {}
+}
+
+/// Credential-lifecycle operations against BMCs and UEFI firmware: setting,
+/// rotating, validating, and clearing passwords, plus the vendor probing the
+/// rotation engine needs.
+///
+/// Split off [`RedfishClientPool`] so the type system, not call-site
+/// discipline, decides who may perform them: the trait is sealed, and only
+/// the direct (BMC-authenticating) pool implements it. Handing these
+/// operations to a pool that routes through an intermediary such as
+/// nico-bmc-proxy is then a compile error rather than a runtime guard.
+/// (The clients the direct pool builds can still be *redirected* -- e.g. the
+/// dynamic `site_explorer.bmc_proxy` dev redirect applies to it too -- so
+/// this is a wrong-pool guard, not a wire-path guarantee.)
+///
+/// Every operation creates its own client from `self` (the direct pool), so
+/// a caller cannot accidentally pair a credential operation with a client
+/// built by some other pool.
+#[async_trait]
+pub trait BmcCredentialOps: RedfishClientPool + sealed::Sealed {
+    /// Updates the host UEFI password from Forge's sitewide password to an
+    /// empty string. Assumes the machine has already updated its UEFI
+    /// password to match the Forge sitewide password.
+    ///
+    /// `current_device_credentials` is the credential the device currently
+    /// carries (the host UEFI password to authenticate the clear with). The
+    /// caller resolves it -- this low-level crate intentionally knows nothing
+    /// about credential versions or the rotation table; it just applies the
+    /// password it is handed.
+    ///
+    /// Builds its own Redfish client from `access`; [`CredentialOpError`]
+    /// separates client-creation failures from device-level ones.
     async fn clear_host_uefi_password(
         &self,
-        client: &dyn Redfish,
+        access: &BmcAccessInfo,
         current_device_credentials: Credentials,
-    ) -> Result<Option<String>, RedfishClientCreationError> {
+    ) -> Result<Option<String>, CredentialOpError> {
+        let client = self
+            .client_by_info(access)
+            .await
+            .map_err(CredentialOpError::ClientCreation)?;
+        let client = client.as_ref();
         let Credentials::UsernamePassword {
             password: current_password,
             ..
@@ -189,30 +228,40 @@ pub trait RedfishClientPool: Send + Sync + 'static {
             .await
             .map_err(|err| redact_password(err, current_password.as_str()))
             .map_err(RedfishClientCreationError::RedfishError)
+            .map_err(CredentialOpError::Operation)
     }
 
-    // `sitewide_uefi_credentials` is the site-wide UEFI credential to set on the
-    // device (host_uefi when `dpu` is false, dpu_uefi when true). The caller
-    // resolves it -- this crate knows nothing about credential versions or the
-    // rotation table. The DPU's factory-default password (the credential the
-    // device still carries before this runs) is a hardware constant, so it is
-    // still read here.
+    /// Sets the device's UEFI (BIOS setup) password to the site-wide value.
+    ///
+    /// `sitewide_uefi_credentials` is the site-wide UEFI credential to set on
+    /// the device (host_uefi when `dpu` is false, dpu_uefi when true). The
+    /// caller resolves it -- this crate knows nothing about credential
+    /// versions or the rotation table. The DPU's factory-default password
+    /// (the credential the device still carries before this runs) is a
+    /// hardware constant, so it is still read here.
+    ///
+    /// Builds its own Redfish client from `access`; [`CredentialOpError`]
+    /// separates client-creation failures from device-level ones.
     async fn uefi_setup(
         &self,
-        client: &dyn Redfish,
+        access: &BmcAccessInfo,
         dpu: bool,
         sitewide_uefi_credentials: Credentials,
-    ) -> Result<Option<String>, RedfishClientCreationError> {
+    ) -> Result<Option<String>, CredentialOpError> {
+        let client = self
+            .client_by_info(access)
+            .await
+            .map_err(CredentialOpError::ClientCreation)?;
+        let client = client.as_ref();
         let Credentials::UsernamePassword {
             password: new_password,
             ..
         } = sitewide_uefi_credentials;
         let mut current_password = String::new();
         if dpu {
-            let bios_attrs = client
-                .bios()
-                .await
-                .map_err(RedfishClientCreationError::RedfishError)?;
+            let bios_attrs = client.bios().await.map_err(|err| {
+                CredentialOpError::Operation(RedfishClientCreationError::RedfishError(err))
+            })?;
 
             // Preserve the non-fatal return for now, but this should become a hard
             // failure once callers can reject DPUs that retain factory credentials.
@@ -234,7 +283,10 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                         model: bmc_vendor::DpuModel::Unknown,
                     },
                 })
-                .await?
+                .await
+                // A store read failure is the transient class: the
+                // operation never reached the device.
+                .map_err(|err| CredentialOpError::ClientCreation(err.into()))?
                 .unwrap_or(Credentials::UsernamePassword {
                     username: "".to_string(),
                     password: "bluefield".to_string(),
@@ -254,6 +306,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
                 .map_err(|err| redact_password(err, new_password.as_str()))
                 .map_err(|err| redact_password(err, current_password.as_str()))
                 .map_err(RedfishClientCreationError::RedfishError)
+                .map_err(CredentialOpError::Operation)
                 .map(|job_id| Some(job_id.unwrap_or_default()));
         } else {
             // For hosts, first try with empty current password (assuming no
@@ -285,6 +338,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
             .map_err(|err| redact_password(err, new_password.as_str()))
             .map_err(|err| redact_password(err, current_password.as_str()))
             .map_err(RedfishClientCreationError::RedfishError)
+            .map_err(CredentialOpError::Operation)
     }
 
     /// Rotate a UEFI (BIOS setup) password to the site-wide target,
@@ -307,10 +361,15 @@ pub trait RedfishClientPool: Send + Sync + 'static {
     /// handed. All errors are password-redacted before they leave this method.
     async fn rotate_uefi_password(
         &self,
-        client: &dyn Redfish,
+        access: &BmcAccessInfo,
         current_password_candidates: &[String],
         new_password: String,
-    ) -> Result<Option<String>, RedfishClientCreationError> {
+    ) -> Result<Option<String>, CredentialOpError> {
+        let client = self
+            .client_by_info(access)
+            .await
+            .map_err(CredentialOpError::ClientCreation)?;
+        let client = client.as_ref();
         let mut last_err = None;
         for candidate in current_password_candidates {
             match client
@@ -332,9 +391,13 @@ pub trait RedfishClientPool: Send + Sync + 'static {
         // The caller contract guarantees at least one candidate (empty for a
         // never-set host, the factory default for a never-set DPU), so `last_err`
         // is populated whenever the loop fell through without an Ok.
-        Err(RedfishClientCreationError::RedfishError(last_err.expect(
-            "rotate_uefi_password requires at least one current-password candidate",
-        )))
+        Err(CredentialOpError::Operation(
+            RedfishClientCreationError::RedfishError(
+                last_err.expect(
+                    "rotate_uefi_password requires at least one current-password candidate",
+                ),
+            ),
+        ))
     }
 
     /// Rotate a BMC's root password in place, then apply the vendor-specific
@@ -536,7 +599,7 @@ pub trait RedfishClientPool: Send + Sync + 'static {
     /// BMC rejects them as unauthorized (401/403), and `Err` for a transport or
     /// other failure the caller should treat as a transient tick error.
     ///
-    /// [`set_bmc_root_password`]: RedfishClientPool::set_bmc_root_password
+    /// [`set_bmc_root_password`]: BmcCredentialOps::set_bmc_root_password
     async fn bmc_credentials_valid(
         &self,
         host: &str,
@@ -585,8 +648,8 @@ pub trait RedfishClientPool: Send + Sync + 'static {
     /// `Ok(false)` on `401`, and `Err` for a transport or other failure the
     /// caller should treat as a transient tick error.
     ///
-    /// [`set_bf4_dpu_service_password`]: RedfishClientPool::set_bf4_dpu_service_password
-    /// [`bmc_credentials_valid`]: RedfishClientPool::bmc_credentials_valid
+    /// [`set_bf4_dpu_service_password`]: BmcCredentialOps::set_bf4_dpu_service_password
+    /// [`bmc_credentials_valid`]: BmcCredentialOps::bmc_credentials_valid
     async fn bf4_dpu_service_credentials_valid(
         &self,
         host: &str,
@@ -1319,6 +1382,115 @@ mod tests {
                 RedfishClientCreationError::RedfishError(ref e) if !e.is_unauthorized()
             ),
             "expected a non-unauthorized RedfishError, got {err:?}",
+        );
+    }
+
+    /// Minimal in-crate pool double for driving the `BmcCredentialOps`
+    /// *default* bodies (which `RedfishSim` overrides): client creation
+    /// delegates to an inner sim, and the credential store always fails, so
+    /// each test isolates one failure source and asserts its
+    /// [`CredentialOpError`] class.
+    struct ClassificationDouble {
+        sim: RedfishSim,
+        reader: FailingCredentialReader,
+    }
+
+    struct FailingCredentialReader;
+
+    #[async_trait]
+    impl CredentialReader for FailingCredentialReader {
+        async fn get_credentials(
+            &self,
+            _key: &CredentialKey,
+        ) -> Result<Option<Credentials>, carbide_secrets::SecretsError> {
+            Err(carbide_secrets::SecretsError::UfmCredentialReadBlocked {
+                fabric: "store unavailable".to_string(),
+            })
+        }
+    }
+
+    #[async_trait]
+    impl RedfishClientPool for ClassificationDouble {
+        async fn create_client(
+            &self,
+            host: &str,
+            port: Option<u16>,
+            auth: RedfishAuth,
+            vendor: Option<RedfishVendor>,
+        ) -> Result<Box<dyn Redfish>, RedfishClientCreationError> {
+            self.sim.create_client(host, port, auth, vendor).await
+        }
+
+        fn credential_reader(&self) -> &dyn CredentialReader {
+            &self.reader
+        }
+    }
+
+    impl sealed::Sealed for ClassificationDouble {}
+
+    #[async_trait]
+    impl BmcCredentialOps for ClassificationDouble {}
+
+    fn double_access() -> BmcAccessInfo {
+        BmcAccessInfo {
+            host: "192.0.2.1".to_string(),
+            port: None,
+            mac_address: "00:11:22:33:44:55".parse().unwrap(),
+        }
+    }
+
+    fn site_creds() -> Credentials {
+        Credentials::UsernamePassword {
+            username: String::new(),
+            password: "site-secret".to_string(),
+        }
+    }
+
+    /// A failed client build inside a credential op is the transient
+    /// ([`CredentialOpError::ClientCreation`]) class: call sites retry it
+    /// instead of quarantining the device.
+    #[tokio::test]
+    async fn uefi_setup_client_creation_failure_is_client_creation_class() {
+        let double = ClassificationDouble {
+            sim: RedfishSim::default(),
+            reader: FailingCredentialReader,
+        };
+        double.sim.set_create_client_error("bmc probe timed out");
+        let err = double
+            .uefi_setup(&double_access(), true, site_creds())
+            .await
+            .expect_err("client creation failure must fail the op");
+        assert!(
+            matches!(err, CredentialOpError::ClientCreation(_)),
+            "a failed client build must be the transient class, got {err:?}"
+        );
+    }
+
+    /// The DPU factory-default store read inside `uefi_setup` fails before
+    /// the operation reaches the device, so it is also the transient
+    /// ([`CredentialOpError::ClientCreation`]) class, not a device-level
+    /// `Operation` failure.
+    #[tokio::test]
+    async fn uefi_setup_dpu_store_read_failure_is_client_creation_class() {
+        let double = ClassificationDouble {
+            sim: RedfishSim::default(),
+            reader: FailingCredentialReader,
+        };
+        // Attributes expose a UEFI password field, so the DPU body proceeds
+        // past its probe to the factory-default store read, which fails.
+        double
+            .sim
+            .set_bios_attributes(std::collections::HashMap::from([(
+                "Attributes".to_string(),
+                serde_json::json!({ "CurrentUefiPassword": "" }),
+            )]));
+        let err = double
+            .uefi_setup(&double_access(), true, site_creds())
+            .await
+            .expect_err("store read failure must fail the op");
+        assert!(
+            matches!(err, CredentialOpError::ClientCreation(_)),
+            "a store read failure never reached the device, got {err:?}"
         );
     }
 }

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -127,6 +127,22 @@ struct RedfishSimState {
     /// is password-redacted, and to exercise the quarantine-and-return-to-Ready
     /// path in host UEFI rotation.
     uefi_password_change_error: Option<String>,
+    /// When set, every `RedfishClientPool::create_client` fails with a
+    /// [`RedfishError::GenericError`] carrying this message, modeling a
+    /// transient client-creation failure (credential store, TCP, or the
+    /// vendor probe). Drives the [`super::CredentialOpError::ClientCreation`]
+    /// retry paths at credential-op call sites.
+    create_client_error: Option<String>,
+    /// When set, the sim's `BmcCredentialOps::uefi_setup` override fails with
+    /// [`super::CredentialOpError::ClientCreation`] carrying this message,
+    /// modeling a client-creation failure inside the credential op (the sim
+    /// override replaces the default body, so `create_client_error` cannot
+    /// reach it).
+    uefi_setup_client_creation_error: Option<String>,
+    /// BIOS attribute map returned by `bios()` when set; the sim's `bios()`
+    /// is otherwise unimplemented. Lets unit tests drive the default
+    /// `BmcCredentialOps::uefi_setup` DPU body past its attribute probe.
+    bios_attributes: Option<HashMap<String, serde_json::Value>>,
     /// Optional ComputerSystem identifier used to drive platform classification.
     system_id: Option<String>,
     /// Physical-port MAC addresses exposed through the adapter Ports collection.
@@ -451,6 +467,42 @@ impl RedfishSim {
     /// recorded rotation error is redacted.
     pub fn set_uefi_password_change_error(&self, message: impl Into<String>) {
         self.state.lock().unwrap().uefi_password_change_error = Some(message.into());
+    }
+
+    /// Force every `create_client` to fail with a
+    /// [`RedfishError::GenericError`] carrying `message`, modeling a transient
+    /// client-creation failure (credential store, TCP, or the vendor probe).
+    /// Clear with [`Self::clear_create_client_error`] to model recovery.
+    pub fn set_create_client_error(&self, message: impl Into<String>) {
+        self.state.lock().unwrap().create_client_error = Some(message.into());
+    }
+
+    /// Let `create_client` succeed again after
+    /// [`Self::set_create_client_error`], modeling the transient failure
+    /// clearing so a retry can be asserted.
+    pub fn clear_create_client_error(&self) {
+        self.state.lock().unwrap().create_client_error = None;
+    }
+
+    /// Force the sim's `uefi_setup` override to fail with
+    /// [`super::CredentialOpError::ClientCreation`] carrying `message`. The
+    /// override replaces the default body, so this (not
+    /// [`Self::set_create_client_error`]) models a client-creation failure
+    /// for callers of `uefi_setup`.
+    pub fn set_uefi_setup_client_creation_error(&self, message: impl Into<String>) {
+        self.state.lock().unwrap().uefi_setup_client_creation_error = Some(message.into());
+    }
+
+    /// Let `uefi_setup` succeed again after
+    /// [`Self::set_uefi_setup_client_creation_error`].
+    pub fn clear_uefi_setup_client_creation_error(&self) {
+        self.state.lock().unwrap().uefi_setup_client_creation_error = None;
+    }
+
+    /// Set the BIOS attribute map returned by the sim client's `bios()`,
+    /// which is otherwise unimplemented.
+    pub fn set_bios_attributes(&self, attributes: HashMap<String, serde_json::Value>) {
+        self.state.lock().unwrap().bios_attributes = Some(attributes);
     }
 
     /// Override the `Vendor` reported by `get_service_root`. Set it to an
@@ -904,7 +956,12 @@ impl Redfish for RedfishSimClient {
         &'a self,
     ) -> libredfish::RedfishFuture<'a, Result<HashMap<String, serde_json::Value>, RedfishError>>
     {
-        Box::pin(async move { todo!() })
+        Box::pin(async move {
+            match self.state.lock().unwrap().bios_attributes.clone() {
+                Some(attributes) => Ok(attributes),
+                None => todo!(),
+            }
+        })
     }
 
     fn set_bios<'a>(
@@ -2490,6 +2547,11 @@ impl RedfishClientPool for RedfishSim {
                 host: host.to_string(),
                 vendor,
             });
+            if let Some(error) = state.create_client_error.clone() {
+                return Err(RedfishClientCreationError::RedfishError(
+                    RedfishError::GenericError { error },
+                ));
+            }
             let default_lockdown = state.default_lockdown.unwrap_or(EnabledDisabled::Disabled);
             state
                 .hosts
@@ -2513,16 +2575,26 @@ impl RedfishClientPool for RedfishSim {
     fn credential_reader(&self) -> &dyn CredentialReader {
         &self.credential_manager
     }
+}
 
+impl super::sealed::Sealed for RedfishSim {}
+
+#[async_trait]
+impl super::BmcCredentialOps for RedfishSim {
     async fn uefi_setup(
         &self,
-        _client: &dyn Redfish,
+        _access: &carbide_utils::redfish::BmcAccessInfo,
         dpu: bool,
         _sitewide_uefi_credentials: carbide_secrets::credentials::Credentials,
-    ) -> Result<Option<String>, RedfishClientCreationError> {
-        self.state
-            .lock()
-            .unwrap()
+    ) -> Result<Option<String>, super::CredentialOpError> {
+        let mut state = self.state.lock().unwrap();
+        // Fail before recording the action: the op never reached the device.
+        if let Some(error) = state.uefi_setup_client_creation_error.clone() {
+            return Err(super::CredentialOpError::ClientCreation(
+                RedfishClientCreationError::RedfishError(RedfishError::GenericError { error }),
+            ));
+        }
+        state
             .platform_actions
             .push(RedfishSimPlatformAction::UefiSetup { dpu });
         Ok(None)

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 use bmc_explorer::Product;
 use carbide_ipmi::IPMITool;
 use carbide_redfish::boot_interface::BootInterfaceTarget;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::BmcCredentialOps;
 use carbide_redfish::libredfish::conv::IntoLibredfish;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use carbide_secrets::credentials::{CredentialManager, Credentials};
@@ -92,8 +92,11 @@ pub struct BmcEndpointExplorer {
 }
 
 impl BmcEndpointExplorer {
+    /// `redfish_client_pool` is the direct pool's credential-operations
+    /// handle ([`BmcCredentialOps`]): exploration sets BMC root passwords
+    /// and probes vendors on the endpoint itself.
     pub fn new(
-        redfish_client_pool: Arc<dyn RedfishClientPool>,
+        redfish_client_pool: Arc<dyn BmcCredentialOps>,
         nv_redfish_client_pool: Arc<NvRedfishClientPool>,
         ipmi_tool: Arc<dyn IPMITool>,
         credential_manager: Arc<dyn CredentialManager>,

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -101,7 +101,7 @@ pub mod errors;
 use std::sync::atomic::AtomicBool;
 
 use carbide_ipmi::IPMITool;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::BmcCredentialOps;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use errors::{SiteExplorerError, SiteExplorerResult};
 
@@ -145,8 +145,11 @@ fn should_scan_host_inband_interface_for_redfish(
             && expected_host_bmc_macs.contains(&interface.mac_address))
 }
 
+/// `redfish_client_pool` is the direct pool's credential-operations handle
+/// ([`BmcCredentialOps`]): exploration sets BMC root passwords and probes
+/// vendors on the endpoint itself.
 pub fn new_bmc_explorer(
-    redfish_client_pool: Arc<dyn RedfishClientPool>,
+    redfish_client_pool: Arc<dyn BmcCredentialOps>,
     nv_redfish_client_pool: Arc<NvRedfishClientPool>,
     ipmi_tool: Arc<dyn IPMITool>,
     credential_manager: Arc<dyn CredentialManager>,

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -25,7 +25,7 @@ use carbide_network::deserialize_input_mac_to_address;
 use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_redfish::libredfish::conv::{IntoModel, bmc_vendor};
 use carbide_redfish::libredfish::dpu_bios::is_dpu_bios_attributes_not_ready;
-use carbide_redfish::libredfish::{RedfishAuth, RedfishClientCreationError, RedfishClientPool};
+use carbide_redfish::libredfish::{BmcCredentialOps, RedfishAuth, RedfishClientCreationError};
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use carbide_secrets::credentials::Credentials;
 use libredfish::model::ODataId;
@@ -50,13 +50,13 @@ const BF4_NDF0_TO_BASE_MAC_OFFSET: u64 = 0x10;
 // TODO: In the future, we should refactor a lot of this client's work to api/src/redfish.rs because other components in carbide can utilize this functionality.
 // Eventually, this file should only have code related to generating the site exploration report.
 pub(super) struct RedfishClient {
-    redfish_client_pool: Arc<dyn RedfishClientPool>,
+    redfish_client_pool: Arc<dyn BmcCredentialOps>,
     nv_redfish_client_pool: Arc<NvRedfishClientPool>,
 }
 
 impl RedfishClient {
     pub(super) fn new(
-        redfish_client_pool: Arc<dyn RedfishClientPool>,
+        redfish_client_pool: Arc<dyn BmcCredentialOps>,
         nv_redfish_client_pool: Arc<NvRedfishClientPool>,
     ) -> Self {
         Self {

--- a/crates/switch-controller/src/context.rs
+++ b/crates/switch-controller/src/context.rs
@@ -19,7 +19,7 @@ use std::sync::Arc;
 
 use carbide_credential_rotation::RotationGate;
 use carbide_health_metrics::PerObjectMetricsRegistry;
-use carbide_redfish::libredfish::RedfishClientPool;
+use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::credentials::CredentialManager;
 use component_manager::component_manager::ComponentManager;
 use sqlx::PgPool;
@@ -41,6 +41,12 @@ pub struct SwitchStateHandlerServices {
     /// Libredfish pool used to converge the switch BMC credential. The
     /// same shared instance the machine-controller uses.
     pub redfish_client_pool: Arc<dyn RedfishClientPool>,
+    /// Credential-lifecycle operations (password set/rotate/clear,
+    /// candidate validation). A sealed trait implemented only by the direct
+    /// pool, so handing these to a wrapper pool is a compile error (a
+    /// wrong-pool guard, not a wire-path guarantee -- see
+    /// [`BmcCredentialOps`]).
+    pub bmc_credential_ops: Arc<dyn BmcCredentialOps>,
     /// Short-TTL cache of the site-wide BMC rotation aggregate, shared across
     /// this replica's per-object ticks so the steady state costs one aggregate
     /// query per TTL window rather than a per-device query every sweep.

--- a/crates/switch-controller/src/rotating_bmc.rs
+++ b/crates/switch-controller/src/rotating_bmc.rs
@@ -196,7 +196,7 @@ async fn rotate_switch_bmc(
     match rotate_bmc(
         &services.db_pool,
         services.credential_manager.as_ref(),
-        services.redfish_client_pool.as_ref(),
+        services.bmc_credential_ops.as_ref(),
         &target,
         force,
     )


### PR DESCRIPTION
Adds new trait `BmcCredentialsOps`, and splits it off RedfishClientPool.

Change would enable better type safe control of the token credentials.

## Related issues
#460 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

