### PR TITLE
feat(agent): Manage VF link states from DPU OS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1040,6 +1040,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "ipnetwork",
+ "itertools 0.14.0",
  "json-patch",
  "lazy_static",
  "libc",

--- a/crates/agent/Cargo.toml
+++ b/crates/agent/Cargo.toml
@@ -84,6 +84,7 @@ humantime = { workspace = true }
 hyper = { workspace = true }
 hyper-util = { workspace = true, features = ["client-legacy"] }
 ipnetwork = { workspace = true }
+itertools = { workspace = true }
 lazy_static = { workspace = true }
 libc = { workspace = true }
 mac_address = { workspace = true }

--- a/crates/agent/src/dpu/host_vf_link.rs
+++ b/crates/agent/src/dpu/host_vf_link.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet};
+use std::error::Error;
+use std::fmt;
 use std::path::Path;
 
 use eyre::WrapErr;
+use itertools::Itertools;
 
 mod parse_hbn_conf;
 
@@ -51,8 +54,204 @@ impl VfInterfaceMap {
     }
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+/// Describes a concrete administrative state for a managed link.
+enum LinkAdminState {
+    Up,
+    Down,
+}
+
+impl LinkAdminState {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Up => "up",
+            Self::Down => "down",
+        }
+    }
+}
+
+impl fmt::Display for LinkAdminState {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(self.as_str())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
+/// Records the reconciler's estimate of a managed link's administrative state.
+enum LinkAdminStateEstimate {
+    #[default]
+    Unknown,
+    Assumed(LinkAdminState),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+/// Describes the desired administrative state change for one managed link.
+struct LinkStateOperation {
+    interface: String,
+    desired_state: LinkAdminState,
+}
+
+impl LinkStateOperation {
+    fn new(interface: impl Into<String>, desired_state: LinkAdminState) -> Self {
+        Self {
+            interface: interface.into(),
+            desired_state,
+        }
+    }
+}
+
+/// Reports whether a failed link operation may have changed the link state.
+trait LinkStateControllerError: Error + Send + Sync + 'static {
+    /// Returns whether the cached administrative state can no longer be trusted.
+    fn maybe_obscured_state(&self) -> bool;
+}
+
+type BoxedLinkStateControllerError = Box<dyn LinkStateControllerError>;
+
+/// Applies administrative state changes selected by the reconciler.
+#[async_trait::async_trait]
+trait LinkStateController: fmt::Debug + Send {
+    /// Applies one requested administrative state change.
+    async fn apply_state_operation(
+        &mut self,
+        operation: &LinkStateOperation,
+    ) -> Result<(), BoxedLinkStateControllerError>;
+}
+
+#[derive(Debug, Default)]
+/// Tracks link-state estimates and selects representors that still need updates.
+struct LinkStateReconciler {
+    state_estimates: HashMap<String, LinkAdminStateEstimate>,
+}
+
+impl LinkStateReconciler {
+    fn new<I, S>(managed_links: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Self {
+            state_estimates: managed_links
+                .into_iter()
+                .map(|interface| (interface.into(), LinkAdminStateEstimate::Unknown))
+                .collect(),
+        }
+    }
+
+    fn invalidate_cached_state(&mut self) {
+        for estimate in self.state_estimates.values_mut() {
+            *estimate = LinkAdminStateEstimate::Unknown;
+        }
+    }
+
+    fn pending_operations<I, S>(&self, active_links: I) -> Vec<LinkStateOperation>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let active_links = active_links
+            .into_iter()
+            .map(Into::into)
+            .collect::<HashSet<_>>();
+
+        self.state_estimates
+            .iter()
+            .filter_map(|(interface, estimate)| {
+                match (*estimate, active_links.contains(interface)) {
+                    (LinkAdminStateEstimate::Assumed(LinkAdminState::Up), true)
+                    | (LinkAdminStateEstimate::Assumed(LinkAdminState::Down), false) => None,
+                    (_, true) => Some(LinkStateOperation::new(interface, LinkAdminState::Up)),
+                    (_, false) => Some(LinkStateOperation::new(interface, LinkAdminState::Down)),
+                }
+            })
+            .collect()
+    }
+
+    async fn reconcile_links<I, S>(
+        &mut self,
+        active_links: I,
+        controller: &mut dyn LinkStateController,
+    ) -> Result<(), LinkStateReconciliationError>
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        let pending_operations = self.pending_operations(active_links);
+        let mut failures = Vec::new();
+
+        for operation in pending_operations {
+            match controller.apply_state_operation(&operation).await {
+                Ok(()) => {
+                    *self
+                        .state_estimates
+                        .get_mut(&operation.interface)
+                        .expect("operation must reference a managed link") =
+                        LinkAdminStateEstimate::Assumed(operation.desired_state);
+                }
+                Err(error) => {
+                    if error.maybe_obscured_state() {
+                        *self
+                            .state_estimates
+                            .get_mut(&operation.interface)
+                            .expect("operation must reference a managed link") =
+                            LinkAdminStateEstimate::Unknown;
+                    }
+                    failures.push(LinkStateOperationFailure { operation, error });
+                }
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(LinkStateReconciliationError { failures })
+        }
+    }
+}
+
+#[derive(Debug)]
+/// Associates one failed administrative operation with its controller error.
+struct LinkStateOperationFailure {
+    operation: LinkStateOperation,
+    error: BoxedLinkStateControllerError,
+}
+
+impl fmt::Display for LinkStateOperationFailure {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "interface={} desired_state={} error={}",
+            self.operation.interface.as_str(),
+            self.operation.desired_state.as_str(),
+            self.error
+        )
+    }
+}
+
+#[derive(Debug)]
+/// Reports every host VF link operation that failed during one reconciliation.
+struct LinkStateReconciliationError {
+    failures: Vec<LinkStateOperationFailure>,
+}
+
+impl fmt::Display for LinkStateReconciliationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut failures = self.failures.iter().collect::<Vec<_>>();
+        failures.sort_by_key(|failure| &failure.operation.interface);
+        write!(
+            formatter,
+            "failed to reconcile host VF links: {}",
+            failures.into_iter().join("; ")
+        )
+    }
+}
+
+impl Error for LinkStateReconciliationError {}
+
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
+
     use super::*;
 
     fn vf_map(entries: &[(u32, &str)]) -> VfInterfaceMap {
@@ -73,5 +272,190 @@ mod tests {
         representors.sort();
 
         assert_eq!(representors, ["pf0vf07", "pf0vf1"]);
+    }
+
+    #[derive(Clone, Debug)]
+    struct FakeControllerError {
+        obscures_state: bool,
+        message: &'static str,
+    }
+
+    impl fmt::Display for FakeControllerError {
+        fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+            formatter.write_str(self.message)
+        }
+    }
+
+    impl Error for FakeControllerError {}
+
+    impl LinkStateControllerError for FakeControllerError {
+        fn maybe_obscured_state(&self) -> bool {
+            self.obscures_state
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct FakeController {
+        failures: HashMap<String, VecDeque<FakeControllerError>>,
+        operations: Vec<LinkStateOperation>,
+    }
+
+    impl FakeController {
+        fn fail_once(
+            mut self,
+            interface: &str,
+            obscures_state: bool,
+            message: &'static str,
+        ) -> Self {
+            self.failures
+                .entry(interface.to_string())
+                .or_default()
+                .push_back(FakeControllerError {
+                    obscures_state,
+                    message,
+                });
+            self
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl LinkStateController for FakeController {
+        async fn apply_state_operation(
+            &mut self,
+            operation: &LinkStateOperation,
+        ) -> Result<(), BoxedLinkStateControllerError> {
+            self.operations.push(operation.clone());
+            match self.failures.get_mut(&operation.interface) {
+                Some(failures) if !failures.is_empty() => {
+                    Err(Box::new(failures.pop_front().unwrap()))
+                }
+                _ => Ok(()),
+            }
+        }
+    }
+
+    fn sorted_operations(operations: &[LinkStateOperation]) -> Vec<LinkStateOperation> {
+        let mut operations = operations.to_vec();
+        operations.sort_by(|left, right| left.interface.cmp(&right.interface));
+        operations
+    }
+
+    #[tokio::test]
+    async fn reconciles_startup_attach_detach_and_cached_noop() {
+        let mut reconciler = LinkStateReconciler::new(["pf0vf0", "pf0vf1"]);
+        let mut controller = FakeController::default();
+
+        reconciler
+            .reconcile_links(["pf0vf0"], &mut controller)
+            .await
+            .unwrap();
+        assert_eq!(
+            sorted_operations(&controller.operations),
+            vec![
+                LinkStateOperation::new("pf0vf0", LinkAdminState::Up),
+                LinkStateOperation::new("pf0vf1", LinkAdminState::Down),
+            ]
+        );
+
+        controller.operations.clear();
+        reconciler
+            .reconcile_links(["pf0vf0"], &mut controller)
+            .await
+            .unwrap();
+        assert!(controller.operations.is_empty());
+
+        reconciler.invalidate_cached_state();
+        reconciler
+            .reconcile_links(["pf0vf0"], &mut controller)
+            .await
+            .unwrap();
+        assert_eq!(
+            sorted_operations(&controller.operations),
+            vec![
+                LinkStateOperation::new("pf0vf0", LinkAdminState::Up),
+                LinkStateOperation::new("pf0vf1", LinkAdminState::Down),
+            ]
+        );
+
+        controller.operations.clear();
+        reconciler
+            .reconcile_links(["pf0vf1"], &mut controller)
+            .await
+            .unwrap();
+        assert_eq!(
+            sorted_operations(&controller.operations),
+            vec![
+                LinkStateOperation::new("pf0vf0", LinkAdminState::Down),
+                LinkStateOperation::new("pf0vf1", LinkAdminState::Up),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn retains_successes_and_retries_only_failed_links() {
+        let mut reconciler = LinkStateReconciler::new(["pf0vf0", "pf0vf1"]);
+        let mut controller = FakeController::default().fail_once("pf0vf1", true, "denied");
+
+        let error = reconciler
+            .reconcile_links(["pf0vf0", "pf0vf1"], &mut controller)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("interface=pf0vf1"));
+
+        controller.operations.clear();
+        reconciler
+            .reconcile_links(["pf0vf0", "pf0vf1"], &mut controller)
+            .await
+            .unwrap();
+        assert_eq!(
+            controller.operations,
+            vec![LinkStateOperation::new("pf0vf1", LinkAdminState::Up)]
+        );
+    }
+
+    #[tokio::test]
+    async fn failure_classification_controls_state_estimate() {
+        for (obscures_state, expect_retry) in [(false, false), (true, true)] {
+            let mut reconciler = LinkStateReconciler::new(["pf0vf0"]);
+            let mut controller = FakeController::default();
+            reconciler
+                .reconcile_links(["pf0vf0"], &mut controller)
+                .await
+                .unwrap();
+
+            controller =
+                FakeController::default().fail_once("pf0vf0", obscures_state, "operation failed");
+            reconciler
+                .reconcile_links(Vec::<&str>::new(), &mut controller)
+                .await
+                .unwrap_err();
+
+            controller.operations.clear();
+            reconciler
+                .reconcile_links(["pf0vf0"], &mut controller)
+                .await
+                .unwrap();
+            assert_eq!(
+                !controller.operations.is_empty(),
+                expect_retry,
+                "obscures_state={obscures_state}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn formats_aggregated_failures_in_interface_order() {
+        let mut reconciler = LinkStateReconciler::new(["pf0vf2", "pf0vf10"]);
+        let mut controller = FakeController::default()
+            .fail_once("pf0vf2", true, "second")
+            .fail_once("pf0vf10", true, "first");
+
+        let error = reconciler
+            .reconcile_links(["pf0vf2", "pf0vf10"], &mut controller)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(error.find("pf0vf10").unwrap() < error.find("pf0vf2").unwrap());
+        assert!(error.contains("desired_state=up"));
     }
 }

--- a/crates/agent/src/dpu/host_vf_link.rs
+++ b/crates/agent/src/dpu/host_vf_link.rs
@@ -1,7 +1,10 @@
 use std::collections::{HashMap, HashSet};
 use std::error::Error;
+use std::ffi::OsString;
 use std::fmt;
 use std::path::Path;
+use std::process::Stdio;
+use std::time::Duration;
 
 use eyre::WrapErr;
 use itertools::Itertools;
@@ -116,6 +119,120 @@ trait LinkStateController: fmt::Debug + Send {
         &mut self,
         operation: &LinkStateOperation,
     ) -> Result<(), BoxedLinkStateControllerError>;
+}
+
+#[derive(Debug)]
+/// Applies administrative state changes to Linux network interfaces.
+struct IpLinkStateController {
+    executable: OsString,
+    timeout: Duration,
+}
+
+impl Default for IpLinkStateController {
+    fn default() -> Self {
+        const DEFAULT_TIMEOUT: Duration = Duration::from_secs(10);
+
+        Self {
+            executable: OsString::from("ip"),
+            timeout: DEFAULT_TIMEOUT,
+        }
+    }
+}
+
+impl IpLinkStateController {
+    fn build_command(&self, operation: &LinkStateOperation) -> tokio::process::Command {
+        let mut command = tokio::process::Command::new(&self.executable);
+        command
+            .args([
+                "link",
+                "set",
+                "dev",
+                operation.interface.as_str(),
+                operation.desired_state.as_str(),
+            ])
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .kill_on_drop(true);
+        command
+    }
+
+    #[cfg(test)]
+    fn with_executable(mut self, executable: impl Into<OsString>) -> Self {
+        self.executable = executable.into();
+        self
+    }
+
+    #[cfg(test)]
+    fn with_timeout(mut self, timeout: Duration) -> Self {
+        self.timeout = timeout;
+        self
+    }
+}
+
+#[derive(Debug)]
+/// Classifies failures from an administrative link-state command.
+enum IpLinkStateControllerError {
+    NotStarted(eyre::Report),
+    Failed(eyre::Report),
+}
+
+impl LinkStateControllerError for IpLinkStateControllerError {
+    fn maybe_obscured_state(&self) -> bool {
+        matches!(self, Self::Failed(_))
+    }
+}
+
+impl fmt::Display for IpLinkStateControllerError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::NotStarted(error) => {
+                write!(formatter, "link command did not start: {error:#}")
+            }
+            Self::Failed(error) => write!(formatter, "link command failed: {error:#}"),
+        }
+    }
+}
+
+impl Error for IpLinkStateControllerError {}
+
+#[async_trait::async_trait]
+impl LinkStateController for IpLinkStateController {
+    async fn apply_state_operation(
+        &mut self,
+        operation: &LinkStateOperation,
+    ) -> Result<(), BoxedLinkStateControllerError> {
+        let mut command = self.build_command(operation);
+        let command_description = crate::pretty_cmd(command.as_std());
+        let child = command.spawn().map_err(|error| {
+            Box::new(IpLinkStateControllerError::NotStarted(eyre::eyre!(
+                "starting command {command_description:?}: {error}"
+            ))) as BoxedLinkStateControllerError
+        })?;
+
+        let output = tokio::time::timeout(self.timeout, child.wait_with_output())
+            .await
+            .map_err(|_| {
+                Box::new(IpLinkStateControllerError::Failed(eyre::eyre!(
+                    "timed out after {:?} waiting for command {command_description:?}",
+                    self.timeout
+                ))) as BoxedLinkStateControllerError
+            })?
+            .map_err(|error| {
+                Box::new(IpLinkStateControllerError::Failed(eyre::eyre!(
+                    "waiting for command {command_description:?}: {error}"
+                ))) as BoxedLinkStateControllerError
+            })?;
+
+        if !output.status.success() {
+            return Err(Box::new(IpLinkStateControllerError::Failed(eyre::eyre!(
+                "command {command_description:?} exited with status {}, stderr: {}",
+                output.status,
+                String::from_utf8_lossy(&output.stderr).trim()
+            ))));
+        }
+
+        Ok(())
+    }
 }
 
 #[derive(Debug, Default)]
@@ -251,6 +368,9 @@ impl Error for LinkStateReconciliationError {}
 #[cfg(test)]
 mod tests {
     use std::collections::VecDeque;
+    use std::ffi::OsStr;
+    use std::os::unix::fs::PermissionsExt;
+    use std::path::{Path, PathBuf};
 
     use super::*;
 
@@ -457,5 +577,71 @@ mod tests {
             .to_string();
         assert!(error.find("pf0vf10").unwrap() < error.find("pf0vf2").unwrap());
         assert!(error.contains("desired_state=up"));
+    }
+
+    fn write_executable(directory: &Path, name: &str, contents: &str) -> PathBuf {
+        let path = directory.join(name);
+        std::fs::write(&path, contents).unwrap();
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        path
+    }
+
+    #[test]
+    fn ip_controller_builds_exact_command() {
+        let controller = IpLinkStateController::default();
+        let command =
+            controller.build_command(&LinkStateOperation::new("pf0vf7", LinkAdminState::Down));
+
+        assert_eq!(command.as_std().get_program(), OsStr::new("ip"));
+        assert_eq!(
+            command.as_std().get_args().collect::<Vec<_>>(),
+            ["link", "set", "dev", "pf0vf7", "down"]
+                .into_iter()
+                .map(OsStr::new)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[tokio::test]
+    async fn ip_controller_classifies_spawn_failure_as_unchanged() {
+        let mut controller =
+            IpLinkStateController::default().with_executable("/path/that/does/not/exist/ip-test");
+        let error = controller
+            .apply_state_operation(&LinkStateOperation::new("pf0vf0", LinkAdminState::Up))
+            .await
+            .unwrap_err();
+        assert!(!error.maybe_obscured_state());
+    }
+
+    #[tokio::test]
+    async fn ip_controller_reports_nonzero_exit_and_stderr() {
+        let directory = tempfile::tempdir().unwrap();
+        let executable = write_executable(
+            directory.path(),
+            "ip-test",
+            "#!/bin/sh\necho permission-denied >&2\nexit 7\n",
+        );
+        let mut controller = IpLinkStateController::default().with_executable(executable);
+        let error = controller
+            .apply_state_operation(&LinkStateOperation::new("pf0vf0", LinkAdminState::Up))
+            .await
+            .unwrap_err();
+        assert!(error.maybe_obscured_state(), "{error}");
+        assert!(error.to_string().contains("permission-denied"));
+    }
+
+    #[tokio::test]
+    async fn ip_controller_classifies_timeout_as_state_obscuring() {
+        let directory = tempfile::tempdir().unwrap();
+        let executable = write_executable(directory.path(), "ip-test", "#!/bin/sh\nsleep 1\n");
+        let mut controller = IpLinkStateController::default()
+            .with_executable(executable)
+            .with_timeout(Duration::from_millis(10));
+        let error = controller
+            .apply_state_operation(&LinkStateOperation::new("pf0vf0", LinkAdminState::Up))
+            .await
+            .unwrap_err();
+        assert!(error.maybe_obscured_state());
+        assert!(error.to_string().contains("timed out"));
     }
 }

--- a/crates/agent/src/dpu/host_vf_link.rs
+++ b/crates/agent/src/dpu/host_vf_link.rs
@@ -1,0 +1,77 @@
+use std::collections::{HashMap, HashSet};
+use std::path::Path;
+
+use eyre::WrapErr;
+
+mod parse_hbn_conf;
+
+#[derive(Debug, Eq, PartialEq)]
+/// Maps tenant VF IDs to their HBN-owned host representors.
+struct VfInterfaceMap {
+    representor_names: HashMap<u32, String>,
+}
+
+impl VfInterfaceMap {
+    /// Loads a validated host VF ownership mapping from an HBN configuration file.
+    async fn load_from(path: impl AsRef<Path>) -> eyre::Result<Self> {
+        let path = path.as_ref();
+        let contents = tokio::fs::read_to_string(path)
+            .await
+            .wrap_err_with(|| format!("reading {}", path.display()))?;
+        Self::parse(&contents).wrap_err_with(|| format!("parsing {}", path.display()))
+    }
+
+    /// Parses host VF ownership entries from an HBN configuration file.
+    ///
+    /// An example minimal valid configuration is:
+    ///
+    /// ```text
+    /// [LINK_PROPAGATION]
+    /// pf0vf7:pf0vf7_if_r
+    /// ```
+    fn parse(contents: &str) -> eyre::Result<Self> {
+        Ok(Self {
+            representor_names: parse_hbn_conf::get_hbn_vf_mapping(contents)?,
+        })
+    }
+
+    /// Returns the names of every host VF representor owned by this mapping.
+    fn managed_host_representors(&self) -> impl Iterator<Item = &str> + '_ {
+        self.representor_names.values().map(String::as_str)
+    }
+
+    /// Returns the owned host representor associated with a VF ID.
+    fn representor_name(&self, vf_id: u32) -> Option<&str> {
+        self.representor_names.get(&vf_id).map(String::as_str)
+    }
+
+    /// Returns the set of VF IDs accepted by this ownership mapping.
+    fn valid_vf_ids(&self) -> HashSet<u32> {
+        self.representor_names.keys().copied().collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn vf_map(entries: &[(u32, &str)]) -> VfInterfaceMap {
+        VfInterfaceMap {
+            representor_names: entries
+                .iter()
+                .map(|(vf_id, interface)| (*vf_id, (*interface).to_string()))
+                .collect(),
+        }
+    }
+
+    #[test]
+    fn retains_configured_host_representor_names() {
+        let interface_map = vf_map(&[(7, "pf0vf07"), (1, "pf0vf1")]);
+        let mut representors = interface_map
+            .managed_host_representors()
+            .collect::<Vec<_>>();
+        representors.sort();
+
+        assert_eq!(representors, ["pf0vf07", "pf0vf1"]);
+    }
+}

--- a/crates/agent/src/dpu/host_vf_link.rs
+++ b/crates/agent/src/dpu/host_vf_link.rs
@@ -6,11 +6,99 @@ use std::path::Path;
 use std::process::Stdio;
 use std::time::Duration;
 
+use ::rpc::forge::{InterfaceFunctionType, ManagedHostNetworkConfigResponse};
 use eyre::WrapErr;
 use itertools::Itertools;
 
 mod parse_hbn_conf;
 
+#[derive(Debug)]
+/// Keeps HBN-owned host VF representors aligned with active tenant VFs.
+pub(crate) struct HostVfLinkManager {
+    interface_map: VfInterfaceMap,
+    reconciler: LinkStateReconciler,
+    controller: Box<dyn LinkStateController>,
+}
+
+impl HostVfLinkManager {
+    /// Creates a manager from the DPU OS host VF propagation configuration.
+    pub(crate) async fn init_for_dpu_os() -> eyre::Result<Self> {
+        let interface_map = VfInterfaceMap::load_from(parse_hbn_conf::HBN_CONF_PATH).await?;
+        Ok(Self::new(
+            interface_map,
+            Box::new(IpLinkStateController::default()),
+        ))
+    }
+
+    fn new(interface_map: VfInterfaceMap, controller: Box<dyn LinkStateController>) -> Self {
+        let reconciler = LinkStateReconciler::new(interface_map.managed_host_representors());
+        Self {
+            interface_map,
+            reconciler,
+            controller,
+        }
+    }
+
+    /// Applies the desired administrative state to every managed host VF representor.
+    pub(crate) async fn reconcile(
+        &mut self,
+        config: &ManagedHostNetworkConfigResponse,
+    ) -> eyre::Result<()> {
+        reconcile_active_vfs(
+            &self.interface_map,
+            &mut self.reconciler,
+            config,
+            self.controller.as_mut(),
+        )
+        .await
+    }
+
+    /// Invalidates every cached link-state estimate.
+    pub(crate) fn invalidate_cached_state(&mut self) {
+        self.reconciler.invalidate_cached_state();
+    }
+}
+
+/// Returns the virtual function IDs attached to tenant network interfaces.
+fn active_vf_ids(config: &ManagedHostNetworkConfigResponse) -> HashSet<u32> {
+    config
+        .tenant_interfaces
+        .iter()
+        .filter(|interface| interface.function_type() == InterfaceFunctionType::Virtual)
+        .filter_map(|interface| interface.virtual_function_id)
+        .collect()
+}
+
+async fn reconcile_active_vfs(
+    interface_map: &VfInterfaceMap,
+    reconciler: &mut LinkStateReconciler,
+    network_config: &ManagedHostNetworkConfigResponse,
+    controller: &mut dyn LinkStateController,
+) -> eyre::Result<()> {
+    let active_vf_ids = active_vf_ids(network_config);
+    let valid_vf_ids = interface_map.valid_vf_ids();
+    let mut missing_vf_ids = active_vf_ids
+        .difference(&valid_vf_ids)
+        .copied()
+        .collect::<Vec<_>>();
+    missing_vf_ids.sort_unstable();
+
+    if !missing_vf_ids.is_empty() {
+        eyre::bail!(
+            "active virtual functions are missing from [{}]: {}",
+            parse_hbn_conf::LINK_PROPAGATION_SECTION,
+            missing_vf_ids.iter().join(", ")
+        );
+    }
+
+    let active_representors = active_vf_ids
+        .into_iter()
+        .filter_map(|vf_id| interface_map.representor_name(vf_id));
+    reconciler
+        .reconcile_links(active_representors, controller)
+        .await
+        .map_err(eyre::Report::new)
+}
 #[derive(Debug, Eq, PartialEq)]
 /// Maps tenant VF IDs to their HBN-owned host representors.
 struct VfInterfaceMap {
@@ -367,10 +455,12 @@ impl Error for LinkStateReconciliationError {}
 
 #[cfg(test)]
 mod tests {
-    use std::collections::VecDeque;
+    use std::collections::{HashSet, VecDeque};
     use std::ffi::OsStr;
     use std::os::unix::fs::PermissionsExt;
     use std::path::{Path, PathBuf};
+
+    use carbide_test_support::{Check, check_values};
 
     use super::*;
 
@@ -392,6 +482,46 @@ mod tests {
         representors.sort();
 
         assert_eq!(representors, ["pf0vf07", "pf0vf1"]);
+    }
+
+    #[test]
+    fn extracts_active_virtual_function_ids() {
+        check_values(
+            [
+                Check {
+                    scenario: "virtual IDs are selected and deduplicated",
+                    input: vec![
+                        (InterfaceFunctionType::Virtual, Some(3)),
+                        (InterfaceFunctionType::Virtual, Some(3)),
+                        (InterfaceFunctionType::Virtual, Some(5)),
+                    ],
+                    expect: HashSet::from([3, 5]),
+                },
+                Check {
+                    scenario: "physical and missing IDs are ignored",
+                    input: vec![
+                        (InterfaceFunctionType::Physical, Some(1)),
+                        (InterfaceFunctionType::Virtual, None),
+                    ],
+                    expect: HashSet::new(),
+                },
+            ],
+            |interfaces| {
+                active_vf_ids(&ManagedHostNetworkConfigResponse {
+                    tenant_interfaces: interfaces
+                        .into_iter()
+                        .map(|(function_type, virtual_function_id)| {
+                            ::rpc::forge::FlatInterfaceConfig {
+                                function_type: function_type.into(),
+                                virtual_function_id,
+                                ..Default::default()
+                            }
+                        })
+                        .collect(),
+                    ..Default::default()
+                })
+            },
+        );
     }
 
     #[derive(Clone, Debug)]
@@ -561,6 +691,30 @@ mod tests {
                 "obscures_state={obscures_state}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn rejects_unmapped_active_vfs_before_link_operations() {
+        let interface_map = vf_map(&[(0, "pf0vf0")]);
+        let mut reconciler = LinkStateReconciler::new(["pf0vf0"]);
+        let mut controller = FakeController::default();
+        let config = ManagedHostNetworkConfigResponse {
+            tenant_interfaces: [7, 2]
+                .into_iter()
+                .map(|virtual_function_id| ::rpc::forge::FlatInterfaceConfig {
+                    function_type: InterfaceFunctionType::Virtual.into(),
+                    virtual_function_id: Some(virtual_function_id),
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+
+        let error = reconcile_active_vfs(&interface_map, &mut reconciler, &config, &mut controller)
+            .await
+            .unwrap_err();
+        assert!(error.to_string().contains("2, 7"));
+        assert!(controller.operations.is_empty());
     }
 
     #[tokio::test]

--- a/crates/agent/src/dpu/host_vf_link/parse_hbn_conf.rs
+++ b/crates/agent/src/dpu/host_vf_link/parse_hbn_conf.rs
@@ -1,0 +1,228 @@
+//! Parses host VF mappings from the contents of the `hbn.conf` file.
+
+use std::collections::HashMap;
+
+use eyre::WrapErr;
+
+pub(super) const LINK_PROPAGATION_SECTION: &str = "LINK_PROPAGATION";
+pub(super) const HBN_CONF_PATH: &str = "/etc/mellanox/hbn.conf";
+
+#[derive(Default)]
+struct SectionSplitState<'a> {
+    next_line_start: usize,
+    section_name: Option<&'a str>,
+    section_contents_start: usize,
+}
+
+impl<'a> SectionSplitState<'a> {
+    fn consume(&mut self, contents: &'a str, line: Option<&'a str>) -> Option<(&'a str, &'a str)> {
+        let Some(line) = line else {
+            return self.finish_section(contents, contents.len());
+        };
+
+        let line_start = self.next_line_start;
+        self.next_line_start += line.len();
+
+        let name = parse_section_header(line)?;
+
+        let completed_section = self.finish_section(contents, line_start);
+        self.section_name = Some(name);
+        self.section_contents_start = self.next_line_start;
+        completed_section
+    }
+
+    fn finish_section(
+        &mut self,
+        contents: &'a str,
+        contents_end: usize,
+    ) -> Option<(&'a str, &'a str)> {
+        self.section_name
+            .take()
+            .map(|name| (name, &contents[self.section_contents_start..contents_end]))
+    }
+}
+
+fn parse_section_header(line: &str) -> Option<&str> {
+    line.trim().strip_prefix('[')?.strip_suffix(']')
+}
+
+fn split_sections(contents: &str) -> impl Iterator<Item = (&str, &str)> {
+    contents
+        .split_inclusive('\n')
+        .map(Some)
+        // This is a sentinel to stand in for EOF.
+        .chain(std::iter::once(None))
+        .scan(SectionSplitState::default(), move |state, line| {
+            Some(state.consume(contents, line))
+        })
+        .flatten()
+}
+
+fn get_link_propagation_section(contents: &str) -> eyre::Result<&str> {
+    let mut matching_sections = split_sections(contents)
+        .filter_map(|(name, contents)| (name == LINK_PROPAGATION_SECTION).then_some(contents));
+    let section = matching_sections
+        .next()
+        .ok_or_else(|| eyre::eyre!("missing [{LINK_PROPAGATION_SECTION}] section"))?;
+
+    if matching_sections.next().is_some() {
+        eyre::bail!("duplicate [{LINK_PROPAGATION_SECTION}] section");
+    }
+
+    Ok(section)
+}
+
+fn parse_mapping_line(line: &str) -> eyre::Result<(&str, &str)> {
+    let (source, destination) = line
+        .split_once(':')
+        .ok_or_else(|| eyre::eyre!("malformed link propagation mapping {line:?}: missing ':'"))?;
+    let source = source.trim();
+    let destination = destination.trim();
+
+    if source.is_empty() {
+        eyre::bail!("malformed link propagation mapping {line:?}: empty source");
+    }
+    if destination.is_empty() {
+        eyre::bail!("malformed link propagation mapping {line:?}: empty destination");
+    }
+    if destination.contains(':') {
+        eyre::bail!("malformed link propagation mapping {line:?}: expected one ':'");
+    }
+
+    Ok((source, destination))
+}
+
+fn get_vf_id(source: &str) -> eyre::Result<Option<u32>> {
+    let Some(vf_id) = source.strip_prefix("pf0vf") else {
+        return Ok(None);
+    };
+
+    if vf_id.is_empty() || !vf_id.bytes().all(|byte| byte.is_ascii_digit()) {
+        eyre::bail!("malformed host VF representor source {source:?}");
+    }
+
+    vf_id
+        .parse::<u32>()
+        .map(Some)
+        .wrap_err_with(|| format!("parsing VF ID from host representor {source:?}"))
+}
+
+/// Parses host VF IDs and representor names from the HBN link-propagation configuration.
+pub(super) fn get_hbn_vf_mapping(contents: &str) -> eyre::Result<HashMap<u32, String>> {
+    let section = get_link_propagation_section(contents)?;
+    let mut vf_mapping = HashMap::new();
+
+    for line in section.lines().map(str::trim) {
+        if line.is_empty() || line.starts_with(['#', ';']) {
+            continue;
+        }
+
+        let (source, _) = parse_mapping_line(line)?;
+        let Some(vf_id) = get_vf_id(source)? else {
+            continue;
+        };
+        if vf_mapping.insert(vf_id, source.to_string()).is_some() {
+            eyre::bail!("duplicate host VF numeric ID {vf_id}");
+        }
+    }
+
+    Ok(vf_mapping)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashMap;
+
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
+
+    use super::*;
+
+    #[test]
+    fn extracts_link_propagation_section() {
+        scenarios!(run = |contents| get_link_propagation_section(contents)
+            .map(str::trim)
+            .map_err(|error| error.to_string());
+            "valid sections" {
+                "[BEFORE]\nignored\n[LINK_PROPAGATION]\npf0vf1:rep1\n[AFTER]\nignored"
+                    => Yields("pf0vf1:rep1"),
+                "[BEFORE]\nignored\n[LINK_PROPAGATION]\npf0vf2:rep2"
+                    => Yields("pf0vf2:rep2"),
+                "[LINK_PROPAGATION]\n[NEXT]" => Yields(""),
+            }
+
+            "invalid sections" {
+                "[OTHER]\npf0vf1:rep1" => Fails,
+                "[link_propagation]\npf0vf1:rep1" => Fails,
+                "[LINK_PROPAGATION]\npf0vf1:rep1\n[OTHER]\nignored\n[LINK_PROPAGATION]"
+                    => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_mapping_lines() {
+        scenarios!(run = |line| parse_mapping_line(line).map_err(|error| error.to_string());
+            "valid mappings" {
+                "pf0vf1:pf0vf1_if_r" => Yields(("pf0vf1", "pf0vf1_if_r")),
+                " pf0vf2 : rep2 " => Yields(("pf0vf2", "rep2")),
+            }
+
+            "invalid mappings" {
+                "pf0vf1" => Fails,
+                ":rep1" => Fails,
+                "pf0vf1:" => Fails,
+                "pf0vf1:rep1:extra" => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn recognizes_host_vf_sources() {
+        scenarios!(run = |source| get_vf_id(source).map_err(|error| error.to_string());
+            "host VFs" {
+                "pf0vf0" => Yields(Some(0)),
+                "pf0vf4294967295" => Yields(Some(u32::MAX)),
+            }
+
+            "unrelated representors" {
+                "p0" => Yields(None),
+                "pf0hpf" => Yields(None),
+                "pf1vf3" => Yields(None),
+            }
+
+            "malformed host VFs" {
+                "pf0vf" => Fails,
+                "pf0vfone" => Fails,
+                "pf0vf4294967296" => Fails,
+            }
+        );
+    }
+
+    #[test]
+    fn parses_host_vf_mapping() {
+        scenarios!(run = |contents| get_hbn_vf_mapping(contents).map_err(|error| error.to_string());
+            "valid configuration" {
+                "[GENERAL]\nignored=value\n\
+                 [LINK_PROPAGATION]\n\
+                 # HBN-owned host VFs\n\
+                 pf0vf1:pf0vf1_if_r\n\
+                 ; preserve the configured source name\n\
+                 pf0vf07:pf0vf7_if_r\n\
+                 p0:p0_if_r\n\
+                 pf0hpf:pf0hpf_if_r\n\
+                 [OTHER]\n\
+                 pf0vf99:ignored"
+                    => Yields(HashMap::from([
+                        (1, "pf0vf1".to_string()),
+                        (7, "pf0vf07".to_string()),
+                    ])),
+            }
+
+            "invalid configuration" {
+                "[LINK_PROPAGATION]\npf0vf1:rep1\npf0vf01:rep01" => Fails,
+                "[LINK_PROPAGATION]\npf0vfbad:rep" => Fails,
+            }
+        );
+    }
+}

--- a/crates/agent/src/dpu/mod.rs
+++ b/crates/agent/src/dpu/mod.rs
@@ -21,6 +21,7 @@ use std::time::Duration;
 use carbide_host_support::agent_config::FmdsDpuNetworkingConfig;
 use ipnetwork::IpNetwork;
 
+pub(crate) mod host_vf_link;
 pub mod interface;
 pub mod link;
 pub mod route;

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -1136,13 +1136,51 @@ impl MainLoop {
                                 tracing::error!(error = %err, "Error reading/setting MTU for p0 or p1");
                             }
 
-                            let can_ack_network_config = self
+                            let ovs_restart_result = self
                                 .restart_ovs_after_admin_network_change_if_needed(
                                     &conf,
                                     &mut status_out,
                                 )
-                                .await
-                                .is_ok();
+                                .await;
+
+                            let (mut can_ack_network_config, must_invalidate_vf_cache) =
+                                match ovs_restart_result {
+                                    Ok(restarted_ovs) => (true, restarted_ovs),
+                                    Err(()) => (false, false),
+                                };
+
+                            // If we haven't failed already at this point and
+                            // we're on a DPU OS, we'll reconcile the VF link
+                            // states.
+                            if can_ack_network_config
+                                && self.options.agent_platform_type.is_dpu_os()
+                            {
+                                match self.get_or_init_vf_link_manager().await {
+                                    Ok(manager) => {
+                                        if must_invalidate_vf_cache {
+                                            manager.invalidate_cached_state();
+                                        }
+                                        if let Err(error) = manager.reconcile(&conf).await {
+                                            tracing::error!(
+                                                managed_host_config_version =
+                                                    conf.managed_host_config_version,
+                                                error = format!("{error:#}"),
+                                                "Failed to reconcile host VF link state"
+                                            );
+                                            status_out.network_config_error =
+                                                Some(error.to_string());
+                                            can_ack_network_config = false;
+                                        }
+                                    }
+                                    Err(error) => {
+                                        let error = format!("{error:#}");
+                                        tracing::error!(%error, "Failed to load host VF link mapping");
+                                        status_out.network_config_error = Some(error);
+                                        can_ack_network_config = false;
+                                    }
+                                }
+                            }
+
                             if can_ack_network_config {
                                 (
                                     current_host_network_config_version,

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -47,6 +47,7 @@ use version_compare::Version;
 
 use crate::command_line::HbnConfigMode;
 use crate::dpu::DpuNetworkInterfaces;
+use crate::dpu::host_vf_link::HostVfLinkManager;
 use crate::dpu::interface::Interface;
 use crate::dpu::route::{DpuRoutePlan, IpRoute, Route};
 use crate::duppet::{SummaryFormat, SyncOptions};
@@ -419,6 +420,7 @@ pub(super) async fn setup_and_run(
         nvue_context,
         dhcp_interface_translation_mode,
         current_network_version: CurrentNetworkVersion::default(),
+        host_vf_link_manager: None,
         last_ovs_restart_version: None,
         ovs_restart_retry_backoff: None,
     };
@@ -456,6 +458,7 @@ struct MainLoop {
     nvue_context: Option<NvueClientContext>,
     dhcp_interface_translation_mode: Option<InterfaceTranslationMode>,
     current_network_version: CurrentNetworkVersion,
+    host_vf_link_manager: Option<HostVfLinkManager>,
     last_ovs_restart_version: Option<String>,
     ovs_restart_retry_backoff: Option<OvsRestartRetryBackoff>,
 }
@@ -783,6 +786,17 @@ impl MainLoop {
                     // the loop_period sleep is interrupted so we will fetch new network config
                 }
                 _ = tokio::time::sleep(result.loop_period) => {}
+            }
+        }
+    }
+
+    async fn get_or_init_vf_link_manager(&mut self) -> eyre::Result<&mut HostVfLinkManager> {
+        match &mut self.host_vf_link_manager {
+            Some(manager) => Ok(manager),
+            slot @ None => {
+                let manager = slot.insert(HostVfLinkManager::init_for_dpu_os().await?);
+                tracing::info!("Loaded host VF link mapping");
+                Ok(manager)
             }
         }
     }

--- a/crates/agent/src/main_loop.rs
+++ b/crates/agent/src/main_loop.rs
@@ -787,24 +787,26 @@ impl MainLoop {
         }
     }
 
+    // The return value uses the outer Result to indicate success/failure and
+    // the inner bool to indicate whether it actually restarted OVS.
     async fn restart_ovs_after_admin_network_change_if_needed(
         &mut self,
         conf: &ManagedHostNetworkConfigResponse,
         status_out: &mut rpc::DpuNetworkStatus,
-    ) -> bool {
+    ) -> Result<bool, ()> {
         if !conf.use_admin_network_changed.unwrap_or_default() {
-            return true;
+            return Ok(false);
         }
 
         let now = Instant::now();
-        let mut can_ack_network_config = true;
-        if !self.options.agent_platform_type.is_dpu_os() {
+        let result = if !self.options.agent_platform_type.is_dpu_os() {
             tracing::info!(
                 agent_platform_type = ?self.options.agent_platform_type,
                 managed_host_config_version =
                     conf.managed_host_config_version.as_str(),
                 "Skip OVS restart because agent is not running on DPU OS"
             );
+            Ok(false)
         } else if self.last_ovs_restart_version.as_deref()
             == Some(conf.managed_host_config_version.as_str())
         {
@@ -812,6 +814,7 @@ impl MainLoop {
                 managed_host_config_version = conf.managed_host_config_version.as_str(),
                 "Skip OVS restart because this network config version already restarted OVS"
             );
+            Ok(false)
         } else if self
             .ovs_restart_retry_backoff
             .as_ref()
@@ -826,34 +829,38 @@ impl MainLoop {
             );
             status_out.network_config_error =
                 Some("waiting to retry OVS restart after prior failure".to_string());
-            can_ack_network_config = false;
+            Err(())
         } else {
             tracing::info!(
                 managed_host_config_version = conf.managed_host_config_version.as_str(),
                 "Restart OVS because use_admin_network_changed is set to true"
             );
-            if let Err(err) = crate::ovs::restart_ovs()
+            match crate::ovs::restart_ovs()
                 .await
                 .wrap_err("restarting OVS after admin network change")
             {
-                carbide_instrument::emit(OvsRestart::Retrying {
-                    error: format!("{err:#}"),
-                    managed_host_config_version: conf.managed_host_config_version.clone(),
-                });
-                status_out.network_config_error = Some(err.to_string());
-                self.ovs_restart_retry_backoff = Some(OvsRestartRetryBackoff {
-                    managed_host_config_version: conf.managed_host_config_version.clone(),
-                    retry_after: Instant::now() + OVS_RESTART_RETRY_BACKOFF,
-                });
-                can_ack_network_config = false;
-            } else {
-                self.last_ovs_restart_version = Some(conf.managed_host_config_version.clone());
-                self.ovs_restart_retry_backoff = None;
+                Err(err) => {
+                    carbide_instrument::emit(OvsRestart::Retrying {
+                        error: format!("{err:#}"),
+                        managed_host_config_version: conf.managed_host_config_version.clone(),
+                    });
+                    status_out.network_config_error = Some(err.to_string());
+                    self.ovs_restart_retry_backoff = Some(OvsRestartRetryBackoff {
+                        managed_host_config_version: conf.managed_host_config_version.clone(),
+                        retry_after: Instant::now() + OVS_RESTART_RETRY_BACKOFF,
+                    });
+                    Err(())
+                }
+                Ok(()) => {
+                    self.last_ovs_restart_version = Some(conf.managed_host_config_version.clone());
+                    self.ovs_restart_retry_backoff = None;
+                    Ok(true)
+                }
             }
-        }
-        tracing::info!(can_ack_network_config, "Finished restarting OVS");
+        };
+        tracing::info!(success = result.is_ok(), "Finished restarting OVS");
 
-        can_ack_network_config
+        result
     }
 
     /// Runs a single iteration of the main loop
@@ -1120,8 +1127,8 @@ impl MainLoop {
                                     &conf,
                                     &mut status_out,
                                 )
-                                .await;
-
+                                .await
+                                .is_ok();
                             if can_ack_network_config {
                                 (
                                     current_host_network_config_version,


### PR DESCRIPTION
This is an implementation that addresses the behavior in #5062. This ended up being quite a bit more code than I initially estimated, partly because determining what VFs we should expect to own requires parsing the `hbn.conf` file to find the mapping.

This work breaks down more or less like this:
- Add a `LinkStateController` trait that manages the admin states of interfaces.
- Add an `IpLinkStateController` implementation of that trait in terms of `ip link set` commands.
- Add a `LinkStateReconciler` to manage the admin link states of a set of interfaces using a `LinkStateController`.
- Add a `HostVfLinkManager` that parses the set of mapped VFs from `hbn.conf` and uses a `LinkStateReconciler` to keep those in sync with the subset that's active in the network config.
- Use the `HostVfLinkManager` from the main loop on the DPU-OS platform path.

Note that this has not been tested on a real DPU, and this branch is still missing health check logic (the inability to parse `hbn.conf` probably needs to be some kind of health alert).

## Related issues
- #5062

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


