### PR TITLE
test(instrument): tolerate histogram sum rounding

### DIFF
--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -1129,7 +1129,7 @@ mod http_request_tests {
         EventObservation {
             request_delta: metrics.counter_delta(REQUEST_METRIC, &[]),
             latency_count_delta: metrics.histogram_count_delta(LATENCY_METRIC, &[]),
-            latency_sum_delta: ApproxHistogramSum(metrics.histogram_sum_delta(LATENCY_METRIC, &[])),
+            latency_sum_delta: metrics.histogram_sum_delta(LATENCY_METRIC, &[]),
             logs,
         }
     }

--- a/crates/agent/src/instrumentation.rs
+++ b/crates/agent/src/instrumentation.rs
@@ -1068,7 +1068,9 @@ mod http_request_tests {
     use axum::http::{Request as HttpRequest, StatusCode};
     use axum::routing::get;
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{
+        ApproxHistogramSum, CapturedFieldKind, MetricsCapture, capture_logs,
+    };
     use carbide_test_support::{Check, check_values};
     use tower::ServiceExt;
 
@@ -1086,7 +1088,7 @@ mod http_request_tests {
     struct EventObservation {
         request_delta: f64,
         latency_count_delta: u64,
-        latency_sum_delta: f64,
+        latency_sum_delta: ApproxHistogramSum,
         logs: Vec<LogObservation>,
     }
 
@@ -1127,7 +1129,7 @@ mod http_request_tests {
         EventObservation {
             request_delta: metrics.counter_delta(REQUEST_METRIC, &[]),
             latency_count_delta: metrics.histogram_count_delta(LATENCY_METRIC, &[]),
-            latency_sum_delta: metrics.histogram_sum_delta(LATENCY_METRIC, &[]),
+            latency_sum_delta: ApproxHistogramSum(metrics.histogram_sum_delta(LATENCY_METRIC, &[])),
             logs,
         }
     }
@@ -1142,7 +1144,7 @@ mod http_request_tests {
                     expect: EventObservation {
                         request_delta: 1.0,
                         latency_count_delta: 0,
-                        latency_sum_delta: 0.0,
+                        latency_sum_delta: ApproxHistogramSum(0.0),
                         logs: vec![LogObservation {
                             metadata_name: "dpu_agent_http_request_started".to_string(),
                             level: tracing::Level::INFO,
@@ -1168,7 +1170,7 @@ mod http_request_tests {
                     expect: EventObservation {
                         request_delta: 0.0,
                         latency_count_delta: 1,
-                        latency_sum_delta: 12.5,
+                        latency_sum_delta: ApproxHistogramSum(12.5),
                         logs: vec![LogObservation {
                             metadata_name: "dpu_agent_http_response_generated".to_string(),
                             level: tracing::Level::INFO,

--- a/crates/api-core/src/measured_boot/metrics_collector/mod.rs
+++ b/crates/api-core/src/measured_boot/metrics_collector/mod.rs
@@ -239,7 +239,7 @@ fn get_bundle_state(
 
 #[cfg(test)]
 mod tests {
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
     use super::*;
@@ -272,7 +272,7 @@ mod tests {
             log_count: usize,
             log: Option<LogObservation>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         const METRIC_NAME: &str = "carbide_measured_boot_collector_iteration_latency_milliseconds";
@@ -291,7 +291,7 @@ mod tests {
                         log_count: 0,
                         log: None,
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 1500.0,
+                        histogram_sum_delta: ApproxHistogramSum(1500.0),
                     },
                 },
                 Check {
@@ -314,7 +314,7 @@ mod tests {
                             error: Some("database unavailable".to_string()),
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 250.0,
+                        histogram_sum_delta: ApproxHistogramSum(250.0),
                     },
                 },
             ],
@@ -347,8 +347,9 @@ mod tests {
                     log,
                     histogram_count_delta: metrics
                         .histogram_count_delta(METRIC_NAME, &[("outcome", outcome_label)]),
-                    histogram_sum_delta: metrics
-                        .histogram_sum_delta(METRIC_NAME, &[("outcome", outcome_label)]),
+                    histogram_sum_delta: ApproxHistogramSum(
+                        metrics.histogram_sum_delta(METRIC_NAME, &[("outcome", outcome_label)]),
+                    ),
                 }
             },
         );

--- a/crates/api-core/src/measured_boot/metrics_collector/mod.rs
+++ b/crates/api-core/src/measured_boot/metrics_collector/mod.rs
@@ -347,9 +347,8 @@ mod tests {
                     log,
                     histogram_count_delta: metrics
                         .histogram_count_delta(METRIC_NAME, &[("outcome", outcome_label)]),
-                    histogram_sum_delta: ApproxHistogramSum(
-                        metrics.histogram_sum_delta(METRIC_NAME, &[("outcome", outcome_label)]),
-                    ),
+                    histogram_sum_delta: metrics
+                        .histogram_sum_delta(METRIC_NAME, &[("outcome", outcome_label)]),
                 }
             },
         );

--- a/crates/bmc-proxy/src/metrics.rs
+++ b/crates/bmc-proxy/src/metrics.rs
@@ -288,7 +288,7 @@ mod tests {
     use std::time::Duration;
 
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values, value_scenarios};
     use opentelemetry::StringValue;
     use tokio::time::timeout;
@@ -741,9 +741,10 @@ mod tests {
             "carbide_bmc_proxy_upstream_request_duration_milliseconds",
             &[("method", "patch"), ("status", "http5xx")],
         );
-        assert!(
-            (sum - 2000.0).abs() < 1e-9,
-            "1500ms + 500ms record as milliseconds, got {sum}"
+        assert_eq!(
+            sum,
+            ApproxHistogramSum(2000.0),
+            "1500ms + 500ms record as milliseconds"
         );
         assert_eq!(
             metrics.histogram_count_delta(

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -1159,10 +1159,10 @@ mod tests {
                         "carbide_dns_request_duration_milliseconds",
                         &[("qtype", qtype_label), ("rcode", rcode_label)],
                     ),
-                    histogram_sum: ApproxHistogramSum(metrics.histogram_sum_delta(
+                    histogram_sum: metrics.histogram_sum_delta(
                         "carbide_dns_request_duration_milliseconds",
                         &[("qtype", qtype_label), ("rcode", rcode_label)],
-                    )),
+                    ),
                 }
             },
         );

--- a/crates/dns/src/lib.rs
+++ b/crates/dns/src/lib.rs
@@ -1004,7 +1004,9 @@ mod tests {
     /// details kept as native structured values.
     #[test]
     fn dns_request_completed_pairs_its_histogram_and_log() {
-        use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+        use carbide_instrument::testing::{
+            ApproxHistogramSum, CapturedFieldKind, MetricsCapture, capture_logs,
+        };
         use carbide_test_support::{Check, check_values};
 
         struct RequestCompletedCase {
@@ -1035,7 +1037,7 @@ mod tests {
             record_count_kind: Option<CapturedFieldKind>,
             duration_milliseconds_kind: Option<CapturedFieldKind>,
             histogram_count: u64,
-            histogram_sum: f64,
+            histogram_sum: ApproxHistogramSum,
         }
 
         check_values(
@@ -1068,7 +1070,7 @@ mod tests {
                         record_count_kind: Some(CapturedFieldKind::I64),
                         duration_milliseconds_kind: Some(CapturedFieldKind::F64),
                         histogram_count: 1,
-                        histogram_sum: 250.0,
+                        histogram_sum: ApproxHistogramSum(250.0),
                     },
                 },
                 Check {
@@ -1099,7 +1101,7 @@ mod tests {
                         record_count_kind: Some(CapturedFieldKind::I64),
                         duration_milliseconds_kind: Some(CapturedFieldKind::F64),
                         histogram_count: 1,
-                        histogram_sum: 1_500.0,
+                        histogram_sum: ApproxHistogramSum(1_500.0),
                     },
                 },
             ],
@@ -1157,10 +1159,10 @@ mod tests {
                         "carbide_dns_request_duration_milliseconds",
                         &[("qtype", qtype_label), ("rcode", rcode_label)],
                     ),
-                    histogram_sum: metrics.histogram_sum_delta(
+                    histogram_sum: ApproxHistogramSum(metrics.histogram_sum_delta(
                         "carbide_dns_request_duration_milliseconds",
                         &[("qtype", qtype_label), ("rcode", rcode_label)],
-                    ),
+                    )),
                 }
             },
         );

--- a/crates/dpa-manager/src/metrics.rs
+++ b/crates/dpa-manager/src/metrics.rs
@@ -227,9 +227,7 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: ApproxHistogramSum(
-                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
-                    ),
+                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
                 }
             };
             "successful iteration stays silent" {

--- a/crates/dpa-manager/src/metrics.rs
+++ b/crates/dpa-manager/src/metrics.rs
@@ -169,7 +169,7 @@ impl DpaMonitorInstruments {
 #[cfg(test)]
 mod tests {
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::value_scenarios;
 
     use super::*;
@@ -198,7 +198,7 @@ mod tests {
             log_count: usize,
             log: Option<LogObservation>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         value_scenarios!(
@@ -227,7 +227,9 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    histogram_sum_delta: ApproxHistogramSum(
+                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    ),
                 }
             };
             "successful iteration stays silent" {
@@ -238,7 +240,7 @@ mod tests {
                     log_count: 0,
                     log: None,
                     histogram_count_delta: 1,
-                    histogram_sum_delta: 125.0,
+                    histogram_sum_delta: ApproxHistogramSum(125.0),
                 },
             }
             "fractional milliseconds remain precise" {
@@ -249,7 +251,7 @@ mod tests {
                     log_count: 0,
                     log: None,
                     histogram_count_delta: 1,
-                    histogram_sum_delta: 125.5,
+                    histogram_sum_delta: ApproxHistogramSum(125.5),
                 },
             }
             "failed iteration retains the warning" {
@@ -267,7 +269,7 @@ mod tests {
                         error: Some("simulated iteration failure".to_string()),
                     }),
                     histogram_count_delta: 1,
-                    histogram_sum_delta: 375.0,
+                    histogram_sum_delta: ApproxHistogramSum(375.0),
                 },
             }
         );

--- a/crates/dpa/src/metrics.rs
+++ b/crates/dpa/src/metrics.rs
@@ -156,9 +156,7 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: ApproxHistogramSum(
-                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
-                    ),
+                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
                 }
             };
             "MQTT queue accepted the command" {

--- a/crates/dpa/src/metrics.rs
+++ b/crates/dpa/src/metrics.rs
@@ -75,7 +75,9 @@ pub(crate) struct DpaCommandSendFailed {
 #[cfg(test)]
 mod tests {
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{
+        ApproxHistogramSum, CapturedFieldKind, MetricsCapture, capture_logs,
+    };
     use carbide_test_support::value_scenarios;
 
     use super::*;
@@ -111,7 +113,7 @@ mod tests {
         log_count: usize,
         log: Option<LogObservation>,
         histogram_count_delta: u64,
-        histogram_sum_delta: f64,
+        histogram_sum_delta: ApproxHistogramSum,
     }
 
     #[test]
@@ -154,7 +156,9 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    histogram_sum_delta: ApproxHistogramSum(
+                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    ),
                 }
             };
             "MQTT queue accepted the command" {
@@ -178,7 +182,7 @@ mod tests {
                         topic_kind: None,
                     }),
                     histogram_count_delta: 1,
-                    histogram_sum_delta: 12.5,
+                    histogram_sum_delta: ApproxHistogramSum(12.5),
                 },
             }
             "MQTT queue rejected the command" {
@@ -202,7 +206,7 @@ mod tests {
                         topic_kind: Some(CapturedFieldKind::Debug),
                     }),
                     histogram_count_delta: 1,
-                    histogram_sum_delta: 375.0,
+                    histogram_sum_delta: ApproxHistogramSum(375.0),
                 },
             }
         );

