### PR TITLE
docs(rest-api): distinguish tenant network workflows

### DIFF
--- a/docs/configuration/tenant_management.md
+++ b/docs/configuration/tenant_management.md
@@ -28,7 +28,7 @@ NICo's authorization model has three roles, all managed in the upstream identity
 |------|-------|-------------|
 | Provider Admin (`PROVIDER_ADMIN`) | Infrastructure provider org | Creating allocations, managing tenant accounts, managing sites and instance types |
 | Provider Viewer (`PROVIDER_VIEWER`) | Infrastructure provider org | Read-only access to provider-scoped resources |
-| Tenant Admin (`TENANT_ADMIN`) | Tenant org | Managing the tenant's instances, VPCs, subnets, SSH keys |
+| Tenant Admin (`TENANT_ADMIN`) | Tenant org | Managing the tenant's instances, VPCs, VPC Prefixes, Subnets, and SSH keys |
 
 A single user can hold roles in multiple orgs simultaneously. On dev/service-account orgs, one user typically holds both Provider Admin and Tenant Admin in the same org.
 
@@ -239,7 +239,7 @@ See the Quick Start Guide, Step 7 for nico-admin-cli access patterns. The REST A
 
 ## Assigning Resources with Allocations
 
-An allocation grants a tenant access to infrastructure at a specific site. Without at least one allocation, a tenant cannot create instances, VPCs, or subnets. Allocations are provider-side operations requiring the Provider Admin role.
+An allocation grants a tenant access to infrastructure at a specific site. Without at least one allocation, a tenant cannot create instances, VPCs, VPC Prefixes, or Subnets. Allocations are provider-side operations requiring the Provider Admin role.
 
 ### Allocation Model
 
@@ -393,7 +393,7 @@ The system validates:
 nicocli allocation delete <allocation-id>
 ```
 
-Deletion is blocked if the tenant has active instances or subnets consuming resources from the allocation. Terminate dependent resources first.
+Deletion is blocked if the tenant has active instances, VPC Prefixes, or Subnets consuming resources from the allocation. Terminate dependent resources first.
 
 ### Multiple Allocations per Tenant
 
@@ -408,13 +408,18 @@ A tenant can have multiple allocations at the same site with different resource 
 5. **Create network allocation(s)** -- One per IP block the tenant needs
 6. **Verify** -- List allocations and confirm they reach `Registered` status
 
-## Creating VPCs and Subnets
+## Creating VPCs and Tenant Networks
 
-After allocations are in place, the tenant can create VPCs and subnets within their allocated resource boundaries.
+After allocations are in place, the tenant can create VPCs and their tenant
+network resources within the allocated boundaries. The VPC's
+`networkVirtualizationType` determines the resource: `FNN` VPCs use VPC
+Prefixes, while `ETHERNET_VIRTUALIZER` VPCs use IPv4 Subnets.
 
 ### VPC Creation
 
-A VPC is the logical network container for tenant workloads. It defines the tenant boundary for networking and provides the parent context for subnets and instances.
+A VPC is the logical network container for tenant workloads. It defines the
+tenant boundary for networking and provides the parent context for VPC
+Prefixes or Subnets and instances.
 
 `nicocli vpc create --help` shows these flags:
 
@@ -423,7 +428,7 @@ A VPC is the logical network container for tenant workloads. It defines the tena
 | `--name` | yes | Unique within the tenant |
 | `--site-id` | yes | The site this VPC belongs to |
 | `--routing-profile` | no | One of `external`, `internal`, `privileged-internal` (REST API mapping); see core docs for semantics |
-| `--network-virtualization-type` | no | `FNN` (production) or `ETHERNET_VIRTUALIZER` (legacy) |
+| `--network-virtualization-type` | no | `FNN` for VPC Prefixes, `ETHERNET_VIRTUALIZER` for IPv4 Subnets, or `FLAT` for zero-DPU and NIC-mode hosts |
 | `--nv-link-logical-partition-id` | no | Attach to a specific NVLink partition (GB200) |
 | `--vni` | no | Pin a specific VXLAN Network Identifier |
 | `--description` | no | |
@@ -438,6 +443,11 @@ nicocli vpc create \
   --network-virtualization-type FNN
 ```
 
+`FNN` is the supported target for production deployments with DPUs. See
+[VPC Routing Profiles](../manuals/vpc/vpc_routing_profiles.md) for the support
+boundary and [Flat VPCs for Zero-DPU and NIC-Mode Hosts](../manuals/vpc/flat_vpcs_zero_dpu.md)
+for the `FLAT` workflow.
+
 TUI flow (prompts in order):
 
 ```bash
@@ -449,6 +459,10 @@ nicocli tui
 2. **VPC name** -- unique name
 3. **Description** -- optional
 
+The specialized TUI does not prompt for `networkVirtualizationType`; it uses
+the Site default. Use the non-interactive command when the VPC type must be
+selected explicitly.
+
 Verify the VPC reaches `Ready` status:
 
 ```bash
