### PR TITLE
patch(v2.1): reconnect to external FMDS on every main-loop iteration

### DIFF
--- a/crates/agent/src/command_line.rs
+++ b/crates/agent/src/command_line.rs
@@ -361,6 +361,15 @@ pub struct RunOptions {
     pub fmds_grpc_server: Option<String>,
     #[clap(
         long,
+        default_value = "3",
+        value_parser = clap::value_parser!(u64).range(1..),
+        help = "Seconds to wait for one connection attempt to --fmds-grpc-server. The agent \
+                reconnects on every main-loop iteration, so this bounds how long an unreachable \
+                FMDS can hold the loop up. Ignored without --fmds-grpc-server."
+    )]
+    pub fmds_connect_timeout_secs: u64,
+    #[clap(
+        long,
         default_value = "container-exec",
         help = "Set the configuration mode for HBN. Specify \"container-exec\" or \"nvue-rest\".",
         env = "HBN_CONFIG_MODE"

--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -16,16 +16,19 @@
  */
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::Duration;
 
 use carbide_host_support::agent_config::MachineIdentityConfig;
-use eyre::eyre;
+use eyre::{WrapErr, eyre};
 use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
+use opentelemetry::metrics::Meter;
 use rpc::fmds::fmds_config_service_client::FmdsConfigServiceClient;
 use rpc::fmds::{
     FmdsConfigUpdate, FmdsMachineIdentityConfig, IbDevice, IbInstance, UpdateConfigRequest,
 };
 use rpc::forge::ManagedHostNetworkConfigResponse;
-use tonic::transport::Channel;
+use tonic::transport::{Channel, Endpoint};
 
 use crate::instance_metadata_endpoint::InstanceMetadataRouterStateImpl;
 use crate::instrumentation::FmdsPush;
