### PR TITLE
patch(v2.1): allow HBN log rotation under AppArmor

### DIFF
--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -496,6 +496,41 @@ fn get_default_grub() -> DpuFlavorGrub {
     }
 }
 
+/// Returns HBN's DPF reference AppArmor extensions.
+///
+/// The rsyslog policy permits the complete rotation chain, while the tcpdump policy accepts
+/// signals from `runc`. Cloud-init writes both before DPF's provisioning reboot loads the profiles.
+/// Since these files are part of the flavor hash, changing them reprovisions every DPF DPU.
+fn hbn_apparmor_config_files() -> [DpuFlavorConfigFiles; 2] {
+    [
+        DpuFlavorConfigFiles {
+            path: "/etc/apparmor.d/local/usr.sbin.rsyslogd".to_string(),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some(
+                concat!(
+                    "signal (receive) peer=runc,\n",
+                    "capability chown,\n",
+                    "/usr/{bin,sbin}/* ixr,\n",
+                    "/etc/logrotate.d/* r,\n",
+                    "/var/lib/logrotate/{,**} rwk,\n",
+                )
+                .to_string(),
+            ),
+            content_from: None,
+            r#type: None,
+        },
+        DpuFlavorConfigFiles {
+            path: "/etc/apparmor.d/local/usr.bin.tcpdump".to_string(),
+            operation: Some(DpuFlavorConfigFilesOperation::Override),
+            permissions: Some("0644".to_string()),
+            raw: Some("signal (receive) peer=runc,\n".to_string()),
+            content_from: None,
+            r#type: None,
+        },
+    ]
+}
+
 /// Returns the base set of config files, plus an optional containerd proxy drop-in if `proxy` is set.
 fn get_config_files(
     proxy: &Option<DpfProxyDetails>,
@@ -575,6 +610,7 @@ fn get_config_files(
             r#type: None,
         },
     ];
+    config_files.extend(hbn_apparmor_config_files());
 
     if let Some(proxy) = proxy {
         validate_proxy_string(&proxy.https_proxy, "https_proxy")?;
@@ -1156,6 +1192,8 @@ fn get_bf4_astra_config_files(
             r#type: None,
         },
     ];
+
+    config_files.extend(hbn_apparmor_config_files());
 
     if let Some(proxy) = proxy {
         validate_proxy_string(&proxy.https_proxy, "https_proxy")?;
@@ -1761,12 +1799,12 @@ mod tests {
                     .count();
                 (files.len(), proxy_file_count)
             };
-            "no proxy keeps only the six Astra base files" {
-                None => (6, 0),
+            "no proxy keeps the eight Astra base files" {
+                None => (8, 0),
             }
 
             "configured proxy appends exactly one proxy file" {
-                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => (7, 1),
+                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => (9, 1),
             }
         );
     }
@@ -1784,16 +1822,69 @@ mod tests {
                     .unwrap()
                     .len()
             };
-            "no proxy yields seven base files" {
-                None => 7,
+            "no proxy yields nine base files" {
+                None => 9,
             }
 
-            "proxy with empty no_proxy appends an eighth" {
-                proxy("http://proxy:3128", &[]) => 8,
+            "proxy with empty no_proxy appends a tenth" {
+                proxy("http://proxy:3128", &[]) => 10,
             }
 
             "proxy with no_proxy list still appends exactly one" {
-                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => 8,
+                proxy("http://proxy:3128", &["10.0.0.0/8", "localhost"]) => 10,
+            }
+        );
+    }
+
+    #[test]
+    fn every_deployment_type_includes_hbn_apparmor_extensions() {
+        value_scenarios!(
+            run = |deployment_type| {
+                let files = default_flavor_for("ns", &None, deployment_type)
+                    .unwrap()
+                    .spec
+                    .config_files
+                    .unwrap();
+                let has_file = |path: &str, raw: &str| {
+                    files.iter().find(|file| file.path == path).is_some_and(|file| {
+                        matches!(
+                            file.operation,
+                            Some(DpuFlavorConfigFilesOperation::Override)
+                        ) && file.permissions.as_deref() == Some("0644")
+                            && file.raw.as_deref() == Some(raw)
+                            && file.content_from.is_none()
+                            && file.r#type.is_none()
+                    })
+                };
+
+                has_file(
+                    "/etc/apparmor.d/local/usr.sbin.rsyslogd",
+                    concat!(
+                        "signal (receive) peer=runc,\n",
+                        "capability chown,\n",
+                        "/usr/{bin,sbin}/* ixr,\n",
+                        "/etc/logrotate.d/* r,\n",
+                        "/var/lib/logrotate/{,**} rwk,\n",
+                    ),
+                ) && has_file(
+                    "/etc/apparmor.d/local/usr.bin.tcpdump",
+                    "signal (receive) peer=runc,\n",
+                )
+            };
+            "BF3" {
+                DpuDeploymentType::Bf3 => true,
+            }
+
+            "GB200 BF3" {
+                DpuDeploymentType::Bf3Gb200 => true,
+            }
+
+            "generic BF4" {
+                DpuDeploymentType::Bf4Generic => true,
+            }
+
+            "Astra BF4" {
+                DpuDeploymentType::Bf4Astra => true,
             }
         );
     }