--- a/crates/firmware/src/tests/downloader.rs
+++ b/crates/firmware/src/tests/downloader.rs
@@ -18,7 +18,7 @@
 use std::path::Path;
 use std::time::Duration;
 
-use carbide_instrument::testing::{CapturedLog, MetricsCapture, capture_logs};
+use carbide_instrument::testing::{ApproxHistogramSum, CapturedLog, MetricsCapture, capture_logs};
 use carbide_instrument::{LabelValue, emit};
 use carbide_test_support::{Check, check_values};
 use sha2::Digest;
@@ -512,9 +512,10 @@ fn download_finished_records_duration_and_owns_the_completion_line() {
             "one observation under outcome={outcome}",
         );
         let sum = metrics.histogram_sum_delta(DOWNLOAD_DURATION_METRIC, &[("outcome", outcome)]);
-        assert!(
-            (sum - seconds).abs() < 1e-9,
-            "outcome={outcome} records {seconds}s, got {sum}"
+        assert_eq!(
+            sum,
+            ApproxHistogramSum(seconds),
+            "outcome={outcome} records {seconds}s"
         );
     }
 }

--- a/crates/fmds/src/http_request_metrics.rs
+++ b/crates/fmds/src/http_request_metrics.rs
@@ -147,7 +147,9 @@ mod tests {
     use axum::body::Body;
     use axum::http::{Request as HttpRequest, StatusCode};
     use axum::routing::get;
-    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{
+        ApproxHistogramSum, CapturedFieldKind, MetricsCapture, capture_logs,
+    };
     use carbide_test_support::{Check, check_values};
     use tower::ServiceExt;
 
@@ -161,20 +163,11 @@ mod tests {
         Response,
     }
 
-    #[derive(Debug)]
-    struct ApproxLatencySum(f64);
-
-    impl PartialEq for ApproxLatencySum {
-        fn eq(&self, other: &Self) -> bool {
-            (self.0 - other.0).abs() < 1e-9
-        }
-    }
-
     #[derive(Debug, PartialEq)]
     struct EventObservation {
         request_delta: f64,
         latency_count_delta: u64,
-        latency_sum_delta: ApproxLatencySum,
+        latency_sum_delta: ApproxHistogramSum,
         logs: Vec<LogObservation>,
     }
 
@@ -215,7 +208,7 @@ mod tests {
         EventObservation {
             request_delta: metrics.counter_delta(REQUEST_METRIC, &[]),
             latency_count_delta: metrics.histogram_count_delta(LATENCY_METRIC, &[]),
-            latency_sum_delta: ApproxLatencySum(metrics.histogram_sum_delta(LATENCY_METRIC, &[])),
+            latency_sum_delta: ApproxHistogramSum(metrics.histogram_sum_delta(LATENCY_METRIC, &[])),
             logs,
         }
     }
@@ -230,7 +223,7 @@ mod tests {
                     expect: EventObservation {
                         request_delta: 1.0,
                         latency_count_delta: 0,
-                        latency_sum_delta: ApproxLatencySum(0.0),
+                        latency_sum_delta: ApproxHistogramSum(0.0),
                         logs: vec![LogObservation {
                             metadata_name: "fmds_http_request_started".to_string(),
                             level: tracing::Level::INFO,
@@ -256,7 +249,7 @@ mod tests {
                     expect: EventObservation {
                         request_delta: 0.0,
                         latency_count_delta: 1,
-                        latency_sum_delta: ApproxLatencySum(12.5),
+                        latency_sum_delta: ApproxHistogramSum(12.5),
                         logs: vec![LogObservation {
                             metadata_name: "fmds_http_response_generated".to_string(),
                             level: tracing::Level::INFO,
@@ -277,46 +270,6 @@ mod tests {
                 },
             ],
             observe_event,
-        );
-    }
-
-    #[test]
-    fn latency_sum_comparison_uses_absolute_tolerance() {
-        struct Comparison {
-            actual: f64,
-            expected: f64,
-        }
-
-        check_values(
-            [
-                Check {
-                    scenario: "accepts insignificant floating-point drift",
-                    input: Comparison {
-                        actual: 12.500000000000002,
-                        expected: 12.5,
-                    },
-                    expect: true,
-                },
-                Check {
-                    scenario: "rejects the strict tolerance boundary",
-                    input: Comparison {
-                        actual: 1e-9,
-                        expected: 0.0,
-                    },
-                    expect: false,
-                },
-                Check {
-                    scenario: "rejects a meaningful difference",
-                    input: Comparison {
-                        actual: 12.500001,
-                        expected: 12.5,
-                    },
-                    expect: false,
-                },
-            ],
-            |comparison| {
-                ApproxLatencySum(comparison.actual) == ApproxLatencySum(comparison.expected)
-            },
         );
     }
 

--- a/crates/fmds/src/http_request_metrics.rs
+++ b/crates/fmds/src/http_request_metrics.rs
@@ -208,7 +208,7 @@ mod tests {
         EventObservation {
             request_delta: metrics.counter_delta(REQUEST_METRIC, &[]),
             latency_count_delta: metrics.histogram_count_delta(LATENCY_METRIC, &[]),
-            latency_sum_delta: ApproxHistogramSum(metrics.histogram_sum_delta(LATENCY_METRIC, &[])),
+            latency_sum_delta: metrics.histogram_sum_delta(LATENCY_METRIC, &[]),
             logs,
         }
     }

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -874,7 +874,7 @@ fn truncate_error_for_metric_label(mut error: String) -> String {
 #[cfg(test)]
 mod tests {
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
     use super::*;
@@ -903,7 +903,7 @@ mod tests {
             log_count: usize,
             log: Option<LogObservation>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         let failure = r#"Internal { message: "simulated iteration failure" }"#;
@@ -919,7 +919,7 @@ mod tests {
                         log_count: 0,
                         log: None,
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 125.0,
+                        histogram_sum_delta: ApproxHistogramSum(125.0),
                     },
                 },
                 Check {
@@ -932,7 +932,7 @@ mod tests {
                         log_count: 0,
                         log: None,
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 125.5,
+                        histogram_sum_delta: ApproxHistogramSum(125.5),
                     },
                 },
                 Check {
@@ -952,7 +952,7 @@ mod tests {
                             error: Some(failure.to_string()),
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 375.0,
+                        histogram_sum_delta: ApproxHistogramSum(375.0),
                     },
                 },
             ],
@@ -981,7 +981,9 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    histogram_sum_delta: ApproxHistogramSum(
+                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    ),
                 }
             },
         );

--- a/crates/ib-fabric/src/metrics.rs
+++ b/crates/ib-fabric/src/metrics.rs
@@ -981,9 +981,7 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: ApproxHistogramSum(
-                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
-                    ),
+                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
                 }
             },
         );

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -226,7 +226,10 @@ impl tracing::field::Visit for CaptureVisitor {
 /// snapshots. A fractional observation recorded before the capture can make
 /// that subtraction differ from the expected delta by a few low-order bits.
 #[derive(Clone, Copy, Debug)]
-pub struct ApproxHistogramSum(pub f64);
+pub struct ApproxHistogramSum(
+    /// The raw histogram sum delta.
+    pub f64,
+);
 
 impl PartialEq for ApproxHistogramSum {
     fn eq(&self, other: &Self) -> bool {
@@ -272,8 +275,8 @@ impl MetricsCapture {
     }
 
     /// The sum the named histogram accumulated since [`MetricsCapture::start`].
-    pub fn histogram_sum_delta(&self, name: &str, labels: &[(&str, &str)]) -> f64 {
-        self.counter_delta(&format!("{name}#sum"), labels)
+    pub fn histogram_sum_delta(&self, name: &str, labels: &[(&str, &str)]) -> ApproxHistogramSum {
+        ApproxHistogramSum(self.counter_delta(&format!("{name}#sum"), labels))
     }
 
     /// The named gauge's current value (with exactly these label pairs). A

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -220,14 +220,15 @@ impl tracing::field::Visit for CaptureVisitor {
     }
 }
 
-/// A histogram sum delta compared with a small absolute tolerance.
+/// A histogram sum delta with approximate equality for floating-point drift.
 ///
 /// [`MetricsCapture::histogram_sum_delta`] subtracts two cumulative `f64`
 /// snapshots. A fractional observation recorded before the capture can make
 /// that subtraction differ from the expected delta by a few low-order bits.
+/// Values compare equal when their absolute difference is less than `1e-9`.
 #[derive(Clone, Copy, Debug)]
 pub struct ApproxHistogramSum(
-    /// The raw histogram sum delta.
+    /// The raw delta for callers that need the exact captured value.
     pub f64,
 );
 
@@ -274,7 +275,8 @@ impl MetricsCapture {
         self.counter_delta(&format!("{name}#count"), labels) as u64
     }
 
-    /// The sum the named histogram accumulated since [`MetricsCapture::start`].
+    /// The named histogram's sum delta since [`MetricsCapture::start`], wrapped
+    /// so values with an absolute difference below `1e-9` compare equal.
     pub fn histogram_sum_delta(&self, name: &str, labels: &[(&str, &str)]) -> ApproxHistogramSum {
         ApproxHistogramSum(self.counter_delta(&format!("{name}#sum"), labels))
     }

--- a/crates/instrument/src/testing.rs
+++ b/crates/instrument/src/testing.rs
@@ -220,6 +220,20 @@ impl tracing::field::Visit for CaptureVisitor {
     }
 }
 
+/// A histogram sum delta compared with a small absolute tolerance.
+///
+/// [`MetricsCapture::histogram_sum_delta`] subtracts two cumulative `f64`
+/// snapshots. A fractional observation recorded before the capture can make
+/// that subtraction differ from the expected delta by a few low-order bits.
+#[derive(Clone, Copy, Debug)]
+pub struct ApproxHistogramSum(pub f64);
+
+impl PartialEq for ApproxHistogramSum {
+    fn eq(&self, other: &Self) -> bool {
+        (self.0 - other.0).abs() < 1e-9
+    }
+}
+
 /// A serialized window onto the process-global test meter.
 ///
 /// The first capture installs a Prometheus-backed meter provider as the

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -20,7 +20,9 @@
 
 use std::time::Duration;
 
-use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+use carbide_instrument::testing::{
+    ApproxHistogramSum, CapturedFieldKind, MetricsCapture, capture_logs,
+};
 use carbide_instrument::{
     Event, LabelValue, LogAt, MetricFamily, MetricKind, Outcome, emit, initialize_counter_series,
 };
@@ -30,6 +32,33 @@ use carbide_test_support::value_scenarios;
 enum Stage {
     PreFlight,
     Apply,
+}
+
+#[test]
+fn histogram_sum_comparison_tolerates_only_low_order_drift() {
+    struct Comparison {
+        actual: f64,
+        expected: f64,
+    }
+
+    value_scenarios!(run = |comparison: Comparison| {
+        ApproxHistogramSum(comparison.actual) == ApproxHistogramSum(comparison.expected)
+    };
+        "histogram delta comparison" {
+            Comparison {
+                actual: 12.500000000000002,
+                expected: 12.5,
+            } => true,
+            Comparison {
+                actual: 1e-9,
+                expected: 0.0,
+            } => false,
+            Comparison {
+                actual: 12.500001,
+                expected: 12.5,
+            } => false,
+        }
+    );
 }
 
 /// log = warn, metric = counter: one emit writes the log line AND moves the

--- a/crates/instrument/tests/matrix.rs
+++ b/crates/instrument/tests/matrix.rs
@@ -425,10 +425,7 @@ fn histogram_records_the_observation_in_declared_units() {
         "carbide_test_matrix_copy_duration_seconds",
         &[("outcome", "ok")],
     );
-    assert!(
-        (sum - 1.5).abs() < 1e-9,
-        "1500ms records as 1.5s, got {sum}"
-    );
+    assert_eq!(sum, ApproxHistogramSum(1.5), "1500ms records as 1.5s");
 }
 
 /// A unit struct works (zero labels), and the declared knob constants are
@@ -581,10 +578,7 @@ fn histogram_units_round_trip() {
     ] {
         assert_eq!(metrics.histogram_count_delta(name, &[]), 1, "{name}");
         let sum = metrics.histogram_sum_delta(name, &[]);
-        assert!(
-            (sum - expected_sum).abs() < 1e-9,
-            "{name}: expected sum {expected_sum}, got {sum}"
-        );
+        assert_eq!(sum, ApproxHistogramSum(expected_sum), "{name}");
     }
 }
 

--- a/crates/nvlink-manager/src/metrics.rs
+++ b/crates/nvlink-manager/src/metrics.rs
@@ -944,9 +944,7 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(METRIC_NAME, &[]),
-                    histogram_sum_delta: ApproxHistogramSum(
-                        metrics.histogram_sum_delta(METRIC_NAME, &[]),
-                    ),
+                    histogram_sum_delta: metrics.histogram_sum_delta(METRIC_NAME, &[]),
                 }
             },
         );
