### PR TITLE
fix(config): ignore unused log-collector subsections when mode is explicitly set

### DIFF
--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1509,37 +1509,20 @@ impl LogsCollectorConfig {
                 }
             }
             LogCollectionMode::Periodic => {
-                if self.auto.is_some() {
-                    return Err(
-                        "[collectors.logs.auto] should not be set when mode = \"periodic\""
-                            .to_string(),
-                    );
-                }
+                // [collectors.logs.auto] and [collectors.logs.sse] are ignored in
+                // periodic mode — no error, just not consulted. This lets a config
+                // file carry all three subsections and switch modes with a single
+                // mode = "..." change without touching the subsection blocks.
                 if self.periodic.is_none() {
                     return Err(
                         "[collectors.logs.periodic] is required when mode = \"periodic\""
                             .to_string(),
                     );
                 }
-                if self.sse.is_some() {
-                    return Err(
-                        "[collectors.logs.sse] should not be set when mode = \"periodic\""
-                            .to_string(),
-                    );
-                }
             }
             LogCollectionMode::Sse => {
-                if self.auto.is_some() {
-                    return Err(
-                        "[collectors.logs.auto] should not be set when mode = \"sse\"".to_string(),
-                    );
-                }
-                if self.periodic.is_some() {
-                    return Err(
-                        "[collectors.logs.periodic] should not be set when mode = \"sse\""
-                            .to_string(),
-                    );
-                }
+                // [collectors.logs.auto] and [collectors.logs.periodic] are ignored
+                // in sse mode for the same reason as above.
                 if let Some(sse) = &self.sse {
                     sse.validate()?;
                 }

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1509,10 +1509,16 @@ impl LogsCollectorConfig {
                 }
             }
             LogCollectionMode::Periodic => {
-                // [collectors.logs.auto] and [collectors.logs.sse] are ignored in
-                // periodic mode — no error, just not consulted. This lets a config
-                // file carry all three subsections and switch modes with a single
-                // mode = "..." change without touching the subsection blocks.
+                if self.auto.is_some() {
+                    tracing::warn!(
+                        "[collectors.logs.auto] is set but ignored when mode = \"periodic\""
+                    );
+                }
+                if self.sse.is_some() {
+                    tracing::warn!(
+                        "[collectors.logs.sse] is set but ignored when mode = \"periodic\""
+                    );
+                }
                 if self.periodic.is_none() {
                     return Err(
                         "[collectors.logs.periodic] is required when mode = \"periodic\""
@@ -1521,8 +1527,14 @@ impl LogsCollectorConfig {
                 }
             }
             LogCollectionMode::Sse => {
-                // [collectors.logs.auto] and [collectors.logs.periodic] are ignored
-                // in sse mode for the same reason as above.
+                if self.auto.is_some() {
+                    tracing::warn!("[collectors.logs.auto] is set but ignored when mode = \"sse\"");
+                }
+                if self.periodic.is_some() {
+                    tracing::warn!(
+                        "[collectors.logs.periodic] is set but ignored when mode = \"sse\""
+                    );
+                }
                 if let Some(sse) = &self.sse {
                     sse.validate()?;
                 }

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -5125,10 +5125,7 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
                     periodic: Some(PeriodicLogConfig::default()),
                     auto: Some(AutoModeConfig::default()),
                     ..LogsCollectorConfig::default()
-                } => FailsWith(
-                    "[collectors.logs.auto] should not be set when mode = \"periodic\""
-                        .to_string()
-                ),
+                } => Yields(()), // auto is ignored in periodic mode (warn only)
 
                 LogsCollectorConfig {
                     mode: LogCollectionMode::Periodic,
@@ -5142,9 +5139,7 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
                     periodic: Some(PeriodicLogConfig::default()),
                     sse: Some(SseLogConfig::default()),
                     ..LogsCollectorConfig::default()
-                } => FailsWith(
-                    "[collectors.logs.sse] should not be set when mode = \"periodic\"".to_string()
-                ),
+                } => Yields(()), // sse is ignored in periodic mode (warn only)
             }
 
             "SSE mode" {
@@ -5163,17 +5158,13 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
                     mode: LogCollectionMode::Sse,
                     auto: Some(AutoModeConfig::default()),
                     ..LogsCollectorConfig::default()
-                } => FailsWith(
-                    "[collectors.logs.auto] should not be set when mode = \"sse\"".to_string()
-                ),
+                } => Yields(()), // auto is ignored in sse mode (warn only)
 
                 LogsCollectorConfig {
                     mode: LogCollectionMode::Sse,
                     periodic: Some(PeriodicLogConfig::default()),
                     ..LogsCollectorConfig::default()
-                } => FailsWith(
-                    "[collectors.logs.periodic] should not be set when mode = \"sse\"".to_string()
-                ),
+                } => Yields(()), // periodic is ignored in sse mode (warn only)
 
                 LogsCollectorConfig {
                     mode: LogCollectionMode::Sse,

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -5277,7 +5277,6 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
                 periodic: Some(PeriodicLogConfig::default()),
                 auto: Some(AutoModeConfig::default()),
                 sse: Some(SseLogConfig::default()),
-                ..LogsCollectorConfig::default()
             }
             .validate()
             .unwrap();

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -5185,6 +5185,7 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
     /// Uses a per-call dispatcher so parallel tests don't interfere.
     fn capture_warnings(f: impl FnOnce()) -> Vec<String> {
         use std::sync::{Arc, Mutex};
+
         use tracing::Level;
         use tracing_subscriber::layer::SubscriberExt;
 

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -5181,6 +5181,179 @@ switch = { serial = "SN-SW-001", physical_slot_number = 7, compute_tray_index = 
         );
     }
 