@@ -42,7 +45,30 @@ pub enum FmdsUpdater {
     /// External will send FMDS updates to an FMDS server,
     /// which is colocated on the same DPU, possibly in its
     /// own container.
-    External(Box<FmdsGrpcClient>),
+    External {
+        address: String,
+        machine_identity: MachineIdentityConfig,
+        connect_timeout: Duration,
+        last_connect_succeeded: Arc<AtomicBool>,
+    },
+}
+
+pub(super) fn register_external_connection_metric(meter: &Meter) -> Arc<AtomicBool> {
+    let last_connect_succeeded = Arc::new(AtomicBool::new(false));
+    let connection_status = Arc::clone(&last_connect_succeeded);
+    meter
+        .u64_observable_gauge("carbide_dpu_agent_fmds_external_connected")
+        .with_description(
+            "Result of the DPU agent's latest connection attempt to its configured external FMDS (1 for success, 0 before success or after failure)",
+        )
+        .with_callback(move |observer| {
+            observer.observe(
+                u64::from(connection_status.load(Ordering::Relaxed)),
+                &[],
+            )
+        })
+        .build();
+    last_connect_succeeded
 }
 
 impl FmdsUpdater {
@@ -52,20 +78,36 @@ impl FmdsUpdater {
         network_config: Option<Arc<ManagedHostNetworkConfigResponse>>,
     ) {
         match self {
-            FmdsUpdater::Embedded(state) => {
-                state.update_instance_data(instance_data);
-                state.update_network_configuration(network_config);
-            }
-            FmdsUpdater::External(client) => {
-                let result = client.update_config(&instance_data, &network_config).await;
-                match &result {
+            FmdsUpdater::External {
+                address,
+                machine_identity,
+                connect_timeout,
+                last_connect_succeeded,
+            } => {
+                let connection =
+                    FmdsGrpcClient::connect(address, machine_identity.clone(), *connect_timeout)
+                        .await;
+                last_connect_succeeded.store(connection.is_ok(), Ordering::Relaxed);
+
+                let result = match connection {
+                    Ok(mut client) => client.update_config(&instance_data, &network_config).await,
+                    Err(err) => Err(err),
+                };
+
+                // A failed push is dropped: the next main-loop iteration
+                // reconnects and pushes again.
+                match result {
                     Ok(()) => FmdsPush::Succeeded.emit(),
                     Err(err) => FmdsPush::Failed {
                         error: format!("{err:#}"),
-                        fmds_address: client.address.clone(),
+                        fmds_address: address.clone(),
                     }
                     .emit(),
                 }
+            }
+            FmdsUpdater::Embedded(state) => {
+                state.update_instance_data(instance_data);
+                state.update_network_configuration(network_config);
             }
         }
     }
@@ -81,10 +123,17 @@ impl FmdsGrpcClient {
     pub async fn connect(
         address: &str,
         machine_identity: MachineIdentityConfig,
+        connect_timeout: Duration,
     ) -> eyre::Result<Self> {
-        let client = FmdsConfigServiceClient::connect(address.to_string()).await?;
+        let channel = Endpoint::from_shared(address.to_string())
+            .wrap_err_with(|| format!("invalid FMDS address {address}"))?
+            .connect_timeout(connect_timeout)
+            .connect()
+            .await
+            .wrap_err_with(|| format!("failed to connect to FMDS at {address}"))?;
+
         Ok(Self {
-            client,
+            client: FmdsConfigServiceClient::new(channel),
             address: address.to_string(),
             machine_identity,
         })
@@ -163,5 +212,191 @@ impl FmdsGrpcClient {
         );
 
         Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::net::{SocketAddr, TcpListener};
+
+    use config_version::ConfigVersion;
+    use rpc::fmds::UpdateConfigResponse;
+    use rpc::fmds::fmds_config_service_server::{FmdsConfigService, FmdsConfigServiceServer};
+    use tokio::sync::mpsc;
+    use tokio::task::JoinHandle;
+    use tonic::{Request, Response, Status};
+
+    use super::*;
+    /// Minimal FMDS server that records the updates it is sent.
+    struct RecordingFmdsServer {
+        updates: mpsc::UnboundedSender<FmdsConfigUpdate>,
+        reject_updates: bool,
+    }
+
+    #[tonic::async_trait]
+    impl FmdsConfigService for RecordingFmdsServer {
+        async fn update_config(
+            &self,
+            request: Request<UpdateConfigRequest>,
+        ) -> Result<Response<UpdateConfigResponse>, Status> {
+            if self.reject_updates {
+                return Err(Status::internal("test update rejection"));
+            }
+
+            let update = request
+                .into_inner()
+                .config_update
+                .ok_or_else(|| Status::invalid_argument("missing config_update"))?;
+            let _ = self.updates.send(update);
+            Ok(Response::new(UpdateConfigResponse {}))
+        }
+    }
+
+    /// Serves [`RecordingFmdsServer`] on `addr`. The caller owns the returned
+    /// handle and aborts it at the end of the test.
+    fn serve_fmds(
+        addr: SocketAddr,
+        reject_updates: bool,
+    ) -> (JoinHandle<()>, mpsc::UnboundedReceiver<FmdsConfigUpdate>) {
+        let (updates, received) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            tonic::transport::Server::builder()
+                .add_service(FmdsConfigServiceServer::new(RecordingFmdsServer {
+                    updates,
+                    reject_updates,
+                }))
+                .serve(addr)
+                .await
+                .expect("FMDS test server");
+        });
+        (handle, received)
+    }
+
+    /// Picks a free port. The listener is dropped, so the port is unbound when
+    /// this returns and the caller can serve on it.
+    fn free_addr() -> SocketAddr {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+        let addr = listener.local_addr().expect("local_addr");
+        drop(listener);
+        addr
+    }
+
+    /// [`serve_fmds`] binds on a spawned task, so it is not necessarily
+    /// listening when it returns. Waits until it is.
+    async fn wait_until_listening(addr: SocketAddr) {
+        for _ in 0..100 {
+            if tokio::net::TcpStream::connect(addr).await.is_ok() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        panic!("FMDS test server never started listening on {addr}");
+    }
+
+    fn test_instance_metadata() -> InstanceMetadata {
+        InstanceMetadata {
+            address: "192.168.1.1".to_string(),
+            hostname: "test-host".to_string(),
+            sitename: Some("test-site".to_string()),
+            instance_id: None,
+            machine_id: None,
+            user_data: "test-user-data".to_string(),
+            ib_devices: None,
+            config_version: ConfigVersion::initial(),
+            network_config_version: ConfigVersion::initial(),
+            extension_service_version: ConfigVersion::initial(),
+        }
+    }
+
+    fn test_external_updater(address: String) -> (FmdsUpdater, Arc<AtomicBool>) {
+        let last_connect_succeeded = Arc::new(AtomicBool::new(false));
+        (
+            FmdsUpdater::External {
+                address,
+                machine_identity: MachineIdentityConfig::default(),
+                connect_timeout: Duration::from_millis(500),
+                last_connect_succeeded: Arc::clone(&last_connect_succeeded),
+            },
+            last_connect_succeeded,
+        )
+    }
+
+    /// The happy path through [`FmdsUpdater::update`]: it dials the external
+    /// FMDS on every call and the update lands on the server.
+    #[tokio::test]
+    async fn external_updater_connects_and_pushes_every_update() {
+        let addr = free_addr();
+        let (server, mut received) = serve_fmds(addr, false);
+        wait_until_listening(addr).await;
+
+        let (mut updater, _) = test_external_updater(format!("http://{addr}"));
+
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        let update = received.recv().await.expect("server received an update");
+        assert_eq!(update.hostname, "test-host");
+        assert_eq!(update.address, "192.168.1.1");
+        assert!(update.machine_identity.is_some());
+
+        // A second iteration reconnects and pushes again.
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        let update = received
+            .recv()
+            .await
+            .expect("server received the second update");
+        assert_eq!(update.hostname, "test-host");
+
+        server.abort();
+    }
+
+    #[tokio::test]
+    async fn external_updater_reports_connection_when_update_is_rejected() {
+        let addr = free_addr();
+        let (server, _) = serve_fmds(addr, true);
+        wait_until_listening(addr).await;
+
+        let (mut updater, last_connect_succeeded) = test_external_updater(format!("http://{addr}"));
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        assert!(last_connect_succeeded.load(Ordering::Relaxed));
+
+        server.abort();
+    }
+
+    /// The recovery this change exists for: an FMDS that is down when the agent
+    /// starts is picked up by a later iteration, instead of the agent degrading
+    /// for its whole lifetime.
+    #[tokio::test]
+    async fn external_updater_recovers_once_fmds_comes_up() {
+        let addr = free_addr();
+        let (mut updater, last_connect_succeeded) = test_external_updater(format!("http://{addr}"));
+        last_connect_succeeded.store(true, Ordering::Relaxed);
+
+        // Nothing is listening yet. The push fails and is dropped, but the
+        // updater stays usable rather than latching onto a degraded mode.
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+        assert!(!last_connect_succeeded.load(Ordering::Relaxed));
+
+        // FMDS shows up, and the next iteration reaches it.
+        let (server, mut received) = serve_fmds(addr, false);
+        wait_until_listening(addr).await;
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+        assert!(last_connect_succeeded.load(Ordering::Relaxed));
+
+        let update = received.recv().await.expect("server received an update");
+        assert_eq!(update.hostname, "test-host");
+
+        server.abort();
     }
 }

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -52,7 +52,7 @@ use crate::duppet::{SummaryFormat, SyncOptions};
 use crate::ethernet_virtualization::{
     InterfaceTranslationMode, NvueClientContext, NvueUpdateFlavor, ServiceAddresses,
 };
-use crate::fmds_client::FmdsUpdater;
+use crate::fmds_client::{FmdsUpdater, register_external_connection_metric};
 use crate::health::HealthCheckParams;
 use crate::host_machine_id::get_host_machine_id_retry;
 use crate::instrumentation::{
@@ -173,34 +173,13 @@ pub async fn setup_and_run(
             fmds_address = fmds_addr,
             "Using FmdsUpdater::External FMDS service"
         );
-        let updater = match crate::fmds_client::FmdsGrpcClient::connect(
-            fmds_addr,
-            agent_config.machine_identity.clone(),
-        )
-        .await
-        {
-            Ok(fmds_client) => FmdsUpdater::External(Box::new(fmds_client)),
-            Err(e) => {
-                tracing::warn!(
-                    error = format!("{e:#}"),
-                    "Failed to connect to external FMDS service, falling back to embedded"
-                );
-                FmdsUpdater::Embedded(instance_metadata_state.clone())
-            }
-        };
-        // External FMDS was configured: expose whether we reached it (1) or fell
-        // back to embedded (0). A gauge, not a counter -- the fallback is decided
-        // once at startup, so a single pre-scrape counter bump would be invisible
-        // to rate()/increase(); a gauge reports the state at every scrape.
-        let reached_external = matches!(updater, FmdsUpdater::External(_));
-        get_dpu_agent_meter()
-            .u64_observable_gauge("carbide_dpu_agent_fmds_external_connected")
-            .with_description(
-                "Whether the DPU agent reached its configured external FMDS (1) or fell back to embedded (0)",
-            )
-            .with_callback(move |observer| observer.observe(reached_external as u64, &[]))
-            .build();
-        updater
+        let last_connect_succeeded = register_external_connection_metric(&get_dpu_agent_meter());
+        FmdsUpdater::External {
+            address: fmds_addr.clone(),
+            machine_identity: agent_config.machine_identity.clone(),
+            connect_timeout: Duration::from_secs(options.fmds_connect_timeout_secs),
+            last_connect_succeeded,
+        }
     } else {
         if options.enable_metadata_service {
             crate::metadata_service::spawn_metadata_service(

--- a/crates/agent/src/tests/common/mod.rs
+++ b/crates/agent/src/tests/common/mod.rs
@@ -120,6 +120,7 @@ pub fn setup_agent_run_env(
             skip_upgrade_check: false,
             dhcp_grpc_server: None,
             fmds_grpc_server: None,
+            fmds_connect_timeout_secs: 3,
             hbn_config_mode: crate::command_line::HbnConfigMode::ContainerExec,
             agent_platform_type: crate::command_line::AgentPlatformType::DpuOs,
             dhcp_server_interface_prepend: None,

--- a/crates/agent/src/tests/fixtures/metrics.txt
+++ b/crates/agent/src/tests/fixtures/metrics.txt
@@ -1,6 +1,9 @@
 # HELP agent_start_time_seconds Timestamp of the agent process's last start
 # TYPE agent_start_time_seconds gauge
 agent_start_time_seconds 1740171801
+# HELP carbide_dpu_agent_fmds_external_connected Result of the DPU agent's latest connection attempt to its configured external FMDS (1 for success, 0 before success or after failure)
+# TYPE carbide_dpu_agent_fmds_external_connected gauge
+carbide_dpu_agent_fmds_external_connected 1
 # HELP client_cert_expiry_time_seconds Timestamp when the agent's TLS client certificate expires
 # TYPE client_cert_expiry_time_seconds gauge
 client_cert_expiry_time_seconds 1742763762

--- a/crates/agent/src/tests/metrics.rs
+++ b/crates/agent/src/tests/metrics.rs
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use opentelemetry::metrics::MeterProvider;
 use prometheus::{Encoder, TextEncoder};
 
+use crate::fmds_client::register_external_connection_metric;
 use crate::instrumentation::NetworkMonitorMetricsState;
 use crate::network_monitor::NetworkMonitorError;
 
@@ -38,6 +40,8 @@ fn test_metrics() {
     let meter = meter_provider.meter("agent");
 
     let metrics = crate::instrumentation::create_metrics(meter.clone());
+    let fmds_connection_status = register_external_connection_metric(&meter);
+    fmds_connection_status.store(true, Ordering::Relaxed);
     metrics.record_machine_boot_time(1740171762);
     metrics.record_agent_start_time(1740171801);
     metrics.record_client_cert_expiry_time(|| Some(1742763762));


### PR DESCRIPTION
Backports `6cbe263bb` from #4989 to `release/v2.1`.

If external FMDS is unavailable when the DPU agent starts, the release selects an embedded updater for the rest of the process. That updater stores metadata in memory, but no embedded metadata service is started when `--fmds-grpc-server` is configured, so the agent cannot recover when FMDS becomes available.

Keep the external FMDS connection parameters in `FmdsUpdater` and reconnect before each update. A failed connection is retried on the next main-loop iteration. Preserve the existing `carbide_dpu_agent_fmds_external_connected` gauge as the result of the latest completed connection attempt, and adapt the upstream tests to v2.1's single-address metadata fields.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5653

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-agent fmds_client` covers repeated updates, recovery after a failed connection, and a successful connection followed by a rejected update RPC.
- `cargo test -p carbide-agent tests::metrics::test_metrics` verifies the exact gauge name, description, type, and observed value.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable tree. The Codex self-review then completed a bounded closure review after the one adopted test change.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 1 | 0 | 1 |
| Claude CLI | 8 | 0 | 8 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **10** | **1** | **9** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted (initial)** -- `crates/agent/src/fmds_client.rs`: The tests did not separate a successful connection from a rejected update RPC. **Resolution:** Added a rejecting server case that verifies the connection state remains `1` after the RPC fails.

### CodeRabbit CLI

1. **Declined** -- `crates/agent/src/fmds_client.rs`: Add timeouts around the test channel receives. **Reason:** This is general hardening of the tests already merged in #4989, not a v2.1 compatibility defect; the focused tests complete normally.

### Claude CLI

1. **Declined** -- `crates/agent/src/command_line.rs`: Narrow the connect-timeout help text and add an RPC timeout. **Reason:** The backport preserves the upstream CLI contract; changing its wording or timeout behavior belongs on `main`.
2. **Declined** -- `crates/agent/src/fmds_client.rs`: Reconsider whether the restored connection gauge is still needed. **Reason:** The gauge is an existing v2.1 operator contract, and its removal was accidental.
3. **Declined** -- `crates/agent/src/fmds_client.rs`: Move metric registration into `instrumentation.rs` and introduce a named state type. **Reason:** The base branch already registered this gauge outside `instrumentation.rs`; that refactor would widen the backport.
4. **Declined** -- `crates/agent/src/fmds_client.rs`: Reformat the observable callback. **Reason:** `cargo make format-nightly` completed cleanly and retained the current formatting.
5. **Declined** -- `crates/agent/src/command_line.rs`: Replace the upstream timeout option with a constant. **Reason:** That would make the v2.1 backport diverge from the merged source interface.
6. **Declined** -- `crates/agent/src/fmds_client.rs`: Skip the FMDS connection when instance metadata is absent. **Reason:** That changes the reconnect behavior merged in #4989 and is outside this backport.
7. **Declined** -- `crates/agent/src/fmds_client.rs`: Rework the test server to bind its listener before spawning. **Reason:** This is upstream test hardening unrelated to the v2.1 compatibility change.
8. **Declined** -- `crates/agent/src/fmds_client.rs`: Validate the FMDS URI at argument parsing time. **Reason:** That changes upstream failure handling and is outside this backport.

### common-nits-reviewer

No findings.

</details>

Closes #5653