@@ -1167,13 +1165,13 @@ mod tests {
                         ("status", case.status_label),
                     ],
                 ),
-                histogram_sum_delta: ApproxHistogramSum(metrics.histogram_sum_delta(
+                histogram_sum_delta: metrics.histogram_sum_delta(
                     METRIC_NAME,
                     &[
                         ("operation", case.operation_label),
                         ("status", case.status_label),
                     ],
-                )),
+                ),
             }
         });
     }

--- a/crates/nvlink-manager/src/metrics.rs
+++ b/crates/nvlink-manager/src/metrics.rs
@@ -719,7 +719,7 @@ fn truncate_error_for_metric_label(mut error: String) -> String {
 #[cfg(test)]
 mod tests {
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
 
     use super::*;
@@ -877,7 +877,7 @@ mod tests {
             log_count: usize,
             log: Option<LogObservation>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         check_values(
@@ -892,7 +892,7 @@ mod tests {
                         log_count: 0,
                         log: None,
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 125.0,
+                        histogram_sum_delta: ApproxHistogramSum(125.0),
                     },
                 },
                 Check {
@@ -915,7 +915,7 @@ mod tests {
                             error: Some("database unavailable".to_string()),
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 375.0,
+                        histogram_sum_delta: ApproxHistogramSum(375.0),
                     },
                 },
             ],
@@ -944,7 +944,9 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(METRIC_NAME, &[]),
-                    histogram_sum_delta: metrics.histogram_sum_delta(METRIC_NAME, &[]),
+                    histogram_sum_delta: ApproxHistogramSum(
+                        metrics.histogram_sum_delta(METRIC_NAME, &[]),
+                    ),
                 }
             },
         );
