### PR TITLE
fix(agent): restore the external FMDS connection gauge

### DIFF
--- a/crates/agent/src/fmds_client.rs
+++ b/crates/agent/src/fmds_client.rs
@@ -16,11 +16,13 @@
  */
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use carbide_host_support::agent_config::MachineIdentityConfig;
 use eyre::{WrapErr, eyre};
 use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
+use opentelemetry::metrics::Meter;
 use rpc::fmds::fmds_config_service_client::FmdsConfigServiceClient;
 use rpc::fmds::{
     FmdsConfigUpdate, FmdsMachineIdentityConfig, IbDevice, IbInstance, UpdateConfigRequest,
@@ -47,7 +49,26 @@ pub(super) enum FmdsUpdater {
         address: String,
         machine_identity: MachineIdentityConfig,
         connect_timeout: Duration,
+        last_connect_succeeded: Arc<AtomicBool>,
     },
+}
+
+pub(super) fn register_external_connection_metric(meter: &Meter) -> Arc<AtomicBool> {
+    let last_connect_succeeded = Arc::new(AtomicBool::new(false));
+    let connection_status = Arc::clone(&last_connect_succeeded);
+    meter
+        .u64_observable_gauge("carbide_dpu_agent_fmds_external_connected")
+        .with_description(
+            "Result of the DPU agent's latest connection attempt to its configured external FMDS (1 for success, 0 before success or after failure)",
+        )
+        .with_callback(move |observer| {
+            observer.observe(
+                u64::from(connection_status.load(Ordering::Relaxed)),
+                &[],
+            )
+        })
+        .build();
+    last_connect_succeeded
 }
 
 impl FmdsUpdater {
@@ -61,14 +82,14 @@ impl FmdsUpdater {
                 address,
                 machine_identity,
                 connect_timeout,
+                last_connect_succeeded,
             } => {
-                let result = match FmdsGrpcClient::connect(
-                    address,
-                    machine_identity.clone(),
-                    *connect_timeout,
-                )
-                .await
-                {
+                let connection =
+                    FmdsGrpcClient::connect(address, machine_identity.clone(), *connect_timeout)
+                        .await;
+                last_connect_succeeded.store(connection.is_ok(), Ordering::Relaxed);
+
+                let result = match connection {
                     Ok(mut client) => client.update_config(&instance_data, &network_config).await,
                     Err(err) => Err(err),
                 };
@@ -213,6 +234,7 @@ mod test {
     /// Minimal FMDS server that records the updates it is sent.
     struct RecordingFmdsServer {
         updates: mpsc::UnboundedSender<FmdsConfigUpdate>,
+        reject_updates: bool,
     }
 
     #[tonic::async_trait]
@@ -221,6 +243,10 @@ mod test {
             &self,
             request: Request<UpdateConfigRequest>,
         ) -> Result<Response<UpdateConfigResponse>, Status> {
+            if self.reject_updates {
+                return Err(Status::internal("test update rejection"));
+            }
+
             let update = request
                 .into_inner()
                 .config_update
@@ -232,12 +258,16 @@ mod test {
 
     /// Serves [`RecordingFmdsServer`] on `addr`. The caller owns the returned
     /// handle and aborts it at the end of the test.
-    fn serve_fmds(addr: SocketAddr) -> (JoinHandle<()>, mpsc::UnboundedReceiver<FmdsConfigUpdate>) {
+    fn serve_fmds(
+        addr: SocketAddr,
+        reject_updates: bool,
+    ) -> (JoinHandle<()>, mpsc::UnboundedReceiver<FmdsConfigUpdate>) {
         let (updates, received) = mpsc::unbounded_channel();
         let handle = tokio::spawn(async move {
             tonic::transport::Server::builder()
                 .add_service(FmdsConfigServiceServer::new(RecordingFmdsServer {
                     updates,
+                    reject_updates,
                 }))
                 .serve(addr)
                 .await
@@ -286,12 +316,17 @@ mod test {
         }
     }
 
-    fn test_external_updater(address: String) -> FmdsUpdater {
-        FmdsUpdater::External {
-            address,
-            machine_identity: MachineIdentityConfig::default(),
-            connect_timeout: Duration::from_millis(500),
-        }
+    fn test_external_updater(address: String) -> (FmdsUpdater, Arc<AtomicBool>) {
+        let last_connect_succeeded = Arc::new(AtomicBool::new(false));
+        (
+            FmdsUpdater::External {
+                address,
+                machine_identity: MachineIdentityConfig::default(),
+                connect_timeout: Duration::from_millis(500),
+                last_connect_succeeded: Arc::clone(&last_connect_succeeded),
+            },
+            last_connect_succeeded,
+        )
     }
 
     /// The happy path through [`FmdsUpdater::update`]: it dials the external
@@ -299,10 +334,10 @@ mod test {
     #[tokio::test]
     async fn external_updater_connects_and_pushes_every_update() {
         let addr = free_addr();
-        let (server, mut received) = serve_fmds(addr);
+        let (server, mut received) = serve_fmds(addr, false);
         wait_until_listening(addr).await;
 
-        let mut updater = test_external_updater(format!("http://{addr}"));
+        let (mut updater, _) = test_external_updater(format!("http://{addr}"));
 
         updater
             .update(Some(Arc::new(test_instance_metadata())), None)
@@ -327,26 +362,45 @@ mod test {
         server.abort();
     }
 
+    #[tokio::test]
+    async fn external_updater_reports_connection_when_update_is_rejected() {
+        let addr = free_addr();
+        let (server, _) = serve_fmds(addr, true);
+        wait_until_listening(addr).await;
+
+        let (mut updater, last_connect_succeeded) = test_external_updater(format!("http://{addr}"));
+        updater
+            .update(Some(Arc::new(test_instance_metadata())), None)
+            .await;
+
+        assert!(last_connect_succeeded.load(Ordering::Relaxed));
+
+        server.abort();
+    }
+
     /// The recovery this change exists for: an FMDS that is down when the agent
     /// starts is picked up by a later iteration, instead of the agent degrading
     /// for its whole lifetime.
     #[tokio::test]
     async fn external_updater_recovers_once_fmds_comes_up() {
         let addr = free_addr();
-        let mut updater = test_external_updater(format!("http://{addr}"));
+        let (mut updater, last_connect_succeeded) = test_external_updater(format!("http://{addr}"));
+        last_connect_succeeded.store(true, Ordering::Relaxed);
 
         // Nothing is listening yet. The push fails and is dropped, but the
         // updater stays usable rather than latching onto a degraded mode.
         updater
             .update(Some(Arc::new(test_instance_metadata())), None)
             .await;
+        assert!(!last_connect_succeeded.load(Ordering::Relaxed));
 
         // FMDS shows up, and the next iteration reaches it.
-        let (server, mut received) = serve_fmds(addr);
+        let (server, mut received) = serve_fmds(addr, false);
         wait_until_listening(addr).await;
         updater
             .update(Some(Arc::new(test_instance_metadata())), None)
             .await;
+        assert!(last_connect_succeeded.load(Ordering::Relaxed));
 
         let update = received.recv().await.expect("server received an update");
         assert_eq!(update.hostname, "test-host");

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -53,7 +53,7 @@ use crate::duppet::{SummaryFormat, SyncOptions};
 use crate::ethernet_virtualization::{
     InterfaceTranslationMode, NvueClientContext, NvueUpdateFlavor, ServiceAddresses,
 };
-use crate::fmds_client::FmdsUpdater;
+use crate::fmds_client::{FmdsUpdater, register_external_connection_metric};
 use crate::health::HealthCheckParams;
 use crate::host_machine_id::get_host_machine_id_retry;
 use crate::instrumentation::{
@@ -174,10 +174,12 @@ pub(super) async fn setup_and_run(
             fmds_address = fmds_addr,
             "Using FmdsUpdater::External FMDS service"
         );
+        let last_connect_succeeded = register_external_connection_metric(&get_dpu_agent_meter());
         FmdsUpdater::External {
             address: fmds_addr.clone(),
             machine_identity: agent_config.machine_identity.clone(),
             connect_timeout: Duration::from_secs(options.fmds_connect_timeout_secs),
+            last_connect_succeeded,
         }
     } else {
         if options.enable_metadata_service {

--- a/crates/agent/src/tests/fixtures/metrics.txt
+++ b/crates/agent/src/tests/fixtures/metrics.txt
@@ -1,6 +1,9 @@
 # HELP agent_start_time_seconds Timestamp of the agent process's last start
 # TYPE agent_start_time_seconds gauge
 agent_start_time_seconds 1740171801
+# HELP carbide_dpu_agent_fmds_external_connected Result of the DPU agent's latest connection attempt to its configured external FMDS (1 for success, 0 before success or after failure)
+# TYPE carbide_dpu_agent_fmds_external_connected gauge
+carbide_dpu_agent_fmds_external_connected 1
 # HELP client_cert_expiry_time_seconds Timestamp when the agent's TLS client certificate expires
 # TYPE client_cert_expiry_time_seconds gauge
 client_cert_expiry_time_seconds 1742763762

--- a/crates/agent/src/tests/metrics.rs
+++ b/crates/agent/src/tests/metrics.rs
@@ -15,11 +15,13 @@
  * limitations under the License.
  */
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
 use std::time::Duration;
 
 use opentelemetry::metrics::MeterProvider;
 use prometheus::{Encoder, TextEncoder};
 
+use crate::fmds_client::register_external_connection_metric;
 use crate::instrumentation::NetworkMonitorMetricsState;
 use crate::network_monitor::NetworkMonitorError;
 
@@ -38,6 +40,8 @@ fn test_metrics() {
     let meter = meter_provider.meter("agent");
 
     let metrics = crate::instrumentation::create_metrics(meter.clone());
+    let fmds_connection_status = register_external_connection_metric(&meter);
+    fmds_connection_status.store(true, Ordering::Relaxed);
     metrics.record_machine_boot_time(1740171762);
     metrics.record_agent_start_time(1740171801);
     metrics.record_client_cert_expiry_time(|| Some(1742763762));


### PR DESCRIPTION
The reconnect change in #4989 kept external FMDS configured across connection failures, but it also removed `carbide_dpu_agent_fmds_external_connected` from the DPU agent's metrics.

Register the observable gauge when external FMDS is configured and update it after each completed connection attempt. Record the connection result before sending metadata so a successful connection followed by a rejected update still reports `1`; a later connection failure changes it to `0`. This restores the existing metric name and gauge type without changing the reconnect cadence, timeout, or metadata payload.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5654

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-agent fmds_client` and the agent metrics test verify failed and recovered connections, the rejected update boundary, and the exact exported gauge.
- Formatting, Clippy, and custom lints for `carbide-agent` pass. The complete custom lint run stops on two existing findings in the unchanged `api-core` DNS integration test.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable tree. The Codex closure review found no defect in the final diff, so no edits were made in response to review.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 7 | 0 | 7 |
| common-nits-reviewer | 1 | 0 | 1 |
| **Total** | **8** | **0** | **8** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Declined** -- `crates/agent/src/fmds_client.rs`: Move the registration helper into `instrumentation.rs` and add a named state type. **Reason:** `FmdsUpdater` updates the connection state, the helper is private to the parent module, and the only production call is in the external FMDS branch; moving it would not fix a reachable defect.
2. **Declined** -- `crates/agent/src/fmds_client.rs`: Add comments for the gauge and rejected update boundary. **Reason:** The metric description and focused test already state that contract; this does not identify incorrect behavior.
3. **Declined** -- `crates/agent/src/fmds_client.rs`: Reformat the observable callback. **Reason:** `cargo make format-nightly` completed cleanly and retained the current formatting.
4. **Declined** -- `crates/agent/src/fmds_client.rs`: Replace the test server's positional `bool` with another helper or enum. **Reason:** The local fixture has one boolean setting, and another abstraction would not strengthen the behavior proof.
5. **Declined** -- `crates/agent/src/fmds_client.rs`: Change the metric description for the state before the first connection attempt. **Reason:** The description already defines `0` before a successful attempt or after a failure, matching the issue contract.
6. **Declined** -- `docs/operations/monitoring-health.md`: Document the metric and its absence in embedded mode. **Reason:** This is separate operator documentation work, not a defect in the restored metric.
7. **Declined** -- `crates/agent/src/fmds_client.rs`: Rename the helper and wrap the atomic in a new type. **Reason:** The current helper is local and explicit; the extra type would add machinery for one boolean value.

### common-nits-reviewer

1. **Declined** -- `crates/agent/src/main_loop.rs`: Add a larger test through the complete production setup branch. **Reason:** Production wiring is a direct registration call and `Arc` handoff; the helper and updater tests cover the exported metric and every required connection transition without extracting more setup code.

</details>

Closes #5654
