### PR TITLE
patch(v2.1): increase DPF OS installation timeout to 90 minutes

### DIFF
--- a/helm-prereqs/operators/dpf/dpfoperatorconfig.yaml.tmpl
+++ b/helm-prereqs/operators/dpf/dpfoperatorconfig.yaml.tmpl
@@ -28,7 +28,7 @@ spec:
   dpuDetector:
     disable: true
   provisioningController:
-    osInstallTimeout: "60m"
+    osInstallTimeout: "90m"
     installInterface:
       installViaRedfish:
         skipDPUNodeDiscovery: true


### PR DESCRIPTION
This backports #5689 to `release/v2.1`. Some DPF OS installations take slightly more than 60 minutes, but this release still configures the provisioning controller to mark them as timed out after 60 minutes while Redfish installation is in progress.

This increases `DPFOperatorConfig.spec.provisioningController.osInstallTimeout` from `60m` to `90m`. The source patch applied without conflict or any adjustment for the release branch. Other DPF health and reconciliation timeouts remain unchanged.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/5684
- Backports https://github.com/NVIDIA/infra-controller/pull/5689

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Rendered the v2.1 `DPFOperatorConfig` template and verified it contains exactly one `osInstallTimeout: "90m"` value with the expected Kubernetes API server substitutions.
- `bash -n helm-prereqs/setup.sh` and `git diff --check` pass; the backport has the same stable patch ID as #5689.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the source patch in #5689. This backport applies that exact reviewed patch without a conflict; a focused release review confirmed one changed value and no adjustment for the release branch.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 0 | 0 | 0 |
| common-nits-reviewer | 1 | 0 | 1 |
| **Total** | **1** | **0** | **1** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

No findings.

### common-nits-reviewer

1. **Declined** -- Include the matching DPF manual update with the source implementation. **Reason:** Repository workflow keeps changes under `docs/` in a separate PR; #5690 owns that documentation change, while this PR backports only the merged configuration patch.

</details>
