### PR TITLE
fix(api): Reject stateful NSGs when site support is disabled

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -697,7 +697,7 @@ client-certificate authentication is not used.
 | Field | Type | Default | Description |
 | ------- | ------ | --------- | ------------- |
 | `max_network_security_group_size` | `u32` | `200` | Max expanded rules per NSG. |
-| `stateful_acls_enabled` | `bool` | `true` | Enable stateful ACLs (toggled on DPU via nvue). |
+| `stateful_acls_enabled` | `bool` | `true` | Allow stateful NSG creation and stateless-to-stateful updates, and enable supporting NVUE configuration on DPUs. When disabled, existing stateful NSGs remain editable but behave statelessly. |
 | `policy_overrides` | `Vec<NetworkSecurityGroupRule>` | `[]` | NSG rules injected before user-defined rules. |
 
 ### `FnnConfig`

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3999,10 +3999,10 @@ pub struct NetworkSecurityGroupConfig {
     /// (src port range * dst port range * src prefix list * dst prefix list)
     #[serde(default = "default_max_network_security_group_size")]
     pub max_network_security_group_size: u32,
-    /// Whether to allow stateful security groups.
-    /// This will initially only be passed through to the
-    /// DPU as a way to toggle default stateful options
-    /// in nvue config.
+    /// Whether NSGs may enable stateful egress and the DPU enables its supporting NVUE options.
+    ///
+    /// When disabled, stateful NSG creation and updates from stateless to stateful are rejected.
+    /// Existing stateful NSGs remain editable, but the DPU applies their rules statelessly.
     #[serde(default = "default_to_true")]
     pub stateful_acls_enabled: bool,
 

--- a/crates/api-core/src/handlers/network_security_group.rs
+++ b/crates/api-core/src/handlers/network_security_group.rs
@@ -77,6 +77,14 @@ pub(crate) async fn create(
         )
     };
 
+    validate_stateful_egress_enablement(
+        None,
+        stateful_egress,
+        api.runtime_config
+            .network_security_group
+            .stateful_acls_enabled,
+    )?;
+
     let max_nsg_size = api
         .runtime_config
         .network_security_group
@@ -352,6 +360,14 @@ pub(crate) async fn update(
         }
     };
 
