### PR TITLE
fix(api): reap dead HTTP/2 connections to stop fd exhaustion

### DIFF
--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -814,7 +814,7 @@ mod keep_alive_tests {
     async fn idle_peer_that_answers_pings_stays_connected() {
         let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
         let addr = listener.local_addr().expect("local_addr");
-        let server = tokio::spawn(serve_one(listener));
+        let mut server = tokio::spawn(serve_one(listener));
 
         let sock = TcpStream::connect(addr).await.expect("connect");
         let (_sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
@@ -824,15 +824,22 @@ mod keep_alive_tests {
             .expect("client handshake");
         // Driving the connection answers the server's pings without sending any
         // requests, which is exactly a healthy but idle peer.
-        let client = tokio::spawn(conn);
+        let mut client = tokio::spawn(conn);
 
-        // Well past several ping intervals and timeouts.
-        let still_open = tokio::time::timeout(INTERVAL * 10, server).await;
+        // Well past several ping intervals and timeouts. Borrowed, so the task
+        // stays owned here and can be joined rather than detached on timeout.
+        let still_open = tokio::time::timeout(INTERVAL * 10, &mut server).await;
         assert!(
             still_open.is_err(),
             "a responsive idle peer was disconnected: {still_open:?}"
         );
+
+        // Both are still running, which is the point of the assertion above.
+        // Cancel and join them so neither outlives the test.
         client.abort();
+        server.abort();
+        let _ = (&mut client).await;
+        let _ = (&mut server).await;
     }
 
     /// Keep-alive armed without a timer panics inside hyper on the first

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -335,12 +335,7 @@ pub(crate) async fn start(
     let listener = TcpListener::bind(listen_port).await?;
     let listen_address = listener.local_addr()?;
     tracing::info!(effective_listen_address = %listen_address, "API listener started");
-    let mut http = http2::Builder::new(TokioExecutor::new());
-    // Ping idle connections so peers that vanish without a clean close get reaped instead of leaking fds.
-    // The timer is required: keep-alive drives its interval through it, and hyper panics without one.
-    http.timer(TokioTimer::new())
-        .keep_alive_interval(Some(Duration::from_secs(30)))
-        .keep_alive_timeout(Duration::from_secs(20));
+    let http = http2_builder(H2_KEEP_ALIVE_INTERVAL, H2_KEEP_ALIVE_TIMEOUT);
 
     let extra_cli_certs = if let Some(auth_config) = auth_config {
         auth_config.cli_certs.clone()
@@ -718,6 +713,31 @@ pub(crate) async fn start(
     Ok(listen_address)
 }
 
+/// How often an idle HTTP/2 connection is pinged, and how long the peer has to
+/// answer before the connection is dropped.
+///
+/// Without this, a peer that disappears without a clean close leaves its
+/// connection -- and its fd -- parked forever, because hyper only ends
+/// `serve_connection` on a transport-level close or error.
+const H2_KEEP_ALIVE_INTERVAL: Duration = Duration::from_secs(30);
+const H2_KEEP_ALIVE_TIMEOUT: Duration = Duration::from_secs(20);
+
+/// Builds the HTTP/2 configuration shared by every accepted connection.
+///
+/// The timer is not optional: keep-alive schedules its interval through it, and
+/// hyper panics on the first connection when keep-alive is armed without one.
+/// Idle pings are always on for servers, so no separate opt-in is needed here.
+fn http2_builder(
+    keep_alive_interval: Duration,
+    keep_alive_timeout: Duration,
+) -> http2::Builder<TokioExecutor> {
+    let mut http = http2::Builder::new(TokioExecutor::new());
+    http.timer(TokioTimer::new())
+        .keep_alive_interval(Some(keep_alive_interval))
+        .keep_alive_timeout(keep_alive_timeout);
+    http
+}
+
 /// Handle the root URL. Health check services often expect a 200 here.
 async fn root_url() -> &'static str {
     const ROOT_CONTENTS: &str = if carbide_version::literal!(build_version).is_empty() {
@@ -726,6 +746,131 @@ async fn root_url() -> &'static str {
         concat!("Forge ", carbide_version::literal!(build_version), "\n")
     };
     ROOT_CONTENTS
+}
+
+#[cfg(test)]
+mod keep_alive_tests {
+    use std::time::Duration;
+
+    use hyper::server::conn::http2;
+    use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
+    use tokio::io::AsyncWriteExt;
+    use tokio::net::{TcpListener, TcpStream};
+
+    use super::http2_builder;
+
+    /// The client connection preface, followed by an empty SETTINGS frame:
+    /// length 0, type 0x4, no flags, stream 0. Enough for the server to finish
+    /// the handshake and start treating the connection as live.
+    const H2_PREFACE: &[u8] = b"PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n";
+    const EMPTY_SETTINGS: &[u8] = &[0, 0, 0, 4, 0, 0, 0, 0, 0];
+
+    const INTERVAL: Duration = Duration::from_millis(100);
+    const TIMEOUT: Duration = Duration::from_millis(100);
+
+    /// Serves one connection with keep-alive on, returning when it ends.
+    async fn serve_one(listener: TcpListener) -> Result<(), hyper::Error> {
+        let (stream, _) = listener.accept().await.expect("accept");
+        // These tests never send a request; the service only satisfies the signature.
+        let service =
+            hyper::service::service_fn(|_req: hyper::Request<hyper::body::Incoming>| async {
+                Ok::<_, std::convert::Infallible>(hyper::Response::new(axum::body::Body::empty()))
+            });
+        http2_builder(INTERVAL, TIMEOUT)
+            .serve_connection(TokioIo::new(stream), service)
+            .await
+    }
+
+    /// The leak this change exists to prevent: a peer that stops answering while
+    /// the connection is idle must be dropped, not parked forever.
+    #[tokio::test]
+    async fn idle_peer_that_stops_answering_is_dropped() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let server = tokio::spawn(serve_one(listener));
+
+        // Complete the handshake, then go silent while holding the socket open.
+        // No FIN is ever sent, so only an active ping can reveal the peer is gone.
+        let mut sock = TcpStream::connect(addr).await.expect("connect");
+        sock.write_all(H2_PREFACE).await.expect("preface");
+        sock.write_all(EMPTY_SETTINGS).await.expect("settings");
+        sock.flush().await.expect("flush");
+
+        let outcome = tokio::time::timeout(Duration::from_secs(10), server)
+            .await
+            .expect("connection was still parked; the idle peer was never reaped")
+            .expect("server task panicked");
+
+        assert!(
+            outcome.is_err(),
+            "expected the connection to end with a keep-alive error, got {outcome:?}"
+        );
+        drop(sock);
+    }
+
+    /// The other half of the contract: pings are answered by the transport, so an
+    /// idle peer that is merely quiet must not be disconnected.
+    #[tokio::test]
+    async fn idle_peer_that_answers_pings_stays_connected() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let server = tokio::spawn(serve_one(listener));
+
+        let sock = TcpStream::connect(addr).await.expect("connect");
+        let (_sender, conn) = hyper::client::conn::http2::Builder::new(TokioExecutor::new())
+            .timer(TokioTimer::new())
+            .handshake::<_, axum::body::Body>(TokioIo::new(sock))
+            .await
+            .expect("client handshake");
+        // Driving the connection answers the server's pings without sending any
+        // requests, which is exactly a healthy but idle peer.
+        let client = tokio::spawn(conn);
+
+        // Well past several ping intervals and timeouts.
+        let still_open = tokio::time::timeout(INTERVAL * 10, server).await;
+        assert!(
+            still_open.is_err(),
+            "a responsive idle peer was disconnected: {still_open:?}"
+        );
+        client.abort();
+    }
+
+    /// Keep-alive armed without a timer panics inside hyper on the first
+    /// connection, which would take down every request rather than leak an fd.
+    #[tokio::test]
+    async fn builder_supplies_a_timer_for_keep_alive() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+        let addr = listener.local_addr().expect("local_addr");
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept");
+            // Same settings as production, minus the timer.
+            let mut http = http2::Builder::new(TokioExecutor::new());
+            http.keep_alive_interval(Some(INTERVAL))
+                .keep_alive_timeout(TIMEOUT);
+            let service =
+                hyper::service::service_fn(|_req: hyper::Request<hyper::body::Incoming>| async {
+                    Ok::<_, std::convert::Infallible>(hyper::Response::new(
+                        axum::body::Body::empty(),
+                    ))
+                });
+            http.serve_connection(TokioIo::new(stream), service).await
+        });
+
+        let mut sock = TcpStream::connect(addr).await.expect("connect");
+        sock.write_all(H2_PREFACE).await.expect("preface");
+        sock.write_all(EMPTY_SETTINGS).await.expect("settings");
+        sock.flush().await.expect("flush");
+
+        let outcome = tokio::time::timeout(Duration::from_secs(10), server)
+            .await
+            .expect("timed out");
+        assert!(
+            outcome.is_err_and(|e| e.is_panic()),
+            "expected hyper to panic without a timer; if this stops panicking, \
+             the timer in http2_builder may no longer be load-bearing"
+        );
+        drop(sock);
+    }
 }
 
 #[cfg(test)]

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -23,7 +23,7 @@ use ::rpc::forge as rpc;
 use carbide_authn::SpiffeContext;
 use carbide_authn::middleware::{CertDescriptionMiddleware, ConnectionAttributes};
 use hyper::server::conn::{http1, http2};
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use hyper_util::service::TowerToHyperService;
 use model::ConfigValidationError;
 use opentelemetry::metrics::Meter;