@@ -987,7 +989,7 @@ mod tests {
         struct OperationObservation {
             log: Option<OperationLog>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         fn expected_log(case: &OperationCase) -> Option<OperationLog> {
@@ -1116,7 +1118,7 @@ mod tests {
             let expect = OperationObservation {
                 log: expected_log(&case),
                 histogram_count_delta: 1,
-                histogram_sum_delta: 1.25,
+                histogram_sum_delta: ApproxHistogramSum(1.25),
             };
             Check {
                 scenario: case.scenario,
@@ -1165,13 +1167,13 @@ mod tests {
                         ("status", case.status_label),
                     ],
                 ),
-                histogram_sum_delta: metrics.histogram_sum_delta(
+                histogram_sum_delta: ApproxHistogramSum(metrics.histogram_sum_delta(
                     METRIC_NAME,
                     &[
                         ("operation", case.operation_label),
                         ("status", case.status_label),
                     ],
-                ),
+                )),
             }
         });
     }

--- a/crates/nvlink-manager/src/switch_cert_monitor.rs
+++ b/crates/nvlink-manager/src/switch_cert_monitor.rs
@@ -1558,9 +1558,7 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(METRIC_NAME, &[]),
-                    histogram_sum_delta: ApproxHistogramSum(
-                        metrics.histogram_sum_delta(METRIC_NAME, &[]),
-                    ),
+                    histogram_sum_delta: metrics.histogram_sum_delta(METRIC_NAME, &[]),
                 }
             },
         );