@@ -457,22 +471,42 @@ nicocli vpc list --output table
 
 > **Routing profiles** govern which VPCs can exchange routes with which others. The REST API accepts `external`, `internal`, and `privileged-internal`; the underlying gRPC API supports any profile defined under `fnn.routing_profiles` in the API server config. For details, see [VPC Routing Profiles](../manuals/vpc/vpc_routing_profiles.md). For the full networking architecture (VRFs, VNI pools, BGP, deny prefixes), see [VPC Network Virtualization](../manuals/vpc/vpc_network_virtualization.md).
 
-### Subnet Creation
+### VPC Prefix Creation for FNN
 
-A subnet is an IP address range within a VPC, carved from an allocated IP block.
+An `FNN` VPC uses a VPC Prefix carved from a tenant IP Block. Create the VPC
+Prefix after the parent VPC reaches `Ready`:
 
-`nicocli subnet create --help` shows these flags. Note the flag name `--ipv4block-id` (no separator between `v4` and `block`) and the IPv6 counterpart:
+```bash
+nicocli vpc-prefix create \
+  --name acme-prefix-1 \
+  --vpc-id <fnn-vpc-uuid> \
+  --ip-block-id <ip-block-uuid> \
+  --prefix-length 28
+```
+
+For the supported IPv4 creation path, `--prefix-length` accepts 8 through 31
+and must be greater than the selected parent IP Block's prefix length. REST
+support for creating IPv6 FNN VPC Prefixes is tracked by
+[#5407](https://github.com/NVIDIA/infra-controller/issues/5407).
+
+### IPv4 Subnet Creation for ETHERNET_VIRTUALIZER
+
+A Subnet is an IPv4 range within an `ETHERNET_VIRTUALIZER` VPC, carved from a
+Ready tenant IPv4 IP Block at the same Site. Subnets do not support IPv6; FNN
+VPCs use VPC Prefixes instead.
+
+`nicocli subnet create --help` shows these flags. Note the flag name
+`--ipv4block-id`, with no separator between `v4` and `block`:
 
 | Flag | Required | Notes |
 |------|----------|-------|
 | `--name` | yes | |
-| `--vpc-id` | yes | Parent VPC |
-| `--prefix-length` | yes | 1-32 |
-| `--ipv4block-id` | one of v4/v6 required | IP block to carve from |
-| `--ipv6block-id` | one of v4/v6 required | IPv6 block to carve from |
+| `--vpc-id` | yes | Ready `ETHERNET_VIRTUALIZER` VPC |
+| `--prefix-length` | yes | IPv4 prefix length from 8 through 30 |
+| `--ipv4block-id` | yes | Ready tenant IPv4 IP Block at the VPC's Site |
 | `--description` | no | |
 
-Non-interactive (IPv4):
+Non-interactive:
 
 ```bash
 nicocli subnet create \
@@ -495,11 +529,11 @@ nicocli tui
 > subnet create
 ```
 
-1. **VPC** -- select the parent VPC
+1. **Ready Ethernet virtualizer VPC** -- select the parent VPC
 2. **Subnet name** -- unique name
 3. **Description** -- optional
-4. **Prefix length** -- 1-32
-5. **IPv4 Block** -- scoped to the VPC's site
+4. **IPv4 prefix length** -- 8 through 30
+5. **Tenant IPv4 Block** -- select a Ready tenant IPv4 IP Block at the VPC's Site
 
 Verify:
 
@@ -529,7 +563,8 @@ An instance in NICo is a bare-metal machine assigned to a tenant within a VPC. C
 
 `interfaces[]` and `sshKeyGroupIds[]` are array-typed and must go through `--data` / `--data-file`.
 
-Non-interactive form (with one interface and one SSH key group):
+Non-interactive form for an `FNN` VPC (with one interface and one SSH key
+group):
 
 ```bash
 nicocli instance create --data-file - <<'EOF'
@@ -559,7 +594,9 @@ nicocli tui
 2. **Machine** -- select from machines in `Ready` state at the VPC's site
 3. **Instance name** -- unique name
 4. **Operating system** -- optional
-5. **VPC prefix** -- network prefix for each interface (loops, can add more)
+5. **Network resource** -- select a VPC Prefix for `FNN` or a Subnet for
+   `ETHERNET_VIRTUALIZER` (loops, can add more). `FLAT` VPCs attach the network
+   automatically and skip this prompt.
 6. **SSH key groups** -- optional, attaches SSH keys for serial-console access
 
 ### Verifying an Instance Is Running
@@ -774,7 +811,8 @@ NICo has no first-class "disable" operation. Options:
 There is no `DELETE /tenant` endpoint -- tenant records are permanent. To fully decommission:
 
 1. **Terminate all instances** -- delete every instance; each must reach `Terminated` status.
-2. **Delete all subnets** -- remove subnets from every VPC.
+2. **Delete all tenant network resources** -- remove VPC Prefixes or Subnets
+   from every VPC, according to its `networkVirtualizationType`.
 3. **Delete all VPCs** -- remove the tenant's VPCs.
 4. **Delete all allocations** -- provider admin removes compute and network allocations.
 5. **Delete the tenant account** -- provider admin severs the link.
@@ -840,16 +878,16 @@ nicocli allocation list --output table --tenant-id <tenant-uuid>
 
 All allocations should show `Registered` status.
 
-### Step 7: Create a VPC (Tenant Admin)
+### Step 7: Create an FNN VPC (Tenant Admin)
 
 ```bash
-nicocli vpc create --name <n> --site-id <site-uuid> --routing-profile internal
+nicocli vpc create --name <n> --site-id <site-uuid> --routing-profile internal --network-virtualization-type FNN
 ```
 
-### Step 8: Create a Subnet (Tenant Admin)
+### Step 8: Create a VPC Prefix (Tenant Admin)
 
 ```bash
-nicocli subnet create --name <n> --vpc-id <vpc-uuid> --ipv4block-id <ip-block-uuid> --prefix-length 28
+nicocli vpc-prefix create --name <n> --vpc-id <vpc-uuid> --ip-block-id <ip-block-uuid> --prefix-length 28
 ```
 
 ### Step 9: Launch an Instance (Tenant Admin)
@@ -872,7 +910,7 @@ nicocli instance list --output table
 nicocli instance status-history <instance-id>
 ```
 
-The instance should reach `Ready` (or `BootCompleted` if `phoneHomeEnabled: true`). Tenant stats should now show non-zero counts for `instance`, `vpc`, and `subnet`.
+The instance should reach `Ready` (or `BootCompleted` if `phoneHomeEnabled: true`). Tenant stats should now show non-zero counts for `instance` and `vpc`.
 
 ## Troubleshooting
 
@@ -950,8 +988,9 @@ Flag-first ordering -- always put flags before positional args.
 | Update constraint | `nicocli allocation constraint update --constraint-value N <alloc-id> <constraint-id>` | Provider Admin |
 | Delete allocation | `nicocli allocation delete <alloc-id>` | Provider Admin |
 | List instance types | `nicocli instance-type list` | Provider or Tenant Admin |
-| Create VPC | `nicocli vpc create --name <n> --site-id <id> --routing-profile internal` | Tenant Admin |
-| Create subnet | `nicocli subnet create --name <n> --vpc-id <id> --ipv4block-id <id> --prefix-length 28` | Tenant Admin |
+| Create FNN VPC | `nicocli vpc create --name <n> --site-id <id> --routing-profile internal --network-virtualization-type FNN` | Tenant Admin |
+| Create FNN VPC Prefix | `nicocli vpc-prefix create --name <n> --vpc-id <id> --ip-block-id <id> --prefix-length 28` | Tenant Admin |
+| Create Ethernet virtualizer IPv4 Subnet | `nicocli subnet create --name <n> --vpc-id <id> --ipv4block-id <id> --prefix-length 28` | Tenant Admin |
 | Create instance | `nicocli instance create --data-file <file>` (interfaces are array-typed) | Tenant Admin |
 | Reboot instance | `nicocli instance update --trigger-reboot=true <instance-id>` | Tenant Admin |
 | Rename instance | `nicocli instance update --name <new> <instance-id>` | Tenant Admin |

--- a/docs/manuals/vpc/flat_vpcs_zero_dpu.md
+++ b/docs/manuals/vpc/flat_vpcs_zero_dpu.md
@@ -321,10 +321,12 @@ Flat VPCs:
   the operator's network responsibility; NICo stores the association but does not
   program a DPU ACL for a zero-DPU host.
 
-> As noted in the operations matrix, the `nicocli` wrapper does not currently
-> send `networkVirtualizationType` on `vpc create`, and its
-> `vpc virtualization update` accepts only `ETHERNET_VIRTUALIZER` / `FNN`. Use
-> the REST API for this step until that gap is closed.
+> The generated `nicocli vpc create` command accepts
+> `--network-virtualization-type FLAT`. The specialized `nicocli tui` VPC
+> creation flow does not prompt for a type and uses the Site default instead.
+> Its `vpc virtualization update` request only supports changing to `FNN` and
+> is rejected while the VPC contains any Subnets or Instances. Create a Flat
+> VPC with the generated command or the REST API.
 
 ### 2. Find the HostInband segment backing the VPC
 
@@ -375,9 +377,10 @@ Rules enforced at allocation:
 - **No DPU extension services.** Extension services run on DPU agents; a zero-DPU
   host has none, so an instance config that requests them is rejected.
 
-> As with VPC creation, `nicocli` does not yet expose `autoNetwork` on
-> `instance create`; use the REST API for this step and file a bug for the
-> wrapper.
+> The generated `nicocli instance create` command accepts
+> `--auto-network=true`. The specialized `nicocli tui` flow sets
+> `autoNetwork: true` automatically when the selected VPC is `FLAT` and skips
+> the interface prompts.
 
 ### 4. Check instance status
 
@@ -478,5 +481,5 @@ operator SDN integration can tie its switch-side configuration to the VPC.
 | Instance allocation fails: segment "is not bound to a Flat VPC" | The host's `HostInband` segment has no VPC; the tenant/operator must bind it to a Flat VPC first |
 | Instance allocation fails: segment bound to a VPC whose `fabric_interface_type` is not `nic` | The `HostInband` segment is attached to a non-Flat VPC; only Flat VPCs may own `HostInband` segments |
 | Instance allocation fails: extension services on a zero-DPU host | Remove `dpu_extension_services` from the instance config; a zero-DPU host cannot run them |
-| `nicocli` won't let me choose `FLAT` / set `autoNetwork` | Known wrapper gap; use the REST API and file a bug against `nicocli` |
+| The specialized TUI does not offer `FLAT` during VPC creation | Use generated `nicocli vpc create --network-virtualization-type FLAT` or the REST API; the TUI uses the Site default |
 | Instance is `Ready` but cannot reach another host | Expected from NICo's side — Flat data-plane reachability is the operator's fabric responsibility, not something NICo programs or verifies |

--- a/docs/provisioning/ingesting-hosts-rest-api.md
+++ b/docs/provisioning/ingesting-hosts-rest-api.md
@@ -181,7 +181,13 @@ A `Ready` machine has `status: Ready` and `isUsableByTenant: true`. Once at leas
 
 With machines ingested and `Ready`, follow the relevant API flow in the REST API Getting Started reference:
 
-- **Service Account**: create Network Allocations against each Site IP Block, create a VPC, create a VPC Prefix or Subnet, create an Operating System, create an Instance.
+- **Service Account**: create Network Allocations against each Site IP Block,
+  create a VPC, wait until it is `Ready`, and create the matching tenant
+  network resource. `FNN` VPCs use VPC Prefixes; `ETHERNET_VIRTUALIZER` VPCs
+  use IPv4 Subnets from a `Ready` tenant-allocated IPv4 IP Block at the VPC's
+  Site; `FLAT` VPCs use neither resource. For a `FLAT` VPC, set `autoNetwork`
+  to `true` and omit `interfaces` when creating the Instance. Then create an
+  Operating System and an Instance.
 - **Provider**: create Tenant Accounts, create Instance Types, associate machines with Instance Types, create Compute and Network Allocations for tenants.
 
 Both flows assume hardware ingestion is complete -- which this page covers.

--- a/rest-api/openapi/example-workflows.md
+++ b/rest-api/openapi/example-workflows.md
@@ -23,18 +23,22 @@ This section provides example REST API workflows for common NICo tasks. All exam
   </Accordion>
 </AccordionGroup>
 
-
 ## Managing Virtual Private Clouds
 
 <Note>
-`networkVirtualizationType` supports two VPC networking mechanisms: **FNN** is recommended for all deployments that include DPUs (instances in FNN VPCs reference a `vpcPrefixId` in their interface configuration.); **Legacy** VPCs use subnets instead of VPC prefixes. New deployments with DPUs should use FNN exclusively.
+`networkVirtualizationType` selects the VPC's tenant network resource. `FNN`
+VPCs use VPC Prefixes, and their Instance interfaces reference a
+`vpcPrefixId`. `ETHERNET_VIRTUALIZER` VPCs use IPv4 Subnets, and their Instance
+interfaces reference a `subnetId`. `FLAT` VPCs attach the network automatically
+and use neither resource. `FNN` is the supported target for production
+deployments with DPUs.
 
 `tenantId` is the ID of the Tenant organization generated during setup. This value is distinct from the organization name used in the API URL path.
 </Note>
 
 <AccordionGroup>
   <Accordion title="Create a VPC">
-    Create the VPC and specify a name.
+    Create an `FNN` VPC and specify a name.
     <Code src="snippets/input/create_vpc.sh" title="Example Call" />
     <Code src="snippets/output/create_vpc.json" title="Example Response" />
   </Accordion>
@@ -44,7 +48,7 @@ This section provides example REST API workflows for common NICo tasks. All exam
     <Code src="snippets/output/poll_vpc_status.json" title="Example Response" />
   </Accordion>
   <Accordion title="Add an Instance with a Single Interface">
-    Add one or more compute instances. The `interfaces` array configures how each DPU port is assigned a network address. For FNN VPCs, specify a `vpcPrefixId`; for Legacy VPCs, specify a `subnetId`.
+    Add one or more compute instances. The `interfaces` array configures how each DPU port is assigned a network address. This example requires the pre-existing `ETHERNET_VIRTUALIZER` VPC and IPv4 Subnet from the Subnet examples below, so the interface specifies a `subnetId`. The VPC ID is distinct from the `FNN` VPC created above.
 
     The `isPhysical` flag determines whether a physical function (PF) or a virtual function (VF) is configured on the DPU port. Set `isPhysical: true` for standard bare-metal configurations. VFs (`isPhysical: false`) are used when running VMs on the host that require direct hardware passthrough of a DPU port.
     <Code src="snippets/input/create_instance_single_interface.sh" title="Example Call" />
@@ -92,6 +96,7 @@ Before assigning Instance Types, you should have the ID of the Instance Type. Yo
 ## Managing Operating Systems
 
 Before adding an operating system image, ensure you have:
+
 - An iPXE script as a one-line string.
 - **Optional**: A cloud-init script as a one-line string.
 - For the iPXE string and cloud-init string, replace newline characters with `\n` and escape quotation marks with `\"`.
@@ -106,11 +111,13 @@ Before adding an operating system image, ensure you have:
 
 ## Managing Subnets and VPC Prefixes
 
-Before managing Subnets, ensure you have at least one IP Block allocated so that you can add a Subnet of the IP Block address space.
+Before managing these resources, ensure you have a tenant IP Block at the VPC's
+Site. An IPv4 Subnet requires that block to be `Ready`. VPC Prefixes configure
+`FNN` VPCs. IPv4 Subnets configure `ETHERNET_VIRTUALIZER` VPCs.
 
 <AccordionGroup>
   <Accordion title="Add a Subnet">
-    Add one or more subnets. The following command sample shows how to add one subnet.
+    Add an IPv4 Subnet to a Ready `ETHERNET_VIRTUALIZER` VPC. Before running this example, use the [Create VPC endpoint](/infra-controller/rest-api-reference/api-reference/vpc/create-vpc) to create that VPC and set `networkVirtualizationType` to `ETHERNET_VIRTUALIZER`. Replace the pre-existing sample VPC ID `f466a2d5-5820-4824-a845-3218fdff801b` with the new VPC's ID. This VPC is distinct from the `FNN` VPC used by the VPC Prefix examples. The Subnet's `ipv4BlockId` identifies a Ready tenant IPv4 IP Block at the same Site, and `prefixLength` accepts values from 8 through 30.
     <Code src="snippets/input/create_subnet.sh" title="Example Call" />
     <Code src="snippets/output/create_subnet.json" title="Example Response" />
   </Accordion>
@@ -120,7 +127,7 @@ Before managing Subnets, ensure you have at least one IP Block allocated so that
     <Code src="snippets/output/poll_subnet_status.json" title="Example Response" />
   </Accordion>
   <Accordion title="Add a VPC Prefix">
-    The following command sample shows how to add one VPC prefix. You can also add multiple VPC prefixes at once.
+    Add a VPC Prefix to the Ready `FNN` VPC created above. The source IP Block determines the VPC Prefix's address family. REST support for creating IPv6 FNN VPC Prefixes is tracked by [#5407](https://github.com/NVIDIA/infra-controller/issues/5407).
     <Code src="snippets/input/create_vpc_prefix.sh" title="Example Call" />
     <Code src="snippets/output/create_vpc_prefix.json" title="Example Response" />
   </Accordion>

--- a/rest-api/openapi/getting-started.md
+++ b/rest-api/openapi/getting-started.md
@@ -1,18 +1,24 @@
+# Getting Started
+
 This section provides a quick overview of the API and how to get started.
 
-### Authentication and Authorization
+## Authentication and Authorization
+
 The first step is to authenticate using a JWT bearer token. Organization structures and roles depend on the authentication and authorization configuration used. For details on authentication and authorization, check the [Authentication and Authorization](/infra-controller/rest-api-reference/authentication-and-authorization) section.
 
-### API Version
+## API Version
+
 The next step is to be aware of the API version being used. The API version can be retrieved by calling the [Retrieve Metadata endpoint](/infra-controller/rest-api-reference/api-reference/metadata/get-metadata). In general, the API maintains backward
 compatibility with the previous versions. Any breaking changes are announced using a deprecation notice. Click on each API resource to see the deprecation notices.
 
-### Service Account Mode
+## Service Account Mode
+
 Depending on the auth configuration used, the NICo REST API may be configured in Service Account mode. In this mode, API users can act as both Provider and Tenant as part of the same organization.
 If this is the case, the user must first retrieve the Service Account by making a call to the [Retrieve Service Account endpoint](/infra-controller/rest-api-reference/api-reference/service-account/get-current-service-account).
 For service accounts, the Tenant entity is initialized as a privileged Tenant with `targetedInstanceCreation` capability enabled.
 
-### Provider or Tenant Mode
+## Provider or Tenant Mode
+
 If NICo REST API is not configured in Service Account mode, the user should retrieve the Infrastructure Provider by making a call to the [Retrieve Infrastructure Provider endpoint](/infra-controller/rest-api-reference/api-reference/infrastructure-provider/get-current-infrastructure-provider)
 or the Tenant by making a call to the [Retrieve Tenant endpoint](/infra-controller/rest-api-reference/api-reference/tenant/get-current-tenant).
 
@@ -20,14 +26,15 @@ In both cases, these calls initialize Provider and Tenant entities for the organ
 
 Once the Provider and the Tenant are initialized, the user can create resources by making calls to the appropriate endpoints.
 
-### Creating Site Level IP Blocks
+## Creating Site IP Blocks
+
 To utilize a NICo Site, the Provider or Service Account holder must create IP Blocks for each network overlay defined in NICo Site configuration toml file.
 
 To create an IP Block, the user must make a call to the [Create IP Block endpoint](/infra-controller/rest-api-reference/api-reference/ip-block/create-ipblock).
 
 > **Note:** From this point onwards, a brief outline is provided for the typical API call flows for various use cases.
 
-### Typical API Call Flow for Service Account
+## Typical API Call Flow for Service Account
 
 - Retrieve available Sites using the [Retrieve All Sites endpoint](/infra-controller/rest-api-reference/api-reference/site/get-all-site) and choose a Site to create resources in. For _Disconnected_ NICo installations where NICo
 REST is deployed alongside NICo Core, typically there will be a single Site available.
@@ -35,14 +42,23 @@ REST is deployed alongside NICo Core, typically there will be a single Site avai
 This will create a Tenant IP Block for each Site IP Block.
 - Creating an Allocation will create the Tenant in NICo Core.
 - Create a VPC using the [Create VPC endpoint](/infra-controller/rest-api-reference/api-reference/vpc/create-vpc).
-- Create a VPC Prefix or Subnet referencing the VPC and a Tenant IP Block
-- If the Site supports Native Networking (FNN), create a VPC Prefix using the [Create VPC Prefix endpoint](/infra-controller/rest-api-reference/api-reference/vpc-prefix/create-vpc-prefix). Otherwise the user should create a Subnet
-using the [Create Subnet endpoint](/infra-controller/rest-api-reference/api-reference/subnet/create-subnet).
+- After the VPC reaches `Ready`, create the network resource that matches its
+  `networkVirtualizationType`, referencing the VPC and a Tenant IP Block.
+  - For an `FNN` VPC, create a VPC Prefix using the
+    [Create VPC Prefix endpoint](/infra-controller/rest-api-reference/api-reference/vpc-prefix/create-vpc-prefix).
+  - For a VPC whose `networkVirtualizationType` is
+    `ETHERNET_VIRTUALIZER`, create an IPv4 Subnet from a `Ready`,
+    tenant-allocated IPv4 IP Block at the VPC's Site using the
+    [Create Subnet endpoint](/infra-controller/rest-api-reference/api-reference/subnet/create-subnet).
+  - For a `FLAT` VPC, do not create a VPC Prefix or Subnet. When creating
+    the Instance, set `autoNetwork` to `true` and omit `interfaces`.
 - Create an Operating System using the [Create Operating System endpoint](/infra-controller/rest-api-reference/api-reference/operating-system/create-operating-system) specifying iPXE script and user data.
 - Retrieve available Machines on Site using the [Retrieve All Machines endpoint](/infra-controller/rest-api-reference/api-reference/machine/get-all-machine)
-- Create an Instance specifying the VPC, VPC Prefix or Subnet, Operating System, and Machine
+- Create an Instance specifying the VPC, Operating System, and Machine. For an
+  `FNN` or `ETHERNET_VIRTUALIZER` VPC, include the matching VPC Prefix or
+  Subnet in `interfaces`.
 
-### Typical API Call Flow for Provider
+## Typical API Call Flow for Provider
 
 - Create a Tenant Account using the [Create Tenant Account endpoint](/infra-controller/rest-api-reference/api-reference/tenant-account/create-tenant-account). Provider must know the Tenant org name.
 - Once the Tenant has accepted the Tenant Account, the Provider can allocate resources to the Tenant.
@@ -56,7 +72,7 @@ using the [Create Subnet endpoint](/infra-controller/rest-api-reference/api-refe
 - Create a Network Allocation for Tenant using the [Create Allocation endpoint](/infra-controller/rest-api-reference/api-reference/allocation/create-allocation) referencing a Site IP Block
 - Creating a Network Allocation will create a Tenant IP Block
 
-### Typical API Call Flow for Tenant
+## Typical API Call Flow for Tenant
 
 - Accept the Tenant Account using the [Update Tenant Account endpoint](/infra-controller/rest-api-reference/api-reference/tenant-account/update-tenant-account).
 - Retrieve available Sites using the [Retrieve All Sites endpoint](/infra-controller/rest-api-reference/api-reference/site/get-all-site) and choose a Site to create resources in. Any Site where the Tenant
@@ -64,10 +80,19 @@ has an Allocation will be returned.
 - Create a VPC using the [Create VPC endpoint](/infra-controller/rest-api-reference/api-reference/vpc/create-vpc).
 - Retrieve available Site IP Blocks using the [Retrieve All IP Blocks endpoint](/infra-controller/rest-api-reference/api-reference/ip-block/get-all-ipblock). Any IP Block for which the Tenant has received
 a Network Allocation from the Provider will be returned.
-- Create a VPC Prefix or Subnet referencing the VPC and a Tenant IP Block
-- Site supports Native Networking (FNN), create a VPC Prefix using the [Create VPC Prefix endpoint](/infra-controller/rest-api-reference/api-reference/vpc-prefix/create-vpc-prefix)
-- Otherwise the user should create a Subnet using the [Create Subnet endpoint](/infra-controller/rest-api-reference/api-reference/subnet/create-subnet)
+- After the VPC reaches `Ready`, create the network resource that matches its
+  `networkVirtualizationType`, referencing the VPC and a Tenant IP Block.
+  - For an `FNN` VPC, create a VPC Prefix using the
+    [Create VPC Prefix endpoint](/infra-controller/rest-api-reference/api-reference/vpc-prefix/create-vpc-prefix).
+  - For a VPC whose `networkVirtualizationType` is
+    `ETHERNET_VIRTUALIZER`, create an IPv4 Subnet from a `Ready`,
+    tenant-allocated IPv4 IP Block at the VPC's Site using the
+    [Create Subnet endpoint](/infra-controller/rest-api-reference/api-reference/subnet/create-subnet).
+  - For a `FLAT` VPC, do not create a VPC Prefix or Subnet. When creating
+    the Instance, set `autoNetwork` to `true` and omit `interfaces`.
 - Create an Operating System using the [Create Operating System endpoint](/infra-controller/rest-api-reference/api-reference/operating-system/create-operating-system) specifying iPXE script and user data.
 - Retrieve available Instance Types using the [Retrieve All Instance Types endpoint](/infra-controller/rest-api-reference/api-reference/instance-type/get-all-instance-type). Any Instance Type for which
 the Tenant has received a Compute Allocation from the Provider will be returned.
-- Create an Instance specifying the VPC, VPC Prefix or Subnet, Operating System, and Instance Type
+- Create an Instance specifying the VPC, Operating System, and Instance Type.
+  For an `FNN` or `ETHERNET_VIRTUALIZER` VPC, include the matching VPC Prefix
+  or Subnet in `interfaces`.

--- a/rest-api/openapi/snippets/input/create_instance_single_interface.sh
+++ b/rest-api/openapi/snippets/input/create_instance_single_interface.sh
@@ -7,7 +7,7 @@ curl -X POST "https://api.example.com/v2/org/{tenant-org-name}/nico/instance" \
    -d '{
       "name": "demo-compute-instance-0",
       "instanceTypeId": "9c4aaa6a-3934-4274-b0a9-5143b253039e",
-      "vpcId": "0b1c53a0-a27e-4714-98d7-0cd3bc579db2",
+      "vpcId": "f466a2d5-5820-4824-a845-3218fdff801b",
       "tenantId": "aaf3cb83-8785-4265-a3bd-61e828f87db8",
       "operatingSystemId": "0865029e-3979-432d-985e-2de396ecce32",
       "userData": null,

--- a/rest-api/openapi/snippets/input/create_subnet.sh
+++ b/rest-api/openapi/snippets/input/create_subnet.sh
@@ -7,7 +7,7 @@ curl -X POST "https://api.example.com/v2/org/{tenant-org-name}/nico/subnet" \
 -d '{
         "name": "demo-ipv4-subnet",
         "description": "Demo IPv4 Tenant Subnet",
-        "vpcId": "0b1c53a0-a27e-4714-98d7-0cd3bc579db2",
+        "vpcId": "f466a2d5-5820-4824-a845-3218fdff801b",
         "ipv4BlockId": "20d7dd4f-ae43-4245-a9d9-d093296009c4",
         "prefixLength": 28
     }'

--- a/rest-api/openapi/snippets/output/create_instance_single_interface.json
+++ b/rest-api/openapi/snippets/output/create_instance_single_interface.json
@@ -7,7 +7,7 @@
    "infrastructureProviderId": "16060041-f146-43fe-8c82-be48460b5583",
    "siteId": "bd4692bd-da95-410e-911a-d492fe2d35f8",
    "instanceTypeId": "9c4aaa6a-3934-4274-b0a9-5143b253039e",
-   "vpcId": "0b1c53a0-a27e-4714-98d7-0cd3bc579db2",
+   "vpcId": "f466a2d5-5820-4824-a845-3218fdff801b",
    "machineId": "fm100hthvos96dbmmai84gsok0dn967v9fap8ublgp34kaknd9tq7pddim0",
    "operatingSystemId": "0865029e-3979-432d-985e-2de396ecce32",
    "ipxeScript": "#!ipxe\nkernel https://github.com/netbootxyz/ubuntu-squash/releases/download/20.04.6-a1b16d57/vmlinuz ip=dhcp fb=false interface=ens5f0 url=https://releases.ubuntu.com/20.04.6/ubuntu-20.04.6-live-server-amd64.iso autoinstall ds=nocloud-net;s=${tenant-cloudinit-url} initrd=initrd.magic\ninitrd https://github.com/netbootxyz/ubuntu-squash/releases/download/20.04.6-a1b16d57/initrd\nboot\n",

--- a/rest-api/openapi/snippets/output/create_subnet.json
+++ b/rest-api/openapi/snippets/output/create_subnet.json
@@ -3,7 +3,7 @@
     "name": "demo-ipv4-subnet",
     "description": "Demo IPv4 Tenant Subnet",
     "siteId": "bd4692bd-da95-410e-911a-d492fe2d35f8",
-    "vpcId": "0b1c53a0-a27e-4714-98d7-0cd3bc579db2",
+    "vpcId": "f466a2d5-5820-4824-a845-3218fdff801b",
     "tenantId": "aaf3cb83-8785-4265-a3bd-61e828f87db8",
     "controllerNetworkSegmentId": null,
     "ipv4Prefix": "192.166.128.0",

--- a/rest-api/openapi/snippets/output/poll_instance_status.json
+++ b/rest-api/openapi/snippets/output/poll_instance_status.json
@@ -7,7 +7,7 @@
    "infrastructureProviderId": "16060041-f146-43fe-8c82-be48460b5583",
    "siteId": "bd4692bd-da95-410e-911a-d492fe2d35f8",
    "instanceTypeId": "9c4aaa6a-3934-4274-b0a9-5143b253039e",
-   "vpcId": "0b1c53a0-a27e-4714-98d7-0cd3bc579db2",
+   "vpcId": "f466a2d5-5820-4824-a845-3218fdff801b",
    "machineId": "fm100hthvos96dbmmai84gsok0dn967v9fap8ublgp34kaknd9tq7pddim0",
    "operatingSystemId": "0865029e-3979-432d-985e-2de396ecce32",
    "ipxeScript": "#!ipxe\nkernel https://github.com/netbootxyz/ubuntu-squash/releases/download/20.04.6-a1b16d57/vmlinuz ip=dhcp fb=false interface=ens5f0 url=https://releases.ubuntu.com/20.04.6/ubuntu-20.04.6-live-server-amd64.iso autoinstall ds=nocloud-net;s=${tenant-cloudinit-url} initrd=initrd.magic\ninitrd https://github.com/netbootxyz/ubuntu-squash/releases/download/20.04.6-a1b16d57/initrd\nboot\n",

--- a/rest-api/openapi/snippets/output/poll_subnet_status.json
+++ b/rest-api/openapi/snippets/output/poll_subnet_status.json
@@ -3,7 +3,7 @@
     "name": "demo-ipv4-subnet",
     "description": "Demo IPv4 Tenant Subnet",
     "siteId": "bd4692bd-da95-410e-911a-d492fe2d35f8",
-    "vpcId": "0b1c53a0-a27e-4714-98d7-0cd3bc579db2",
+    "vpcId": "f466a2d5-5820-4824-a845-3218fdff801b",
     "tenantId": "aaf3cb83-8785-4265-a3bd-61e828f87db8",
     "controllerNetworkSegmentId": "f5634c31-4cd4-453b-8ac5-e81f2a19ab05",
     "ipv4Prefix": "192.166.128.0",


### PR DESCRIPTION
REST documentation still mixes two tenant network workflows. FNN VPCs use VPC Prefixes, while `ETHERNET_VIRTUALIZER` (ETV) VPCs use IPv4 Subnets. The existing guidance advertises unsupported Subnet inputs and reuses an FNN VPC in ETV examples.

This updates the guides and snippets so the VPC's `networkVirtualizationType` determines which tenant network resource to use, documents the ETV Subnet `/8` through `/30` IPv4 contract, and keeps the FNN and ETV walkthroughs on separate VPCs. It also explains how the generated CLI and specialized TUI handle `FLAT` VPCs. The OpenAPI source, generated SDK, and REST behavior remain unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5505.

This documents https://github.com/NVIDIA/infra-controller/issues/5397. REST support for creating IPv6 FNN VPC Prefixes is tracked by https://github.com/NVIDIA/infra-controller/issues/5407.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `bash -n` passed for both changed shell snippets, and `jq empty` passed for all four changed JSON snippets.
- `rumdl` reports no issues for `AGENTS.md` or the five changed Markdown files. Fern 5.108.0 validates all 141 MDX files and the documentation definitions, with only the expected warning that the published redirect check was skipped without Fern authentication.
- The generated `nicocli` help for Subnet, VPC, and Instance creation confirms the documented Subnet inputs, the lack of an IPv6 Subnet input, `--network-virtualization-type`, and `--auto-network`.
- `git diff --check` passes.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

Four local reviewers covered the change. Nine findings were adopted, and six were declined after checking them against the documented behavior and the scope of #5505.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 4 | 4 | 0 |
| Claude CLI | 10 | 4 | 6 |
| common-nits-reviewer | 1 | 1 | 0 |
| **Total** | **15** | **9** | **6** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

1. **Adopted (4 findings)** -- Made the separate ETV VPC creation path explicit, added the `FLAT` Service Account path, documented the `Ready` gates before either tenant network resource can be created, and simplified “Site Level IP Blocks” to the established “Site IP Blocks” domain term.

### Claude CLI

1. **Adopted (4 findings)** -- Restored the production and FNN guidance, documented `FLAT` where an edited type list and TUI flow could otherwise appear exhaustive, distinguished generated CLI flags from specialized TUI defaults, and made the separate ETV example an explicit prerequisite.
2. **Declined (6 findings)** -- The remaining recommendations concerned existing snippet data inconsistencies, capitalization and title case, line wrapping, legacy nil compatibility wording, and adjacent reference page summaries. Those changes are outside #5505.

### common-nits-reviewer

1. **Adopted** -- The Flat VPC page directly conflicted with the updated CLI guidance. **Resolution:** It now documents both the generated CLI flags and the specialized TUI behavior for VPC and Instance creation.

</details>
