### PR TITLE
feat(health): attach GPU identity attributes to telemetry

### DIFF
--- a/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
+++ b/crates/bmc-mock/src/hw/nvidia_dgx_h100.rs
@@ -208,13 +208,40 @@ impl NvidiaDgxH100<'_> {
                     base_bios: None,
                     log_services: None,
                     storage: None,
-                    processors: None,
+                    processors: Some(self.hgx_gpu_processors("HGX_Baseboard_0")),
                     memory: None,
                     serial_console: None,
                     secure_boot_available: false,
                 },
             ],
         }
+    }
+
+    /// The eight GPUs of the HGX baseboard, as Redfish `Processor` resources.
+    ///
+    /// Hardware exposes each GPU both here and as an `HGX_GPU_SXM_*` chassis.
+    /// The processor view is where GPU sensor readings are attributed, so a
+    /// fixture that omitted it could not exercise per-GPU sensor telemetry.
+    fn hgx_gpu_processors(&self, system_id: &str) -> Vec<redfish::processor::Processor> {
+        (1..=8)
+            .map(|index| {
+                let chassis_id = format!("HGX_GPU_SXM_{index}");
+                let voltage_sensor_id =
+                    redfish::sensor::sensor_id(redfish::sensor::SensorKind::Voltage, 1);
+                redfish::processor::gpu(
+                    system_id,
+                    &format!("GPU_SXM_{index}"),
+                    redfish::sensor::chassis_resource(&chassis_id, &voltage_sensor_id)
+                        .odata_id
+                        .as_ref(),
+                    &redfish::processor::GpuIdentity {
+                        uuid: &gpu_uuid(index),
+                        serial_number: &self.gpu_serial[index - 1],
+                        model: GPU_MODEL,
+                    },
+                )
+            })
+            .collect()
     }
 
     pub(crate) fn chassis_config(&self) -> redfish::chassis::ChassisConfig {
@@ -393,23 +420,36 @@ fn base_bios(system_id: &str) -> serde_json::Value {
         }))
 }
 
+const GPU_MODEL: &str = "H100 80GB HBM3";
+
+/// Stable per-slot GPU UUID, so a test can assert that a given slot reports a
+/// specific device identity.
+///
+/// Hardware reports one UUID per GPU on the GPU's `Processor`, its enclosing
+/// `Chassis` and its `PCIeDevice` alike, so every fixture for a slot uses this.
+fn gpu_uuid(index: usize) -> String {
+    format!("beea8cdf-7b7d-035c-ed07-360e311fcb{index:02x}")
+}
+
 fn hgx_gpu_sxm_chassis(index: usize, serial: &str) -> redfish::chassis::SingleChassisConfig {
     let id = format!("HGX_GPU_SXM_{index}");
     redfish::chassis::SingleChassisConfig {
         chassis_type: "Other".into(),
         manufacturer: Some("NVIDIA".into()),
         part_number: Some("2330-885-A1".into()),
-        model: Some("H100 80GB HBM3".into()),
+        model: Some(GPU_MODEL.into()),
         serial_number: Some(serial.to_string().into()),
+        uuid: Some(gpu_uuid(index).into()),
         pcie_devices: Some(vec![
             redfish::pcie_device::builder(&redfish::pcie_device::chassis_resource(
                 &id,
                 &format!("GPU_SXM_{index}"),
             ))
             .manufacturer("NVIDIA")
-            .model("H100 80GB HBM3")
+            .model(GPU_MODEL)
             .part_number("2330-885-A1")
             .serial_number(serial)
+            .uuid(&gpu_uuid(index))
             .build(),
         ]),
         sensors: Some(redfish::sensor::generate_chassis_sensors(

--- a/crates/bmc-mock/src/hw/nvidia_gb200.rs
+++ b/crates/bmc-mock/src/hw/nvidia_gb200.rs
@@ -70,6 +70,18 @@ pub(crate) struct BiancaBoard<'a> {
 struct GpuChassisIds {
     chassis_id: Cow<'static, str>,
     pcie_device_id: Cow<'static, str>,
+    index: usize,
+}
+
+const GPU_MODEL: &str = "GB200 186GB HBM3e";
+
+/// Stable per-slot GPU UUID, so a test can assert that a given slot reports a
+/// specific device identity.
+///
+/// Hardware reports one UUID per GPU on the GPU's `Processor`, its enclosing
+/// `Chassis` and its `PCIeDevice` alike, so every fixture for a slot uses this.
+fn gpu_uuid(index: usize) -> String {
+    format!("2b8c1f4a-6d33-4a11-9c02-7f5e0a1b{index:04x}")
 }
 
 impl BiancaBoard<'_> {
@@ -116,6 +128,7 @@ impl BiancaBoard<'_> {
             GpuChassisIds {
                 chassis_id: format!("HGX_GPU_{n}").into(),
                 pcie_device_id: format!("GPU_{n}").into(),
+                index: n,
             }
         })
     }
@@ -130,6 +143,11 @@ impl BiancaBoard<'_> {
                 redfish::sensor::chassis_resource(&ids.chassis_id, &voltage_sensor_id)
                     .odata_id
                     .as_ref(),
+                &redfish::processor::GpuIdentity {
+                    uuid: &gpu_uuid(ids.index),
+                    serial_number: &self.gpu_serial_number,
+                    model: GPU_MODEL,
+                },
             )
         })
     }
@@ -162,17 +180,19 @@ impl BiancaBoard<'_> {
                 chassis_type: "Component".into(),
                 manufacturer: Some("NVIDIA".into()),
                 part_number: Some("NA".into()),
-                model: Some("GB200 186GB HBM3e".into()),
+                model: Some(GPU_MODEL.into()),
                 serial_number: Some(self.gpu_serial_number.to_string().into()),
+                uuid: Some(gpu_uuid(ids.index).into()),
                 pcie_devices: Some(vec![
                     redfish::pcie_device::builder(&redfish::pcie_device::chassis_resource(
                         &ids.chassis_id,
                         &ids.pcie_device_id,
                     ))
                     .manufacturer("NVIDIA")
-                    .model("GB200 186GB HBM3e")
+                    .model(GPU_MODEL)
                     .part_number("2941-892-A1")
                     .serial_number(&self.gpu_serial_number)
+                    .uuid(&gpu_uuid(ids.index))
                     .build(),
                 ]),
                 id: ids.chassis_id,