--- a/crates/nvlink-manager/src/switch_cert_monitor.rs
+++ b/crates/nvlink-manager/src/switch_cert_monitor.rs
@@ -1277,7 +1277,7 @@ fn switch_cert_monitor_error_kind(error: &str) -> SwitchCertMonitorErrorKind {
 #[cfg(test)]
 mod tests {
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
     use rcgen::{CertifiedKey, generate_simple_self_signed};
     use rustls_pki_types::UnixTime;
@@ -1491,7 +1491,7 @@ mod tests {
             log_count: usize,
             log: Option<LogObservation>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         check_values(
@@ -1506,7 +1506,7 @@ mod tests {
                         log_count: 0,
                         log: None,
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 225.0,
+                        histogram_sum_delta: ApproxHistogramSum(225.0),
                     },
                 },
                 Check {
@@ -1529,7 +1529,7 @@ mod tests {
                             error: Some("certificate query failed".to_string()),
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 425.0,
+                        histogram_sum_delta: ApproxHistogramSum(425.0),
                     },
                 },
             ],
@@ -1558,7 +1558,9 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(METRIC_NAME, &[]),
-                    histogram_sum_delta: metrics.histogram_sum_delta(METRIC_NAME, &[]),
+                    histogram_sum_delta: ApproxHistogramSum(
+                        metrics.histogram_sum_delta(METRIC_NAME, &[]),
+                    ),
                 }
             },
         );

