### PR TITLE
fix(machine-controller): wait for DPU network before rebooting into scout

### DIFF
--- a/crates/agent/src/health/probe_ids.rs
+++ b/crates/agent/src/health/probe_ids.rs
@@ -23,7 +23,7 @@ lazy_static::lazy_static! {
     pub static ref ServiceRunning: HealthProbeId = "ServiceRunning".parse().unwrap();
     pub static ref DhcpRelay: HealthProbeId = "DhcpRelay".parse().unwrap();
     pub static ref DhcpServer: HealthProbeId = "DhcpServer".parse().unwrap();
-    pub static ref BgpStats: HealthProbeId = "BgpStats".parse().unwrap();
+    pub static ref BgpStats: HealthProbeId = HealthProbeId::bgp_stats();
     pub static ref BgpPeeringTor: HealthProbeId = HealthProbeId::bgp_peering_tor();
     pub static ref BgpPeeringRouteServer: HealthProbeId = "BgpPeeringRouteServer".parse().unwrap();
     pub static ref UnexpectedBgpPeer: HealthProbeId = "UnexpectedBgpPeer".parse().unwrap();
@@ -32,8 +32,8 @@ lazy_static::lazy_static! {
     pub static ref FileIsValid: HealthProbeId = "FileIsValid".parse().unwrap();
     pub static ref BgpDaemonEnabled: HealthProbeId = "BgpDaemonEnabled".parse().unwrap();
     pub static ref RestrictedMode: HealthProbeId = "RestrictedMode".parse().unwrap();
-    pub static ref PostConfigCheckWait: HealthProbeId = "PostConfigCheckWait".parse().unwrap();
+    pub static ref PostConfigCheckWait: HealthProbeId = HealthProbeId::post_config_check_wait();
     pub static ref DpuDiskUtilizationCheck: HealthProbeId = "DpuDiskUtilizationCheck".parse().unwrap();
     pub static ref DpuDiskUtilizationCritical: HealthProbeId = "DpuDiskUtilizationCritical".parse().unwrap();
-    pub static ref NvueApiRunning: HealthProbeId = "NvueApiRunning".parse().unwrap();
+    pub static ref NvueApiRunning: HealthProbeId = HealthProbeId::nvue_api_running();
 }

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -22,6 +22,7 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, SystemTime};
 
 use ::rpc::forge::forge_server::Forge;
+use carbide_redfish::libredfish::test_support::RedfishSimAction;
 use carbide_uuid::instance::InstanceId;
 use carbide_uuid::machine_validation::MachineValidationId;
 use carbide_uuid::network::NetworkSegmentId;