+    validate_stateful_egress_enablement(
+        Some(current_network_security_group.stateful_egress),
+        stateful_egress,
+        api.runtime_config
+            .network_security_group
+            .stateful_acls_enabled,
+    )?;
+
     // Prepare the version match if present.
     if let Some(if_version_match) = req.if_version_match {
         let target_version = if_version_match
@@ -621,6 +637,24 @@ pub(crate) async fn get_attachments(
     Ok(Response::new(rpc_out))
 }
 
+/// Rejects newly enabled stateful egress when the site does not support stateful ACLs.
+fn validate_stateful_egress_enablement(
+    current_stateful_egress: Option<bool>,
+    requested_stateful_egress: bool,
+    stateful_acls_enabled: bool,
+) -> Result<(), CarbideError> {
+    // Existing stateful groups remain editable if the site flag is disabled after creation.
+    if !stateful_acls_enabled && requested_stateful_egress && current_stateful_egress != Some(true)
+    {
+        return Err(CarbideError::InvalidArgument(
+            "stateful_egress requires network_security_group.stateful_acls_enabled to be true"
+                .to_string(),
+        ));
+    }
+
+    Ok(())
+}
+
 fn validate_expanded_rule_set(
     rules: &[NetworkSecurityGroupRule],
     limit: usize,
@@ -674,4 +708,39 @@ fn validate_expanded_rule_set(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
+
+    use super::*;
+
+    /// Verifies the validator rejects only new stateful intent while site support is disabled.
+    ///
+    /// Existing stateful groups must remain editable after an operator disables the site flag.
+    #[test]
+    fn stateful_egress_enablement_requires_site_support() {
+        scenarios!(
+            run = |(current, requested, site_enabled)| {
+                validate_stateful_egress_enablement(current, requested, site_enabled).map_err(drop)
+            };
+            "site support disabled" {
+                // Stateless NSGs remain supported when stateful ACLs are unavailable.
+                (None, false, false) => Yields(()),
+                // Creation must not persist stateful intent the site cannot provide.
+                (None, true, false) => Fails,
+                // A stateless NSG cannot become stateful while support is unavailable.
+                (Some(false), true, false) => Fails,
+                // Disabling the site flag must not prevent unrelated edits to existing stateful NSGs.
+                (Some(true), true, false) => Yields(()),
+            }
+
+            "site support enabled" {
+                // Stateful NSGs are valid when the site advertises the required capability.
+                (None, true, true) => Yields(()),
+            }
+        );
+    }
 }

--- a/crates/api-core/src/tests/network_security_group.rs
+++ b/crates/api-core/src/tests/network_security_group.rs
@@ -38,7 +38,8 @@ use crate::tests::common::api_fixtures::instance::{
 };
 use crate::tests::common::api_fixtures::test_managed_host::TestManagedHost;
 use crate::tests::common::api_fixtures::{
-    create_test_env, populate_network_security_groups, site_explorer,
+    TestEnvOverrides, create_test_env, create_test_env_with_overrides, get_config,
+    populate_network_security_groups, site_explorer,
 };
 use crate::tests::common::rpc_builder::VpcCreationRequest;
 
@@ -486,6 +487,140 @@ async fn test_network_security_group_create(
 
     //Verify the metadata
     assert_eq!(network_security_group.metadata, metadata);
+
+    Ok(())
+}
+
+/// Verifies disabled site support rejects new stateful intent without mutating persistence.
+///
+/// This prevents accepted NSG state from promising statefulness the site cannot provide.
+#[crate::sqlx_test]
+async fn test_network_security_group_stateful_egress_requires_site_support(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut config = get_config();
+    config.network_security_group.stateful_acls_enabled = false;
+    let env = create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await;
+
+    let tenant_organization_id = "stateful_nsg_tenant";
+    let rejected_id = "08b4c3fa-bf88-4a61-b435-a2f398545652";
+    let stateless_id = "c34d8b63-2189-4bda-9340-266bf762442d";
+    let metadata = Some(rpc::forge::Metadata {
+        name: "stateful NSG gate".to_string(),
+        description: String::new(),
+        labels: vec![],
+    });
+
+    // Create the tenant required by the public NSG API.
+    env.api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: tenant_organization_id.to_string(),
+            routing_profile_type: None,
+            metadata: Some(rpc::forge::Metadata {
+                name: tenant_organization_id.to_string(),
+                description: String::new(),
+                labels: vec![],
+            }),
+        }))
+        .await
+        .expect("tenant creation should succeed");
+
+    // Reject a stateful create before it can persist an unusable group.
+    let error = env
+        .api
+        .create_network_security_group(tonic::Request::new(
+            rpc::forge::CreateNetworkSecurityGroupRequest {
+                id: Some(rejected_id.to_string()),
+                tenant_organization_id: tenant_organization_id.to_string(),
+                metadata: metadata.clone(),
+                network_security_group_attributes: Some(
+                    rpc::forge::NetworkSecurityGroupAttributes {
+                        stateful_egress: true,
+                        rules: vec![],
+                    },
+                ),
+            },
+        ))
+        .await
+        .expect_err("stateful creation should require site support");
+    assert_eq!(error.code(), Code::InvalidArgument);
+
+    // Reload through the public API to prove the rejected create left no record.
+    let rejected_groups = env
+        .api
+        .find_network_security_groups_by_ids(tonic::Request::new(
+            rpc::forge::FindNetworkSecurityGroupsByIdsRequest {
+                network_security_group_ids: vec![rejected_id.to_string()],
+                tenant_organization_id: Some(tenant_organization_id.to_string()),
+            },
+        ))
+        .await?
+        .into_inner()
+        .network_security_groups;
+    assert!(rejected_groups.is_empty());
+
+    // Stateless NSGs remain valid while site-level stateful ACLs are disabled.
+    let stateless_network_security_group = env
+        .api
+        .create_network_security_group(tonic::Request::new(
+            rpc::forge::CreateNetworkSecurityGroupRequest {
+                id: Some(stateless_id.to_string()),
+                tenant_organization_id: tenant_organization_id.to_string(),
+                metadata: metadata.clone(),
+                network_security_group_attributes: Some(
+                    rpc::forge::NetworkSecurityGroupAttributes {
+                        stateful_egress: false,
+                        rules: vec![],
+                    },
+                ),
+            },
+        ))
+        .await?
+        .into_inner()
+        .network_security_group
+        .expect("create response should contain the NSG");
+    assert!(
+        !stateless_network_security_group
+            .attributes
+            .as_ref()
+            .expect("created NSG should contain attributes")
+            .stateful_egress
+    );
+
+    // Reject the unsupported false-to-true transition.
+    let error = env
+        .api
+        .update_network_security_group(tonic::Request::new(
+            rpc::forge::UpdateNetworkSecurityGroupRequest {
+                id: stateless_id.to_string(),
+                tenant_organization_id: tenant_organization_id.to_string(),
+                metadata,
+                network_security_group_attributes: Some(
+                    rpc::forge::NetworkSecurityGroupAttributes {
+                        stateful_egress: true,
+                        rules: vec![],
+                    },
+                ),
+                if_version_match: Some(stateless_network_security_group.version.clone()),
+            },
+        ))
+        .await
+        .expect_err("enabling stateful egress should require site support");
+    assert_eq!(error.code(), Code::InvalidArgument);
+
+    // Reload the NSG to prove the rejected update changed neither data nor version.
+    let persisted_groups = env
+        .api
+        .find_network_security_groups_by_ids(tonic::Request::new(
+            rpc::forge::FindNetworkSecurityGroupsByIdsRequest {
+                network_security_group_ids: vec![stateless_id.to_string()],
+                tenant_organization_id: Some(tenant_organization_id.to_string()),
+            },
+        ))
+        .await?
+        .into_inner()
+        .network_security_groups;
+    assert_eq!(persisted_groups, vec![stateless_network_security_group]);
 
     Ok(())
 }

