### PR TITLE
fix(dpf): allow HBN log rotation under AppArmor

### DIFF
--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -887,6 +887,41 @@ fn get_default_grub() -> DpuFlavorGrub {
     }
 }
 
+/// Returns HBN's DPF reference AppArmor extensions.
+///
+/// The rsyslog policy permits the complete rotation chain, while the tcpdump policy accepts
+/// signals from `runc`. Cloud-init writes both before DPF's provisioning reboot loads the profiles.
+/// Since these files are part of the flavor hash, changing them reprovisions every DPF DPU.
+fn hbn_apparmor_config_files() -> [DpuFlavorConfigFiles; 2] {
+    [
+        DpuFlavorConfigFiles {
+            path: "/etc/apparmor.d/local/usr.sbin.rsyslogd".to_string(),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(
+                concat!(
+                    "signal (receive) peer=runc,\n",
+                    "capability chown,\n",
+                    "/usr/{bin,sbin}/* ixr,\n",
+                    "/etc/logrotate.d/* r,\n",
+                    "/var/lib/logrotate/{,**} rwk,\n",
+                )
+                .to_string(),
+            ),
+            content_from: None,
+            r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            path: "/etc/apparmor.d/local/usr.bin.tcpdump".to_string(),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some("signal (receive) peer=runc,\n".to_string()),
+            content_from: None,
+            r#type: None,
+        },
+    ]
+}
+
 /// Returns the base set of config files, plus an optional containerd proxy drop-in if `proxy` is set.
 ///
 /// `deployment_type` selects the few settings that differ between the deployments sharing this
@@ -975,6 +1010,8 @@ fn get_config_files(
             r#type: None,
         },
     ];
+
+    config_files.extend(hbn_apparmor_config_files());
     config_files.extend(ovn_encap_config_files());
 
     if let Some(proxy) = proxy {
@@ -1503,6 +1540,9 @@ fn get_bf4_astra_config_files(
             r#type: Some(DpuFlavorConfigFilesType::AgentApplied),
         },
     ];
+
+    config_files.extend(hbn_apparmor_config_files());
+
     if let Some(proxy) = proxy {
         validate_proxy_string(&proxy.https_proxy, "https_proxy")?;
 
@@ -2883,12 +2923,12 @@ mod tests {
                     .count();
                 (files.len(), proxy_file_count)
             };
-            "no proxy keeps the twelve Astra base files" {
-                None => (12, 0),
+            "no proxy keeps the fourteen Astra base files" {
+                None => (14, 0),
             }
 
             "configured proxy appends exactly one proxy file" {
-                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => (13, 1),
+                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => (15, 1),
             }
         );
     }
@@ -2906,16 +2946,74 @@ mod tests {
                     .unwrap()
                     .len()
             };
-            "no proxy yields nine base files" {
-                None => 9,
+            "no proxy yields eleven base files" {
+                None => 11,
             }
 
-            "proxy with empty no_proxy appends a tenth" {
-                proxy("http://proxy:3128", &[]) => 10,
+            "proxy with empty no_proxy appends a twelfth" {
+                proxy("http://proxy:3128", &[]) => 12,
             }
 
             "proxy with no_proxy list still appends exactly one" {
-                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => 10,
+                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => 12,
+            }
+        );
+    }
+
+    #[test]
+    fn every_deployment_type_includes_hbn_apparmor_extensions() {
+        value_scenarios!(
+            run = |deployment_type| {
+                let files = match deployment_type {
+                    DpuDeploymentType::Bf4Astra => {
+                        astra_flavor_spec(&None).config_files.unwrap()
+                    }
+                    deployment_type => default_flavor_for("ns", &None, deployment_type)
+                        .unwrap()
+                        .spec
+                        .config_files
+                        .unwrap(),
+                };
+                let has_file = |path: &str, raw: &str| {
+                    files.iter().find(|file| file.path == path).is_some_and(|file| {
+                        matches!(
+                            file.operation,
+                            Some(DpuFlavorConfigFilesOperation::Override)
+                        ) && file.permissions.as_deref() == Some("0644")
+                            && file.raw.as_deref() == Some(raw)
+                            && file.content_from.is_none()
+                            && file.r#type.is_none()
+                    })
+                };
+
+                has_file(
+                    "/etc/apparmor.d/local/usr.sbin.rsyslogd",
+                    concat!(
+                        "signal (receive) peer=runc,\n",
+                        "capability chown,\n",
+                        "/usr/{bin,sbin}/* ixr,\n",
+                        "/etc/logrotate.d/* r,\n",
+                        "/var/lib/logrotate/{,**} rwk,\n",
+                    ),
+                ) && has_file(
+                    "/etc/apparmor.d/local/usr.bin.tcpdump",
+                    "signal (receive) peer=runc,\n",
+                )
+            };
+            "BF3" {
+                DpuDeploymentType::Bf3 => true,
+            }
+
+            "GB200 BF3" {
+                DpuDeploymentType::Bf3Gb200 => true,
+            }
+
+            "generic BF4" {
+                DpuDeploymentType::Bf4Generic => true,
+            }
+
+            "Astra BF4" {
+                DpuDeploymentType::Bf4Astra => true,
             }
         );
     }