--- a/crates/preingestion-manager/src/metrics.rs
+++ b/crates/preingestion-manager/src/metrics.rs
@@ -748,7 +748,7 @@ mod tests {
     use std::sync::Arc;
     use std::time::Duration;
 
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values, value_scenarios};
     use carbide_utils::test_support::test_meter::TestMeter;
     use prometheus_text_parser::ParsedPrometheusMetrics;
@@ -906,9 +906,10 @@ mod tests {
                 "carbide_preingestion_bfb_copy_duration_seconds",
                 &[("outcome", outcome)],
             );
-            assert!(
-                (sum - seconds).abs() < 1e-9,
-                "outcome={outcome} records {seconds}s, got {sum}"
+            assert_eq!(
+                sum,
+                ApproxHistogramSum(seconds),
+                "outcome={outcome} records {seconds}s"
             );
         }
     }

--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -1746,9 +1746,7 @@ mod tests {
                 log_count: logs.len(),
                 log,
                 histogram_count_delta: metrics.histogram_count_delta(METRIC_NAME, &labels),
-                histogram_sum_delta: ApproxHistogramSum(
-                    metrics.histogram_sum_delta(METRIC_NAME, &labels),
-                ),
+                histogram_sum_delta: metrics.histogram_sum_delta(METRIC_NAME, &labels),
             }
         }
 