--- a/deploy/nico-base/api/config-files/carbide-api-config.toml
+++ b/deploy/nico-base/api/config-files/carbide-api-config.toml
@@ -91,14 +91,14 @@ failure_retry_time = "90m"
 vpc_prefix_drain_time = "5m"
 
 [network_security_group]
-# Controls whether additional config to support
-# stateful/reflexive ACLs will be inserted into
-# the HBN config.
-# This is expected to remain off at least until all sites
-# are running HBN 2.3 or higher.  The reflexive-acl
-# implementation in earlier versions exposes a way for
-# users to accidentally permit-all in both directions
-# with a single rule in one direction.
+# Controls whether NSGs may enable stateful egress and whether
+# stateful/reflexive ACL support is inserted into HBN configuration.
+# When false, Core rejects stateful NSG creation and updates from
+# stateless to stateful. Existing stateful NSGs remain editable but
+# are applied statelessly.
+# Leave disabled until every DPU in the site runs HBN 2.3 or later.
+# Earlier reflexive-ACL implementations allow one directional rule
+# to unintentionally permit traffic in both directions.
 stateful_acls_enabled = false
 
 # Maximum number of security groups rules

--- a/docs/manuals/networking/network_security_groups.md
+++ b/docs/manuals/networking/network_security_groups.md
@@ -71,7 +71,7 @@ An NSG is a tenant-owned object with the following shape:
 |---|---|
 | `id` | NSG identifier, optionally supplied by the caller as a UUID at creation. If omitted, NICo generates one. Either way, it is returned on the created NSG. A supplied `id` that collides with an existing NSG is rejected with `409 Conflict`. |
 | `tenant_organization_id` | The owning tenant |
-| `stateful_egress` | When `true`, return traffic for egress flows is permitted automatically. Requires the site-level `stateful_acls_enabled` flag (see below) |
+| `stateful_egress` | When `true`, return traffic for egress flows is permitted automatically. It can be enabled only when the site-level `stateful_acls_enabled` flag is `true` (see below) |
 | `rules` | Ordered list of `NetworkSecurityGroupRule` entries, evaluated by priority |
 | `version` | Optimistic-concurrency token; required when updating the NSG |
 
@@ -247,8 +247,11 @@ the DPU side.
 Toggling this flag controls whether NICo will configure the DPU's default
 stateful-ACL options in the NVUE config it pushes. Stateful NSG behaviour
 also requires the tenant to set `stateful_egress = true` on the NSG;
-without the site-level switch, the DPU treats every rule as stateless
-regardless of the per-NSG flag.
+when the site-level switch is disabled, NICo rejects stateful NSG
+creation and updates that enable stateful egress. An existing stateful
+NSG can still be otherwise updated if an operator later disables the
+site flag, but the DPU treats its rules as stateless until site support
+is enabled again.
 
 Leave `stateful_acls_enabled = false` until every DPU in the site is
 running HBN 2.3 or later. Earlier HBN versions implement reflexive ACLs in
@@ -335,9 +338,9 @@ worth knowing before designing rule sets:
 - **IPv4 and IPv6 are separate rules.** A rule has an `ipv6` boolean and
   applies only to one address family; if a tenant needs both, two rules
   are required.
-- **`stateful_egress` requires the site flag.** A tenant may set
-  `stateful_egress = true` on the NSG, but it has no effect until the
-  site-level `stateful_acls_enabled = true`.
+- **`stateful_egress` requires the site flag.** Creating an NSG with
+  `stateful_egress = true`, or updating it from `false` to `true`, is
+  rejected unless the site-level `stateful_acls_enabled` flag is `true`.
 - **Updates require version-token agreement.** An NSG update takes the
   NSG's `version` and fails if it has been concurrently modified. This is
   the standard NICo optimistic-concurrency pattern.
