### PR TITLE
chore(bmc): Refactor/authenticated bmc client

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -39,7 +39,7 @@ use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::{
     BmcCredentialType, CredentialKey, CredentialManager, CredentialType, Credentials,
 };
-use carbide_site_explorer::{EndpointExplorationService, EndpointExplorer};
+use carbide_site_explorer::{AuthenticatedBmc, EndpointExplorationService, EndpointExplorer};
 use carbide_uuid::machine::{MachineId, MachineIdSubtypeTrait, MachineInterfaceId};
 use db::db_read::PgPoolReader;
 use db::work_lock_manager::WorkLockManagerHandle;
@@ -83,6 +83,8 @@ pub struct Api {
     pub(crate) dpu_health_log_limiter: LogLimiter<MachineId>,
     pub dynamic_settings: DynamicSettings,
     pub(crate) endpoint_explorer: Arc<dyn EndpointExplorer>,
+    /// Authenticated BMC client for admin ops; same object as `endpoint_explorer`.
+    pub(crate) bmc_client: Arc<dyn AuthenticatedBmc>,
     pub(crate) endpoint_exploration_service: Arc<EndpointExplorationService>,
     pub(crate) scout_stream_registry: ConnectionRegistry,
     #[allow(unused)]

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -83,7 +83,8 @@ pub struct Api {
     pub(crate) dpu_health_log_limiter: LogLimiter<MachineId>,
     pub dynamic_settings: DynamicSettings,
     pub(crate) endpoint_explorer: Arc<dyn EndpointExplorer>,
-    /// Authenticated BMC client for admin ops; same object as `endpoint_explorer`.
+    /// Authenticated BMC client for admin operations, supplied independently of
+    /// endpoint exploration.
     pub(crate) bmc_client: Arc<dyn AuthenticatedBmc>,
     pub(crate) endpoint_exploration_service: Arc<EndpointExplorationService>,
     pub(crate) scout_stream_registry: ConnectionRegistry,

--- a/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
+++ b/crates/api-core/src/handlers/bmc_endpoint_explorer.rs
@@ -512,7 +512,7 @@ pub(crate) async fn disable_secure_boot(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &bmc_endpoint_request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .disable_secure_boot(bmc_addr, &machine_interface)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -552,7 +552,7 @@ pub(crate) async fn lockdown(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &bmc_endpoint_request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .lockdown(bmc_addr, &machine_interface, action)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -589,7 +589,7 @@ pub(crate) async fn lockdown_status(
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
     let response = api
-        .endpoint_explorer
+        .bmc_client
         .lockdown_status(bmc_addr, &machine_interface)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -622,7 +622,7 @@ pub(crate) async fn enable_infinite_boot(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &bmc_endpoint_request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .enable_infinite_boot(bmc_addr, &machine_interface)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -662,7 +662,7 @@ pub(crate) async fn is_infinite_boot_enabled(
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
     let is_enabled = api
-        .endpoint_explorer
+        .bmc_client
         .is_infinite_boot_enabled(bmc_addr, &machine_interface)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -754,7 +754,7 @@ pub(crate) async fn machine_setup(
         entered_mac,
     );
 
-    api.endpoint_explorer
+    api.bmc_client
         .machine_setup(bmc_addr, &machine_interface, boot_interface.as_ref())
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -844,7 +844,7 @@ pub(crate) async fn set_dpu_first_boot_order(
         )
     })?;
 
-    api.endpoint_explorer
+    api.bmc_client
         .set_boot_order_dpu_first(bmc_addr, &machine_interface, &boot_interface)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -1000,7 +1000,7 @@ async fn redfish_reset_bmc(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .redfish_reset_bmc(bmc_addr, &machine_interface, reset_type)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -1015,7 +1015,7 @@ async fn ipmitool_reset_bmc(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .ipmitool_reset_bmc(bmc_addr, &machine_interface)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -1031,7 +1031,7 @@ async fn redfish_power_control(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .redfish_power_control(bmc_addr, &machine_interface, action)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -1048,10 +1048,7 @@ pub(crate) async fn bmc_credential_status(
     let (_bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &req).await?;
 
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
-    let have_credentials = api
-        .endpoint_explorer
-        .have_credentials(&machine_interface)
-        .await;
+    let have_credentials = api.bmc_client.have_credentials(&machine_interface).await;
 
     Ok(Response::new(rpc::BmcCredentialStatusResponse {
         have_credentials,
@@ -1341,7 +1338,7 @@ pub(crate) async fn set_bmc_root_password(
 
     tracing::info!(bmc_address = %bmc_addr, "Setting BMC root password");
 
-    api.endpoint_explorer
+    api.bmc_client
         .set_bmc_root_password(bmc_addr, &machine_interface, &req.new_password)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -1374,7 +1371,7 @@ pub(crate) async fn probe_bmc_vendor(
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
     let vendor = api
-        .endpoint_explorer
+        .bmc_client
         .probe_bmc_vendor(bmc_addr, &machine_interface)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;
@@ -1396,7 +1393,7 @@ async fn do_create_bmc_user(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .create_bmc_user(
             bmc_addr,
             &machine_interface,
@@ -1418,7 +1415,7 @@ async fn do_delete_bmc_user(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .delete_bmc_user(bmc_addr, &machine_interface, delete_user)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;

--- a/crates/api-core/src/handlers/gpu_reset.rs
+++ b/crates/api-core/src/handlers/gpu_reset.rs
@@ -93,7 +93,7 @@ pub(crate) async fn admin_gpu_reset(
     let (bmc_addr, bmc_mac_address) = resolve_bmc_interface(api, &bmc_endpoint_request).await?;
     let machine_interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 
-    api.endpoint_explorer
+    api.bmc_client
         .redfish_chassis_reset(bmc_addr, &machine_interface, &chassis_id, action)
         .await
         .map_err(|e| CarbideError::internal(e.to_string()))?;

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -58,7 +58,7 @@ use carbide_rack_controller::io::RackStateControllerIO;
 use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::{CredentialManager, CredentialReader};
-use carbide_site_explorer::{EndpointExplorationService, EndpointExplorer, SiteExplorer};
+use carbide_site_explorer::{AuthenticatedBmcClient, EndpointExplorationService, SiteExplorer};
 use carbide_spdm_controller::context::SpdmStateHandlerServices;
 use carbide_spdm_controller::handler::SpdmAttestationStateHandler;
 use carbide_spdm_controller::io::SpdmStateControllerIO;
@@ -399,11 +399,14 @@ pub(crate) async fn start_runtime(
         carbide_config.bmc_max_sessions_per_caller,
     ));
 
-    let bmc_explorer = carbide_site_explorer::new_bmc_explorer(
+    let bmc_client = Arc::new(AuthenticatedBmcClient::new(
         bmc_credential_ops.clone(),
         shared_nv_redfish_pool,
         ipmi_tool.clone(),
         credential_manager.clone(),
+    ));
+    let bmc_explorer = carbide_site_explorer::new_bmc_explorer(
+        bmc_client.clone(),
         carbide_config
             .site_explorer
             .rotate_switch_nvos_credentials
@@ -411,11 +414,9 @@ pub(crate) async fn start_runtime(
         carbide_config.site_explorer.explore_mode,
         db_pool.clone(),
     );
-    let bmc_client = bmc_explorer.authenticated_bmc_client();
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         db_pool.clone(),
         bmc_explorer.clone(),
-        bmc_client.clone(),
         Arc::new(carbide_config.get_firmware_config()),
     ));
 
@@ -1905,6 +1906,7 @@ async fn initialize_and_start_controllers<'a>(
         site_explorer_config,
         meter.clone(),
         endpoint_exploration_service.clone(),
+        api_service.bmc_client.clone(),
         common_pools.clone(),
         work_lock_manager_handle.clone(),
         carbide_config.rack_profiles.clone(),

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -58,7 +58,7 @@ use carbide_rack_controller::io::RackStateControllerIO;
 use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::{CredentialManager, CredentialReader};
-use carbide_site_explorer::{EndpointExplorationService, SiteExplorer};
+use carbide_site_explorer::{EndpointExplorationService, EndpointExplorer, SiteExplorer};
 use carbide_spdm_controller::context::SpdmStateHandlerServices;
 use carbide_spdm_controller::handler::SpdmAttestationStateHandler;
 use carbide_spdm_controller::io::SpdmStateControllerIO;
@@ -411,9 +411,11 @@ pub(crate) async fn start_runtime(
         carbide_config.site_explorer.explore_mode,
         db_pool.clone(),
     );
+    let bmc_client = bmc_explorer.authenticated_bmc_client();
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         db_pool.clone(),
         bmc_explorer.clone(),
+        bmc_client.clone(),
         Arc::new(carbide_config.get_firmware_config()),
     ));
 
@@ -522,6 +524,7 @@ pub(crate) async fn start_runtime(
         dpu_health_log_limiter: LogLimiter::default(),
         dynamic_settings,
         endpoint_explorer: bmc_explorer,
+        bmc_client,
         endpoint_exploration_service: endpoint_exploration_service.clone(),
         eth_data,
         ib_fabric_manager,

--- a/crates/api-core/src/test_support/builder.rs
+++ b/crates/api-core/src/test_support/builder.rs
@@ -28,7 +28,9 @@ use carbide_secrets::test_support::certificates::TestCertificateProvider;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_site_explorer::config::SiteExplorerExploreMode;
 use carbide_site_explorer::test_support::MockEndpointExplorer;
-use carbide_site_explorer::{AuthenticatedBmc, EndpointExplorationService, EndpointExplorer};
+use carbide_site_explorer::{
+    AuthenticatedBmc, AuthenticatedBmcClient, EndpointExplorationService, EndpointExplorer,
+};
 use carbide_utils::test_support::test_meter::TestMeter;
 use db::work_lock_manager::WorkLockManagerHandle;
 use libnmxc::NmxcPool;
@@ -229,36 +231,34 @@ impl TestApiBuilder {
         // behind it), so a supplied mock serves exploration -- but forwards its
         // boot-order/machine-setup calls to this real, `RedfishSim`-backed
         // explorer. With no mock, the API uses the real explorer (prod wiring).
-        let real_endpoint_explorer = carbide_site_explorer::new_bmc_explorer(
+        let real_bmc_client = Arc::new(AuthenticatedBmcClient::new(
             redfish_pool.clone(),
             nv_redfish_pool,
             carbide_ipmi::test_support(),
             credential_manager.clone(),
+        ));
+        let real_endpoint_explorer = carbide_site_explorer::new_bmc_explorer(
+            real_bmc_client.clone(),
             Arc::new(std::sync::atomic::AtomicBool::new(false)),
             SiteExplorerExploreMode::NvRedfish,
             self.db_pool.clone(),
         );
-        // The BMC admin client the API uses is the same object exploration runs
-        // on: for a mock, the mock's own `AuthenticatedBmc` (so tests asserting on
-        // it still see the calls); otherwise the real explorer's client.
+        // A mock supplies both narrow interfaces so tests asserting on BMC calls
+        // still see them; production-like tests use the independently constructed
+        // authenticated client shared with the real explorer.
         let (endpoint_explorer, bmc_client): (
             Arc<dyn EndpointExplorer>,
             Arc<dyn AuthenticatedBmc>,
         ) = match self.endpoint_explorer {
             Some(mock) => {
-                let backend = real_endpoint_explorer.authenticated_bmc_client();
-                let mock = Arc::new(mock.with_redfish_backend(backend));
+                let mock = Arc::new(mock.with_redfish_backend(real_bmc_client));
                 (mock.clone(), mock)
             }
-            None => (
-                real_endpoint_explorer.clone(),
-                real_endpoint_explorer.authenticated_bmc_client(),
-            ),
+            None => (real_endpoint_explorer, real_bmc_client),
         };
         let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
             self.db_pool.clone(),
             endpoint_explorer.clone(),
-            bmc_client.clone(),
             Arc::new(runtime_config.get_firmware_config()),
         ));
         let metric_emitter = self.metric_emitter.unwrap_or_else(|| {

--- a/crates/api-core/src/test_support/builder.rs
+++ b/crates/api-core/src/test_support/builder.rs
@@ -28,7 +28,7 @@ use carbide_secrets::test_support::certificates::TestCertificateProvider;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_site_explorer::config::SiteExplorerExploreMode;
 use carbide_site_explorer::test_support::MockEndpointExplorer;
-use carbide_site_explorer::{EndpointExplorationService, EndpointExplorer};
+use carbide_site_explorer::{AuthenticatedBmc, EndpointExplorationService, EndpointExplorer};
 use carbide_utils::test_support::test_meter::TestMeter;
 use db::work_lock_manager::WorkLockManagerHandle;
 use libnmxc::NmxcPool;
@@ -238,13 +238,27 @@ impl TestApiBuilder {
             SiteExplorerExploreMode::NvRedfish,
             self.db_pool.clone(),
         );
-        let endpoint_explorer: Arc<dyn EndpointExplorer> = match self.endpoint_explorer {
-            Some(mock) => Arc::new(mock.with_redfish_backend(real_endpoint_explorer)),
-            None => real_endpoint_explorer,
+        // The BMC admin client the API uses is the same object exploration runs
+        // on: for a mock, the mock's own `AuthenticatedBmc` (so tests asserting on
+        // it still see the calls); otherwise the real explorer's client.
+        let (endpoint_explorer, bmc_client): (
+            Arc<dyn EndpointExplorer>,
+            Arc<dyn AuthenticatedBmc>,
+        ) = match self.endpoint_explorer {
+            Some(mock) => {
+                let backend = real_endpoint_explorer.authenticated_bmc_client();
+                let mock = Arc::new(mock.with_redfish_backend(backend));
+                (mock.clone(), mock)
+            }
+            None => (
+                real_endpoint_explorer.clone(),
+                real_endpoint_explorer.authenticated_bmc_client(),
+            ),
         };
         let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
             self.db_pool.clone(),
             endpoint_explorer.clone(),
+            bmc_client.clone(),
             Arc::new(runtime_config.get_firmware_config()),
         ));
         let metric_emitter = self.metric_emitter.unwrap_or_else(|| {
@@ -284,6 +298,7 @@ impl TestApiBuilder {
             ib_fabric_manager,
             dynamic_settings,
             endpoint_explorer,
+            bmc_client,
             endpoint_exploration_service,
             dpu_health_log_limiter,
             scout_stream_registry,

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1698,6 +1698,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         },
         test_meter.meter(),
         api.endpoint_exploration_service.clone(),
+        api.bmc_client.clone(),
         common_pools.clone(),
         api.work_lock_manager_handle.clone(),
         site_explorer_rack_profiles,

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -25,8 +25,8 @@ use carbide_redfish::boot_interface::BootInterfaceTarget;
 use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use carbide_secrets::credentials::Credentials;
 use carbide_secrets::test_support::credentials::TestCredentialManager;
-use carbide_site_explorer::BmcEndpointExplorer;
 use carbide_site_explorer::config::SiteExplorerExploreMode;
+use carbide_site_explorer::{AuthenticatedBmcClient, BmcEndpointExplorer};
 use clap::Parser;
 use mac_address::MacAddress;
 use tracing_subscriber::fmt;
@@ -107,11 +107,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     };
     let rotate_switch_nvos_credentials = Default::default();
 
-    let explorer = BmcEndpointExplorer::new(
+    let bmc_client = Arc::new(AuthenticatedBmcClient::new(
         redfish_client_pool,
         Arc::new(NvRedfishClientPool::new(proxy_address)),
         carbide_ipmi::test_support(),
         credential_provider.clone(),
+    ));
+    let explorer = BmcEndpointExplorer::new(
+        bmc_client,
         rotate_switch_nvos_credentials,
         mode,
         // Standalone debug tool: no database, so rotation bookkeeping is skipped.

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -86,9 +86,26 @@ pub struct AuthenticatedBmcClient {
     credential_client: CredentialClient,
 }
 
+impl AuthenticatedBmcClient {
+    /// Build the shared authenticated BMC client used by endpoint exploration
+    /// and by callers performing BMC administration.
+    pub fn new(
+        redfish_client_pool: Arc<dyn BmcCredentialOps>,
+        nv_redfish_client_pool: Arc<NvRedfishClientPool>,
+        ipmi_tool: Arc<dyn IPMITool>,
+        credential_manager: Arc<dyn CredentialManager>,
+    ) -> Self {
+        Self {
+            redfish_client: RedfishClient::new(redfish_client_pool, nv_redfish_client_pool),
+            ipmi_tool,
+            credential_client: CredentialClient::new(credential_manager),
+        }
+    }
+}
+
 /// An `EndpointExplorer` which uses redfish APIs to query the endpoint
 pub struct BmcEndpointExplorer {
-    bmc_client: AuthenticatedBmcClient,
+    bmc_client: Arc<AuthenticatedBmcClient>,
     rotate_switch_nvos_credentials: Arc<AtomicBool>,
     mode: SiteExplorerExploreMode,
     /// Used to record per-device BMC rotation convergence at the moment the
@@ -99,50 +116,26 @@ pub struct BmcEndpointExplorer {
     database_connection: Option<PgPool>,
 }
 
-// Deref lets exploration methods keep using `self.redfish_client` etc. after
-// ownership of those clients moved onto the extracted type.
-impl std::ops::Deref for BmcEndpointExplorer {
-    type Target = AuthenticatedBmcClient;
-
-    fn deref(&self) -> &Self::Target {
-        &self.bmc_client
-    }
-}
-
 impl BmcEndpointExplorer {
-    /// `redfish_client_pool` is the direct pool's credential-operations
-    /// handle ([`BmcCredentialOps`]): exploration sets BMC root passwords
-    /// and probes vendors on the endpoint itself.
+    /// Build an explorer over the shared authenticated BMC client.
     pub fn new(
-        redfish_client_pool: Arc<dyn BmcCredentialOps>,
-        nv_redfish_client_pool: Arc<NvRedfishClientPool>,
-        ipmi_tool: Arc<dyn IPMITool>,
-        credential_manager: Arc<dyn CredentialManager>,
+        bmc_client: Arc<AuthenticatedBmcClient>,
         rotate_switch_nvos_credentials: Arc<AtomicBool>,
         mode: SiteExplorerExploreMode,
         database_connection: Option<PgPool>,
     ) -> Self {
         Self {
-            bmc_client: AuthenticatedBmcClient {
-                redfish_client: RedfishClient::new(redfish_client_pool, nv_redfish_client_pool),
-                ipmi_tool,
-                credential_client: CredentialClient::new(credential_manager),
-            },
+            bmc_client,
             rotate_switch_nvos_credentials,
             mode,
             database_connection,
         }
     }
 
-    /// A shared [`AuthenticatedBmc`] handle to the same client exploration runs
-    /// on. Callers needing only BMC admin ops hold this instead of the explorer.
-    pub fn authenticated_bmc_client(&self) -> Arc<dyn AuthenticatedBmc> {
-        Arc::new(self.bmc_client.clone())
-    }
-
     pub async fn get_sitewide_bmc_password(&self) -> Result<String, EndpointExplorationError> {
         let version = self.current_sitewide_bmc_version().await?;
         let credentials = self
+            .bmc_client
             .credential_client
             .get_sitewide_bmc_root_credentials(version)
             .await?;
@@ -159,7 +152,8 @@ impl BmcEndpointExplorer {
         create_if_missing: bool,
     ) -> Result<String, EndpointExplorationError> {
         let version = self.current_sitewide_dpu_bmc_service_version().await?;
-        self.credential_client
+        self.bmc_client
+            .credential_client
             .get_sitewide_dpu_bmc_service_password(version, create_if_missing)
             .await
     }
@@ -259,8 +253,13 @@ impl BmcEndpointExplorer {
     }
 
     async fn get_dpu_factory_default_credentials(&self, bmc_ip_address: SocketAddr) -> Credentials {
-        let model = self.redfish_client.get_dpu_model_hint(bmc_ip_address).await;
-        self.credential_client
+        let model = self
+            .bmc_client
+            .redfish_client
+            .get_dpu_model_hint(bmc_ip_address)
+            .await;
+        self.bmc_client
+            .credential_client
             .get_dpu_factory_default_credentials(model)
             .await
     }
@@ -269,7 +268,8 @@ impl BmcEndpointExplorer {
         &self,
         bmc_mac_address: MacAddress,
     ) -> Result<Credentials, EndpointExplorationError> {
-        self.credential_client
+        self.bmc_client
+            .credential_client
             .get_switch_nvos_admin_credentials(bmc_mac_address)
             .await
     }
@@ -279,7 +279,8 @@ impl BmcEndpointExplorer {
         bmc_mac_address: MacAddress,
         credentials: &Credentials,
     ) -> Result<(), EndpointExplorationError> {
-        self.credential_client
+        self.bmc_client
+            .credential_client
             .set_bmc_root_credentials(bmc_mac_address, credentials)
             .await?;
 
@@ -318,7 +319,8 @@ impl BmcEndpointExplorer {
         root_credentials: &Credentials,
     ) -> Result<(), EndpointExplorationError> {
         let new_password = self.get_sitewide_dpu_bmc_service_password(true).await?;
-        self.redfish_client
+        self.bmc_client
+            .redfish_client
             .set_bf4_dpu_service_password(bmc_ip_address, root_credentials.clone(), new_password)
             .await?;
 
@@ -360,7 +362,8 @@ impl BmcEndpointExplorer {
     ) -> Result<EndpointExplorationReport, EndpointExplorationError> {
         match self.mode {
             SiteExplorerExploreMode::LibRedfish => {
-                self.redfish_client
+                self.bmc_client
+                    .redfish_client
                     .generate_exploration_report(
                         bmc_ip_address,
                         credentials.clone(),
@@ -370,12 +373,14 @@ impl BmcEndpointExplorer {
                     .await
             }
             SiteExplorerExploreMode::NvRedfish => {
-                self.redfish_client
+                self.bmc_client
+                    .redfish_client
                     .nv_generate_exploration_report(bmc_ip_address, credentials, boot_interface)
                     .await
             }
             SiteExplorerExploreMode::CompareResult => {
                 let libredfish = self
+                    .bmc_client
                     .redfish_client
                     .generate_exploration_report(
                         bmc_ip_address,
@@ -385,6 +390,7 @@ impl BmcEndpointExplorer {
                     )
                     .await;
                 let nvredfish = self
+                    .bmc_client
                     .redfish_client
                     .nv_generate_exploration_report(bmc_ip_address, credentials, boot_interface)
                     .await;
@@ -451,6 +457,7 @@ impl BmcEndpointExplorer {
             // return an error if we cannot log into the machine's BMC using current credentials
             let sitewide_bmc_password = self.get_sitewide_bmc_password().await?;
             let rotation = self
+                .bmc_client
                 .set_bmc_root_password(
                     bmc_ip_address,
                     vendor,
@@ -495,6 +502,7 @@ impl BmcEndpointExplorer {
 
         let version = self.current_sitewide_bmc_version().await?;
         let sitewide_credentials = self
+            .bmc_client
             .credential_client
             .get_sitewide_bmc_root_credentials(version)
             .await?;
@@ -509,7 +517,8 @@ impl BmcEndpointExplorer {
         // before validating with the sitewide credentials.
         tokio::time::sleep(BMC_AUTH_RETRY_DURATION).await;
 
-        self.redfish_client
+        self.bmc_client
+            .redfish_client
             .validate_bmc_credentials(bmc_ip_address, credentials.clone())
             .await?;
 
@@ -539,7 +548,8 @@ impl BmcEndpointExplorer {
                 %bmc_mac_address,
                 "Storing NVOS admin credentials in vault"
             );
-            self.credential_client
+            self.bmc_client
+                .credential_client
                 .set_bmc_nvos_admin_credentials(
                     bmc_mac_address,
                     &Credentials::UsernamePassword {
@@ -553,8 +563,6 @@ impl BmcEndpointExplorer {
     }
 }
 
-// Authenticated BMC ops live on the client, not the explorer. Exploration code
-// reaches these through `BmcEndpointExplorer`'s `Deref` to this type.
 impl AuthenticatedBmcClient {
     pub async fn get_bmc_root_credentials(
         &self,
@@ -754,7 +762,10 @@ impl EndpointExplorer for BmcEndpointExplorer {
         &self,
         metrics: &mut SiteExplorationMetrics,
     ) -> Result<(), EndpointExplorationError> {
-        self.credential_client.check_preconditions(metrics).await
+        self.bmc_client
+            .credential_client
+            .check_preconditions(metrics)
+            .await
     }
 
     // 1) Authenticate and set the BMC root account credentials
@@ -776,7 +787,12 @@ impl EndpointExplorer for BmcEndpointExplorer {
         }
 
         let bmc_mac_address = interface.mac_address;
-        let vendor = match self.redfish_client.get_redfish_vendor(bmc_ip_address).await {
+        let vendor = match self
+            .bmc_client
+            .redfish_client
+            .get_redfish_vendor(bmc_ip_address)
+            .await
+        {
             Ok(vendor) => vendor,
             Err(e) => {
                 tracing::error!(
@@ -796,18 +812,22 @@ impl EndpointExplorer for BmcEndpointExplorer {
                     return Err(e);
                 };
 
-                let (username, password) =
-                    match self.get_bmc_root_credentials(bmc_mac_address).await {
-                        Ok(Credentials::UsernamePassword { username, password }) => {
-                            (username, password)
-                        }
-                        Err(_) => (eps.bmc_username.clone(), eps.bmc_password.clone()),
-                    };
+                let (username, password) = match self
+                    .bmc_client
+                    .get_bmc_root_credentials(bmc_mac_address)
+                    .await
+                {
+                    Ok(Credentials::UsernamePassword { username, password }) => {
+                        (username, password)
+                    }
+                    Err(_) => (eps.bmc_username.clone(), eps.bmc_password.clone()),
+                };
 
                 // Lite-On and Delta power shelf BMCs don't expose vendor
                 // details in the service root, so we fall back to checking the
                 // Manufacturer field across all Chassis entries.
                 let vendor = match self
+                    .bmc_client
                     .redfish_client
                     .probe_vendor_name_from_chassis(bmc_ip_address, username, password)
                     .await
@@ -845,7 +865,11 @@ impl EndpointExplorer for BmcEndpointExplorer {
         // Case 1: Vault contains a path at "bmc/{bmc_mac_address}/root"
         // This machine has its BMC set to the carbide sitewide BMC root password.
         // Create the redfish client and generate the report.
-        let report = match self.get_bmc_root_credentials(bmc_mac_address).await {
+        let report = match self
+            .bmc_client
+            .get_bmc_root_credentials(bmc_mac_address)
+            .await
+        {
             Ok(credentials) => {
                 match self
                     .generate_exploration_report(
@@ -949,6 +973,7 @@ impl EndpointExplorer for BmcEndpointExplorer {
                 };
 
                 let product = self
+                    .bmc_client
                     .redfish_client
                     .get_redfish_product(bmc_ip_address)
                     .await?;
@@ -1941,15 +1966,14 @@ mod tests {
         let mode = crate::config::SiteExplorerConfig::default_explore_mode();
         assert_eq!(mode, SiteExplorerExploreMode::NvRedfish);
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
-        let explorer = BmcEndpointExplorer::new(
+        let bmc_client = Arc::new(AuthenticatedBmcClient::new(
             Arc::new(RedfishSim::default()),
             Arc::new(NvRedfishClientPool::new(proxy_address)),
             carbide_ipmi::test_support(),
             Arc::new(TestCredentialManager::default()),
-            Arc::new(AtomicBool::new(false)),
-            mode,
-            None,
-        );
+        ));
+        let explorer =
+            BmcEndpointExplorer::new(bmc_client, Arc::new(AtomicBool::new(false)), mode, None);
 
         explorer
             .generate_exploration_report(
@@ -2075,11 +2099,14 @@ mod tests {
     ) -> Result<Vec<Option<RedfishSimBootInterfaceRef>>, String> {
         let sim = Arc::new(RedfishSim::default());
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
-        let explorer = BmcEndpointExplorer::new(
+        let bmc_client = Arc::new(AuthenticatedBmcClient::new(
             sim.clone(),
             Arc::new(NvRedfishClientPool::new(proxy_address)),
             carbide_ipmi::test_support(),
             Arc::new(TestCredentialManager::default()),
+        ));
+        let explorer = BmcEndpointExplorer::new(
+            bmc_client,
             Arc::new(AtomicBool::new(false)),
             SiteExplorerExploreMode::LibRedfish,
             None,
@@ -2194,11 +2221,14 @@ mod tests {
             .expect("seed site-wide BMC credentials");
 
         let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
-        let explorer = BmcEndpointExplorer::new(
+        let bmc_client = Arc::new(AuthenticatedBmcClient::new(
             sim.clone(),
             Arc::new(NvRedfishClientPool::new(proxy_address)),
             carbide_ipmi::test_support(),
             credential_manager.clone(),
+        ));
+        let explorer = BmcEndpointExplorer::new(
+            bmc_client,
             Arc::new(AtomicBool::new(false)),
             SiteExplorerExploreMode::LibRedfish,
             None,

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -564,7 +564,7 @@ impl BmcEndpointExplorer {
 }
 
 impl AuthenticatedBmcClient {
-    pub async fn get_bmc_root_credentials(
+    async fn get_bmc_root_credentials(
         &self,
         bmc_mac_address: MacAddress,
     ) -> Result<Credentials, EndpointExplorationError> {
@@ -573,7 +573,7 @@ impl AuthenticatedBmcClient {
             .await
     }
 
-    pub async fn set_bmc_root_password(
+    async fn set_bmc_root_password(
         &self,
         bmc_ip_address: SocketAddr,
         vendor: RedfishVendor,
@@ -597,162 +597,6 @@ impl AuthenticatedBmcClient {
             username: user,
             password: new_password,
         })
-    }
-
-    pub async fn redfish_reset_bmc(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        reset_type: Option<libredfish::ManagerResetType>,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .reset_bmc(bmc_ip_address, credentials, reset_type)
-            .await
-    }
-
-    pub async fn redfish_power_control(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        action: libredfish::SystemPowerControl,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .power(bmc_ip_address, credentials, action)
-            .await
-    }
-
-    pub async fn machine_setup(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        boot_interface: Option<&BootInterfaceTarget>,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .machine_setup(bmc_ip_address, credentials, boot_interface)
-            .await
-    }
-
-    pub async fn set_boot_order_dpu_first(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        boot_interface: &BootInterfaceTarget,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .set_boot_order_dpu_first(bmc_ip_address, credentials, boot_interface)
-            .await
-    }
-
-    pub async fn set_nic_mode(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        mode: BlueFieldOperatingMode,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .set_nic_mode(bmc_ip_address, credentials, mode.into_libredfish())
-            .await
-    }
-
-    async fn is_viking(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-    ) -> Result<bool, EndpointExplorationError> {
-        self.redfish_client
-            .is_viking(bmc_ip_address, credentials)
-            .await
-    }
-
-    pub async fn clear_nvram(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .clear_nvram(bmc_ip_address, credentials)
-            .await
-    }
-
-    pub async fn disable_secure_boot(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .disable_secure_boot(bmc_ip_address, credentials)
-            .await
-    }
-
-    pub async fn lockdown(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        action: libredfish::EnabledDisabled,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .lockdown(bmc_ip_address, credentials, action)
-            .await
-    }
-
-    pub async fn lockdown_status(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-    ) -> Result<LockdownStatus, EndpointExplorationError> {
-        self.redfish_client
-            .lockdown_status(bmc_ip_address, credentials)
-            .await
-    }
-
-    pub async fn enable_infinite_boot(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .enable_infinite_boot(bmc_ip_address, credentials)
-            .await
-    }
-
-    pub async fn is_infinite_boot_enabled(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-    ) -> Result<Option<bool>, EndpointExplorationError> {
-        self.redfish_client
-            .is_infinite_boot_enabled(bmc_ip_address, credentials)
-            .await
-    }
-
-    async fn create_bmc_user(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        new_username: &str,
-        new_password: &str,
-        role_id: libredfish::RoleId,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .create_bmc_user(
-                bmc_ip_address,
-                credentials,
-                new_username,
-                new_password,
-                role_id,
-            )
-            .await
-    }
-
-    async fn delete_bmc_user(
-        &self,
-        bmc_ip_address: SocketAddr,
-        credentials: Credentials,
-        delete_username: &str,
-    ) -> Result<(), EndpointExplorationError> {
-        self.redfish_client
-            .delete_bmc_user(bmc_ip_address, credentials, delete_username)
-            .await
     }
 }
 
@@ -1119,7 +963,8 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
             Ok(credentials) => {
-                self.redfish_reset_bmc(bmc_ip_address, credentials, reset_type)
+                self.redfish_client
+                    .reset_bmc(bmc_ip_address, credentials, reset_type)
                     .await
             }
             Err(e) => {
@@ -1187,7 +1032,8 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
             Ok(credentials) => {
-                self.redfish_power_control(bmc_ip_address, credentials, action)
+                self.redfish_client
+                    .power(bmc_ip_address, credentials, action)
                     .await
             }
             Err(e) => {
@@ -1223,7 +1069,11 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
         let bmc_mac_address = interface.mac_address;
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
-            Ok(credentials) => self.disable_secure_boot(bmc_ip_address, credentials).await,
+            Ok(credentials) => {
+                self.redfish_client
+                    .disable_secure_boot(bmc_ip_address, credentials)
+                    .await
+            }
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
@@ -1245,7 +1095,11 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
         let bmc_mac_address = interface.mac_address;
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
-            Ok(credentials) => self.lockdown(bmc_ip_address, credentials, action).await,
+            Ok(credentials) => {
+                self.redfish_client
+                    .lockdown(bmc_ip_address, credentials, action)
+                    .await
+            }
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
@@ -1266,7 +1120,11 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
         let bmc_mac_address = interface.mac_address;
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
-            Ok(credentials) => self.lockdown_status(bmc_ip_address, credentials).await,
+            Ok(credentials) => {
+                self.redfish_client
+                    .lockdown_status(bmc_ip_address, credentials)
+                    .await
+            }
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
@@ -1287,7 +1145,11 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
         let bmc_mac_address = interface.mac_address;
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
-            Ok(credentials) => self.enable_infinite_boot(bmc_ip_address, credentials).await,
+            Ok(credentials) => {
+                self.redfish_client
+                    .enable_infinite_boot(bmc_ip_address, credentials)
+                    .await
+            }
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
@@ -1309,7 +1171,8 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
             Ok(credentials) => {
-                self.is_infinite_boot_enabled(bmc_ip_address, credentials)
+                self.redfish_client
+                    .is_infinite_boot_enabled(bmc_ip_address, credentials)
                     .await
             }
             Err(e) => {
@@ -1334,7 +1197,8 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
             Ok(credentials) => {
-                self.machine_setup(bmc_ip_address, credentials, boot_interface)
+                self.redfish_client
+                    .machine_setup(bmc_ip_address, credentials, boot_interface)
                     .await
             }
             Err(e) => {
@@ -1359,7 +1223,8 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
             Ok(credentials) => {
-                self.set_boot_order_dpu_first(bmc_ip_address, credentials, boot_interface)
+                self.redfish_client
+                    .set_boot_order_dpu_first(bmc_ip_address, credentials, boot_interface)
                     .await
             }
             Err(e) => {
@@ -1383,7 +1248,11 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
         let bmc_mac_address = interface.mac_address;
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
-            Ok(credentials) => self.set_nic_mode(bmc_ip_address, credentials, mode).await,
+            Ok(credentials) => {
+                self.redfish_client
+                    .set_nic_mode(bmc_ip_address, credentials, mode.into_libredfish())
+                    .await
+            }
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
@@ -1404,7 +1273,11 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
         let bmc_mac_address = interface.mac_address;
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
-            Ok(credentials) => self.is_viking(bmc_ip_address, credentials).await,
+            Ok(credentials) => {
+                self.redfish_client
+                    .is_viking(bmc_ip_address, credentials)
+                    .await
+            }
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
@@ -1425,7 +1298,11 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
         let bmc_mac_address = interface.mac_address;
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
-            Ok(credentials) => self.clear_nvram(bmc_ip_address, credentials).await,
+            Ok(credentials) => {
+                self.redfish_client
+                    .clear_nvram(bmc_ip_address, credentials)
+                    .await
+            }
             Err(e) => {
                 tracing::info!(
                     %bmc_ip_address,
@@ -1450,7 +1327,8 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
             Ok(credentials) => {
-                self.create_bmc_user(bmc_ip_address, credentials, username, password, role_id)
+                self.redfish_client
+                    .create_bmc_user(bmc_ip_address, credentials, username, password, role_id)
                     .await
             }
             Err(e) => {
@@ -1475,7 +1353,8 @@ impl AuthenticatedBmc for AuthenticatedBmcClient {
 
         match self.get_bmc_root_credentials(bmc_mac_address).await {
             Ok(credentials) => {
-                self.delete_bmc_user(bmc_ip_address, credentials, username)
+                self.redfish_client
+                    .delete_bmc_user(bmc_ip_address, credentials, username)
                     .await
             }
             Err(e) => {

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -38,11 +38,11 @@ use model::site_explorer::{
 };
 use sqlx::PgPool;
 
-use super::EndpointExplorer;
 use super::config::SiteExplorerExploreMode;
 use super::credentials::{CredentialClient, get_bmc_root_credential_key};
 use super::metrics::SiteExplorationMetrics;
 use super::redfish::RedfishClient;
+use super::{AuthenticatedBmc, EndpointExplorer};
 
 const BMC_AUTH_RETRY_DURATION: Duration = Duration::from_secs(3);
 
@@ -76,11 +76,19 @@ struct BmcPasswordRotationFinished {
     error: String,
 }
 
-/// An `EndpointExplorer` which uses redfish APIs to query the endpoint
-pub struct BmcEndpointExplorer {
+/// Credential resolution plus authenticated Redfish/IPMI access. Owns the
+/// [`AuthenticatedBmc`] implementation, so BMC admin ops live here rather than
+/// on the explorer.
+#[derive(Clone)]
+pub struct AuthenticatedBmcClient {
     redfish_client: RedfishClient,
     ipmi_tool: Arc<dyn IPMITool>,
     credential_client: CredentialClient,
+}
+
+/// An `EndpointExplorer` which uses redfish APIs to query the endpoint
+pub struct BmcEndpointExplorer {
+    bmc_client: AuthenticatedBmcClient,
     rotate_switch_nvos_credentials: Arc<AtomicBool>,
     mode: SiteExplorerExploreMode,
     /// Used to record per-device BMC rotation convergence at the moment the
@@ -89,6 +97,16 @@ pub struct BmcEndpointExplorer {
     /// `bmc-explorer-cli` debug tool, which runs against an in-memory credential
     /// store and no database; in that case the rotation bookkeeping is skipped.
     database_connection: Option<PgPool>,
+}
+
+// Deref lets exploration methods keep using `self.redfish_client` etc. after
+// ownership of those clients moved onto the extracted type.
+impl std::ops::Deref for BmcEndpointExplorer {
+    type Target = AuthenticatedBmcClient;
+
+    fn deref(&self) -> &Self::Target {
+        &self.bmc_client
+    }
 }
 
 impl BmcEndpointExplorer {
@@ -105,13 +123,21 @@ impl BmcEndpointExplorer {
         database_connection: Option<PgPool>,
     ) -> Self {
         Self {
-            redfish_client: RedfishClient::new(redfish_client_pool, nv_redfish_client_pool),
-            ipmi_tool,
-            credential_client: CredentialClient::new(credential_manager),
+            bmc_client: AuthenticatedBmcClient {
+                redfish_client: RedfishClient::new(redfish_client_pool, nv_redfish_client_pool),
+                ipmi_tool,
+                credential_client: CredentialClient::new(credential_manager),
+            },
             rotate_switch_nvos_credentials,
             mode,
             database_connection,
         }
+    }
+
+    /// A shared [`AuthenticatedBmc`] handle to the same client exploration runs
+    /// on. Callers needing only BMC admin ops hold this instead of the explorer.
+    pub fn authenticated_bmc_client(&self) -> Arc<dyn AuthenticatedBmc> {
+        Arc::new(self.bmc_client.clone())
     }
 
     pub async fn get_sitewide_bmc_password(&self) -> Result<String, EndpointExplorationError> {
@@ -239,15 +265,6 @@ impl BmcEndpointExplorer {
             .await
     }
 
-    pub async fn get_bmc_root_credentials(
-        &self,
-        bmc_mac_address: MacAddress,
-    ) -> Result<Credentials, EndpointExplorationError> {
-        self.credential_client
-            .get_bmc_root_credentials(bmc_mac_address)
-            .await
-    }
-
     pub async fn get_switch_nvos_admin_credentials(
         &self,
         bmc_mac_address: MacAddress,
@@ -292,32 +309,6 @@ impl BmcEndpointExplorer {
         }
 
         Ok(())
-    }
-
-    pub async fn set_bmc_root_password(
-        &self,
-        bmc_ip_address: SocketAddr,
-        vendor: RedfishVendor,
-        current_bmc_credentials: Credentials,
-        new_password: String,
-    ) -> Result<Credentials, EndpointExplorationError> {
-        self.redfish_client
-            .set_bmc_root_password(
-                bmc_ip_address,
-                vendor,
-                current_bmc_credentials.clone(),
-                new_password.clone(),
-            )
-            .await?;
-
-        let (user, _) = match current_bmc_credentials {
-            Credentials::UsernamePassword { username, password } => (username, password),
-        };
-
-        Ok(Credentials::UsernamePassword {
-            username: user,
-            password: new_password,
-        })
     }
 
     async fn rotate_dpu_service_password_from_factory_defaults(
@@ -560,6 +551,45 @@ impl BmcEndpointExplorer {
         }
         Ok(())
     }
+}
+
+// Authenticated BMC ops live on the client, not the explorer. Exploration code
+// reaches these through `BmcEndpointExplorer`'s `Deref` to this type.
+impl AuthenticatedBmcClient {
+    pub async fn get_bmc_root_credentials(
+        &self,
+        bmc_mac_address: MacAddress,
+    ) -> Result<Credentials, EndpointExplorationError> {
+        self.credential_client
+            .get_bmc_root_credentials(bmc_mac_address)
+            .await
+    }
+
+    pub async fn set_bmc_root_password(
+        &self,
+        bmc_ip_address: SocketAddr,
+        vendor: RedfishVendor,
+        current_bmc_credentials: Credentials,
+        new_password: String,
+    ) -> Result<Credentials, EndpointExplorationError> {
+        self.redfish_client
+            .set_bmc_root_password(
+                bmc_ip_address,
+                vendor,
+                current_bmc_credentials.clone(),
+                new_password.clone(),
+            )
+            .await?;
+
+        let (user, _) = match current_bmc_credentials {
+            Credentials::UsernamePassword { username, password } => (username, password),
+        };
+
+        Ok(Credentials::UsernamePassword {
+            username: user,
+            password: new_password,
+        })
+    }
 
     pub async fn redfish_reset_bmc(
         &self,
@@ -725,12 +755,6 @@ impl EndpointExplorer for BmcEndpointExplorer {
         metrics: &mut SiteExplorationMetrics,
     ) -> Result<(), EndpointExplorationError> {
         self.credential_client.check_preconditions(metrics).await
-    }
-
-    async fn have_credentials(&self, interface: &MachineInterfaceSnapshot) -> bool {
-        self.get_bmc_root_credentials(interface.mac_address)
-            .await
-            .is_ok()
     }
 
     // 1) Authenticate and set the BMC root account credentials
@@ -1049,6 +1073,15 @@ impl EndpointExplorer for BmcEndpointExplorer {
         }
 
         Ok(report)
+    }
+}
+
+#[async_trait::async_trait]
+impl AuthenticatedBmc for AuthenticatedBmcClient {
+    async fn have_credentials(&self, interface: &MachineInterfaceSnapshot) -> bool {
+        self.get_bmc_root_credentials(interface.mac_address)
+            .await
+            .is_ok()
     }
 
     async fn redfish_reset_bmc(

--- a/crates/site-explorer/src/credentials.rs
+++ b/crates/site-explorer/src/credentials.rs
@@ -36,6 +36,7 @@ fn get_bmc_nvos_admin_credential_key(bmc_mac_address: MacAddress) -> CredentialK
     CredentialKey::SwitchNvosAdmin { bmc_mac_address }
 }
 
+#[derive(Clone)]
 pub(super) struct CredentialClient {
     credential_manager: Arc<dyn CredentialManager>,
 }

--- a/crates/site-explorer/src/endpoint_exploration_service.rs
+++ b/crates/site-explorer/src/endpoint_exploration_service.rs
@@ -29,7 +29,7 @@ use model::site_explorer::{EndpointExplorationError, EndpointExplorationReport, 
 use sqlx::PgPool;
 
 use crate::endpoint_lock::{EndpointExplorationGuard, EndpointExplorationLocks};
-use crate::{AuthenticatedBmc, EndpointExplorer, enrich_endpoint_exploration_report};
+use crate::{EndpointExplorer, enrich_endpoint_exploration_report};
 
 #[derive(Debug, thiserror::Error)]
 pub enum EndpointExplorationServiceError {
@@ -72,9 +72,6 @@ pub(crate) struct EndpointProbeResult {
 pub struct EndpointExplorationService {
     database_connection: PgPool,
     endpoint_explorer: Arc<dyn EndpointExplorer>,
-    /// The authenticated BMC client for the same endpoint object exploration
-    /// runs on, typed narrowly so BMC ops don't route through the explorer.
-    bmc_client: Arc<dyn AuthenticatedBmc>,
     firmware_config: Arc<FirmwareConfig>,
     locks: EndpointExplorationLocks,
 }
@@ -83,13 +80,11 @@ impl EndpointExplorationService {
     pub fn new(
         database_connection: PgPool,
         endpoint_explorer: Arc<dyn EndpointExplorer>,
-        bmc_client: Arc<dyn AuthenticatedBmc>,
         firmware_config: Arc<FirmwareConfig>,
     ) -> Self {
         Self {
             database_connection,
             endpoint_explorer,
-            bmc_client,
             firmware_config,
             locks: EndpointExplorationLocks::default(),
         }
@@ -97,10 +92,6 @@ impl EndpointExplorationService {
 
     pub(crate) fn endpoint_explorer(&self) -> Arc<dyn EndpointExplorer> {
         self.endpoint_explorer.clone()
-    }
-
-    pub(crate) fn authenticated_bmc_client(&self) -> Arc<dyn AuthenticatedBmc> {
-        self.bmc_client.clone()
     }
 
     pub(crate) async fn firmware_config_snapshot(

--- a/crates/site-explorer/src/endpoint_exploration_service.rs
+++ b/crates/site-explorer/src/endpoint_exploration_service.rs
@@ -29,7 +29,7 @@ use model::site_explorer::{EndpointExplorationError, EndpointExplorationReport, 
 use sqlx::PgPool;
 
 use crate::endpoint_lock::{EndpointExplorationGuard, EndpointExplorationLocks};
-use crate::{EndpointExplorer, enrich_endpoint_exploration_report};
+use crate::{AuthenticatedBmc, EndpointExplorer, enrich_endpoint_exploration_report};
 
 #[derive(Debug, thiserror::Error)]
 pub enum EndpointExplorationServiceError {
@@ -72,6 +72,9 @@ pub(crate) struct EndpointProbeResult {
 pub struct EndpointExplorationService {
     database_connection: PgPool,
     endpoint_explorer: Arc<dyn EndpointExplorer>,
+    /// The authenticated BMC client for the same endpoint object exploration
+    /// runs on, typed narrowly so BMC ops don't route through the explorer.
+    bmc_client: Arc<dyn AuthenticatedBmc>,
     firmware_config: Arc<FirmwareConfig>,
     locks: EndpointExplorationLocks,
 }
@@ -80,11 +83,13 @@ impl EndpointExplorationService {
     pub fn new(
         database_connection: PgPool,
         endpoint_explorer: Arc<dyn EndpointExplorer>,
+        bmc_client: Arc<dyn AuthenticatedBmc>,
         firmware_config: Arc<FirmwareConfig>,
     ) -> Self {
         Self {
             database_connection,
             endpoint_explorer,
+            bmc_client,
             firmware_config,
             locks: EndpointExplorationLocks::default(),
         }
@@ -92,6 +97,10 @@ impl EndpointExplorationService {
 
     pub(crate) fn endpoint_explorer(&self) -> Arc<dyn EndpointExplorer> {
         self.endpoint_explorer.clone()
+    }
+
+    pub(crate) fn authenticated_bmc_client(&self) -> Arc<dyn AuthenticatedBmc> {
+        self.bmc_client.clone()
     }
 
     pub(crate) async fn firmware_config_snapshot(

--- a/crates/site-explorer/src/endpoint_explorer.rs
+++ b/crates/site-explorer/src/endpoint_explorer.rs
@@ -49,7 +49,13 @@ pub trait EndpointExplorer: Send + Sync + 'static {
         &self,
         metrics: &mut SiteExplorationMetrics,
     ) -> Result<(), EndpointExplorationError>;
+}
 
+/// Authenticated BMC operations, resolving stored credentials from the
+/// endpoint's interface. Kept separate from [`EndpointExplorer`] so BMC ops
+/// don't route through the explorer.
+#[async_trait::async_trait]
+pub trait AuthenticatedBmc: Send + Sync + 'static {
     // redfish_reset_bmc issues a BMC reset through redfish.
     async fn redfish_reset_bmc(
         &self,

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -100,9 +100,6 @@ pub mod config;
 pub mod errors;
 use std::sync::atomic::AtomicBool;
 
-use carbide_ipmi::IPMITool;
-use carbide_redfish::libredfish::BmcCredentialOps;
-use carbide_redfish::nv_redfish::NvRedfishClientPool;
 use errors::{SiteExplorerError, SiteExplorerResult};
 
 use self::metrics::{
@@ -145,23 +142,16 @@ fn should_scan_host_inband_interface_for_redfish(
             && expected_host_bmc_macs.contains(&interface.mac_address))
 }
 
-/// `redfish_client_pool` is the direct pool's credential-operations handle
-/// ([`BmcCredentialOps`]): exploration sets BMC root passwords and probes
-/// vendors on the endpoint itself.
+/// Build an endpoint explorer over the authenticated BMC client supplied by
+/// the application composition root.
 pub fn new_bmc_explorer(
-    redfish_client_pool: Arc<dyn BmcCredentialOps>,
-    nv_redfish_client_pool: Arc<NvRedfishClientPool>,
-    ipmi_tool: Arc<dyn IPMITool>,
-    credential_manager: Arc<dyn CredentialManager>,
+    bmc_client: Arc<AuthenticatedBmcClient>,
     rotate_switch_nvos_credentials: Arc<AtomicBool>,
     mode: SiteExplorerExploreMode,
     database_connection: PgPool,
 ) -> Arc<BmcEndpointExplorer> {
     BmcEndpointExplorer::new(
-        redfish_client_pool,
-        nv_redfish_client_pool,
-        ipmi_tool,
-        credential_manager,
+        bmc_client,
         rotate_switch_nvos_credentials,
         mode,
         Some(database_connection),
@@ -478,9 +468,8 @@ pub struct SiteExplorer {
     config: SiteExplorerConfig,
     metric_holder: Arc<metrics::MetricHolder>,
     endpoint_explorer: Arc<dyn EndpointExplorer>,
-    /// Authenticated BMC client for remediation (reset, power, NIC mode, etc.);
-    /// same object as `endpoint_explorer`, typed narrowly so BMC ops don't route
-    /// through the explorer.
+    /// Authenticated BMC client for remediation (reset, power, NIC mode, etc.),
+    /// supplied independently so BMC operations don't route through the explorer.
     bmc_client: Arc<dyn AuthenticatedBmc>,
     endpoint_exploration_service: Arc<EndpointExplorationService>,
     work_lock_manager_handle: WorkLockManagerHandle,
@@ -508,6 +497,7 @@ impl SiteExplorer {
         explorer_config: SiteExplorerConfig,
         meter: opentelemetry::metrics::Meter,
         endpoint_exploration_service: Arc<EndpointExplorationService>,
+        bmc_client: Arc<dyn AuthenticatedBmc>,
         common_pools: Arc<CommonPools>,
         work_lock_manager_handle: WorkLockManagerHandle,
         rack_profiles: RackProfileConfig,
@@ -528,7 +518,6 @@ impl SiteExplorer {
         ));
         let rack_profiles = Arc::new(rack_profiles);
         let endpoint_explorer = endpoint_exploration_service.endpoint_explorer();
-        let bmc_client = endpoint_exploration_service.authenticated_bmc_client();
 
         SiteExplorer {
             machine_creator: MachineCreator::new(

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -65,7 +65,7 @@ use tokio_util::sync::CancellationToken;
 use tracing::Instrument;
 use version_compare::Cmp;
 mod endpoint_explorer;
-pub use endpoint_explorer::EndpointExplorer;
+pub use endpoint_explorer::{AuthenticatedBmc, EndpointExplorer};
 mod endpoint_exploration_service;
 pub use endpoint_exploration_service::{
     EndpointExplorationService, EndpointExplorationServiceError,
@@ -78,7 +78,7 @@ pub mod test_support;
 pub use metrics::{SiteExplorationMetrics, site_explorer_latency_histogram_view};
 mod bmc_endpoint_explorer;
 mod redfish;
-pub use bmc_endpoint_explorer::BmcEndpointExplorer;
+pub use bmc_endpoint_explorer::{AuthenticatedBmcClient, BmcEndpointExplorer};
 mod boot_order_tracker;
 use boot_order_tracker::BootOrderTracker;
 mod machine_creator;
@@ -478,6 +478,10 @@ pub struct SiteExplorer {
     config: SiteExplorerConfig,
     metric_holder: Arc<metrics::MetricHolder>,
     endpoint_explorer: Arc<dyn EndpointExplorer>,
+    /// Authenticated BMC client for remediation (reset, power, NIC mode, etc.);
+    /// same object as `endpoint_explorer`, typed narrowly so BMC ops don't route
+    /// through the explorer.
+    bmc_client: Arc<dyn AuthenticatedBmc>,
     endpoint_exploration_service: Arc<EndpointExplorationService>,
     work_lock_manager_handle: WorkLockManagerHandle,
     machine_creator: MachineCreator,
@@ -524,6 +528,7 @@ impl SiteExplorer {
         ));
         let rack_profiles = Arc::new(rack_profiles);
         let endpoint_explorer = endpoint_exploration_service.endpoint_explorer();
+        let bmc_client = endpoint_exploration_service.authenticated_bmc_client();
 
         SiteExplorer {
             machine_creator: MachineCreator::new(
@@ -542,6 +547,7 @@ impl SiteExplorer {
             config: explorer_config,
             metric_holder,
             endpoint_explorer,
+            bmc_client,
             endpoint_exploration_service,
             work_lock_manager_handle,
             boot_order_tracker: BootOrderTracker::default(),
@@ -3151,11 +3157,7 @@ impl SiteExplorer {
         }
 
         // If site explorer can't log in, there's nothing we can do.
-        if !self
-            .endpoint_explorer
-            .have_credentials(endpoint.iface)
-            .await
-        {
+        if !self.bmc_client.have_credentials(endpoint.iface).await {
             return;
         }
 
@@ -3359,7 +3361,7 @@ impl SiteExplorer {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
         match self
-            .endpoint_explorer
+            .bmc_client
             .ipmitool_reset_bmc(bmc_target_addr, endpoint.iface)
             .await
         {
@@ -3408,7 +3410,7 @@ impl SiteExplorer {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
         match self
-            .endpoint_explorer
+            .bmc_client
             .redfish_reset_bmc(bmc_target_addr, endpoint.iface, None)
             .await
         {
@@ -3445,7 +3447,7 @@ impl SiteExplorer {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
 
-        self.endpoint_explorer
+        self.bmc_client
             .redfish_get_power_state(bmc_target_addr, endpoint.iface)
             .await
             .map(IntoModel::into_model)
@@ -3464,7 +3466,7 @@ impl SiteExplorer {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
 
-        self.endpoint_explorer
+        self.bmc_client
             .redfish_power_control(bmc_target_addr, endpoint.iface, action)
             .await
             .map_err(|err| SiteExplorerError::EndpointExplorationError {
@@ -3485,7 +3487,7 @@ impl SiteExplorer {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
         match self
-            .endpoint_explorer
+            .bmc_client
             .is_viking(bmc_target_addr, endpoint.iface)
             .await
         {
@@ -3508,7 +3510,7 @@ impl SiteExplorer {
         let bmc_target_port = self.config.override_target_port.unwrap_or(443);
         let bmc_target_addr = SocketAddr::new(endpoint.address, bmc_target_port);
 
-        self.endpoint_explorer
+        self.bmc_client
             .clear_nvram(bmc_target_addr, endpoint.iface)
             .await
             .map_err(|err| {
@@ -3622,7 +3624,7 @@ impl SiteExplorer {
             .find_machine_interface_for_ip(dpu_endpoint.address)
             .await?;
 
-        self.endpoint_explorer
+        self.bmc_client
             .set_nic_mode(bmc_target_addr, &interface, mode)
             .await
             .map_err(|err| SiteExplorerError::EndpointExplorationError {
@@ -3641,7 +3643,7 @@ impl SiteExplorer {
 
         let interface = self.find_machine_interface_for_ip(bmc_ip_address).await?;
 
-        self.endpoint_explorer
+        self.bmc_client
             .redfish_power_control(bmc_target_addr, &interface, action)
             .await
             .map_err(|err| SiteExplorerError::EndpointExplorationError {
@@ -3784,7 +3786,7 @@ impl SiteExplorer {
                 Some(err) if err.is_unauthorized() || err.is_unreachable() => None,
                 _ => match interface.as_ref() {
                     Some(interface) => self
-                        .endpoint_explorer
+                        .bmc_client
                         .redfish_get_power_state(bmc_target_addr, interface)
                         .await
                         .ok()
@@ -3815,7 +3817,7 @@ impl SiteExplorer {
                 );
 
                 if let Some(interface) = interface.as_ref() {
-                    self.endpoint_explorer
+                    self.bmc_client
                         .redfish_power_control(
                             bmc_target_addr,
                             interface,
@@ -3916,7 +3918,7 @@ impl SiteExplorer {
                 .find_machine_interface_for_ip(bmc_target_addr.ip())
                 .await?;
 
-            self.endpoint_explorer
+            self.bmc_client
                 .machine_setup(bmc_target_addr, &interface, None)
                 .await
                 .inspect_err(|err| {
@@ -3928,7 +3930,7 @@ impl SiteExplorer {
                 })
                 .ok();
 
-            self.endpoint_explorer
+            self.bmc_client
                 .redfish_power_control(
                     bmc_target_addr,
                     &interface,

--- a/crates/site-explorer/src/redfish.rs
+++ b/crates/site-explorer/src/redfish.rs
@@ -49,6 +49,7 @@ const BF4_NDF0_TO_BASE_MAC_OFFSET: u64 = 0x10;
 // RedfishClient is a wrapper around a redfish client pool and implements redfish utility functions that the site explorer utilizes.
 // TODO: In the future, we should refactor a lot of this client's work to api/src/redfish.rs because other components in carbide can utilize this functionality.
 // Eventually, this file should only have code related to generating the site exploration report.
+#[derive(Clone)]
 pub(super) struct RedfishClient {
     redfish_client_pool: Arc<dyn BmcCredentialOps>,
     nv_redfish_client_pool: Arc<NvRedfishClientPool>,

--- a/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
+++ b/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
@@ -31,7 +31,7 @@ use model::site_explorer::{
 };
 use tokio::sync::Notify;
 
-use crate::{EndpointExplorer, SiteExplorationMetrics};
+use crate::{AuthenticatedBmc, EndpointExplorer, SiteExplorationMetrics};
 
 /// One recorded endpoint exploration and its boot-interface target.
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -89,10 +89,10 @@ pub struct MockEndpointExplorer {
     /// Records each call to `explore_endpoint`.
     pub explore_endpoint_calls: Arc<Mutex<Vec<EndpointExplorationCall>>>,
     next_exploration_blocker: Arc<Mutex<Option<MockEndpointExplorationBlocker>>>,
-    /// Real explorer that `machine_setup`/`set_boot_order_dpu_first` forward to
-    /// (see [`Self::with_redfish_backend`]); `None` for the pure in-memory mock
-    /// used by site-explorer's own tests.
-    redfish_backend: Option<Arc<dyn EndpointExplorer>>,
+    /// Authenticated BMC client that `machine_setup`/`set_boot_order_dpu_first`
+    /// forward to (see [`Self::with_redfish_backend`]); `None` for the pure
+    /// in-memory mock used by site-explorer's own tests.
+    redfish_backend: Option<Arc<dyn AuthenticatedBmc>>,
 }
 
 impl Default for MockEndpointExplorer {
@@ -167,8 +167,9 @@ impl MockEndpointExplorer {
     }
 
     /// Forward `machine_setup`/`set_boot_order_dpu_first` to `backend` (a real,
-    /// `RedfishSim`-backed explorer) instead of no-op'ing them; see the type docs.
-    pub fn with_redfish_backend(mut self, backend: Arc<dyn EndpointExplorer>) -> Self {
+    /// `RedfishSim`-backed authenticated BMC client) instead of no-op'ing them;
+    /// see the type docs.
+    pub fn with_redfish_backend(mut self, backend: Arc<dyn AuthenticatedBmc>) -> Self {
         self.redfish_backend = Some(backend);
         self
     }
@@ -214,7 +215,10 @@ impl EndpointExplorer for MockEndpointExplorer {
         });
         res.clone()
     }
+}
 
+#[async_trait::async_trait]
+impl AuthenticatedBmc for MockEndpointExplorer {
     async fn redfish_reset_bmc(
         &self,
         _address: SocketAddr,

--- a/crates/site-explorer/tests/integration/env.rs
+++ b/crates/site-explorer/tests/integration/env.rs
@@ -66,7 +66,6 @@ pub(super) fn test_site_explorer(
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
-        endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
     ));
     let site_explorer = SiteExplorer::new(
@@ -74,6 +73,7 @@ pub(super) fn test_site_explorer(
         explorer_config,
         test_harness.test_meter.meter(),
         endpoint_exploration_service,
+        endpoint_explorer.clone(),
         api.common_pools().clone(),
         api.work_lock_manager_handle(),
         api.runtime_config.rack_profiles.clone(),

--- a/crates/site-explorer/tests/integration/env.rs
+++ b/crates/site-explorer/tests/integration/env.rs
@@ -66,6 +66,7 @@ pub(super) fn test_site_explorer(
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
+        endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
     ));
     let site_explorer = SiteExplorer::new(

--- a/crates/site-explorer/tests/integration/health_report.rs
+++ b/crates/site-explorer/tests/integration/health_report.rs
@@ -64,6 +64,7 @@ fn test_site_explorer(
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
+        endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
     ));
     let site_explorer = SiteExplorer::new(

--- a/crates/site-explorer/tests/integration/health_report.rs
+++ b/crates/site-explorer/tests/integration/health_report.rs
@@ -64,7 +64,6 @@ fn test_site_explorer(
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
-        endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
     ));
     let site_explorer = SiteExplorer::new(
@@ -72,6 +71,7 @@ fn test_site_explorer(
         explorer_config,
         test_harness.test_meter.meter(),
         endpoint_exploration_service,
+        endpoint_explorer.clone(),
         api.common_pools().clone(),
         api.work_lock_manager_handle(),
         api.runtime_config.rack_profiles.clone(),

--- a/crates/site-explorer/tests/integration/zero_dpu.rs
+++ b/crates/site-explorer/tests/integration/zero_dpu.rs
@@ -61,7 +61,6 @@ async fn init(pool: PgPool) -> ZeroDpuEnv {
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
-        endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
     ));
     let create_machines = Arc::new(AtomicBool::new(true));
@@ -79,6 +78,7 @@ async fn init(pool: PgPool) -> ZeroDpuEnv {
             },
             test_harness.test_meter.meter(),
             endpoint_exploration_service,
+            endpoint_explorer.clone(),
             api.common_pools().clone(),
             api.work_lock_manager_handle(),
             api.runtime_config.rack_profiles.clone(),

--- a/crates/site-explorer/tests/integration/zero_dpu.rs
+++ b/crates/site-explorer/tests/integration/zero_dpu.rs
@@ -61,6 +61,7 @@ async fn init(pool: PgPool) -> ZeroDpuEnv {
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
+        endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
     ));
     let create_machines = Arc::new(AtomicBool::new(true));

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -130,6 +130,7 @@ impl TestHarness {
         let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
             api.database_connection.clone(),
             endpoint_explorer.clone(),
+            endpoint_explorer.clone(),
             Arc::new(api.runtime_config.get_firmware_config()),
         ));
         let site_explorer = SiteExplorer::new(

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -130,7 +130,6 @@ impl TestHarness {
         let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
             api.database_connection.clone(),
             endpoint_explorer.clone(),
-            endpoint_explorer.clone(),
             Arc::new(api.runtime_config.get_firmware_config()),
         ));
         let site_explorer = SiteExplorer::new(
@@ -138,6 +137,7 @@ impl TestHarness {
             config,
             self.test_meter.meter(),
             endpoint_exploration_service,
+            endpoint_explorer.clone(),
             api.common_pools().clone(),
             api.work_lock_manager_handle(),
             api.runtime_config.rack_profiles.clone(),


### PR DESCRIPTION
Extracts admin BMC operations (power, reset, lockdown, users, etc.) out of BmcEndpointExplorer into an AuthenticatedBmcClient and dedicated AuthenticatedBmc trait, so API admin handlers call api.bmc_client.* instead of reaching through the explorer. EndpointExplorer becomes a supertrait so exploration keeps working, and the mock implements both traits to preserve existing test assertions. 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