@@ -1393,7 +1394,7 @@ async fn test_instance_waits_for_primary_dpu_bgp_before_pxe_reboot(
 
     fn post_config_wait_health() -> rpc::health::HealthReport {
         dpu_health_alert(
-            "PostConfigCheckWait",
+            health_report::HealthProbeId::post_config_check_wait().as_str(),
             None,
             vec![
                 health_report::HealthAlertClassification::prevent_allocations(),
@@ -1567,6 +1568,142 @@ async fn test_instance_waits_for_primary_dpu_bgp_before_pxe_reboot(
         },
     )
     .await;
+}
+
+#[crate::sqlx_test]
+async fn test_instance_release_waits_for_primary_dpu_network_health_before_discovery_reboot(
+    _: PgPoolOptions,
+    options: PgConnectOptions,
+) {
+    const DPU_NETWORK_READY_WAIT_REASON: &str =
+        "Waiting for the primary DPU network to become ready before PXE reboot";
+
+    fn agent_health(alert_id: Option<health_report::HealthProbeId>) -> rpc::health::HealthReport {
+        rpc::health::HealthReport {
+            source: "forge-dpu-agent".to_string(),
+            triggered_by: None,
+            observed_at: None,
+            successes: vec![],
+            alerts: alert_id
+                .map(|id| rpc::health::HealthProbeAlert {
+                    id: id.to_string(),
+                    target: None,
+                    in_alert_since: None,
+                    message: "test primary DPU network health".to_string(),
+                    tenant_message: None,
+                    classifications: vec![
+                        health_report::HealthAlertClassification::prevent_allocations().to_string(),
+                        health_report::HealthAlertClassification::prevent_host_state_changes()
+                            .to_string(),
+                    ],
+                })
+                .into_iter()
+                .collect(),
+        }
+    }
+
+    async fn assert_release_is_waiting(env: &TestEnv, mh: &TestManagedHost, scenario: &str) {
+        let mut txn = env.db_txn().await;
+        let host = mh.host().db_machine(&mut txn).await;
+        assert_eq!(
+            host.current_state(),
+            &ManagedHostState::Assigned {
+                instance_state: InstanceState::WaitingForDpusToUp,
+            },
+            "{scenario}",
+        );
+        let Some(PersistentStateHandlerOutcome::Wait { reason, .. }) =
+            &host.controller_state_outcome
+        else {
+            panic!("{scenario}: release gate should persist a Wait outcome");
+        };
+        assert_eq!(reason, DPU_NETWORK_READY_WAIT_REASON, "{scenario}");
+        txn.commit().await.unwrap();
+    }
+
+    let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
+    let env = create_test_env(pool).await;
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let mh = create_managed_host(&env).await;
+    let instance = mh
+        .instance_builer(&env)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+
+    env.api
+        .release_instance(tonic::Request::new(InstanceReleaseRequest {
+            id: Some(instance.id),
+            issue: None,
+            is_repair_tenant: None,
+            delete_attribution: None,
+        }))
+        .await
+        .expect("Delete instance failed.");
+
+    let mut txn = env.db_txn().await;
+    db::machine::update_state(
+        &mut txn,
+        &mh.host().id,
+        &ManagedHostState::Assigned {
+            instance_state: InstanceState::WaitingForDpusToUp,
+        },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    let redfish_checkpoint = env.redfish_sim.timepoint();
+    network_configured_with_health(
+        &env,
+        &mh.dpu_ids[0],
+        Some(agent_health(Some(
+            health_report::HealthProbeId::nvue_api_running(),
+        ))),
+    )
+    .await;
+    env.run_machine_state_controller_iteration().await;
+    assert_release_is_waiting(&env, &mh, "NVUE API is unavailable").await;
+
+    let power_actions = env
+        .redfish_sim
+        .actions_since(&redfish_checkpoint)
+        .all_hosts()
+        .into_iter()
+        .filter(|action| matches!(action, RedfishSimAction::Power(_)))
+        .collect::<Vec<_>>();
+    assert!(
+        power_actions.is_empty(),
+        "release must not reboot the host before primary DPU network health is ready: {power_actions:?}",
+    );
+
+    network_configured_with_health(&env, &mh.dpu_ids[0], Some(agent_health(None))).await;
+    env.run_machine_state_controller_iteration().await;
+
+    let mut txn = env.db_txn().await;
+    assert_eq!(
+        mh.host().db_machine(&mut txn).await.current_state(),
+        &ManagedHostState::Assigned {
+            instance_state: InstanceState::BootingWithDiscoveryImage {
+                retry: model::machine::RetryInfo { count: 0 },
+            },
+        }
+    );
+    txn.commit().await.unwrap();
+
+    let power_actions = env
+        .redfish_sim
+        .actions_since(&redfish_checkpoint)
+        .all_hosts()
+        .into_iter()
+        .filter(|action| matches!(action, RedfishSimAction::Power(_)))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        power_actions,
+        vec![RedfishSimAction::Power(
+            libredfish::SystemPowerControl::ForceRestart,
+        )],
+    );
 }
 
 #[crate::sqlx_test]

--- a/crates/health-report/src/lib.rs
+++ b/crates/health-report/src/lib.rs
@@ -609,9 +609,24 @@ impl HealthProbeId {
         HealthProbeId("IbPortDown".to_string())
     }
 
+    /// The ID used by the FRR BGP health check.
+    pub fn bgp_stats() -> Self {
+        HealthProbeId("BgpStats".to_string())
+    }
+
     /// The ID used when an expected DPU-to-ToR BGP session is unavailable.
     pub fn bgp_peering_tor() -> Self {
         HealthProbeId("BgpPeeringTor".to_string())
+    }
+
+    /// The ID used by the NVUE API availability check.
+    pub fn nvue_api_running() -> Self {
+        HealthProbeId("NvueApiRunning".to_string())
+    }
+
+    /// The ID used while a new HBN configuration waits for a later health sample.
+    pub fn post_config_check_wait() -> Self {
+        HealthProbeId("PostConfigCheckWait".to_string())
     }
 }
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -6221,6 +6221,8 @@ const PRIMARY_DPU_BGP_WAIT_REASON: &str =
     "Waiting for the primary DPU p0 BGP session to be established";
 const HOST_HEALTH_WAIT_REASON: &str =
     "Waiting for lifecycle-blocking host health alerts to clear before PXE reboot";
+const DPU_NETWORK_READY_WAIT_REASON: &str =
+    "Waiting for the primary DPU network to become ready before PXE reboot";
 
 /// `provisioning_pxe_reboot_wait_reason` returns the safety condition blocking a provisioning PXE
 /// reboot.
@@ -6255,39 +6257,82 @@ fn report_has_pxe_blocking_bgp_alert(report: &HealthReport) -> bool {
     report.alerts.iter().any(is_pxe_blocking_bgp_alert)
 }
 
-/// Checks whether effective health data contains the p0 BGP condition that blocks PXE.
-///
-/// The agent marks a failed p0 session with `PreventAllocations` because PXE
-/// boot depends on p0. A host Replace report overrides all DPU reports.
-/// Otherwise, only the primary attached DPU is checked: its Replace report
-/// overrides its Merge reports, and any Merge report may contain the blocking
-/// BGP alert when there is no Replace report.
-fn primary_dpu_has_pxe_blocking_bgp_alert(state: &ManagedHostStateSnapshot) -> bool {
-    if let Some(host_replace_report) = state.host_snapshot.health_reports.replace.as_ref() {
-        return report_has_pxe_blocking_bgp_alert(host_replace_report);
-    }
+/// Returns the DPU attached to the host's primary interface.
+fn primary_dpu_snapshot(state: &ManagedHostStateSnapshot) -> Option<&Machine> {
+    let primary_dpu_id = state.host_snapshot.primary_attached_dpu_machine_id()?;
 
-    let Some(primary_dpu_id) = state.host_snapshot.primary_attached_dpu_machine_id() else {
-        return false;
-    };
-
-    let Some(primary_dpu) = state
+    state
         .dpu_snapshots
         .iter()
-        .find(|dpu| dpu.id == primary_dpu_id.into())
-    else {
+        .find(|dpu| dpu.id == MachineId::from(primary_dpu_id))
+}
+
+/// Returns whether a health alert shows that the primary DPU network is not ready for release PXE.
+fn is_release_pxe_blocking_network_alert(alert: &HealthProbeAlert) -> bool {
+    let network_health_probe_ids = [
+        HealthProbeId::nvue_api_running(),
+        HealthProbeId::bgp_stats(),
+        HealthProbeId::post_config_check_wait(),
+    ];
+
+    (network_health_probe_ids.contains(&alert.id)
+        && alert
+            .classifications
+            .contains(&HealthAlertClassification::prevent_allocations()))
+        || is_pxe_blocking_bgp_alert(alert)
+}
+
+/// Checks whether a health report contains a network alert that should block release PXE.
+fn report_has_release_pxe_blocking_network_alert(report: &HealthReport) -> bool {
+    report
+        .alerts
+        .iter()
+        .any(is_release_pxe_blocking_network_alert)
+}
+
+/// Checks host and primary DPU health reports using their effective precedence.
+///
+/// A host Replace report overrides all DPU reports. Otherwise, the primary
+/// DPU's Replace report overrides its Merge reports, and any Merge report may
+/// match when there is no Replace report.
+fn primary_dpu_effective_health_matches(
+    state: &ManagedHostStateSnapshot,
+    report_matches: impl Fn(&HealthReport) -> bool,
+) -> bool {
+    if let Some(host_replace_report) = state.host_snapshot.health_reports.replace.as_ref() {
+        return report_matches(host_replace_report);
+    }
+
+    let Some(primary_dpu) = primary_dpu_snapshot(state) else {
         return false;
     };
 
     if let Some(dpu_replace_report) = primary_dpu.health_reports.replace.as_ref() {
-        return report_has_pxe_blocking_bgp_alert(dpu_replace_report);
+        return report_matches(dpu_replace_report);
     }
 
     primary_dpu
         .health_reports
         .merges
         .values()
-        .any(report_has_pxe_blocking_bgp_alert)
+        .any(report_matches)
+}
+
+/// Checks whether effective primary DPU health explicitly blocks release PXE.
+///
+/// Missing reports do not block instance deletion. The caller has already
+/// required a fresh network status from every managed DPU, while an operator
+/// Replace report retains its existing precedence over agent health.
+fn primary_dpu_has_release_pxe_blocking_network_alert(state: &ManagedHostStateSnapshot) -> bool {
+    primary_dpu_effective_health_matches(state, report_has_release_pxe_blocking_network_alert)
+}
+
+/// Checks whether effective health data contains the p0 BGP condition that blocks PXE.
+///
+/// The agent marks a failed p0 session with `PreventAllocations` because PXE
+/// boot depends on p0.
+fn primary_dpu_has_pxe_blocking_bgp_alert(state: &ManagedHostStateSnapshot) -> bool {
+    primary_dpu_effective_health_matches(state, report_has_pxe_blocking_bgp_alert)
 }
 
 /// Whether a captured desired target can be replaced before this substate runs.
@@ -8964,6 +9009,18 @@ impl StateHandler for InstanceStateHandler {
                         };
                         Ok(StateHandlerOutcome::transition(next_state))
                     } else {
+                        // Current DPU health can show that Scout's primary network path is not
+                        // ready even after every DPU publishes a fresh status. Other flows must
+                        // continue to BootingWithDiscoveryImage because that state starts repair.
+                        if instance.deleted.is_some()
+                            && mh_snapshot.has_managed_dpus()
+                            && primary_dpu_has_release_pxe_blocking_network_alert(mh_snapshot)
+                        {
+                            return Ok(StateHandlerOutcome::wait(
+                                DPU_NETWORK_READY_WAIT_REASON.to_string(),
+                            ));
+                        }
+
                         handler_host_power_control(
                             mh_snapshot,
                             ctx,
@@ -14251,6 +14308,84 @@ mod tests {
                     classifications,
                 })
             },
+        );
+    }
+
+    #[test]
+    fn release_pxe_waits_only_for_relevant_network_alerts() {
+        fn report(alerts: Vec<HealthProbeAlert>) -> HealthReport {
+            HealthReport {
+                source: HealthReport::DPU_AGENT_SOURCE.to_string(),
+                triggered_by: None,
+                observed_at: None,
+                successes: vec![],
+                alerts,
+            }
+        }
+
+        fn alert(
+            probe_id: HealthProbeId,
+            classifications: Vec<HealthAlertClassification>,
+        ) -> HealthProbeAlert {
+            HealthProbeAlert {
+                id: probe_id,
+                target: None,
+                in_alert_since: None,
+                message: "test alert".to_string(),
+                tenant_message: None,
+                classifications,
+            }
+        }
+
+        fn allocation_blocking_alert(probe_id: HealthProbeId) -> HealthProbeAlert {
+            alert(
+                probe_id,
+                vec![HealthAlertClassification::prevent_allocations()],
+            )
+        }
+
+        check_values(
+            [
+                Check {
+                    scenario: "no network alert",
+                    input: report(vec![]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "NVUE API is unavailable",
+                    input: report(vec![allocation_blocking_alert(
+                        HealthProbeId::nvue_api_running(),
+                    )]),
+                    expect: true,
+                },
+                Check {
+                    scenario: "FRR BGP health check failed",
+                    input: report(vec![allocation_blocking_alert(HealthProbeId::bgp_stats())]),
+                    expect: true,
+                },
+                Check {
+                    scenario: "network config is still settling",
+                    input: report(vec![allocation_blocking_alert(
+                        HealthProbeId::post_config_check_wait(),
+                    )]),
+                    expect: true,
+                },
+                Check {
+                    scenario: "informational NVUE alert does not block release",
+                    input: report(vec![alert(HealthProbeId::nvue_api_running(), vec![])]),
+                    expect: false,
+                },
+                Check {
+                    scenario: "unrelated critical alert does not block release",
+                    input: report(vec![alert(
+                        HealthProbeId::from_str("DpuDiskUtilizationCritical")
+                            .expect("valid test probe id"),
+                        vec![HealthAlertClassification::prevent_host_state_changes()],
+                    )]),
+                    expect: false,
+                },
+            ],
+            |report| report_has_release_pxe_blocking_network_alert(&report),
         );
     }
 


### PR DESCRIPTION
Releasing an instance can reboot a host into `scout` even while the primary DPU's health reports show:

- NVUE is unavailable (`NvueApiRunning`).
- FRR cannot gather BGP health (`BgpStats`).
- A newly applied HBN configuration is still settling (`PostConfigCheckWait`).
- The primary `p0` BGP session is not established (`BgpPeeringTor`).

`scout` then has no usable network path for its HTTP boot, and instance release waits for the next reboot attempt.

This change checks effective primary DPU health immediately before rebooting into `scout` during instance release. It waits while any of these alerts is classified with `PreventAllocations`.

This preserves existing health report precedence and fails open when health is missing or empty, so this additional check does not introduce another deletion blocker for report producers that do not provide those alerts.

Custom PXE, hosts without managed DPUs, an isolated `p1` failure without `PreventAllocations`, and remediation flows retain their existing behavior.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5700

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the complete change, and every recommendation has the disposition recorded below.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 2 | 2 | 0 |
| CodeRabbit CLI | 1 | 0 | 1 |
| Claude CLI | 22 | 16 | 6 |
| common-nits-reviewer | 1 | 0 | 1 |
| **Total** | **26** | **18** | **8** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- The wait reason did not identify the blocked path. **Resolution:** It now names primary DPU network readiness before PXE.
2. **Adopted** -- Initial comments obscured the health precedence and freshness assumptions. **Resolution:** The final comments state both contracts directly.

### CodeRabbit CLI

1. **Declined** -- Match BGP alerts by the literal primary interface target. **Reason:** The agent uses `PreventAllocations` as the p0 safety signal; target matching could fail open for untargeted reports, while secondary link degradation is unclassified.

### Claude CLI

1. **Adopted** -- The first gate also covered remediation. **Resolution:** It now requires a deleted instance.
2. **Adopted** -- Missing and empty health initially failed closed. **Resolution:** Only explicit classified alerts wait.
3. **Declined** -- Add a timeout that eventually reboots despite a persistent alert. **Reason:** That would restore the known unsafe `scout` reboot; Replace reports remain the operator escape.
4. **Adopted** -- The initial check ignored Replace and Merge precedence. **Resolution:** Both PXE predicates share one precedence helper.
5. **Adopted** -- Shared probe IDs were bare strings. **Resolution:** `HealthProbeId` now owns typed constructors.
6. **Adopted** -- The remediation bypass lacked rationale. **Resolution:** The call site explains why repair flows must proceed.
7. **Adopted** -- Initial health comments described completion unclearly. **Resolution:** They now describe explicit alert matching.
8. **Adopted** -- Predicate names obscured report semantics. **Resolution:** They now use the established `report_has_*` form.
9. **Adopted** -- The first integration setup did not make its blocking cause clear. **Resolution:** It now uses an explicit NVUE failure.
10. **Adopted** -- The test wait constant differed from production naming. **Resolution:** Both use `DPU_NETWORK_READY_WAIT_REASON`.
11. **Declined** -- Collapse the persisted-state helper and power checks. **Reason:** Their separation keeps the two observable phases readable.
12. **Adopted** -- Initial p0 and p1 rows repeated existing BGP coverage. **Resolution:** The new table keeps only distinct release behavior.
13. **Declined** -- Update lifecycle documentation in this code PR. **Reason:** The drift is real, but repository ownership requires a separate documentation PR.
14. **Adopted** -- `BgpStats` documentation implied success only. **Resolution:** It now describes the shared health check ID.
15. **Adopted** -- The fresh status precondition was implicit. **Resolution:** The caller requirement is now documented.
16. **Adopted** -- A test passed a transaction differently from neighboring tests. **Resolution:** It now passes `&mut txn`.
17. **Adopted** -- Named network alerts ignored classifications. **Resolution:** They now require `PreventAllocations`, with an informational-alert regression case.
18. **Declined** -- Add another lifecycle setup solely for the remediation bypass. **Reason:** The direct deletion guard and existing remediation tests already prove the separated paths.
19. **Declined** -- Include the probe ID in the wait reason. **Reason:** Health reports expose the exact probe, while a stable reason follows controller convention.
20. **Adopted** -- Precedence details remained on the BGP wrapper after extraction. **Resolution:** They now document the generic helper that implements them.
21. **Adopted** -- A neighboring test retained the new probe ID as a literal. **Resolution:** It now uses the typed constructor.
22. **Declined** -- Replace the explicit empty second report with an implicit fixture default. **Reason:** The explicit report makes alert clearing visible.

### common-nits-reviewer

1. **Declined** -- Existing lifecycle and operator documentation still describes the old release transition. **Reason:** It requires the separate documentation PR identified above.

</details>


Closes #5700