--- a/crates/scout/src/metrics.rs
+++ b/crates/scout/src/metrics.rs
@@ -1112,7 +1112,9 @@ mod tests {
     use std::str::FromStr as _;
 
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{CapturedFieldKind, MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{
+        ApproxHistogramSum, CapturedFieldKind, MetricsCapture, capture_logs,
+    };
     use carbide_test_support::{Check, check_values};
 
     use super::*;
@@ -1694,7 +1696,7 @@ mod tests {
             log_count: usize,
             log: Option<LogObservation>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         fn observe(case: CleanupCase) -> Observation {
@@ -1744,7 +1746,9 @@ mod tests {
                 log_count: logs.len(),
                 log,
                 histogram_count_delta: metrics.histogram_count_delta(METRIC_NAME, &labels),
-                histogram_sum_delta: metrics.histogram_sum_delta(METRIC_NAME, &labels),
+                histogram_sum_delta: ApproxHistogramSum(
+                    metrics.histogram_sum_delta(METRIC_NAME, &labels),
+                ),
             }
         }
 
@@ -1772,7 +1776,7 @@ mod tests {
                             error_kind: None,
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 0.25,
+                        histogram_sum_delta: ApproxHistogramSum(0.25),
                     },
                 },
                 Check {
@@ -1798,7 +1802,7 @@ mod tests {
                             error_kind: Some(CapturedFieldKind::Debug),
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 0.5,
+                        histogram_sum_delta: ApproxHistogramSum(0.5),
                     },
                 },
                 Check {
@@ -1823,7 +1827,7 @@ mod tests {
                             error_kind: None,
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 0.75,
+                        histogram_sum_delta: ApproxHistogramSum(0.75),
                     },
                 },
                 Check {
@@ -1849,7 +1853,7 @@ mod tests {
                             error_kind: Some(CapturedFieldKind::Debug),
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 1.0,
+                        histogram_sum_delta: ApproxHistogramSum(1.0),
                     },
                 },
             ],

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -1784,9 +1784,7 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: ApproxHistogramSum(
-                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
-                    ),
+                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
                 }
             },
         );

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -1286,7 +1286,7 @@ impl MetricHolder {
 #[cfg(test)]
 mod tests {
     use carbide_instrument::emit;
-    use carbide_instrument::testing::{MetricsCapture, capture_logs};
+    use carbide_instrument::testing::{ApproxHistogramSum, MetricsCapture, capture_logs};
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Check, check_values, scenarios, value_scenarios};
     use opentelemetry::metrics::MeterProvider;
@@ -1719,7 +1719,7 @@ mod tests {
             log_count: usize,
             log: Option<LogObservation>,
             histogram_count_delta: u64,
-            histogram_sum_delta: f64,
+            histogram_sum_delta: ApproxHistogramSum,
         }
 
         let failure = r#"Internal { message: "simulated iteration failure" }"#;
@@ -1735,7 +1735,7 @@ mod tests {
                         log_count: 0,
                         log: None,
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 125.0,
+                        histogram_sum_delta: ApproxHistogramSum(125.0),
                     },
                 },
                 Check {
@@ -1755,7 +1755,7 @@ mod tests {
                             error: Some(failure.to_string()),
                         }),
                         histogram_count_delta: 1,
