### PR TITLE
chore: Fix availability graphs in BMC performance dashboard

### DIFF
--- a/helm/observability/dashboards/nico-bmc-performance.json
+++ b/helm/observability/dashboards/nico-bmc-performance.json
@@ -156,7 +156,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}) / sum(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"})",
+          "expr": "sum(increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}[5m])) / sum(increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"}[5m]))",
           "instant": false,
           "legendFormat": "request success rate",
           "range": true,
@@ -247,7 +247,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(machine_id) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}) / sum by(machine_id) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"})",
+          "expr": "sum by(machine_id) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}[5m])) / sum by(machine_id) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"}[5m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -338,7 +338,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(server_address) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}) / sum by(server_address) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"})",
+          "expr": "sum by(server_address) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}[5m])) / sum by(server_address) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"}[5m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -429,7 +429,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "bottomk(20, sum by(http_path) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}) / sum by(http_path) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"}))",
+          "expr": "bottomk(20, sum by(http_path) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}[5m])) / sum by(http_path) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"}[5m])))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -520,7 +520,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(bmc_vendor, bmc_model) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}) / sum by(bmc_vendor, bmc_model) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"})",
+          "expr": "sum by(bmc_vendor, bmc_model) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code=~\"2.*\"}[5m])) / sum by(bmc_vendor, bmc_model) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\"}[5m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -548,7 +548,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Shows the Redfish requests that are failing",
+      "description": "Shows failing Redfish requests over the last 5 minutes",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -628,7 +628,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"}",
+          "expr": "increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"}[5m])",
           "instant": false,
           "legendFormat": "",
           "range": true,
@@ -643,7 +643,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Shows the Redfish requests that are failing by machine",
+      "description": "Shows failing Redfish requests by machine over the last 5 minutes",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -723,7 +723,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(machine_id) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"})",
+          "expr": "sum by(machine_id) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"}[5m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -738,7 +738,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Shows the Redfish requests that are failing by BMC IP",
+      "description": "Shows failing Redfish requests by BMC IP over the last 5 minutes",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -818,7 +818,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(server_address) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"})",
+          "expr": "sum by(server_address) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"}[5m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -833,7 +833,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Shows the Redfish requests that are failing by path (top 20)",
+      "description": "Shows the 20 paths with the most failing Redfish requests over the last 5 minutes",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -913,7 +913,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "topk(20, sum by(http_path) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"}))",
+          "expr": "topk(20, sum by(http_path) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"}[5m])))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,
@@ -928,7 +928,7 @@
         "type": "prometheus",
         "uid": "${datasource}"
       },
-      "description": "Shows the Redfish requests that are failing by vendor and model",
+      "description": "Shows failing Redfish requests by vendor and model over the last 5 minutes",
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -1008,7 +1008,7 @@
             "uid": "${datasource}"
           },
           "editorMode": "code",
-          "expr": "sum by(bmc_vendor, bmc_model) (${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"})",
+          "expr": "sum by(bmc_vendor, bmc_model) (increase(${metric_prefix}_hardware_health_bmc_latency_ms_count{job=~\"$job\",http_response_status_code!~\"2.*\"}[5m]))",
           "instant": false,
           "legendFormat": "__auto",
           "range": true,


### PR DESCRIPTION
## Related issues

Fixes the availability and error graphs in the BMC performance dashboard to only show increments of errors in 5min intervals instead of an absolute counter.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

