### PR TITLE
fix(ssh-console): handle silent Lenovo SOL activation

### DIFF
--- a/crates/machine-a-tron/src/mock_ssh_server.rs
+++ b/crates/machine-a-tron/src/mock_ssh_server.rs
@@ -17,6 +17,7 @@
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::result::Result as StdResult;
 use std::sync::Arc;
+use std::time::Duration;
 
 use bmc_mock::HostnameQuerying;
 use eyre::Context;
@@ -331,12 +332,13 @@ impl server::Handler for MockSshHandler {
             ConsoleState::Bmc => {
                 if data == b"\n" || data == b"\r\n" || data == b"\r" {
                     let command = std::mem::take(&mut self.buffer);
-                    match self.prompt_behavior {
+                    let print_prompt = match self.prompt_behavior {
                         PromptBehavior::Dell if command.starts_with(b"connect com2") => {
                             tracing::info!(
                                 "Got `connect com2` in bmc prompt, simulating system console"
                             );
                             self.console_state = ConsoleState::SystemConsole;
+                            true
                         }
                         PromptBehavior::LenovoSr650 if command.starts_with(b"console kill 1") => {
                             tracing::info!(
@@ -346,24 +348,37 @@ impl server::Handler for MockSshHandler {
                                 channel,
                                 "\r\nThe command line contains extraneous arguments\r\n",
                             )?;
+                            // Model the fragmented XCC3 response seen in production: the error
+                            // text and trailing BMC prompt arrive in separate SSH packets.
+                            tokio::time::sleep(Duration::from_millis(100)).await;
+                            true
                         }
                         PromptBehavior::LenovoSr650 if command.starts_with(b"console kill") => {
                             tracing::info!(
                                 "Got Lenovo `console kill`, simulating terminated SOL session"
                             );
                             session.data(channel, "\r\nSession on channel 1 is terminated\r\n")?;
+                            true
                         }
                         PromptBehavior::LenovoSr650 if command.starts_with(b"console start") => {
-                            tracing::info!("Got Lenovo `console start`, simulating system console");
+                            tracing::info!(
+                                "Got Lenovo `console start`, simulating silent system console"
+                            );
                             self.console_state = ConsoleState::SystemConsole;
+                            // XCC3 emits no success message after `console start`. The host prompt
+                            // appears only after the connected frontend sends input.
+                            false
                         }
                         PromptBehavior::Hpe if command.starts_with(b"vsp") => {
                             tracing::info!("Got HPE `vsp`, simulating system console");
                             self.console_state = ConsoleState::SystemConsole;
+                            true
                         }
-                        _ => {}
+                        _ => true,
+                    };
+                    if print_prompt {
+                        self.print_prompt(session, channel)?;
                     }
-                    self.print_prompt(session, channel)?;
                 } else {
                     self.buffer = [&self.buffer, data].concat();
                     session.data(channel, data.to_owned())?;

--- a/crates/ssh-console/src/bmc/connection_impl/ssh.rs
+++ b/crates/ssh-console/src/bmc/connection_impl/ssh.rs
@@ -45,6 +45,7 @@ use crate::bmc::vendor::SshBmcVendor;
 
 static RUSSH_CLIENT_CONFIG: LazyLock<Arc<russh::client::Config>> =
     LazyLock::new(russh_client_config);
+const LENOVO_SOL_ACTIVATION_RESPONSE_GRACE: Duration = Duration::from_secs(2);
 
 /// Connect to a BMC one time, returning a [`Handle`]. Will not retry on connection errors.
 pub(in crate::bmc) async fn spawn(
@@ -241,6 +242,8 @@ pub(in crate::bmc) enum ConsoleActivateError {
     },
     #[error("unable to activate serial console after timeout")]
     Timeout,
+    #[error("BMC returned to its command prompt while activating serial console")]
+    ReturnedToBmcPrompt,
 }
 
 /// Builds and authenticates an SSH client to a machine, using credentials from carbide-api or
@@ -452,12 +455,29 @@ async fn trigger_and_await_sol_console(
     let mut fallback_activate_sent = false;
     let mut fallback_activate_commands: Option<&'static [&'static [u8]]> = None;
     let mut next_fallback_command_index = 0;
+    let mut lenovo_confirmation_pending = false;
+    let mut lenovo_confirmation_deadline = timeout;
+    let mut lenovo_confirmation_command: Option<&'static [u8]> = None;
 
     let mut activation_step = SerialConsoleActivationStep::WaitingForBmcPrompt;
     loop {
         tokio::select! {
             _ = tokio::time::sleep_until(timeout) => {
                 return Err(ConsoleActivateError::Timeout);
+            }
+            _ = tokio::time::sleep_until(lenovo_confirmation_deadline), if lenovo_confirmation_pending => {
+                let confirmation_command = lenovo_confirmation_command
+                    .expect("BUG: pending Lenovo confirmation must have a command");
+                let activation_output = output_after_last_command(&prompt_buf, confirmation_command)
+                    .expect("BUG: pending Lenovo confirmation command must be in output");
+                if activation_output
+                    .windows(bmc_prompt.len())
+                    .any(|window| window == bmc_prompt)
+                {
+                    return Err(ConsoleActivateError::ReturnedToBmcPrompt);
+                }
+                tracing::debug!(%machine_id, "Lenovo activation response grace period elapsed without a BMC prompt, letting client use console");
+                break;
             }
             res = ssh_client_channel.wait() => {
                 let Some(msg) = res else {
@@ -504,6 +524,8 @@ async fn trigger_and_await_sol_console(
                             fallback_activate_sent = true;
                             fallback_activate_commands = Some(fallback_commands);
                             next_fallback_command_index = 0;
+                            lenovo_confirmation_pending = false;
+                            lenovo_confirmation_command = None;
                             let fallback_command = fallback_commands[next_fallback_command_index];
                             next_fallback_command_index += 1;
                             skip_data_read_len = bmc_prompt.len() + fallback_command.len();
@@ -525,6 +547,8 @@ async fn trigger_and_await_sol_console(
                         {
                             let fallback_command = fallback_commands[next_fallback_command_index];
                             next_fallback_command_index += 1;
+                            lenovo_confirmation_pending = false;
+                            lenovo_confirmation_command = None;
                             skip_data_read_len = bmc_prompt.len() + fallback_command.len();
                             timeout = tokio::time::Instant::now() + std::time::Duration::from_secs(30);
                             send_command_bytewise(
@@ -540,30 +564,42 @@ async fn trigger_and_await_sol_console(
                             .is_some_and(|commands| next_fallback_command_index < commands.len());
                         let fallback_sequence_complete = fallback_activate_commands
                             .is_some_and(|commands| next_fallback_command_index == commands.len());
-                        let activation_output = if fallback_sequence_complete
+                        let final_activation_command = if fallback_sequence_complete
                             && let Some(fallback_commands) = fallback_activate_commands
                         {
-                            let final_fallback_command = fallback_commands[fallback_commands.len() - 1];
-                            prompt_buf
-                                .windows(final_fallback_command.len())
-                                .rposition(|window| window == final_fallback_command)
-                                .map(|command_offset| &prompt_buf[command_offset..])
+                            fallback_commands[fallback_commands.len() - 1]
+                        } else {
+                            activate_command
+                        };
+                        let activation_output = if matches!(bmc_vendor, SshBmcVendor::Lenovo) {
+                            output_after_last_command(&prompt_buf, final_activation_command)
                         } else {
                             Some(prompt_buf.as_slice())
                         };
                         if matches!(activation_step, SerialConsoleActivationStep::ActivateSent)
                             && !waiting_for_fallback_prompt
                             && let Some(activation_output) = activation_output
-                            && !(fallback_sequence_complete
-                                && activation_output
+                        {
+                            if matches!(bmc_vendor, SshBmcVendor::Lenovo) {
+                                if activation_output
                                     .windows(bmc_prompt.len())
-                                    .any(|window| window == bmc_prompt))
-                            && bmc_vendor.should_accept_sol_activation_output(
+                                    .any(|window| window == bmc_prompt)
+                                {
+                                    return Err(ConsoleActivateError::ReturnedToBmcPrompt);
+                                }
+                                if !lenovo_confirmation_pending {
+                                    lenovo_confirmation_pending = true;
+                                    lenovo_confirmation_deadline = tokio::time::Instant::now()
+                                        + LENOVO_SOL_ACTIVATION_RESPONSE_GRACE;
+                                    lenovo_confirmation_command = Some(final_activation_command);
+                                }
+                            } else if bmc_vendor.should_accept_sol_activation_output(
                                 activation_output,
                                 skip_data_read_len,
                             ) {
-                            tracing::debug!(%machine_id, "confirmed serial activate command sent, letting client use console");
-                            break;
+                                tracing::debug!(%machine_id, "confirmed serial activate command sent, letting client use console");
+                                break;
+                            }
                         }
                     }
                     msg => {
@@ -579,6 +615,21 @@ async fn trigger_and_await_sol_console(
     }
 
     Ok(())
+}
+
+/// Return the output beginning at the last echo of the final command in a command sequence.
+///
+/// Lenovo's legacy activation sequence contains two newline-separated commands. Ignoring output
+/// before the final command lets the expected prompt after `console kill 1` coexist with a
+/// successful, silent `console 1` transition.
+fn output_after_last_command<'a>(output: &'a [u8], command_sequence: &[u8]) -> Option<&'a [u8]> {
+    let final_command = command_sequence
+        .rsplit(|byte| *byte == b'\n')
+        .find(|command| !command.is_empty())?;
+    output
+        .windows(final_command.len())
+        .rposition(|window| window == final_command)
+        .map(|command_offset| &output[command_offset..])
 }
 
 struct Handler;
@@ -697,6 +748,31 @@ fn test_ringbuf_contains() {
     assert!(ringbuf_contains(&rb, b"")); // empty always true
     assert!(!ringbuf_contains(&rb, b"rustacean")); // longer than buf
     assert!(!ringbuf_contains(&rb, b"aean")); // non-contiguous
+}
+
+#[test]
+fn output_after_last_command_uses_final_command_echo() {
+    assert_eq!(
+        output_after_last_command(
+            b"console kill 1\r\nsystem> console 1\r\n",
+            b"console kill 1\nconsole 1",
+        ),
+        Some(b"console 1\r\n".as_slice()),
+    );
+    assert_eq!(
+        output_after_last_command(
+            b"stale console start\r\nsystem> console start\r\n",
+            b"console start",
+        ),
+        Some(b"console start\r\n".as_slice()),
+    );
+    assert_eq!(
+        output_after_last_command(
+            b"console kill 1\r\nThe command line contains extraneous arguments\r\n",
+            b"console kill 1\nconsole 1",
+        ),
+        None,
+    );
 }
 
 #[derive(Clone)]

--- a/crates/ssh-console/src/bmc/vendor.rs
+++ b/crates/ssh-console/src/bmc/vendor.rs
@@ -195,9 +195,11 @@ impl SshBmcVendor {
         prompt_buf: &[u8],
         skip_data_read_len: usize,
     ) -> bool {
-        let lenovo_failure_pending = matches!(self, SshBmcVendor::Lenovo)
-            && bytes_contains(prompt_buf, LENOVO_SOL_PRIMARY_FAILURE);
-        !lenovo_failure_pending && prompt_buf.len() > skip_data_read_len
+        // Lenovo command failures can arrive in multiple SSH packets. Do not accept a Lenovo
+        // activation based on byte count because a partial failure response can look successful
+        // until the trailing BMC prompt arrives. The SSH connection implementation confirms
+        // Lenovo activation after a short response grace period instead.
+        !matches!(self, SshBmcVendor::Lenovo) && prompt_buf.len() > skip_data_read_len
     }
 
     pub fn filter_escape_sequences<'a>(
@@ -648,12 +650,12 @@ mod tests {
                 } => false,
             }
 
-            "Lenovo fallback start succeeds by byte count" {
+            "Lenovo fallback waits for delayed confirmation" {
                 AcceptActivationCase {
                     vendor: SshBmcVendor::Lenovo,
                     output: b"console start\r\nroot@host # ",
                     skip_data_read_len: lenovo_start_skip_len,
-                } => true,
+                } => false,
             }
 
             "non-Lenovo activation still succeeds by byte count" {


### PR DESCRIPTION
Lenovo XCC3 can split a failed SOL activation response across multiple SSH
packets. The current implementation can see the initial error text, satisfy its
byte-count check, and declare activation successful before the trailing
`system>` prompt arrives.

The SR650 V4 fallback has the opposite problem: a successful `console start`
can transition into SOL without emitting any response. Waiting for positive
output therefore times out even though the console is active.

This change:

- stops accepting Lenovo activation based only on received byte count
- evaluates output after the final command in each Lenovo activation sequence
- treats a returned `system>` prompt as activation failure
- accepts a silent activation after a short response grace period
- preserves the legacy Lenovo command sequence and SR650 V4 fallback
- leaves activation handling for other BMC vendors unchanged
- updates the SSH mock to reproduce fragmented XCC3 failure output and silent
  `console start` success

## Related issues

Follow-up to #2919 and #2943.

Related to #5173, but this does not address the separate XCC firmware condition
where an SOL channel remains stuck in `In Progress`.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Validation will include:

- `cargo +nightly-2026-06-16 fmt --all -- --check`
- focused Lenovo fallback integration testing
- the complete `carbide-ssh-console` test suite
- `cargo clippy -p carbide-ssh-console --all-targets -- -D warnings`
- `cargo make --no-workspace clippy-flow`

## Additional Notes

The same behavior was backported to the exact deployed v2.0.2 source and tested
using the pinned v2.0.2 Linux build container. Its focused Lenovo integration
test, SSH-console integration suite, formatting, clippy, full-workspace release
build, and production-runtime image checks passed.

Live Lenovo XCC3 validation has not yet been performed with the patched image.