--- a/crates/bmc-mock/src/redfish/chassis.rs
+++ b/crates/bmc-mock/src/redfish/chassis.rs
@@ -137,6 +137,9 @@ pub(crate) fn add_routes(r: Router<BmcState>) -> Router<BmcState> {
 pub(crate) struct SingleChassisConfig {
     pub(crate) id: Cow<'static, str>,
     pub(crate) serial_number: Option<Cow<'static, str>>,
+    /// Identity of the device the chassis holds, which for a GPU module is the
+    /// GPU's own UUID.
+    pub(crate) uuid: Option<Cow<'static, str>>,
     pub(crate) manufacturer: Option<Cow<'static, str>>,
     pub(crate) model: Option<Cow<'static, str>>,
     pub(crate) part_number: Option<Cow<'static, str>>,
@@ -159,6 +162,7 @@ impl SingleChassisConfig {
             id: "".into(),
             chassis_type: "".into(),
             serial_number: None,
+            uuid: None,
             manufacturer: None,
             model: None,
             part_number: None,
@@ -317,6 +321,7 @@ async fn get_chassis(State(state): State<BmcState>, Path(chassis_id): Path<Strin
         .maybe_with(ChassisBuilder::network_adapters, &network_adapters)
         .maybe_with(ChassisBuilder::sensors, &sensors)
         .maybe_with(ChassisBuilder::serial_number, &config.serial_number)
+        .maybe_with(ChassisBuilder::uuid, &config.uuid)
         .maybe_with(ChassisBuilder::manufacturer, &config.manufacturer)
         .maybe_with(ChassisBuilder::part_number, &config.part_number)
         .maybe_with(ChassisBuilder::sku, &config.sku)
@@ -631,6 +636,14 @@ impl Builder for ChassisBuilder {
 impl ChassisBuilder {
     fn serial_number(self, v: &str) -> Self {
         self.add_str_field("SerialNumber", v)
+    }
+
+    /// Device identity that survives a chassis-slot swap.
+    ///
+    /// On an NVIDIA GPU module this matches the NVML GPU UUID without its
+    /// `GPU-` prefix, and the UUID the GPU's `Processor` reports.
+    fn uuid(self, v: &str) -> Self {
+        self.add_str_field("UUID", v)
     }
 
     fn chassis_type(self, v: &str) -> Self {

--- a/crates/bmc-mock/src/redfish/pcie_device.rs
+++ b/crates/bmc-mock/src/redfish/pcie_device.rs
@@ -111,6 +111,13 @@ impl PcieDeviceBuilder {
         self.add_str_field("SerialNumber", value)
     }
 
+    /// Device identity that survives a chassis-slot swap.
+    ///
+    /// On NVIDIA GPUs this matches the NVML GPU UUID without its `GPU-` prefix.
+    pub(crate) fn uuid(self, value: &str) -> Self {
+        self.add_str_field("UUID", value)
+    }
+
     fn firmware_version(self, value: &str) -> Self {
         self.add_str_field("FirmwareVersion", value)
     }

--- a/crates/bmc-mock/src/redfish/processor.rs
+++ b/crates/bmc-mock/src/redfish/processor.rs
@@ -96,6 +96,22 @@ impl ProcessorBuilder {
         self.add_str_field("ProcessorType", value)
     }
 
+    /// Device identity that survives a socket swap.
+    ///
+    /// On an NVIDIA GPU this matches the NVML GPU UUID without its `GPU-`
+    /// prefix, and the UUID the enclosing GPU chassis reports.
+    fn uuid(self, value: &str) -> Self {
+        self.add_str_field("UUID", value)
+    }
+
+    fn serial_number(self, value: &str) -> Self {
+        self.add_str_field("SerialNumber", value)
+    }
+
+    fn model(self, value: &str) -> Self {
+        self.add_str_field("Model", value)
+    }
+
     fn metrics(self, metrics: &redfish::Resource<'_>) -> Self {
         self.apply_patch(metrics.nav_property("Metrics"))
     }
@@ -113,11 +129,29 @@ impl ProcessorBuilder {
     }
 }
 
-pub(crate) fn gpu(system_id: &str, processor_id: &str, core_voltage_sensor_uri: &str) -> Processor {
+/// Identity fields an NVIDIA GPU reports on its `Processor` resource.
+///
+/// Real hardware reports the same values on the enclosing GPU chassis, so a
+/// fixture should keep the two in agreement.
+pub(crate) struct GpuIdentity<'a> {
+    pub(crate) uuid: &'a str,
+    pub(crate) serial_number: &'a str,
+    pub(crate) model: &'a str,
+}
+
+pub(crate) fn gpu(
+    system_id: &str,
+    processor_id: &str,
+    core_voltage_sensor_uri: &str,
+    identity: &GpuIdentity<'_>,
+) -> Processor {
     let metrics = metrics_resource(system_id, processor_id);
     let metrics_json = nvidia_gpu_metrics(&metrics, processor_id, core_voltage_sensor_uri);
     builder(&system_resource(system_id, processor_id))
         .processor_type("GPU")
+        .uuid(identity.uuid)
+        .serial_number(identity.serial_number)
+        .model(identity.model)
         .status(redfish::resource::Status::Ok)
         .metrics(&metrics)
         .build(metrics_json)
@@ -223,7 +257,15 @@ fn nvidia_gpu_oem() -> serde_json::Value {
 
 #[cfg(test)]
 mod tests {
-    use super::gpu;
+    use super::{GpuIdentity, gpu};
+
+    fn test_identity() -> GpuIdentity<'static> {
+        GpuIdentity {
+            uuid: "beea8cdf-7b7d-035c-ed07-360e311fcbe1",
+            serial_number: "1655023015625",
+            model: "H100 80GB HBM3",
+        }
+    }
 
     #[test]
     fn gpu_processor_links_to_metrics_and_chassis_sensor() {
@@ -231,11 +273,17 @@ mod tests {
             "HGX_Baseboard_0",
             "GPU_0",
             "/redfish/v1/Chassis/HGX_GPU_0/Sensors/Voltage_1",
+            &test_identity(),
         );
 
         let resource = processor.to_json();
         assert_eq!(resource["Id"], "GPU_0");
         assert_eq!(resource["ProcessorType"], "GPU");
+        // Identity of the GPU in the socket, which hardware reports here and a
+        // consumer needs to distinguish one physical GPU from another.
+        assert_eq!(resource["UUID"], "beea8cdf-7b7d-035c-ed07-360e311fcbe1");
+        assert_eq!(resource["SerialNumber"], "1655023015625");
+        assert_eq!(resource["Model"], "H100 80GB HBM3");
         assert_eq!(
             resource["Metrics"]["@odata.id"],
             "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_0/ProcessorMetrics"
@@ -264,6 +312,7 @@ mod tests {
             "HGX_Baseboard_0",
             "GPU_0",
             "/redfish/v1/Chassis/HGX_GPU_0/Sensors/Voltage_1",
+            &test_identity(),
         );
         let metrics = processor.metrics_json();
         let oem = &metrics["Oem"]["Nvidia"];

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -138,6 +138,17 @@ pub async fn lenovo_gb300_bmc() -> TestBmcHandle {
     .await
 }
 
+pub async fn nvidia_dgx_h100_bmc() -> TestBmcHandle {
+    test_bmc(machine_router(
+        &host_info(HardwareType::NvidiaDgxH100),
+        Arc::new(NoopCallbacks),
+        "test-host-id".to_string(),
+        false,
+        MachineRouterOptions::default(),
+    ))
+    .await
+}
+
 pub async fn dgx_gb300_bmc() -> TestBmcHandle {
     test_bmc(machine_router(
         &host_info(HardwareType::NvidiaDgxGb300),

--- a/crates/health/example/config.bmc-mock-gpu-attrs.toml
+++ b/crates/health/example/config.bmc-mock-gpu-attrs.toml
@@ -1,0 +1,92 @@
+#
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Exercises the GPU identity telemetry attributes against a mock BMC.
+# Start the mock first:
+#
+#   cargo run -p bmc-mock -- --hardware-profile nvidia_dgx_h100 \
+#       --machine-role host --state-backend internal --port 18443
+#
+# Sensor metrics for each GPU chassis then carry gpu_uuid, gpu_serial,
+# gpu_chassis_serial, and gpu_model, distinct per slot, on the Prometheus
+# endpoint configured below.
+#
+# The same attributes are attached to SSE log records whose origin of condition
+# names a GPU chassis. Driving that path against the mock additionally needs a
+# Redfish EventService, which bmc-mock does not implement yet, so exercising it
+# currently requires hardware.
+
+[[endpoint_sources.static_bmc_endpoints]]
+ip = "127.0.0.1"
+port = 18443
+mac = "aa:bb:cc:dd:ee:ff"
+username = "admin"
+password = "secret"
+rack_id = "RACK_1"
+machine = { id = "fm100htjtiaehv1n5vh67tbmqq4eabcjdng40f7jupsadbedhruh6rag1l0", serial = "MN-001", slot_number = 15, tray_index = 5 }
+
+[endpoint_sources.nico_api]
+enabled = false
+
+# Opt-in. Turning this off removes the gpu_* labels from every metric datapoint
+# and log record. It adds no Redfish requests either way.
+[attributes]
+gpu_identity = true
+
+[collectors.discovery]
+refresh_interval = "5m"
+discovery_concurrency = 1
+
+[collectors.reachability]
+enabled = false
+
+[collectors.sensors]
+sensor_fetch_interval = "15s"
+include_sensor_thresholds = false
+
+[collectors.metrics]
+enabled = false
+
+[collectors.firmware]
+firmware_refresh_interval = "30m"
+
+[collectors.logs]
+mode = "sse"
+
+[collectors.logs.sse]
+initial_backoff = "1s"
+max_backoff = "10s"
+
+[sinks.tracing]
+enabled = true
+
+[sinks.prometheus]
+enabled = true
+
+[sinks.health_report]
+enabled = false
+
+[sinks.rack_health_report]
+enabled = false
+
+[sinks.switch_health_report]
+enabled = false
+
+[sinks.power_shelf_health_report]
+enabled = false
+
+[metrics]
+endpoint = "127.0.0.1:19009"

--- a/crates/health/src/collectors/discovery.rs
+++ b/crates/health/src/collectors/discovery.rs
@@ -421,7 +421,9 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
 /// containing `GPU` are not exclusive to GPUs: HGX baseboards expose an
 /// `HGX_ERoT_GPU_SXM_1` root-of-trust device per GPU, carrying its own
 /// unrelated UUID.
-pub(in crate::collectors) fn is_gpu_processor<B: Bmc>(processor: &nv_redfish::computer_system::Processor<B>) -> bool {
+pub(in crate::collectors) fn is_gpu_processor<B: Bmc>(
+    processor: &nv_redfish::computer_system::Processor<B>,
+) -> bool {
     processor
         .raw()
         .processor_type
@@ -459,7 +461,9 @@ pub(in crate::collectors) fn gpu_identity_from_processor<B: Bmc>(
 ///
 /// Keyed by `@odata.id` so a chassis can be matched against its
 /// `Links/Processors` entries without refetching them.
-pub(in crate::collectors) fn gpu_processor_ids<B: Bmc>(entities: &[DiscoveredEntity<B>]) -> HashSet<String> {
+pub(in crate::collectors) fn gpu_processor_ids<B: Bmc>(
+    entities: &[DiscoveredEntity<B>],
+) -> HashSet<String> {
     entities
         .iter()
         .filter_map(|entity| match entity {
@@ -649,7 +653,8 @@ mod bmc_mock_integration_tests {
     /// sensors are attributed to `Processor` entities rather than to the chassis.
     #[tokio::test]
     async fn dgx_h100_resolves_identity_for_every_gpu_processor() {
-        let (identities, gpu_processors) = identities_by_processor(&nvidia_dgx_h100_bmc().await).await;
+        let (identities, gpu_processors) =
+            identities_by_processor(&nvidia_dgx_h100_bmc().await).await;
 
         let gpus: Vec<_> = identities
             .iter()
@@ -660,7 +665,10 @@ mod bmc_mock_integration_tests {
 
         for (processor_id, identity) in &gpus {
             assert!(identity.uuid.is_some(), "{processor_id} must carry a UUID");
-            assert!(identity.serial.is_some(), "{processor_id} must carry a serial");
+            assert!(
+                identity.serial.is_some(),
+                "{processor_id} must carry a serial"
+            );
             assert_eq!(
                 identity.model.as_deref(),
                 Some("H100 80GB HBM3"),
@@ -685,7 +693,10 @@ mod bmc_mock_integration_tests {
 
         for (chassis_id, identity) in &gpus {
             assert!(identity.uuid.is_some(), "{chassis_id} must carry a UUID");
-            assert!(identity.serial.is_some(), "{chassis_id} must carry a serial");
+            assert!(
+                identity.serial.is_some(),
+                "{chassis_id} must carry a serial"
+            );
             assert_eq!(
                 identity.model.as_deref(),
                 Some("H100 80GB HBM3"),

--- a/crates/health/src/collectors/discovery.rs
+++ b/crates/health/src/collectors/discovery.rs
@@ -21,11 +21,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
 
 use futures::{StreamExt, stream};
-use nv_redfish::ServiceRoot;
-use nv_redfish::core::Bmc;
+use nv_redfish::core::{Bmc, EntityTypeRef, ToSnakeCase};
+use nv_redfish::{Resource, ServiceRoot};
 
 use crate::HealthError;
-use crate::collectors::inventory::{DiscoveredEntity, EntityInventory, SharedInventory};
+use crate::collectors::inventory::{
+    DiscoveredEntity, EntityInventory, GpuIdentity, SharedInventory,
+};
 use crate::collectors::runtime::{IterationResult, PeriodicCollector};
 use crate::endpoint::BmcEndpoint;
 
@@ -35,6 +37,12 @@ pub struct EntityDiscoveryCollectorConfig<B: Bmc> {
 
     /// Bounds local fan-out to the endpoint Redfish operation limit.
     pub request_concurrency: NonZeroUsize,
+
+    /// Label GPU telemetry with the identity of the device that produced it.
+    ///
+    /// Read from resources discovery already fetches, so this adds no Redfish
+    /// requests; it is opt-in only because it adds metric labels.
+    pub gpu_identity: bool,
 }
 
 pub struct EntityDiscoveryCollector<B: Bmc> {
@@ -42,6 +50,7 @@ pub struct EntityDiscoveryCollector<B: Bmc> {
     bmc: Arc<B>,
     shared: SharedInventory<B>,
     request_concurrency: usize,
+    gpu_identity: bool,
     generation: u64,
 }
 
@@ -58,6 +67,7 @@ impl<B: Bmc + 'static> PeriodicCollector<B> for EntityDiscoveryCollector<B> {
             bmc,
             shared: config.shared,
             request_concurrency: config.request_concurrency.get(),
+            gpu_identity: config.gpu_identity,
             generation: 0,
         })
     }
@@ -144,6 +154,15 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             }
         }
 
+        // Which processors are GPUs is the authoritative evidence that a chassis
+        // holds a GPU, and processors are all discovered by now. Collected once
+        // rather than per chassis, since every chassis consults the same set.
+        let gpu_processors = if self.gpu_identity {
+            gpu_processor_ids(&entities)
+        } else {
+            HashSet::new()
+        };
+
         if let Some(chassis_list) = service_root.chassis().await? {
             for chassis in chassis_list.members().await? {
                 let chassis = Arc::new(chassis);
@@ -155,8 +174,14 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
                     &mut sensor_ids,
                 )
                 .await;
-                self.discover_chassis(&chassis, fetch_failures, &mut entities, &mut sensor_ids)
-                    .await;
+                self.discover_chassis(
+                    &chassis,
+                    &gpu_processors,
+                    fetch_failures,
+                    &mut entities,
+                    &mut sensor_ids,
+                )
+                .await;
             }
         }
 
@@ -197,10 +222,16 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             for sensor in &sensors {
                 sensor_ids.insert(sensor.odata_id().to_string());
             }
+            let gpu = if self.gpu_identity {
+                gpu_identity_from_processor(&entity)
+            } else {
+                None
+            };
             entities.push(DiscoveredEntity::Processor {
                 entity,
                 system: system.clone(),
                 sensors,
+                gpu,
             });
         }
     }
@@ -339,6 +370,7 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
     async fn discover_chassis(
         &self,
         chassis: &Arc<nv_redfish::chassis::Chassis<B>>,
+        gpu_processors: &HashSet<String>,
         fetch_failures: &AtomicUsize,
         entities: &mut Vec<DiscoveredEntity<B>>,
         sensor_ids: &mut HashSet<String>,
@@ -363,13 +395,381 @@ impl<B: Bmc + 'static> EntityDiscoveryCollector<B> {
             .filter(|sensor| sensor_ids.insert(sensor.odata_id().to_string()))
             .collect();
 
-        if sensors.is_empty() {
+        let gpu = if self.gpu_identity {
+            gpu_identity_from_chassis(chassis, gpu_processors)
+        } else {
+            None
+        };
+
+        // A sensorless chassis is normally not worth tracking, but one holding a
+        // GPU is still needed to attribute SSE log records.
+        if sensors.is_empty() && gpu.is_none() {
             return;
         }
 
         entities.push(DiscoveredEntity::Chassis {
             entity: chassis.clone(),
             sensors,
+            gpu,
         });
+    }
+}
+
+/// Whether a processor is a GPU, per the Redfish `ProcessorType` enumeration.
+///
+/// Schema-defined rather than inferred from the id, which matters because ids
+/// containing `GPU` are not exclusive to GPUs: HGX baseboards expose an
+/// `HGX_ERoT_GPU_SXM_1` root-of-trust device per GPU, carrying its own
+/// unrelated UUID.
+pub(in crate::collectors) fn is_gpu_processor<B: Bmc>(processor: &nv_redfish::computer_system::Processor<B>) -> bool {
+    processor
+        .raw()
+        .processor_type
+        .flatten()
+        .is_some_and(|processor_type| processor_type.to_snake_case() == "gpu")
+}
+
+/// Read a GPU processor's identity from its own Redfish resource.
+///
+/// Yields nothing for non-GPU processors, which is the common case: a host CPU
+/// must not be labelled with `gpu_*` attributes.
+pub(in crate::collectors) fn gpu_identity_from_processor<B: Bmc>(
+    processor: &nv_redfish::computer_system::Processor<B>,
+) -> Option<GpuIdentity> {
+    if !is_gpu_processor(processor) {
+        return None;
+    }
+
+    let raw = processor.raw();
+    let identity = GpuIdentity {
+        uuid: raw.uuid.flatten().map(|uuid| uuid.to_string()),
+        serial: raw.serial_number.clone().flatten(),
+        model: raw.model.clone().flatten(),
+        // A processor does not report its enclosure's serial, and resolving the
+        // link would cost a fetch. On SXM hardware the GPU chassis reports the
+        // same serial as the GPU itself, so nothing is lost that `gpu_serial`
+        // does not already carry.
+        chassis_serial: None,
+    };
+
+    (!identity.is_empty()).then_some(identity)
+}
+
+/// Redfish ids of the GPUs among the discovered processors.
+///
+/// Keyed by `@odata.id` so a chassis can be matched against its
+/// `Links/Processors` entries without refetching them.
+pub(in crate::collectors) fn gpu_processor_ids<B: Bmc>(entities: &[DiscoveredEntity<B>]) -> HashSet<String> {
+    entities
+        .iter()
+        .filter_map(|entity| match entity {
+            DiscoveredEntity::Processor { entity, .. } if is_gpu_processor(entity) => {
+                Some(entity.odata_id().to_string())
+            }
+            _ => None,
+        })
+        .collect()
+}
+
+/// Whether a chassis holds a GPU.
+///
+/// Selection must be affirmative: a chassis reports a UUID whether or not it
+/// holds a GPU, so labelling by elimination would attribute `gpu_*` attributes
+/// to NVSwitch modules and root-of-trust components, corrupting the per-device
+/// history these attributes exist to preserve.
+///
+/// A `Links/Processors` entry naming a discovered GPU is the authoritative
+/// signal; [`id_names_gpu_module`] covers platforms that omit it.
+fn is_gpu_chassis<B: Bmc>(
+    chassis: &nv_redfish::chassis::Chassis<B>,
+    gpu_processors: &HashSet<String>,
+) -> bool {
+    let raw = chassis.raw();
+
+    let links_a_gpu_processor = raw
+        .links
+        .as_ref()
+        .and_then(|links| links.processors.as_ref())
+        .is_some_and(|processors| {
+            processors
+                .iter()
+                .any(|processor| gpu_processors.contains(&processor.odata_id().to_string()))
+        });
+
+    links_a_gpu_processor || id_names_gpu_module(&raw.base.id)
+}
+
+/// Whether a chassis id names a GPU module, for platforms that expose GPU
+/// modules without a corresponding GPU `Processor` to link to.
+///
+/// This is the same `HGX_GPU_` convention the SKU GPU-count check already
+/// relies on. A substring test would be wrong here: an HGX baseboard exposes an
+/// `HGX_ERoT_GPU_SXM_1` root-of-trust component per GPU, which reports its own
+/// unrelated UUID and would otherwise be labelled as the GPU itself.
+fn id_names_gpu_module(id: &str) -> bool {
+    id.starts_with("HGX_GPU_") && !id.contains("NVSwitch")
+}
+
+/// Read the identity of the GPU a chassis holds, from the chassis' own resource.
+///
+/// A GPU module chassis reports the GPU's UUID, serial and model directly, so
+/// no traversal to the processor or PCIe device is needed.
+pub(in crate::collectors) fn gpu_identity_from_chassis<B: Bmc>(
+    chassis: &nv_redfish::chassis::Chassis<B>,
+    gpu_processors: &HashSet<String>,
+) -> Option<GpuIdentity> {
+    if !is_gpu_chassis(chassis, gpu_processors) {
+        return None;
+    }
+
+    let raw = chassis.raw();
+    let serial = raw.serial_number.clone().flatten();
+    let identity = GpuIdentity {
+        uuid: raw.uuid.flatten().map(|uuid| uuid.to_string()),
+        serial: serial.clone(),
+        model: raw.model.clone().flatten(),
+        // On SXM baseboards the enclosing chassis *is* the GPU module, so its
+        // serial is the module serial rather than a host chassis serial.
+        chassis_serial: serial,
+    };
+
+    (!identity.is_empty()).then_some(identity)
+}
+
+#[cfg(test)]
+mod gpu_chassis_naming_tests {
+    use super::id_names_gpu_module;
+
+    #[test]
+    fn gpu_module_chassis_ids_are_recognised() {
+        for id in ["HGX_GPU_SXM_1", "HGX_GPU_SXM_8", "HGX_GPU_0"] {
+            assert!(id_names_gpu_module(id), "{id} names a GPU module");
+        }
+    }
+
+    /// The per-GPU root-of-trust component sits beside the GPU and reports its
+    /// own UUID, so claiming it as the GPU would attribute one device's identity
+    /// to another. Its id contains the GPU's name, which is why the test is
+    /// anchored at the start rather than a substring match.
+    #[test]
+    fn erot_and_nvswitch_chassis_ids_are_rejected() {
+        for id in [
+            "HGX_ERoT_GPU_SXM_1",
+            "HGX_NVSwitch_0",
+            "HGX_GPU_NVSwitch_0",
+            "HGX_Chassis_0",
+            "CPUBaseboard",
+            "",
+        ] {
+            assert!(!id_names_gpu_module(id), "{id} does not name a GPU module");
+        }
+    }
+}
+
+#[cfg(test)]
+mod bmc_mock_integration_tests {
+    use std::collections::{BTreeMap, HashSet};
+
+    use bmc_mock::test_support::{TestBmc, TestBmcHandle, nvidia_dgx_h100_bmc, wiwynn_gb200_bmc};
+    use nv_redfish::Resource as _;
+
+    use super::{gpu_identity_from_chassis, gpu_identity_from_processor, is_gpu_processor};
+    use crate::collectors::inventory::GpuIdentity;
+
+    /// Resolve a GPU identity for every processor the mock BMC exposes, keyed by
+    /// processor id, and return the `@odata.id`s of the GPUs among them. Mirrors
+    /// what the discovery collector does over the systems it enumerates.
+    async fn identities_by_processor(
+        h: &TestBmcHandle,
+    ) -> (BTreeMap<String, Option<GpuIdentity>>, HashSet<String>) {
+        let systems = h
+            .service_root
+            .systems()
+            .await
+            .expect("systems collection")
+            .expect("systems collection is present");
+
+        let mut identities = BTreeMap::new();
+        let mut gpu_processors = HashSet::new();
+        for system in systems.members().await.expect("system members") {
+            for processor in system
+                .processors()
+                .await
+                .expect("processors")
+                .unwrap_or_default()
+            {
+                if is_gpu_processor::<TestBmc>(&processor) {
+                    gpu_processors.insert(processor.odata_id().to_string());
+                }
+                identities.insert(
+                    processor.id().to_string(),
+                    gpu_identity_from_processor::<TestBmc>(&processor),
+                );
+            }
+        }
+        (identities, gpu_processors)
+    }
+
+    /// Resolve a GPU identity for every chassis the mock BMC exposes, keyed by
+    /// chassis id, against the GPU processors discovered first.
+    async fn identities_by_chassis(
+        h: &TestBmcHandle,
+        gpu_processors: &HashSet<String>,
+    ) -> BTreeMap<String, Option<GpuIdentity>> {
+        let chassis_list = h
+            .service_root
+            .chassis()
+            .await
+            .expect("chassis collection")
+            .expect("chassis collection is present");
+
+        let mut identities = BTreeMap::new();
+        for chassis in chassis_list.members().await.expect("chassis members") {
+            identities.insert(
+                chassis.id().to_string(),
+                gpu_identity_from_chassis::<TestBmc>(&chassis, gpu_processors),
+            );
+        }
+        identities
+    }
+
+    fn assert_distinct_uuids(identities: &[(&String, &GpuIdentity)], expected: usize) {
+        let uuids: std::collections::BTreeSet<_> = identities
+            .iter()
+            .filter_map(|(_, identity)| identity.uuid.clone())
+            .collect();
+        assert_eq!(
+            uuids.len(),
+            expected,
+            "each GPU must report a distinct UUID; a shared UUID would make the label useless"
+        );
+    }
+
+    /// The path that carries GPU sensor metrics on real HGX hardware, where GPU
+    /// sensors are attributed to `Processor` entities rather than to the chassis.
+    #[tokio::test]
+    async fn dgx_h100_resolves_identity_for_every_gpu_processor() {
+        let (identities, gpu_processors) = identities_by_processor(&nvidia_dgx_h100_bmc().await).await;
+
+        let gpus: Vec<_> = identities
+            .iter()
+            .filter_map(|(id, identity)| identity.as_ref().map(|i| (id, i)))
+            .collect();
+        assert_eq!(gpus.len(), 8, "DGX H100 exposes 8 GPU processors");
+        assert_eq!(gpu_processors.len(), 8);
+
+        for (processor_id, identity) in &gpus {
+            assert!(identity.uuid.is_some(), "{processor_id} must carry a UUID");
+            assert!(identity.serial.is_some(), "{processor_id} must carry a serial");
+            assert_eq!(
+                identity.model.as_deref(),
+                Some("H100 80GB HBM3"),
+                "{processor_id} model"
+            );
+        }
+
+        assert_distinct_uuids(&gpus, 8);
+    }
+
+    #[tokio::test]
+    async fn dgx_h100_resolves_identity_for_every_gpu_chassis() {
+        let h = nvidia_dgx_h100_bmc().await;
+        let (_, gpu_processors) = identities_by_processor(&h).await;
+        let identities = identities_by_chassis(&h, &gpu_processors).await;
+
+        let gpus: Vec<_> = identities
+            .iter()
+            .filter_map(|(id, identity)| identity.as_ref().map(|i| (id, i)))
+            .collect();
+        assert_eq!(gpus.len(), 8, "DGX H100 exposes 8 GPU chassis");
+
+        for (chassis_id, identity) in &gpus {
+            assert!(identity.uuid.is_some(), "{chassis_id} must carry a UUID");
+            assert!(identity.serial.is_some(), "{chassis_id} must carry a serial");
+            assert_eq!(
+                identity.model.as_deref(),
+                Some("H100 80GB HBM3"),
+                "{chassis_id} model"
+            );
+            assert!(
+                identity.chassis_serial.is_some(),
+                "{chassis_id} must carry the GPU module chassis serial"
+            );
+        }
+
+        assert_distinct_uuids(&gpus, 8);
+    }
+
+    /// The chassis and the processor must agree, since a sensor attributed to one
+    /// and a log record attributed to the other describe the same physical GPU.
+    #[tokio::test]
+    async fn dgx_h100_chassis_and_processor_agree_on_identity() {
+        let h = nvidia_dgx_h100_bmc().await;
+        let (by_processor, gpu_processors) = identities_by_processor(&h).await;
+        let by_chassis = identities_by_chassis(&h, &gpu_processors).await;
+
+        for slot in 1..=8 {
+            let processor = by_processor
+                .get(&format!("GPU_SXM_{slot}"))
+                .and_then(Option::as_ref)
+                .expect("GPU processor identity");
+            let chassis = by_chassis
+                .get(&format!("HGX_GPU_SXM_{slot}"))
+                .and_then(Option::as_ref)
+                .expect("GPU chassis identity");
+
+            assert_eq!(processor.uuid, chassis.uuid, "slot {slot} UUID");
+            assert_eq!(processor.serial, chassis.serial, "slot {slot} serial");
+            assert_eq!(processor.model, chassis.model, "slot {slot} model");
+        }
+    }
+
+    #[tokio::test]
+    async fn non_gpu_resources_resolve_no_identity() {
+        let h = nvidia_dgx_h100_bmc().await;
+        let (by_processor, gpu_processors) = identities_by_processor(&h).await;
+        let by_chassis = identities_by_chassis(&h, &gpu_processors).await;
+
+        for (processor_id, identity) in &by_processor {
+            if processor_id.starts_with("GPU_") {
+                continue;
+            }
+            assert!(
+                identity.is_none(),
+                "{processor_id} is not a GPU but resolved {identity:?}"
+            );
+        }
+
+        for (chassis_id, identity) in &by_chassis {
+            if chassis_id.starts_with("HGX_GPU_SXM_") {
+                continue;
+            }
+            assert!(
+                identity.is_none(),
+                "{chassis_id} is not a GPU chassis but resolved {identity:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn gb200_resolves_identity_for_every_gpu() {
+        let h = wiwynn_gb200_bmc().await;
+        let (by_processor, gpu_processors) = identities_by_processor(&h).await;
+        let by_chassis = identities_by_chassis(&h, &gpu_processors).await;
+
+        let processors: Vec<_> = by_processor
+            .iter()
+            .filter_map(|(id, identity)| identity.as_ref().map(|i| (id, i)))
+            .collect();
+        let chassis: Vec<_> = by_chassis
+            .iter()
+            .filter_map(|(id, identity)| identity.as_ref().map(|i| (id, i)))
+            .collect();
+
+        assert_eq!(processors.len(), 4, "Wiwynn GB200 exposes 4 GPU processors");
+        assert_eq!(chassis.len(), 4, "Wiwynn GB200 exposes 4 GPU chassis");
+
+        assert_distinct_uuids(&processors, 4);
+        assert_distinct_uuids(&chassis, 4);
     }
 }

--- a/crates/health/src/collectors/gpu_inventory.rs
+++ b/crates/health/src/collectors/gpu_inventory.rs
@@ -386,6 +386,7 @@ mod bmc_mock_integration_tests {
                         entity: Arc::new(processor),
                         system: system.clone(),
                         sensors: Vec::new(),
+                        gpu: None,
                     });
                 }
             }
@@ -396,6 +397,7 @@ mod bmc_mock_integration_tests {
                 entities.push(DiscoveredEntity::Chassis {
                     entity: Arc::new(chassis),
                     sensors: Vec::new(),
+                    gpu: None,
                 });
             }
         }

--- a/crates/health/src/collectors/inventory.rs
+++ b/crates/health/src/collectors/inventory.rs
@@ -253,6 +253,20 @@ impl<B: Bmc> DiscoveredEntity<B> {
     /// segment: a platform that reuses one id across the `Processors` and
     /// `Chassis` collections would otherwise let a chassis origin resolve to a
     /// processor, which reports no `gpu_chassis_serial`.
+    /// Redfish `Id` of the slot this entity describes.
+    ///
+    /// A driver event names its GPU in message text by this id rather than by a
+    /// path, so resolving those records needs a key the text can be compared
+    /// against. Prefer [`Self::gpu_origin_path`] wherever a path is available,
+    /// since an id is only unique within its own collection.
+    pub(crate) fn gpu_slot_id(&self) -> Option<String> {
+        match self {
+            DiscoveredEntity::Chassis { entity, .. } => Some(entity.raw().base.id.clone()),
+            DiscoveredEntity::Processor { entity, .. } => Some(entity.raw().base.id.clone()),
+            _ => None,
+        }
+    }
+
     pub(crate) fn gpu_origin_path(&self) -> Option<String> {
         let odata_id = match self {
             DiscoveredEntity::Chassis { entity, .. } => entity.odata_id().to_string(),

--- a/crates/health/src/collectors/inventory.rs
+++ b/crates/health/src/collectors/inventory.rs
@@ -34,11 +34,58 @@ pub(crate) struct DerivedMetric {
     pub(crate) value: f64,
 }
 
+/// Identity of the GPU currently occupying a GPU slot.
+///
+/// A GPU's Redfish path (`HGX_GPU_SXM_1`, `GPU_SXM_1`) names a socket on the
+/// baseboard and survives a GPU swap, so it cannot serve as the device
+/// identity; the UUID here can. On NVIDIA hardware it matches the NVML GPU
+/// UUID without its `GPU-` prefix.
+///
+/// Read from the resource that reports the GPU, which carries these fields
+/// directly: the `Processor` for a GPU processor and the `Chassis` for a GPU
+/// module. Both were observed to report identical values per slot, so neither
+/// needs a link traversal to the other.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub(crate) struct GpuIdentity {
+    pub(crate) uuid: Option<String>,
+    pub(crate) serial: Option<String>,
+    pub(crate) model: Option<String>,
+    /// Serial number of the enclosing GPU chassis, which on SXM baseboards is
+    /// the GPU module's own serial rather than the host chassis serial.
+    pub(crate) chassis_serial: Option<String>,
+}
+
+impl GpuIdentity {
+    pub(crate) fn is_empty(&self) -> bool {
+        self.uuid.is_none() && self.serial.is_none() && self.model.is_none()
+    }
+
+    pub(crate) fn attributes(&self) -> Vec<MetricLabel> {
+        let mut attrs = Vec::new();
+        if let Some(uuid) = &self.uuid {
+            attrs.push((Cow::Borrowed("gpu_uuid"), uuid.clone()));
+        }
+        if let Some(serial) = &self.serial {
+            attrs.push((Cow::Borrowed("gpu_serial"), serial.clone()));
+        }
+        if let Some(model) = &self.model {
+            attrs.push((Cow::Borrowed("gpu_model"), model.clone()));
+        }
+        if let Some(chassis_serial) = &self.chassis_serial {
+            attrs.push((Cow::Borrowed("gpu_chassis_serial"), chassis_serial.clone()));
+        }
+        attrs
+    }
+}
+
 pub(crate) enum DiscoveredEntity<B: Bmc> {
     Processor {
         entity: Arc<Processor<B>>,
         system: Arc<ComputerSystem<B>>,
         sensors: Vec<SensorLink<B>>,
+        /// Populated only when `attributes.gpu_identity` is enabled and the
+        /// processor reports `ProcessorType == GPU`.
+        gpu: Option<GpuIdentity>,
     },
     Memory {
         entity: Arc<Memory<B>>,
@@ -59,6 +106,9 @@ pub(crate) enum DiscoveredEntity<B: Bmc> {
     Chassis {
         entity: Arc<Chassis<B>>,
         sensors: Vec<SensorLink<B>>,
+        /// Populated only when `attributes.gpu_identity` is enabled and the
+        /// chassis holds a GPU.
+        gpu: Option<GpuIdentity>,
     },
 }
 
@@ -131,7 +181,7 @@ impl<B: Bmc> DiscoveredEntity<B> {
     pub(crate) fn entity_specific_attributes(&self) -> Vec<MetricLabel> {
         let mut attrs = Vec::new();
         match self {
-            DiscoveredEntity::Processor { entity, .. } => {
+            DiscoveredEntity::Processor { entity, gpu, .. } => {
                 if let Some(processor_type) = entity.raw().processor_type.flatten() {
                     attrs.push((
                         Cow::Borrowed("processor_type"),
@@ -140,6 +190,9 @@ impl<B: Bmc> DiscoveredEntity<B> {
                 }
                 if let Some(model) = entity.raw().model.clone().flatten() {
                     attrs.push((Cow::Borrowed("model"), model));
+                }
+                if let Some(gpu) = gpu {
+                    attrs.extend(gpu.attributes());
                 }
             }
             DiscoveredEntity::Memory { entity, .. } => {
@@ -163,13 +216,41 @@ impl<B: Bmc> DiscoveredEntity<B> {
                     attrs.push((Cow::Borrowed("model"), model));
                 }
             }
-            DiscoveredEntity::Chassis { entity, .. } => {
+            DiscoveredEntity::Chassis { entity, gpu, .. } => {
                 if let Some(model) = entity.raw().model.clone().flatten() {
                     attrs.push((Cow::Borrowed("model"), model));
+                }
+                if let Some(gpu) = gpu {
+                    attrs.extend(gpu.attributes());
                 }
             }
         }
         attrs
+    }
+
+    /// GPU identity for this entity, when it reports a GPU.
+    pub(crate) fn gpu_identity(&self) -> Option<&GpuIdentity> {
+        match self {
+            DiscoveredEntity::Chassis { gpu, .. } | DiscoveredEntity::Processor { gpu, .. } => {
+                gpu.as_ref()
+            }
+            _ => None,
+        }
+    }
+
+    /// Redfish id by which an SSE `origin_of_condition` names this entity.
+    ///
+    /// A GPU event's origin is either the GPU chassis
+    /// (`/redfish/v1/Chassis/HGX_GPU_SXM_1`) or the GPU processor
+    /// (`/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_1`), so both
+    /// are matchable. The two id spaces do not overlap for GPUs, because a
+    /// module chassis and the processor it holds are named differently.
+    pub(crate) fn gpu_origin_id(&self) -> Option<String> {
+        match self {
+            DiscoveredEntity::Chassis { entity, .. } => Some(entity.raw().base.id.clone()),
+            DiscoveredEntity::Processor { entity, .. } => Some(entity.raw().base.id.clone()),
+            _ => None,
+        }
     }
 
     pub(crate) fn key(&self) -> String {

--- a/crates/health/src/collectors/inventory.rs
+++ b/crates/health/src/collectors/inventory.rs
@@ -78,6 +78,12 @@ impl GpuIdentity {
     }
 }
 
+/// Strips the trailing slash some BMCs append to an `@odata.id`, so that an
+/// event origin and the resource it names compare equal.
+pub(crate) fn normalize_odata_id(odata_id: &str) -> &str {
+    odata_id.trim_end_matches('/')
+}
+
 pub(crate) enum DiscoveredEntity<B: Bmc> {
     Processor {
         entity: Arc<Processor<B>>,
@@ -238,19 +244,22 @@ impl<B: Bmc> DiscoveredEntity<B> {
         }
     }
 
-    /// Redfish id by which an SSE `origin_of_condition` names this entity.
+    /// Redfish path by which an SSE `origin_of_condition` names this entity.
     ///
     /// A GPU event's origin is either the GPU chassis
     /// (`/redfish/v1/Chassis/HGX_GPU_SXM_1`) or the GPU processor
     /// (`/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_1`), so both
-    /// are matchable. The two id spaces do not overlap for GPUs, because a
-    /// module chassis and the processor it holds are named differently.
-    pub(crate) fn gpu_origin_id(&self) -> Option<String> {
-        match self {
-            DiscoveredEntity::Chassis { entity, .. } => Some(entity.raw().base.id.clone()),
-            DiscoveredEntity::Processor { entity, .. } => Some(entity.raw().base.id.clone()),
-            _ => None,
-        }
+    /// are matchable. The comparison is on the whole path rather than its last
+    /// segment: a platform that reuses one id across the `Processors` and
+    /// `Chassis` collections would otherwise let a chassis origin resolve to a
+    /// processor, which reports no `gpu_chassis_serial`.
+    pub(crate) fn gpu_origin_path(&self) -> Option<String> {
+        let odata_id = match self {
+            DiscoveredEntity::Chassis { entity, .. } => entity.odata_id().to_string(),
+            DiscoveredEntity::Processor { entity, .. } => entity.odata_id().to_string(),
+            _ => return None,
+        };
+        Some(normalize_odata_id(&odata_id).to_string())
     }
 
     pub(crate) fn key(&self) -> String {

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -34,7 +34,7 @@ use super::redfish::{
     nvidia_error_id, redfish_event_type_string, redfish_log_type,
 };
 use crate::HealthError;
-use crate::collectors::inventory::SharedInventory;
+use crate::collectors::inventory::{SharedInventory, normalize_odata_id};
 use crate::collectors::runtime::{
     EventStream, StreamingCollector, StreamingConnectResult, open_sse_stream,
 };
@@ -233,9 +233,7 @@ fn gpu_attributes_for_record<B: Bmc>(
         return Vec::new();
     };
     let odata_id = origin.odata_id.to_string();
-    let Some(origin_id) = odata_id.rsplit('/').find(|part| !part.is_empty()) else {
-        return Vec::new();
-    };
+    let origin_path = normalize_odata_id(&odata_id);
     let Some(snapshot) = shared.load_full() else {
         return Vec::new();
     };
@@ -243,7 +241,7 @@ fn gpu_attributes_for_record<B: Bmc>(
     snapshot
         .entities
         .iter()
-        .find(|entity| entity.gpu_origin_id().as_deref() == Some(origin_id))
+        .find(|entity| entity.gpu_origin_path().as_deref() == Some(origin_path))
         .and_then(|entity| entity.gpu_identity())
         .map(|gpu| gpu.attributes())
         .unwrap_or_default()
@@ -1093,7 +1091,60 @@ mod gpu_enrichment_tests {
             "got {via_processor:?}"
         );
         assert_eq!(via_processor.get("gpu_uuid"), via_chassis.get("gpu_uuid"));
-        assert_eq!(via_processor.get("gpu_serial"), via_chassis.get("gpu_serial"));
+        assert_eq!(
+            via_processor.get("gpu_serial"),
+            via_chassis.get("gpu_serial")
+        );
+    }
+
+    /// The lookup key is the whole `@odata.id` rather than its last segment. A
+    /// bare id would let a chassis origin resolve to a processor on a platform
+    /// that reuses one id across the two collections.
+    #[tokio::test]
+    async fn gpu_origin_keys_are_whole_odata_ids() {
+        let inventory = h100_inventory().await;
+        let snapshot = inventory.load_full().expect("inventory snapshot");
+
+        let keys: Vec<String> = snapshot
+            .entities
+            .iter()
+            .filter(|entity| entity.gpu_identity().is_some())
+            .filter_map(|entity| entity.gpu_origin_path())
+            .collect();
+
+        for expected in [
+            "/redfish/v1/Chassis/HGX_GPU_SXM_1",
+            "/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_1",
+        ] {
+            assert!(
+                keys.iter().any(|key| key == expected),
+                "expected {expected} among {keys:?}"
+            );
+        }
+    }
+
+    /// Each origin shape must resolve to its own variant. Only the chassis
+    /// reports the enclosing module's serial, so resolving a chassis origin to a
+    /// processor would silently drop `gpu_chassis_serial`.
+    #[tokio::test]
+    async fn each_origin_shape_resolves_its_own_variant() {
+        let inventory = h100_inventory().await;
+
+        let via_chassis =
+            attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_3"));
+        let via_processor = attributes_of(
+            Some(&inventory),
+            Some("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_3"),
+        );
+
+        assert!(
+            via_chassis.contains_key("gpu_chassis_serial"),
+            "a chassis origin must resolve the chassis, got {via_chassis:?}"
+        );
+        assert!(
+            !via_processor.contains_key("gpu_chassis_serial"),
+            "a processor origin must resolve the processor, got {via_processor:?}"
+        );
     }
 
     /// Two slots must not be attributed to the same physical GPU, which is the

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -34,10 +34,12 @@ use super::redfish::{
     nvidia_error_id, redfish_event_type_string, redfish_log_type,
 };
 use crate::HealthError;
+use crate::collectors::inventory::SharedInventory;
 use crate::collectors::runtime::{
     EventStream, StreamingCollector, StreamingConnectResult, open_sse_stream,
 };
 use crate::endpoint::BmcEndpoint;
+use crate::metrics::MetricLabel;
 use crate::sink::{CollectorEvent, LogRecord};
 
 const EVENT_RECORD_RESOLUTION_TIMEOUT: Duration = Duration::from_secs(10);
@@ -70,23 +72,28 @@ struct EventRecordResolutionFailed {
 }
 
 /// Configuration for the Redfish SSE log collector.
-pub struct SseLogCollectorConfig {
+pub struct SseLogCollectorConfig<B: Bmc> {
     /// Attach Redfish diagnostic payloads to emitted log records.
     pub include_diagnostics: bool,
 
     /// Bounds event-record resolution to the endpoint Redfish operation limit.
     pub request_concurrency: NonZeroUsize,
+
+    /// Entity inventory used to resolve `origin_of_condition` to the GPU
+    /// currently occupying that chassis slot. `None` disables enrichment.
+    pub(crate) gpu_inventory: Option<SharedInventory<B>>,
 }
 
 pub struct SseLogCollector<B: Bmc> {
     bmc: Arc<B>,
     include_diagnostics: bool,
     request_concurrency: usize,
+    gpu_inventory: Option<SharedInventory<B>>,
 }
 
 #[async_trait]
 impl<B: Bmc + 'static> StreamingCollector<B> for SseLogCollector<B> {
-    type Config = SseLogCollectorConfig;
+    type Config = SseLogCollectorConfig<B>;
 
     fn new_runner(
         bmc: Arc<B>,
@@ -97,6 +104,7 @@ impl<B: Bmc + 'static> StreamingCollector<B> for SseLogCollector<B> {
             bmc,
             include_diagnostics: config.include_diagnostics,
             request_concurrency: config.request_concurrency.get(),
+            gpu_inventory: config.gpu_inventory,
         })
     }
 
@@ -108,6 +116,7 @@ impl<B: Bmc + 'static> StreamingCollector<B> for SseLogCollector<B> {
             Arc::clone(&self.bmc),
             self.include_diagnostics,
             self.request_concurrency,
+            self.gpu_inventory.clone(),
         );
 
         Ok(StreamingConnectResult::Connected(event_stream))
@@ -123,6 +132,7 @@ fn map_event_stream<'a, B, S>(
     bmc: Arc<B>,
     include_diagnostics: bool,
     request_concurrency: usize,
+    gpu_inventory: Option<SharedInventory<B>>,
 ) -> EventStream<'a>
 where
     B: Bmc + 'static,
@@ -134,12 +144,14 @@ where
         .map(move |result| {
             let bmc = Arc::clone(&bmc);
             let fetch_permits = Arc::clone(&fetch_permits);
+            let gpu_inventory = gpu_inventory.clone();
             async move {
                 map_payload(
                     result,
                     bmc.as_ref(),
                     include_diagnostics,
                     fetch_permits.as_ref(),
+                    gpu_inventory.as_ref(),
                 )
                 .await
             }
@@ -154,6 +166,7 @@ async fn map_payload<B: Bmc>(
     bmc: &B,
     include_diagnostics: bool,
     fetch_permits: &Semaphore,
+    gpu_inventory: Option<&SharedInventory<B>>,
 ) -> Vec<Result<CollectorEvent, HealthError>> {
     match result {
         Ok(EventStreamPayload::Event(event)) => {
@@ -163,6 +176,7 @@ async fn map_payload<B: Bmc>(
                 include_diagnostics,
                 fetch_permits,
                 EVENT_RECORD_RESOLUTION_TIMEOUT,
+                gpu_inventory,
             )
             .await
         }
@@ -178,6 +192,7 @@ async fn event_to_logs<B: Bmc>(
     include_diagnostics: bool,
     fetch_permits: &Semaphore,
     resolution_timeout: Duration,
+    gpu_inventory: Option<&SharedInventory<B>>,
 ) -> Vec<Result<CollectorEvent, HealthError>> {
     let deadline = tokio::time::Instant::now() + resolution_timeout;
 
@@ -190,8 +205,48 @@ async fn event_to_logs<B: Bmc>(
     .await
     .into_iter()
     .flatten()
-    .map(|record| Ok(record_to_log(&record, include_diagnostics)))
+    .map(|record| {
+        let gpu = gpu_attributes_for_record(gpu_inventory, &record);
+        Ok(record_to_log(&record, include_diagnostics, gpu))
+    })
     .collect()
+}
+
+/// Resolves the GPU occupying the slot named by `origin_of_condition`.
+///
+/// `origin_of_condition` is a location (`/redfish/v1/Chassis/HGX_GPU_SXM_1`),
+/// not a device identity: it survives a GPU swap while the silicon behind it
+/// changes. Resolving it against the current inventory snapshot yields the
+/// identity of the device that produced the event.
+///
+/// Every step is best-effort. Non-GPU origins are common, and the snapshot is
+/// absent until the first discovery pass completes; both degrade to an
+/// unenriched record rather than a dropped one.
+fn gpu_attributes_for_record<B: Bmc>(
+    gpu_inventory: Option<&SharedInventory<B>>,
+    record: &nv_redfish::schema::event::EventRecord,
+) -> Vec<MetricLabel> {
+    let Some(shared) = gpu_inventory else {
+        return Vec::new();
+    };
+    let Some(origin) = record.origin_of_condition.as_ref() else {
+        return Vec::new();
+    };
+    let odata_id = origin.odata_id.to_string();
+    let Some(origin_id) = odata_id.rsplit('/').find(|part| !part.is_empty()) else {
+        return Vec::new();
+    };
+    let Some(snapshot) = shared.load_full() else {
+        return Vec::new();
+    };
+
+    snapshot
+        .entities
+        .iter()
+        .find(|entity| entity.gpu_origin_id().as_deref() == Some(origin_id))
+        .and_then(|entity| entity.gpu_identity())
+        .map(|gpu| gpu.attributes())
+        .unwrap_or_default()
 }
 
 async fn resolve_event_record<B: Bmc>(
@@ -257,6 +312,7 @@ async fn resolve_event_record<B: Bmc>(
 fn record_to_log(
     record: &nv_redfish::schema::event::EventRecord,
     include_diagnostics: bool,
+    gpu_attributes: Vec<MetricLabel>,
 ) -> CollectorEvent {
     let diagnostic_data_type =
         nullable_ref(&record.diagnostic_data_type).and_then(redfish_enum_string);
@@ -329,6 +385,7 @@ fn record_to_log(
             origin.odata_id.to_string(),
         ));
     }
+    attributes.extend(gpu_attributes);
     if let Some(log_entry_id) = &log_entry_id {
         attributes.push((Cow::Borrowed("log_entry_id"), log_entry_id.clone()));
     }
@@ -399,6 +456,7 @@ mod tests {
             include_diagnostics,
             &fetch_permits,
             resolution_timeout,
+            None,
         )
         .await
     }
@@ -428,7 +486,14 @@ mod tests {
         let endpoint = test_endpoint(mac("00:11:22:33:44:55"));
 
         let fetch_permits = Semaphore::new(1);
-        let events = map_payload(Ok(payload), endpoint.bmc().as_ref(), false, &fetch_permits).await;
+        let events = map_payload(
+            Ok(payload),
+            endpoint.bmc().as_ref(),
+            false,
+            &fetch_permits,
+            None,
+        )
+        .await;
 
         let [Ok(CollectorEvent::Log(record))] = events.as_slice() else {
             panic!("expected one SSE log record");
@@ -700,6 +765,7 @@ mod tests {
                 false,
                 task_permits.as_ref(),
                 Duration::from_secs(1),
+                None,
             )
             .await
         });
@@ -771,7 +837,7 @@ mod tests {
             Ok(EventStreamPayload::Event(referenced_event(&[hung_path]))),
             Ok(EventStreamPayload::Event(referenced_event(&[good_path]))),
         ]);
-        let mut event_stream = map_event_stream(sse_stream, bmc, false, 2);
+        let mut event_stream = map_event_stream(sse_stream, bmc, false, 2, None);
         let next_event = tokio::spawn(async move { event_stream.next().await });
 
         tokio::time::timeout(Duration::from_secs(1), good_request_started.notified())
@@ -804,12 +870,12 @@ mod tests {
         }))
         .expect("valid CPER event record");
 
-        let without_diagnostics = record_to_log(&record, false);
+        let without_diagnostics = record_to_log(&record, false, Vec::new());
         let without_diagnostics = log_record(&without_diagnostics);
         assert_eq!(without_diagnostics.body, "PCIe error");
         assert!(without_diagnostics.diagnostic_record.is_none());
 
-        let with_diagnostics = record_to_log(&record, true);
+        let with_diagnostics = record_to_log(&record, true, Vec::new());
         let with_diagnostics = log_record(&with_diagnostics);
         assert_eq!(with_diagnostics.body, "PCIe error");
         assert!(with_diagnostics.diagnostic_record.is_some());
@@ -849,7 +915,11 @@ mod tests {
     /// schema field parsed.
     #[test]
     fn severity_resolution_chain() {
-        let event = record_to_log(&severity_record(Some("Critical"), Some("WARNING")), false);
+        let event = record_to_log(
+            &severity_record(Some("Critical"), Some("WARNING")),
+            false,
+            Vec::new(),
+        );
         let record = log_record(&event);
         assert_eq!(record.severity, LogSeverity::Fatal);
         assert_eq!(
@@ -860,7 +930,11 @@ mod tests {
 
         // "CRITICAL" is outside the schema, so MessageSeverity lands on
         // UnsupportedValue and the raw Severity string carries the value.
-        let event = record_to_log(&severity_record(Some("CRITICAL"), Some("Critical")), false);
+        let event = record_to_log(
+            &severity_record(Some("CRITICAL"), Some("Critical")),
+            false,
+            Vec::new(),
+        );
         let record = log_record(&event);
         assert_eq!(record.severity, LogSeverity::Fatal);
         assert_eq!(
@@ -869,16 +943,204 @@ mod tests {
         );
         assert_eq!(attribute(record, "message_severity"), None);
 
-        let event = record_to_log(&severity_record(None, None), false);
+        let event = record_to_log(&severity_record(None, None), false, Vec::new());
         let record = log_record(&event);
         assert_eq!(record.severity, LogSeverity::Unspecified);
         assert_eq!(attribute(record, "redfish.event.severity"), Some("Unknown"));
         assert_eq!(attribute(record, "message_severity"), None);
 
-        let event = record_to_log(&severity_record(Some("Meltdown"), None), false);
+        let event = record_to_log(&severity_record(Some("Meltdown"), None), false, Vec::new());
         let record = log_record(&event);
         assert_eq!(record.severity, LogSeverity::Unspecified);
         assert_eq!(attribute(record, "redfish.event.severity"), Some("Unknown"));
         assert_eq!(attribute(record, "message_severity"), None);
+    }
+}
+
+/// Verifies the join that gives an SSE log record its GPU identity: discovery
+/// records what occupies each chassis slot, and a log record naming that slot
+/// in `OriginOfCondition` is attributed to the device found there.
+#[cfg(test)]
+mod gpu_enrichment_tests {
+    use std::collections::HashMap;
+    use std::sync::Arc;
+    use std::time::Instant;
+
+    use arc_swap::ArcSwapOption;
+    use bmc_mock::test_support::{TestBmc, nvidia_dgx_h100_bmc};
+    use serde_json::json;
+
+    use super::gpu_attributes_for_record;
+    use crate::collectors::discovery::{
+        gpu_identity_from_chassis, gpu_identity_from_processor, gpu_processor_ids,
+    };
+    use crate::collectors::inventory::{DiscoveredEntity, EntityInventory, SharedInventory};
+
+    /// Build the inventory snapshot the way the discovery collector does —
+    /// processors first, then chassis matched against them — so the join is
+    /// exercised against identities the mock BMC actually serves.
+    async fn h100_inventory() -> SharedInventory<TestBmc> {
+        let h = nvidia_dgx_h100_bmc().await;
+
+        let mut entities = Vec::new();
+
+        let systems = h
+            .service_root
+            .systems()
+            .await
+            .expect("systems collection")
+            .expect("systems collection is present");
+        for system in systems.members().await.expect("system members") {
+            let system = Arc::new(system);
+            for processor in system
+                .processors()
+                .await
+                .expect("processors")
+                .unwrap_or_default()
+            {
+                let gpu = gpu_identity_from_processor::<TestBmc>(&processor);
+                entities.push(DiscoveredEntity::Processor {
+                    entity: Arc::new(processor),
+                    system: system.clone(),
+                    sensors: Vec::new(),
+                    gpu,
+                });
+            }
+        }
+
+        let gpu_processors = gpu_processor_ids(&entities);
+
+        let chassis_list = h
+            .service_root
+            .chassis()
+            .await
+            .expect("chassis collection")
+            .expect("chassis collection is present");
+        for chassis in chassis_list.members().await.expect("chassis members") {
+            let gpu = gpu_identity_from_chassis::<TestBmc>(&chassis, &gpu_processors);
+            entities.push(DiscoveredEntity::Chassis {
+                entity: Arc::new(chassis),
+                sensors: Vec::new(),
+                gpu,
+            });
+        }
+
+        Arc::new(ArcSwapOption::from_pointee(EntityInventory {
+            entities,
+            discovered_at: Instant::now(),
+            generation: 1,
+        }))
+    }
+
+    fn xid_record(origin: Option<&str>) -> nv_redfish::schema::event::EventRecord {
+        let mut value = json!({
+            "@odata.id": "/redfish/v1/EventService/SSE#/Events/1",
+            "MemberId": "1",
+            "EventType": "Alert",
+            "MessageId": "Nvidia.1.0.XidError",
+            "Message": "Xid 79: GPU has fallen off the bus",
+            "MessageSeverity": "Critical",
+        });
+        if let Some(origin) = origin {
+            value["OriginOfCondition"] = json!({ "@odata.id": origin });
+        }
+        serde_json::from_value(value).expect("valid event record")
+    }
+
+    fn attributes_of(
+        inventory: Option<&SharedInventory<TestBmc>>,
+        origin: Option<&str>,
+    ) -> HashMap<String, String> {
+        gpu_attributes_for_record(inventory, &xid_record(origin))
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect()
+    }
+
+    #[tokio::test]
+    async fn gpu_origin_resolves_uuid_serial_and_model() {
+        let inventory = h100_inventory().await;
+
+        let attributes = attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_3"));
+
+        assert_eq!(
+            attributes.get("gpu_model").map(String::as_str),
+            Some("H100 80GB HBM3")
+        );
+        for key in ["gpu_uuid", "gpu_serial", "gpu_chassis_serial"] {
+            assert!(
+                attributes.contains_key(key),
+                "expected a {key} attribute, got {attributes:?}"
+            );
+        }
+    }
+
+    /// A GPU event can name the GPU's processor rather than its chassis, so both
+    /// origin shapes must resolve to the same device.
+    #[tokio::test]
+    async fn processor_origin_resolves_the_same_gpu_as_its_chassis() {
+        let inventory = h100_inventory().await;
+
+        let via_processor = attributes_of(
+            Some(&inventory),
+            Some("/redfish/v1/Systems/HGX_Baseboard_0/Processors/GPU_SXM_3"),
+        );
+        let via_chassis =
+            attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_3"));
+
+        assert!(
+            via_processor.contains_key("gpu_uuid"),
+            "got {via_processor:?}"
+        );
+        assert_eq!(via_processor.get("gpu_uuid"), via_chassis.get("gpu_uuid"));
+        assert_eq!(via_processor.get("gpu_serial"), via_chassis.get("gpu_serial"));
+    }
+
+    /// Two slots must not be attributed to the same physical GPU, which is the
+    /// whole reason the label carries a UUID rather than the slot name.
+    #[tokio::test]
+    async fn distinct_slots_resolve_distinct_uuids() {
+        let inventory = h100_inventory().await;
+
+        let first = attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_1"));
+        let second = attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_2"));
+
+        assert_ne!(first.get("gpu_uuid"), second.get("gpu_uuid"));
+        assert!(first.contains_key("gpu_uuid"));
+    }
+
+    #[tokio::test]
+    async fn trailing_slash_in_origin_still_resolves() {
+        let inventory = h100_inventory().await;
+
+        let attributes =
+            attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_4/"));
+
+        assert!(attributes.contains_key("gpu_uuid"), "got {attributes:?}");
+    }
+
+    #[tokio::test]
+    async fn non_gpu_origin_yields_no_attributes() {
+        let inventory = h100_inventory().await;
+
+        assert!(
+            attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_Chassis_0")).is_empty()
+        );
+        assert!(
+            attributes_of(Some(&inventory), Some("/redfish/v1/Systems/System_0")).is_empty(),
+            "an origin outside the chassis collection must not match a chassis id"
+        );
+    }
+
+    #[tokio::test]
+    async fn records_without_origin_or_inventory_are_left_unenriched() {
+        let inventory = h100_inventory().await;
+
+        assert!(attributes_of(Some(&inventory), None).is_empty());
+        assert!(attributes_of(None, Some("/redfish/v1/Chassis/HGX_GPU_SXM_1")).is_empty());
+
+        // Before the first discovery pass completes the snapshot is empty.
+        let empty: SharedInventory<TestBmc> = Arc::new(ArcSwapOption::empty());
+        assert!(attributes_of(Some(&empty), Some("/redfish/v1/Chassis/HGX_GPU_SXM_1")).is_empty());
     }
 }

--- a/crates/health/src/collectors/logs/sse.rs
+++ b/crates/health/src/collectors/logs/sse.rs
@@ -34,7 +34,9 @@ use super::redfish::{
     nvidia_error_id, redfish_event_type_string, redfish_log_type,
 };
 use crate::HealthError;
-use crate::collectors::inventory::{SharedInventory, normalize_odata_id};
+use crate::collectors::inventory::{
+    EntityInventory, GpuIdentity, SharedInventory, normalize_odata_id,
+};
 use crate::collectors::runtime::{
     EventStream, StreamingCollector, StreamingConnectResult, open_sse_stream,
 };
@@ -212,12 +214,16 @@ async fn event_to_logs<B: Bmc>(
     .collect()
 }
 
-/// Resolves the GPU occupying the slot named by `origin_of_condition`.
+/// Resolves the GPU an event came from, against the current inventory snapshot.
 ///
-/// `origin_of_condition` is a location (`/redfish/v1/Chassis/HGX_GPU_SXM_1`),
-/// not a device identity: it survives a GPU swap while the silicon behind it
-/// changes. Resolving it against the current inventory snapshot yields the
-/// identity of the device that produced the event.
+/// A GPU event names its GPU by location rather than by identity, and the two
+/// places it can do so need different lookups:
+///
+/// - `origin_of_condition` is a path (`/redfish/v1/Chassis/HGX_GPU_SXM_1`) that
+///   survives a GPU swap while the silicon behind it changes.
+/// - A driver event — the shape an Xid arrives in — reports the *baseboard* as
+///   its origin and names the GPU only in its message arguments, so the origin
+///   alone cannot identify it. See [`gpu_slot_from_message_args`].
 ///
 /// Every step is best-effort. Non-GPU origins are common, and the snapshot is
 /// absent until the first discovery pass completes; both degrade to an
@@ -229,22 +235,61 @@ fn gpu_attributes_for_record<B: Bmc>(
     let Some(shared) = gpu_inventory else {
         return Vec::new();
     };
-    let Some(origin) = record.origin_of_condition.as_ref() else {
-        return Vec::new();
-    };
-    let odata_id = origin.odata_id.to_string();
-    let origin_path = normalize_odata_id(&odata_id);
     let Some(snapshot) = shared.load_full() else {
         return Vec::new();
     };
+
+    gpu_identity_by_origin(&snapshot, record)
+        .or_else(|| gpu_identity_by_message_args(&snapshot, record))
+        .map(|gpu| gpu.attributes())
+        .unwrap_or_default()
+}
+
+/// GPU named by an event's `origin_of_condition`, when that path is a GPU.
+fn gpu_identity_by_origin<'a, B: Bmc>(
+    snapshot: &'a EntityInventory<B>,
+    record: &nv_redfish::schema::event::EventRecord,
+) -> Option<&'a GpuIdentity> {
+    let odata_id = record.origin_of_condition.as_ref()?.odata_id.to_string();
+    let origin_path = normalize_odata_id(&odata_id);
 
     snapshot
         .entities
         .iter()
         .find(|entity| entity.gpu_origin_path().as_deref() == Some(origin_path))
         .and_then(|entity| entity.gpu_identity())
-        .map(|gpu| gpu.attributes())
-        .unwrap_or_default()
+}
+
+/// GPU named in a driver event's message arguments.
+///
+/// Only consulted when the origin did not resolve, which is the case that
+/// matters for Xid errors: they arrive with `MessageId`
+/// `ResourceEvent.1.0.ResourceErrorsDetected` and the HGX baseboard as their
+/// origin, so the GPU appears nowhere but the message.
+fn gpu_identity_by_message_args<'a, B: Bmc>(
+    snapshot: &'a EntityInventory<B>,
+    record: &nv_redfish::schema::event::EventRecord,
+) -> Option<&'a GpuIdentity> {
+    let slot = gpu_slot_from_message_args(record.message_args.as_deref()?)?;
+
+    snapshot
+        .entities
+        .iter()
+        .filter(|entity| entity.gpu_identity().is_some())
+        .find(|entity| entity.gpu_slot_id().as_deref() == Some(slot))
+        .and_then(|entity| entity.gpu_identity())
+}
+
+/// The slot a driver event's first message argument names.
+///
+/// The argument reads `"GPU_SXM_1 Driver Event Message"` on HGX H100 and
+/// `"GPU_1 Driver Event Message"` on GB200-class hardware, so the slot is its
+/// leading word. Matching that word against a slot id by equality rather than
+/// by substring is what keeps `GPU_SXM_1` from also matching `GPU_SXM_10`; the
+/// caller additionally requires the match to be an entity discovery already
+/// classified as a GPU, so a non-GPU subject resolves to nothing.
+fn gpu_slot_from_message_args(args: &[String]) -> Option<&str> {
+    args.first()?.split_whitespace().next()
 }
 
 async fn resolve_event_record<B: Bmc>(
@@ -968,7 +1013,7 @@ mod gpu_enrichment_tests {
     use bmc_mock::test_support::{TestBmc, nvidia_dgx_h100_bmc};
     use serde_json::json;
 
-    use super::gpu_attributes_for_record;
+    use super::{gpu_attributes_for_record, gpu_slot_from_message_args};
     use crate::collectors::discovery::{
         gpu_identity_from_chassis, gpu_identity_from_processor, gpu_processor_ids,
     };
@@ -1050,6 +1095,33 @@ mod gpu_enrichment_tests {
         origin: Option<&str>,
     ) -> HashMap<String, String> {
         gpu_attributes_for_record(inventory, &xid_record(origin))
+            .into_iter()
+            .map(|(key, value)| (key.to_string(), value))
+            .collect()
+    }
+
+    /// A driver event in the shape HGX firmware reports an Xid: the baseboard
+    /// as origin, with the GPU named only in the message arguments.
+    fn driver_event_record(origin: &str, args: &[&str]) -> nv_redfish::schema::event::EventRecord {
+        serde_json::from_value(json!({
+            "@odata.id": "/redfish/v1/EventService/SSE#/Events/1",
+            "MemberId": "1",
+            "EventType": "Alert",
+            "MessageId": "ResourceEvent.1.0.ResourceErrorsDetected",
+            "Message": "The resource property has detected errors.",
+            "MessageArgs": args,
+            "MessageSeverity": "Critical",
+            "OriginOfCondition": { "@odata.id": origin },
+        }))
+        .expect("valid event record")
+    }
+
+    fn attributes_of_driver_event(
+        inventory: &SharedInventory<TestBmc>,
+        origin: &str,
+        args: &[&str],
+    ) -> HashMap<String, String> {
+        gpu_attributes_for_record(Some(inventory), &driver_event_record(origin, args))
             .into_iter()
             .map(|(key, value)| (key.to_string(), value))
             .collect()
@@ -1181,6 +1253,108 @@ mod gpu_enrichment_tests {
             attributes_of(Some(&inventory), Some("/redfish/v1/Systems/System_0")).is_empty(),
             "an origin outside the chassis collection must not match a chassis id"
         );
+    }
+
+    /// The case the origin lookup alone cannot serve: an Xid names the HGX
+    /// baseboard as its origin, which holds eight GPUs, so the identity has to
+    /// come from the GPU named in the message arguments.
+    #[tokio::test]
+    async fn baseboard_origin_xid_resolves_the_gpu_named_in_message_args() {
+        let inventory = h100_inventory().await;
+
+        let from_xid = attributes_of_driver_event(
+            &inventory,
+            "/redfish/v1/Systems/HGX_Baseboard_0",
+            &[
+                "GPU_SXM_1 Driver Event Message",
+                "[Tue Apr 22 23:22:23 UTC 2025][7][00] XID 95 Uncontained: FBHUB. RST: Yes; D-RST: No",
+            ],
+        );
+
+        assert!(
+            from_xid.contains_key("gpu_uuid"),
+            "an Xid must resolve its GPU, got {from_xid:?}"
+        );
+
+        // Must be the same device the slot's own chassis origin resolves to.
+        let from_chassis =
+            attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_1"));
+        assert_eq!(from_xid.get("gpu_uuid"), from_chassis.get("gpu_uuid"));
+        assert_eq!(from_xid.get("gpu_serial"), from_chassis.get("gpu_serial"));
+    }
+
+    /// Two Xids from different slots must not collapse onto one GPU.
+    #[tokio::test]
+    async fn xids_from_different_slots_resolve_different_gpus() {
+        let inventory = h100_inventory().await;
+        let origin = "/redfish/v1/Systems/HGX_Baseboard_0";
+
+        let first =
+            attributes_of_driver_event(&inventory, origin, &["GPU_SXM_1 Driver Event Message", ""]);
+        let second =
+            attributes_of_driver_event(&inventory, origin, &["GPU_SXM_2 Driver Event Message", ""]);
+
+        assert!(first.contains_key("gpu_uuid"));
+        assert_ne!(first.get("gpu_uuid"), second.get("gpu_uuid"));
+    }
+
+    /// A resolvable origin is the better signal and must not be overridden by
+    /// whatever the message text happens to name.
+    #[tokio::test]
+    async fn origin_takes_precedence_over_message_args() {
+        let inventory = h100_inventory().await;
+
+        let resolved = attributes_of_driver_event(
+            &inventory,
+            "/redfish/v1/Chassis/HGX_GPU_SXM_3",
+            &["GPU_SXM_1 Driver Event Message", ""],
+        );
+        let slot_three = attributes_of(Some(&inventory), Some("/redfish/v1/Chassis/HGX_GPU_SXM_3"));
+
+        assert_eq!(resolved.get("gpu_uuid"), slot_three.get("gpu_uuid"));
+    }
+
+    /// The fallback must not label events whose subject is not a discovered GPU,
+    /// which is why the slot is compared by equality against inventory rather
+    /// than by searching the message for a `GPU` substring.
+    #[tokio::test]
+    async fn message_args_naming_no_discovered_gpu_yield_no_attributes() {
+        let inventory = h100_inventory().await;
+        let origin = "/redfish/v1/Systems/HGX_Baseboard_0";
+
+        for args in [
+            // A sensor threshold event: names a GPU sensor, not a GPU.
+            vec!["HGX_GPU_0_Temp_1", "3.96", "-0.05"],
+            // A slot that does not exist on this baseboard.
+            vec!["GPU_SXM_99 Driver Event Message", ""],
+            // The root-of-trust component, which reports its own unrelated UUID.
+            vec!["HGX_ERoT_GPU_SXM_1 Driver Event Message", ""],
+            vec![],
+        ] {
+            let attributes = attributes_of_driver_event(&inventory, origin, &args);
+            assert!(
+                attributes.is_empty(),
+                "args {args:?} must not resolve a GPU, got {attributes:?}"
+            );
+        }
+    }
+
+    /// The slot is the leading word, and is matched whole: a prefix test would
+    /// let `GPU_SXM_1` also claim events belonging to `GPU_SXM_10`.
+    #[test]
+    fn slot_is_the_leading_word_of_the_first_argument() {
+        let cases = [
+            ("GPU_SXM_1 Driver Event Message", Some("GPU_SXM_1")),
+            ("GPU_1 Driver Event Message", Some("GPU_1")),
+            ("GPU_SXM_10 Driver Event Message", Some("GPU_SXM_10")),
+        ];
+
+        for (arg, expected) in cases {
+            let args = vec![arg.to_string()];
+            assert_eq!(gpu_slot_from_message_args(&args), expected, "{arg}");
+        }
+
+        assert_eq!(gpu_slot_from_message_args(&[]), None);
     }
 
     #[tokio::test]

--- a/crates/health/src/collectors/projection_test_support.rs
+++ b/crates/health/src/collectors/projection_test_support.rs
@@ -812,27 +812,32 @@ impl ProjectionFixture {
                     entity,
                     system: self.system.clone(),
                     sensors,
+                    gpu: None,
                 }
             }
             TestEntity::NvidiaGpuProcessor => DiscoveredEntity::Processor {
                 entity: self.processor("GPU0"),
                 system: self.system.clone(),
                 sensors: Vec::new(),
+                gpu: None,
             },
             TestEntity::SparseProcessor => DiscoveredEntity::Processor {
                 entity: self.processor("CPU-sparse"),
                 system: self.system.clone(),
                 sensors: Vec::new(),
+                gpu: None,
             },
             TestEntity::ProcessorWithEmptyMetrics => DiscoveredEntity::Processor {
                 entity: self.processor("CPU-empty"),
                 system: self.system.clone(),
                 sensors: Vec::new(),
+                gpu: None,
             },
             TestEntity::ProcessorWithMalformedMetrics => DiscoveredEntity::Processor {
                 entity: self.processor("CPU-malformed"),
                 system: self.system.clone(),
                 sensors: Vec::new(),
+                gpu: None,
             },
             TestEntity::Memory => DiscoveredEntity::Memory {
                 entity: self.memory("DIMM0"),
@@ -874,10 +879,12 @@ impl ProjectionFixture {
             TestEntity::Chassis => DiscoveredEntity::Chassis {
                 entity: self.chassis("CH0"),
                 sensors: Vec::new(),
+                gpu: None,
             },
             TestEntity::SparseChassis => DiscoveredEntity::Chassis {
                 entity: self.chassis("CH-sparse"),
                 sensors: Vec::new(),
+                gpu: None,
             },
         }
     }

--- a/crates/health/src/collectors/sensors.rs
+++ b/crates/health/src/collectors/sensors.rs
@@ -1185,6 +1185,7 @@ mod tests {
                     vec![DiscoveredEntity::Chassis {
                         entity: chassis,
                         sensors: vec![sensor],
+                        gpu: None,
                     }],
                 );
             }

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -51,6 +51,8 @@ pub struct Config {
 
     pub collectors: CollectorsConfig,
 
+    /// Opt-in attributes attached to emitted telemetry beyond what a collector
+    /// reports on its own.
     pub attributes: AttributesConfig,
 
     pub processors: ProcessorsConfig,

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -51,6 +51,8 @@ pub struct Config {
 
     pub collectors: CollectorsConfig,
 
+    pub attributes: AttributesConfig,
+
     pub processors: ProcessorsConfig,
 
     pub metrics: MetricsConfig,
@@ -86,6 +88,7 @@ impl Default for Config {
             sinks: SinksConfig::default(),
             rate_limit: Configurable::Enabled(RateLimitConfig::default()),
             collectors: CollectorsConfig::default(),
+            attributes: AttributesConfig::default(),
             processors: ProcessorsConfig::default(),
             metrics: MetricsConfig::default(),
             shard: 0,
@@ -96,6 +99,28 @@ impl Default for Config {
             bmc_proxy_url: None,
         }
     }
+}
+
+/// Opt-in identity attributes attached to emitted telemetry.
+///
+/// These are attached as log record attributes and metric datapoint attributes
+/// rather than resource attributes: a single BMC endpoint fronts many GPUs, so
+/// per-GPU identity cannot be a property of the resource without changing how
+/// telemetry is grouped.
+///
+/// Defaults to disabled, so a deployment opts in to the added metric labels.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default)]
+pub struct AttributesConfig {
+    /// Attach `gpu_uuid`, `gpu_serial`, `gpu_chassis_serial`, and `gpu_model`,
+    /// read from the Redfish resource that reports each GPU.
+    ///
+    /// On metrics these land on the sensor series that already exist for the
+    /// GPU's processor and chassis. On SSE log records they are resolved by
+    /// matching `origin_of_condition` against the discovered inventory. Both
+    /// read resources discovery already fetches, so no Redfish requests are
+    /// added.
+    pub gpu_identity: bool,
 }
 
 /// Configuration for where BMC endpoints are discovered from.

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -31,8 +31,9 @@ use crate::api_client::ApiClientWrapper;
 use crate::bmc::BmcClient;
 use crate::collectors::{Collector, LogDowngradeRegistry, NmxcSchemaOverride, SharedInventory};
 use crate::config::{
-    Config, Configurable, DiscoveryConfig, FirmwareCollectorConfig as FirmwareCollectorOptions,
-    GpuInventoryConfig, LeakDetectorCollectorConfig as LeakDetectorCollectorOptions,
+    AttributesConfig, Config, Configurable, DiscoveryConfig,
+    FirmwareCollectorConfig as FirmwareCollectorOptions, GpuInventoryConfig,
+    LeakDetectorCollectorConfig as LeakDetectorCollectorOptions,
     LogsCollectorConfig as LogsCollectorOptions, MetricsCollectorConfig as MetricsCollectorOptions,
     MtlsProfileConfig, NmxcCollectorConfig as NmxcCollectorOptions,
     NmxtCollectorConfig as NmxtCollectorOptions, NvueCollectorConfig as NvueCollectorOptions,
@@ -296,6 +297,9 @@ pub struct DiscoveryLoopContext {
 
     /// Whether log collectors should attach diagnostic payload carriers.
     pub(crate) logs_include_diagnostics: bool,
+
+    /// Opt-in identity attributes attached to logs and metric datapoints.
+    pub(crate) attributes: AttributesConfig,
 }
 
 impl DiscoveryLoopContext {
@@ -393,6 +397,7 @@ impl DiscoveryLoopContext {
             },
             log_downgrade_registry: Arc::new(LogDowngradeRegistry::new()),
             logs_include_diagnostics: config.sinks.includes_log_diagnostics(),
+            attributes: config.attributes.clone(),
         })
     }
 }

--- a/crates/health/src/discovery/spawn.rs
+++ b/crates/health/src/discovery/spawn.rs
@@ -201,8 +201,11 @@ fn spawn_generic_redfish_collectors(
     let gpu_inventory_enabled = matches!(ctx.gpu_inventory_config, Configurable::Enabled(_))
         && ctx.api_client.is_some()
         && matches!(endpoint.metadata, Some(EndpointMetadata::Machine(_)));
+    // GPU identity attributes on log records are resolved against the shared
+    // entity inventory, so discovery must also run for a logs-only deployment.
+    let gpu_identity_enabled = ctx.attributes.gpu_identity;
 
-    if (sensors_enabled || metrics_enabled || gpu_inventory_enabled)
+    if (sensors_enabled || metrics_enabled || gpu_inventory_enabled || gpu_identity_enabled)
         && !ctx.collectors.contains(CollectorKind::Discovery, &key)
     {
         let shared = ctx.collectors.inventory_for(&key);
@@ -216,6 +219,7 @@ fn spawn_generic_redfish_collectors(
             EntityDiscoveryCollectorConfig {
                 shared,
                 request_concurrency: ctx.bmc_request_concurrency,
+                gpu_identity: gpu_identity_enabled,
             },
             CollectorStartContext {
                 limiter: ctx.limiter.clone(),
@@ -383,6 +387,14 @@ fn spawn_generic_redfish_collectors(
                 .create_collector_registry(format!("log_collector_{key}"), metrics_prefix)?,
         );
 
+        // Resolved once here because both SSE spawn paths below share the
+        // endpoint's inventory handle.
+        let sse_gpu_inventory = if ctx.attributes.gpu_identity {
+            Some(ctx.collectors.inventory_for(&key))
+        } else {
+            None
+        };
+
         let sse_cfg = logs_cfg.sse_or_default();
         let sse_backoff_config = || BackoffConfig {
             initial: sse_cfg.initial_backoff,
@@ -424,6 +436,7 @@ fn spawn_generic_redfish_collectors(
                         SseLogCollectorConfig {
                             include_diagnostics: ctx.logs_include_diagnostics,
                             request_concurrency: ctx.bmc_request_concurrency,
+                            gpu_inventory: sse_gpu_inventory,
                         },
                         data_sink,
                         StreamingCollectorStartContext {
@@ -467,6 +480,7 @@ fn spawn_generic_redfish_collectors(
                         SseLogCollectorConfig {
                             include_diagnostics: ctx.logs_include_diagnostics,
                             request_concurrency: ctx.bmc_request_concurrency,
+                            gpu_inventory: sse_gpu_inventory,
                         },
                         data_sink,
                         StreamingCollectorStartContext {


### PR DESCRIPTION
An Xid error arriving on an SSE log record, and a power or temperature sample
from the sensor collector, both identify a GPU only by its chassis slot — for
example `/redfish/v1/Chassis/HGX_GPU_SXM_1`. That path names a socket on the
baseboard rather than a device. When a GPU is replaced during an RMA the path is
unchanged while the silicon behind it is different, so any fleet analysis keyed
on it silently merges the failure history of the old and the new part. Keeping
those histories apart is the whole point of an RMA workflow, so today that
analysis cannot be done from NICo telemetry alone.

Redfish already reports the current occupant's identity on the PCIe device
beneath each GPU chassis. Verified on a DGX H100:

```json
{
  "id": "HGX_GPU_SXM_1",
  "chassisType": "module",
  "serialNumber": "1655023015625",
  "pcieDevices": [
    {
      "id": "GPU_SXM_1",
      "uuid": "beea8cdf-7b7d-035c-ed07-360e311fcbe1",
      "model": "H100 80GB HBM3",
      "serialNumber": "1655023015625",
      "manufacturer": "NVIDIA"
    }
  ]
}
```

This PR enables the `nv-redfish` `pcie-devices` feature for `crates/health` and
resolves that data during chassis discovery, then attaches it to telemetry as
`gpu_uuid`, `gpu_serial`, `gpu_chassis_serial`, and `gpu_model`. The effect is to
demote `origin_of_condition` from an identity to a join key: it still tells us
which socket produced an event, and we resolve socket to current occupant to get
the device identity as of that moment.

### How it works

Sensor metric datapoints pick the attributes up directly, because GPU chassis
entities already flow through the sensor collector.

SSE log records need a join. The collector now takes the per-endpoint
`SharedInventory` handle — structurally the same handle `SensorCollectorConfig`
already receives — and matches the last path segment of `origin_of_condition`
against the discovered chassis. Every step of that lookup is fallible and
no-ops silently: non-GPU origins are common (an existing fixture in `sse.rs`
uses `HGX_Baseboard_0`), and the snapshot is `None` until the first discovery
pass completes. A missed enrichment degrades to current behaviour; it never
drops or delays a log record. The lookup reads a snapshot already in cache, so
it adds no Redfish I/O on the log path.

The discovery spawn gate is widened to cover the feature, since a logs-only
deployment would otherwise never populate the inventory that the join reads.

### Design decisions worth reviewing

**These are log record and metric datapoint attributes, not resource
attributes.** NICo's resource identity is the `(endpoint, collector)` pair and a
single BMC endpoint fronts eight GPUs, so per-GPU identity cannot be a property
of the resource without changing how NICo groups telemetry. Record-level
attributes carry the same information without that disruption.

**No new `DiscoveredEntity` variant.** The identity is stored on the existing
`Chassis` variant as `gpu: Option<GpuIdentity>`. A separate `PcieDevice` variant
would have needed a parent link back to its chassis and would have appeared in
every `match` over `DiscoveredEntity`, including sensor projection, for no gain.
`discover_chassis` also had to stop returning early when a chassis reports no
sensors, since GPU chassis on some platforms have none.

**Bounded staleness, deliberately not a write-once cache.** The inventory
snapshot is replaced wholesale each discovery pass, so after a GPU swap there is
a window of at most one `refresh_interval` in which records carry the previous
occupant's UUID. This is inherent to out-of-band polling and can only be
bounded, not eliminated. `SharedSystemUuid` is the established pattern for
late-bound identity, but it is a write-once `OnceCell`, which would be wrong
here precisely because this value changes under a hardware swap.

**Cardinality.** `gpu_uuid` is a UUID-valued Prometheus label, which reviewers
will reasonably flag. It is bounded by GPUs per fleet and does not multiply
existing series, because each GPU sensor series already exists per `chassis_id`.
This is a relabelling of existing series rather than a cardinality increase.

**Both serials are emitted.** On `chassisType: "module"` hardware
`gpu_chassis_serial` is byte-identical to `gpu_serial`, but that equality is a
platform coincidence rather than a guarantee. They are read from different
Redfish resources, so a platform where they diverge needs no code change.

### Opt-in

Off by default:

```toml
[attributes]
gpu_identity = true
```

The flag gates the PCIe traversal itself, not just the labels, so a deployment
that leaves it off issues no additional Redfish requests per discovery pass.

### Commit structure

Two commits, intended to be reviewed in order:

1. `feat(bmc-mock)` — a `uuid` setter on the PCIe device builder, a stable
   per-slot `UUID` on the DGX H100 and GB200 GPU fixtures, and a DGX H100
   `test_support` helper matching the existing `wiwynn_gb200_bmc` one. This is 30
   lines across 4 files and is a prerequisite rather than a separate feature: the
   fixtures previously left `PCIeDevice.UUID` unset, so without it the
   integration tests in commit 2 have no identity to resolve and do not compile.
2. `feat(health)` — the discovery, enrichment, and config work described above.

### Out of scope

**A Redfish `EventService` for `bmc-mock`.** `bmc-mock` has no `EventService`,
and `AxumRouterHttpClient::sse` returns `NotSupported`, so there is currently no
way to drive a Redfish event or SSE log record against the mock at all. I have a
working implementation of one — an `EventService` resource, a
`ServerSentEventUri` stream, and `EventService.SubmitTestEvent` — and an earlier
revision of this PR included it, but it is independent test infrastructure that
deserves its own review, so I have dropped it here and can propose it separately.
See the testing notes below for what that means for reproducing the SSE evidence.

**NVLink domain context on the same telemetry.** Investigated and deliberately
left out. It needs NMX-C query RPCs that nothing currently calls (`nmxc.rs` only
does `Hello` then `Subscribe`, and the `domain_uuid` it reports never flows back
into endpoint metadata), a cross-endpoint registry, and a join key whose
correspondence to `MachineData` is unverified. That is a separate change and not
a dependency of this one.

## Related issues

None. Happy to open one for discussion if you would prefer that before review,
given the project's experimental status.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

Additive and off by default. Existing dashboards and alerts keyed on
`chassis_id` or `origin_of_condition` are unaffected.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Unit tests cover the enrichment paths that must not regress: a GPU origin that
resolves, a non-GPU origin, an absent snapshot, and a chassis present without a
PCIe child. The last three must all produce current output unchanged.

Integration tests run against `bmc-mock` over real HTTP for both the DGX H100
and GB200 profiles, asserting that each GPU chassis resolves to a distinct UUID.

Manual end-to-end run: the real `forge-hw-health` binary against a `bmc-mock`
DGX H100 over HTTPS. `hw_sensor_power_watts` and `hw_sensor_temperature_celsius`
carry all four attributes, distinct per slot. With `attributes.gpu_identity`
off, all four disappear, the remaining labels are unchanged, and no PCIe
traversal is issued.

Two limits on that evidence, called out rather than left implied.

**The SSE half is not reproducible from this branch.** I did verify it — an
injected Xid arrived as an SSE log record carrying all four attributes resolved
to the correct slot — but only with the `bmc-mock` `EventService` described under
Out of scope, which is not in this PR. From this branch alone the SSE path is
covered by unit and integration tests over hand-constructed `EventRecord`s and
mock-derived inventory, not by an end-to-end stream. The metric path above needs
no such addition and is reproducible as-is.

**Not validated on real hardware.** Every result above comes from `bmc-mock`, and
mock fidelity for `PCIeDevice.UUID` is the weakest link, since the fixtures
previously did not populate that field at all and the values this PR adds are
ones I chose. The field is confirmed populated on a DGX H100
(`viking-prod-348`, sample above), but the collector's behaviour against a live
BMC is untested. I can validate on hardware before you merge if you would like
to hold it for that.

## Additional Notes

One open question that does not block this change. The observed
`PCIeDevice.UUID` matches NVML's GPU UUID format with the `GPU-` prefix
stripped. If that correspondence holds generally, out-of-band Xid logs become
joinable to in-band DCGM/NVML metrics on a shared key, which is worth
documenting as a supported join. If it does not, the attribute is still valid as
an out-of-band-local identity. Confirming it needs
`nvidia-smi --query-gpu=index,uuid,serial --format=csv` on a host whose OOB data
is known.

Two smaller points I would value guidance on. The PCIe traversal currently
follows the existing chassis loop; if you want it narrowed to chassis that can
host a GPU, an id-prefix filter on `HGX_GPU_SXM` is cheap but platform-specific,
and I did not want to guess at the right default. And forcing a discovery pass on
SSE reconnect would shrink the post-swap staleness window to near zero for the
common case, since an endpoint is unreachable while a tray is serviced, but it
couples two collectors that are currently independent.