### PR DESCRIPTION
HBN 3.4.0 keeps the host `rsyslogd` AppArmor profile in enforce mode unless `HBN_APPARMOR_COMPLAIN=true`. NICo's generated DPF flavors do not install the local extensions that allow HBN's log rotation chain. Once `nvued.log` reaches its configured size limit, `startup_yaml_validator.sh` can miss NVUE's successful apply message and restart HBN even though the configuration applied.

Non-DPF HBN 3.2.3 avoids this failure because its privileged init container runs `aa-complain /usr/sbin/rsyslogd` on the DPU host. This change follows HBN's DPF reference configuration instead, installing local `rsyslogd` and `tcpdump` extensions so the required operations remain available while AppArmor stays in enforce mode.

The files become part of every generated flavor hash. Existing BF3, GB200, generic BF4, and Astra DPF deployments will therefore reprovision their DPUs once when the updated flavor is selected.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5657

Closes #5657

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-dpf` verifies the expected policy and file metadata across all four generated deployment types; Clippy, nightly formatting, and the `carbide-dpf` custom lint also pass.
- On an affected DPF DPU running HBN 3.4.0, the exact generated files loaded successfully, the oversized `nvued.log` rotated, the validator accepted the new apply marker, and HBN remained stable beyond its ten-minute failure window with BGP established.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable tree, followed by a focused review of the final diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 9 | 4 | 5 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **9** | **4** | **5** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- The policy files are written after AppArmor initially loads. **Resolution:** The helper now records that DPF's provisioning reboot loads the profiles before HBN starts.
2. **Declined** -- Confirm whether the target BFB names the tcpdump profile `usr.bin.tcpdump`. **Reason:** HBN's DPF reference configuration and the target HBN image both use that profile name.
3. **Adopted** -- The `rsyslogd` executable rule is broader than the immediate rotation command. **Resolution:** The helper now identifies this as HBN's reference policy; narrowing it here could omit commands used by its rotation scripts.
4. **Adopted** -- Adding these files changes every generated flavor hash. **Resolution:** The rollout paragraph and helper documentation state that existing DPF DPUs reprovision once.
5. **Declined** -- Reduce the deployment table to the two current builder paths. **Reason:** The four rows preserve the policy contract for every supported deployment type if their builder routing later changes.
6. **Declined** -- Fold the assertions into neighboring config file tests. **Reason:** A focused test keeps the complete AppArmor content and metadata checks together across every deployment type.
7. **Declined** -- Append to any policy supplied by a future BFB instead of replacing it. **Reason:** Deterministic replacement matches HBN's DPF reference configuration and the existing config file convention in this module.
8. **Adopted** -- Explain why both policy extensions are required. **Resolution:** The helper documents the `rsyslogd` rotation chain and the `tcpdump` signal permission.
9. **Declined** -- Return a `Vec` for consistency with another helper. **Reason:** This helper always returns exactly two files, so the fixed array states that contract directly.

### common-nits-reviewer

No findings.

</details>