### PR DESCRIPTION
Backports `2f314d7b3` from #5665 to `release/v2.1`.

DPF HBN 3.4.0 can block its log rotation chain because NICo's generated flavors do not install HBN's local AppArmor extensions. Once `nvued.log` reaches its size limit, `startup_yaml_validator.sh` can miss NVUE's successful apply message and restart HBN even though the configuration was applied.

This adds HBN's reference `rsyslogd` and `tcpdump` extensions to both v2.1 flavor builders so BF3, GB200, generic BF4, and Astra deployments receive the policy. The files become part of each flavor hash, so existing DPF DPUs will reprovision once when the updated flavor is selected. The one conflict came from differences in the older flavor builders; the resolution adds only these files and their release tests without pulling in main's OVN or newer Astra configuration.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/5657
- Backports https://github.com/NVIDIA/infra-controller/pull/5665

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test -p carbide-dpf` passes all 119 release tests, including exact policy content and metadata for all four deployment types.
- The exact two policy files were manually applied to an affected DPF DPU before #5665 merged; HBN then rotated `nvued.log`, found the successful apply message, and stayed running through the next validator cycle.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers reviewed the source patch in #5665. This backport keeps the resulting policy unchanged, and a focused review of the release conflict covered the older builder entry points and adjusted file counts.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 9 | 4 | 5 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **9** | **4** | **5** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- The policy files are written after AppArmor initially loads. **Resolution:** The helper now records that DPF's provisioning reboot loads the profiles before HBN starts.
2. **Declined** -- Confirm whether the target BFB names the tcpdump profile `usr.bin.tcpdump`. **Reason:** HBN's DPF reference configuration and the target HBN image both use that profile name.
3. **Adopted** -- The `rsyslogd` executable rule is broader than the immediate rotation command. **Resolution:** The helper now identifies this as HBN's reference policy; narrowing it here could omit commands used by its rotation scripts.
4. **Adopted** -- Adding these files changes every generated flavor hash. **Resolution:** The rollout paragraph and helper documentation state that existing DPF DPUs reprovision once.
5. **Declined** -- Reduce the deployment table to the two current builder paths. **Reason:** The four rows preserve the policy contract for every supported deployment type if their builder routing later changes.
6. **Declined** -- Fold the assertions into neighboring config file tests. **Reason:** A focused test keeps the complete AppArmor content and metadata checks together across every deployment type.
7. **Declined** -- Append to any policy supplied by a future BFB instead of replacing it. **Reason:** Deterministic replacement matches HBN's DPF reference configuration and the existing config file convention in this module.
8. **Adopted** -- Explain why both policy extensions are required. **Resolution:** The helper documents the `rsyslogd` rotation chain and the `tcpdump` signal permission.
9. **Declined** -- Return a `Vec` for consistency with another helper. **Reason:** This helper always returns exactly two files, so the fixed array states that contract directly.

### common-nits-reviewer

No findings.

</details>