@@ -416,6 +419,7 @@ For a given tenant configuration, confirm:
 | Symptom | Likely cause |
 |---|---|
 | `network-security-group create` fails with size-limit error | Expanded rule count exceeds `max_network_security_group_size` |
+| NSG creation or update fails when enabling stateful egress | `stateful_acls_enabled = false` site-wide |
 | `network-security-group create` fails with a conflict (`409`) on `id` | A caller-supplied NSG `id` collides with an existing NSG; omit the `id` to auto-generate one, or choose a different UUID |
 | Stateful return traffic is being dropped | `stateful_acls_enabled = false` site-wide, or `stateful_egress = false` on the NSG, or DPU on HBN earlier than 2.3 |
 | Tenant rule that "should permit" a flow has no effect | An operator `policy_overrides` rule denies the same flow at higher (earlier-evaluated) priority |

--- a/helm/charts/nico-api/files/carbide-api-config.toml
+++ b/helm/charts/nico-api/files/carbide-api-config.toml
@@ -110,11 +110,12 @@ failure_retry_time = "90m"
 vpc_prefix_drain_time = "5m"
 
 [network_security_group]
-# Controls whether additional config to support
-# stateful/reflexive ACLs will be inserted into
-# the HBN config.
-# This is expected to remain off at least until
-# NICo v2025.12.19 is fully in production.
+# Controls whether NSGs may enable stateful egress and whether
+# stateful/reflexive ACL support is inserted into HBN configuration.
+# When false, Core rejects stateful NSG creation and updates from
+# stateless to stateful. Existing stateful NSGs remain editable but
+# are applied statelessly.
+# Leave disabled until every DPU in the site runs HBN 2.3 or later.
 stateful_acls_enabled = false
 
 # Maximum number of security groups rules


### PR DESCRIPTION
Reject NSG creation with stateful_egress=true and updates from stateless to stateful when site-level stateful ACL support is disabled.

This prevents NICo from accepting policies the DPU cannot enforce while preserving stateless NSGs and updates to existing stateful groups.


## Related issues
NVBUG 6627320

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
NVBUG 6627320

<details><summary>Deeper Dive</summary>

 ## Behavioral overview

  The branch changes NSG admission behavior so NICo no longer accepts new stateful intent that the site cannot honor.
| site flag | action | result |
 |------------|--------------|------|
 |  false  |                       Create with stateful_egress=false |   Succeeds|
 |  false   |                      Create with stateful_egress=true  |   Rejected|
 |  false   |                      Update false → true                |  Rejected|
 |  false   |                      Update an existing true → true |      Succeeds|
 |  true    |                      Any of the above                    | Existing behavior; succeeds if otherwise valid|

  ### API and persistence promises

  A rejected create is validated before opening its database transaction, so it creates no record. A rejected update reads the existing NSG to identify whether this is a new enablement, but rejects before writing anything; the NSG’s attributes, metadata, rules, and version remain
  unchanged.

  The public-API coverage reloads state after both rejection paths, proving these persistence guarantees rather than relying only on handler responses.

  ### Operational promises

  Operators can use stateful_acls_enabled=false as a gate against any new stateful NSG intent. Enabling the site flag restores the existing ability to create stateful NSGs or convert stateless NSGs to stateful.

  This remains startup/runtime configuration rather than a dynamic policy. Configuration loading, defaults, and restart requirements are unchanged.

  The branch does not alter rule rendering, DPU propagation, attachments, expanded-rule limits, policy overrides, or stateful ACL implementation. It only controls which NSG configurations Core accepts.

  ### Compatibility

  This is intentionally stricter for one previously accepted request class: clients that submit stateful_egress=true while site support is disabled will now receive a client error instead of success.

  The following remain compatible:

  - Stateless NSG creation and updates.
  - Stateful NSGs at sites where stateful ACL support is enabled.
  - Existing stateful NSGs if an operator later disables the site flag.
  - Existing protobuf messages, database schema, and stored representation—there is no wire-format or migration change.

  Because an existing stateful NSG remains editable after the site flag is disabled, clients do not have to clear stateful_egress merely to update its metadata or rules.

  ### Limits and non-promises

  The branch prevents new incompatible state, but it does not repair or backfill existing NSGs. An NSG already stored with stateful_egress=true remains stored that way when site support is disabled, and the DPU continues treating it as stateless. Operators must either re-enable
  site support or explicitly update the NSG to false.

  No REST code was changed. Core now emits gRPC INVALID_ARGUMENT; REST client-error behavior continues to depend on the existing REST-to-Core error translation and is not directly tested in this branch.


</details>