### PR TITLE
docs(dpf): update OS installation timeout to 90 minutes

### DIFF
--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -514,7 +514,7 @@ spec:
   dpuDetector:
     disable: true
   provisioningController:
-    osInstallTimeout: "60m"
+    osInstallTimeout: "90m"
     installInterface:
       installViaRedfish:
         skipDPUNodeDiscovery: true
@@ -538,7 +538,7 @@ Field-by-field:
 | Field | Meaning |
 | --- | --- |
 | `dpuDetector.disable: true` | DPF normally polls hosts to discover new DPUs. NICo disables auto-discovery because DPUs are fed in via `DPUSet` CRs from the orchestrator. |
-| `provisioningController.osInstallTimeout: "60m"` | Total budget for the OS install flow per DPU. |
+| `provisioningController.osInstallTimeout: "90m"` | Total budget for the OS install flow per DPU. |
 | `provisioningController.installViaRedfish` | Provision DPUs by talking Redfish to the host BMC (vs. PXE-based). |
 | `skipDPUNodeDiscovery: true` | Do not auto-detect DPUs as Kubernetes nodes — DPF is told about them explicitly by NICo. |
 | `overrides.kubernetesAPIServerVIP` | Replace `REPLACE_ME` with the host-cluster API-server VIP that DPUs should reach. |


### PR DESCRIPTION
After #5684 increases the DPF OS installation timeout, the setup manual would still tell operators to configure `60m` in both its example `DPFOperatorConfig` and field table.

This updates both references to `90m` so manual installations use the same timeout as `helm-prereqs`. This documentation should merge after #5684.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5685

Parent issue: https://github.com/NVIDIA/infra-controller/issues/5684

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

- `rumdl` reports no issues for `docs/manuals/dpf.md`.
- The pinned Fern CLI validates the Markdown and documentation definitions.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable diff. The only recommendation was to preserve merge ordering with the companion code change.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 0 | 0 | 0 |
| common-nits-reviewer | 1 | 1 | 0 |
| **Total** | **1** | **1** | **0** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

No findings.

### common-nits-reviewer

1. **Adopted** -- Keep the manual from publishing before the `90m` operator configuration. **Resolution:** The PR description records the dependency on #5684, and this docs PR will merge afterward.

</details>