@@ -335,7 +335,12 @@ pub(crate) async fn start(
     let listener = TcpListener::bind(listen_port).await?;
     let listen_address = listener.local_addr()?;
     tracing::info!(effective_listen_address = %listen_address, "API listener started");
-    let http = http2::Builder::new(TokioExecutor::new());
+    let mut http = http2::Builder::new(TokioExecutor::new());
+    // Ping idle connections so peers that vanish without a clean close get reaped instead of leaking fds.
+    // The timer is required: keep-alive drives its interval through it, and hyper panics without one.
+    http.timer(TokioTimer::new())
+        .keep_alive_interval(Some(Duration::from_secs(30)))
+        .keep_alive_timeout(Duration::from_secs(20));
 
     let extra_cli_certs = if let Some(auth_config) = auth_config {
         auth_config.cli_certs.clone()

--- a/helm/charts/nico-api/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-api/tests/file_descriptor_limit_test.yaml
@@ -6,31 +6,27 @@ tests:
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'FD_LIMIT=8192'
-      - matchRegex:
-          path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn "\$FD_LIMIT"'
+          pattern: 'FD_LIMIT=8192\n[\s\S]*?\n\s*ulimit -Sn "\$FD_LIMIT"'
       # A bare `ulimit -n` lowers the hard limit too, and an unprivileged
       # process can never raise it back.
       - notMatchRegex:
           path: spec.template.spec.containers[0].command[2]
           pattern: 'ulimit -n [0-9]'
-  - it: clamps to the hard limit and fails loudly when the limit cannot be applied
+  - it: clamps the target to the hard limit only when the hard limit is lower
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'FD_HARD="\$\(ulimit -Hn\)"'
+          pattern: 'FD_HARD="\$\(ulimit -Hn\)"\n\s*if \[ "\$FD_HARD" != "unlimited" \] && \[ "\$FD_LIMIT" -gt "\$FD_HARD" \]; then\n[\s\S]*?\n\s*FD_LIMIT="\$FD_HARD"\n\s*fi\n'
+  - it: aborts startup when the soft limit cannot be applied
+    asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'FD_LIMIT="\$FD_HARD"'
-      - matchRegex:
-          path: spec.template.spec.containers[0].command[2]
-          pattern: 'exit 1'
+          pattern: 'ulimit -Sn "\$FD_LIMIT" \|\| \{[^\n]*exit 1; \}'
   - it: applies the limit before starting either api binary
     asserts:
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn[\s\S]*exec /opt/nico/nico-api run'
+          pattern: 'ulimit -Sn "\$FD_LIMIT"[\s\S]*?exec /opt/nico/nico-api run'
       - matchRegex:
           path: spec.template.spec.containers[0].command[2]
-          pattern: 'ulimit -Sn[\s\S]*exec /opt/carbide/carbide-api run'
+          pattern: 'ulimit -Sn "\$FD_LIMIT"[\s\S]*?exec /opt/carbide/carbide-api run'

--- a/helm/charts/nico-api/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-api/tests/file_descriptor_limit_test.yaml
@@ -1,0 +1,36 @@
+suite: nico-api file descriptor limit
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: raises the soft limit without touching the hard limit
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=8192'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn "\$FD_LIMIT"'
+      # A bare `ulimit -n` lowers the hard limit too, and an unprivileged
+      # process can never raise it back.
+      - notMatchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -n [0-9]'
+  - it: clamps to the hard limit and fails loudly when the limit cannot be applied
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_HARD="\$\(ulimit -Hn\)"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT="\$FD_HARD"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'exit 1'
+  - it: applies the limit before starting either api binary
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn[\s\S]*exec /opt/nico/nico-api run'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn[\s\S]*exec /opt/carbide/carbide-api run'

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -250,6 +250,16 @@ command:
   - /bin/sh
   - -c
   - |
+    # Default nofile (1024) is too low for fleet-scale DPU connections; bounded
+    # bump, not maxed to the hard limit. Use -Sn: a bare `ulimit -n` also lowers
+    # the hard limit, which an unprivileged process can never raise back.
+    FD_LIMIT=8192
+    FD_HARD="$(ulimit -Hn)"
+    if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
+      echo "fd limit ${FD_LIMIT} exceeds hard limit ${FD_HARD}; clamping" >&2
+      FD_LIMIT="$FD_HARD"
+    fi
+    ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
     if [ -x /opt/nico/nico-api ]; then
       exec /opt/nico/nico-api run \
         --config-path /etc/nico/nico-api/nico-api-config.toml \


### PR DESCRIPTION
`nico-api`'s HTTP/2 listener had no keepalive, so a peer that disappeared without a clean close left its connection parked forever. On pdx-dev3 a pod reached 1020 of 1024 open file descriptors and began rejecting new connections with `Too many open files`, breaking both inbound gRPC traffic and outbound BMC Redfish exploration.

This enables HTTP/2 keepalive so dead connections are reaped within roughly 50 seconds, and raises the container's soft file-descriptor limit from the 1024 default. Healthy idle connections are unaffected.

Resource impact is negligible and net negative. Connections carrying traffic never ping, and an idle one exchanges 34 bytes per 30s. Reclaiming a dead connection frees a descriptor, a task, and its TLS and HTTP/2 buffers, which outweighs the per-connection timer.

## Related issues

Fixes https://github.com/NVIDIA/infra-controller/issues/5680

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Tested with a manual script by opening parallel 50 connections. The server script opens N HTTP/2 TLS connections to nico-api, then drops the FIN packets on close via iptables so the server never sees them disconnect.

```bash
TIME        OPEN_FDS    FD_LIMIT  PORT_CONNS  NOTE
----        --------    --------  ----------  ----
14:22:15          37     1048576           5  baseline
14:22:20          37     1048576           5  no rise yet (peak 5 vs baseline 5) -- test conns not in view
14:22:26          86     1048576          54  HOLDING 49 above baseline
14:22:31          86     1048576          54  HOLDING 49 above baseline
---------------- --------------- -------------------
14:23:09          86     1048576          54  HOLDING 49 above baseline
14:23:14          36     1048576           4  REAPED -- rose to 54, back to 4
14:23:19          36     1048576           4  REAPED -- rose to 54, back to 4
```

## Additional Notes

The descriptor ceiling is bounded rather than maxed to the hard limit, so a future leak still fails loudly instead of growing into the pod's memory limit and becoming an OOM kill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)