+    /// Capture tracing WARN events emitted during a closure.
+    /// Uses a per-call dispatcher so parallel tests don't interfere.
+    fn capture_warnings(f: impl FnOnce()) -> Vec<String> {
+        use std::sync::{Arc, Mutex};
+        use tracing::Level;
+        use tracing_subscriber::layer::SubscriberExt;
+
+        let captured: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let captured_clone = Arc::clone(&captured);
+
+        struct WarnCapture(Arc<Mutex<Vec<String>>>);
+
+        impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for WarnCapture {
+            fn on_event(
+                &self,
+                event: &tracing::Event<'_>,
+                _ctx: tracing_subscriber::layer::Context<'_, S>,
+            ) {
+                if *event.metadata().level() != Level::WARN {
+                    return;
+                }
+                struct Visitor(String);
+                impl tracing::field::Visit for Visitor {
+                    fn record_debug(
+                        &mut self,
+                        field: &tracing::field::Field,
+                        value: &dyn std::fmt::Debug,
+                    ) {
+                        if field.name() == "message" {
+                            self.0 = format!("{value:?}").trim_matches('"').to_string();
+                        }
+                    }
+                    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+                        if field.name() == "message" {
+                            self.0 = value.to_string();
+                        }
+                    }
+                }
+                let mut v = Visitor(String::new());
+                event.record(&mut v);
+                self.0.lock().unwrap().push(v.0);
+            }
+        }
+
+        tracing::subscriber::with_default(
+            tracing_subscriber::registry().with(WarnCapture(captured_clone)),
+            f,
+        );
+        Arc::try_unwrap(captured).unwrap().into_inner().unwrap()
+    }
+
+    #[test]
+    fn logs_collector_ignored_subsection_warnings() {
+        // periodic mode + auto: warn about auto
+        let warnings = capture_warnings(|| {
+            LogsCollectorConfig {
+                mode: LogCollectionMode::Periodic,
+                periodic: Some(PeriodicLogConfig::default()),
+                auto: Some(AutoModeConfig::default()),
+                ..LogsCollectorConfig::default()
+            }
+            .validate()
+            .unwrap();
+        });
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.auto]") && w.contains("periodic")),
+            "expected auto-ignored warning in periodic mode, got: {warnings:?}"
+        );
+
+        // periodic mode + sse: warn about sse
+        let warnings = capture_warnings(|| {
+            LogsCollectorConfig {
+                mode: LogCollectionMode::Periodic,
+                periodic: Some(PeriodicLogConfig::default()),
+                sse: Some(SseLogConfig::default()),
+                ..LogsCollectorConfig::default()
+            }
+            .validate()
+            .unwrap();
+        });
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.sse]") && w.contains("periodic")),
+            "expected sse-ignored warning in periodic mode, got: {warnings:?}"
+        );
+
+        // periodic mode + auto + sse: warn about both
+        let warnings = capture_warnings(|| {
+            LogsCollectorConfig {
+                mode: LogCollectionMode::Periodic,
+                periodic: Some(PeriodicLogConfig::default()),
+                auto: Some(AutoModeConfig::default()),
+                sse: Some(SseLogConfig::default()),
+                ..LogsCollectorConfig::default()
+            }
+            .validate()
+            .unwrap();
+        });
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.auto]") && w.contains("periodic")),
+            "expected auto warning in periodic+auto+sse: {warnings:?}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.sse]") && w.contains("periodic")),
+            "expected sse warning in periodic+auto+sse: {warnings:?}"
+        );
+
+        // SSE mode + auto: warn about auto
+        let warnings = capture_warnings(|| {
+            LogsCollectorConfig {
+                mode: LogCollectionMode::Sse,
+                auto: Some(AutoModeConfig::default()),
+                ..LogsCollectorConfig::default()
+            }
+            .validate()
+            .unwrap();
+        });
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.auto]") && w.contains("sse")),
+            "expected auto-ignored warning in sse mode, got: {warnings:?}"
+        );
+
+        // SSE mode + periodic: warn about periodic
+        let warnings = capture_warnings(|| {
+            LogsCollectorConfig {
+                mode: LogCollectionMode::Sse,
+                periodic: Some(PeriodicLogConfig::default()),
+                ..LogsCollectorConfig::default()
+            }
+            .validate()
+            .unwrap();
+        });
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.periodic]") && w.contains("sse")),
+            "expected periodic-ignored warning in sse mode, got: {warnings:?}"
+        );
+
+        // SSE mode + auto + periodic: warn about both
+        let warnings = capture_warnings(|| {
+            LogsCollectorConfig {
+                mode: LogCollectionMode::Sse,
+                auto: Some(AutoModeConfig::default()),
+                periodic: Some(PeriodicLogConfig::default()),
+                ..LogsCollectorConfig::default()
+            }
+            .validate()
+            .unwrap();
+        });
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.auto]") && w.contains("sse")),
+            "expected auto warning in sse+auto+periodic: {warnings:?}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("[collectors.logs.periodic]") && w.contains("sse")),
+            "expected periodic warning in sse+auto+periodic: {warnings:?}"
+        );
+    }
+
     #[test]
     fn log_config_parsing() {
         scenarios!(run = |toml| {


### PR DESCRIPTION
Closes #5661

When `mode = "periodic"` is set, hw-health previously rejected `[collectors.logs.auto]` and
`[collectors.logs.sse]` with a hard validation error. Similarly, `mode = "sse"` rejected
`[collectors.logs.auto]` and `[collectors.logs.periodic]`. This forced operators to delete
subsection blocks whenever they switched modes, rather than just changing the `mode` line.
This was particularly painful when a config file intentionally carries all three subsections
so the active mode can be changed with a single-line edit.

`mode` is now the single authoritative selector. Non-applicable subsections are ignored with
a `tracing::warn!` instead of a hard error:

- `mode = "periodic"` → `[collectors.logs.auto]` and `[collectors.logs.sse]` are ignored
- `mode = "sse"` → `[collectors.logs.auto]` and `[collectors.logs.periodic]` are ignored
- `mode = "auto"` → all three subsections are validated as before (no change)

The `[collectors.logs.auto]` fallback still uses its own nested periodic settings — that behaviour is unchanged.

## Related issues

Closes #5661

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Tested locally using a Docker-based hw-health deployment against a real mini-rack (gb-nvl-124-mini06, 2 compute trays + switch). Config has all three subsections (`[collectors.logs.auto]`, `[collectors.logs.sse]`, `[collectors.logs.periodic]`) present simultaneously. For each mode:

| Check | periodic | auto | sse |
|---|---|---|---|
| `/livez` responds | ✅ | ✅ | ✅ |
| No "should not be set" error | ✅ | ✅ | ✅ |
| Config dump confirms active mode | ✅ `Periodic` | ✅ `Auto` | ✅ `Sse` |
| All three subsections parsed | ✅ | ✅ | ✅ |

Unit tests updated to assert `Ok(())` for previously-rejected combinations. New `logs_collector_ignored_subsection_warnings` test captures `tracing::warn!` events and verifies one warning per ignored subsection.

Signed-off-by: Dasa Chandramouli <dchandramoul@nvidia.com>