-                        histogram_sum_delta: 375.0,
+                        histogram_sum_delta: ApproxHistogramSum(375.0),
                     },
                 },
             ],
@@ -1784,7 +1784,9 @@ mod tests {
                     log_count: logs.len(),
                     log,
                     histogram_count_delta: metrics.histogram_count_delta(EXPOSED_METRIC, &[]),
-                    histogram_sum_delta: metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    histogram_sum_delta: ApproxHistogramSum(
+                        metrics.histogram_sum_delta(EXPOSED_METRIC, &[]),
+                    ),
                 }
             },
         );


### PR DESCRIPTION
Cumulative Prometheus histogram sums are stored as `f64` values.
`MetricsCapture::histogram_sum_delta()` subtracts two snapshots, so a
fractional observation recorded before a capture can make a correct delta
differ by a few low-order bits. This made HTTP metrics tests intermittently
compare values such as `12.499999999999998` or `12.500000000000002` with
`12.5`.

Add a shared `ApproxHistogramSum` test value with an absolute difference below
`1e-9` and return it directly from `histogram_sum_delta()`, making the tolerant
comparison structural for every caller. The existing FMDS-local wrapper and
all hand-written histogram-sum tolerance checks are replaced by the shared
helper, whose boundary coverage is centralized in the instrumentation crate.
Counters, histogram counts, logs, and production metrics remain exact and
unchanged.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Focused tests for the shared comparator and each migrated histogram check
- `cargo test -p carbide-agent --lib -- --test-threads=64` (256 passed)
- Agent HTTP instrumentation tests in 200 fresh processes (200 passed)
- Linux `cargo check` for all 14 affected packages with test targets
- Linux `cargo clippy` for the shared helper and three newly migrated packages
  with test targets and `-D warnings`
- `rustup run nightly cargo fmt --all -- --check`
- `git diff --check`

## Additional Notes

No production code changes. The tolerance applies only to cumulative histogram
sum deltas; counter and count assertions remain exact.
