### PR TITLE
fix(dpf): increase OS installation timeout to 90 minutes

### DIFF
--- a/helm-prereqs/operators/dpf/dpfoperatorconfig.yaml.tmpl
+++ b/helm-prereqs/operators/dpf/dpfoperatorconfig.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
   dpuDetector:
     disable: true
   provisioningController:
-    osInstallTimeout: "60m"
+    osInstallTimeout: "90m"
     installInterface:
       installViaRedfish:
         skipDPUNodeDiscovery: true


### PR DESCRIPTION
Some DPF OS installations take slightly more than 60 minutes. The DPF provisioning controller currently reaches its configured timeout and marks those DPUs as timed out while their Redfish installations are still in progress.

This increases `DPFOperatorConfig.spec.provisioningController.osInstallTimeout` from `60m` to `90m`. Other DPF health and reconciliation timeouts remain unchanged. The matching manual update is tracked in #5685 and should merge after this PR.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5684

Documentation companion: https://github.com/NVIDIA/infra-controller/issues/5685

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Rendered the `DPFOperatorConfig` template and verified it contains exactly one `osInstallTimeout: "90m"` value with the expected Kubernetes API server substitutions.
- `bash -n helm-prereqs/setup.sh`, workspace formatting, Clippy, and the CI equivalent Carbide lints pass.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable diff. No source changes were needed after review.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 0 | 0 | 0 |
| common-nits-reviewer | 1 | 0 | 1 |
| **Total** | **1** | **0** | **1** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

No findings.

### common-nits-reviewer

1. **Declined** -- Update the DPF manual in this PR so it does not retain `60m`. **Reason:** Repository workflow keeps changes under `docs/` in a separate PR; #5685 contains both matching documentation updates and will merge after this PR.

</details>


Closes #5684
