### PR TITLE
feat(tui): support full range of OS fields

### DIFF
--- a/rest-api/api/pkg/api/model/operatingsystem.go
+++ b/rest-api/api/pkg/api/model/operatingsystem.go
@@ -727,17 +727,17 @@ func (osur *APIOperatingSystemUpdateRequest) Validate(existingOS *cdbm.Operating
 	} else {
 		err = validation.ValidateStruct(osur,
 			validation.Field(&osur.ImageSHA,
-				validation.Nil.Error("imageSHA cannot be specified if imageURL is not specified")),
+				validation.Nil.Error("imageSHA cannot be specified unless OS is image-based")),
 			validation.Field(&osur.ImageAuthType,
-				validation.Nil.Error("imageAuthType cannot be specified if imageURL is not specified")),
+				validation.Nil.Error("imageAuthType cannot be specified unless OS is image-based")),
 			validation.Field(&osur.ImageAuthToken,
-				validation.Nil.Error("imageAuthToken cannot be specified if imageURL is not specified")),
+				validation.Nil.Error("imageAuthToken cannot be specified unless OS is image-based")),
 			validation.Field(&osur.ImageDisk,
-				validation.Nil.Error("imageDisk cannot be specified if imageURL is not specified")),
+				validation.Nil.Error("imageDisk cannot be specified unless OS is image-based")),
 			validation.Field(&osur.RootFsID,
-				validation.Nil.Error("rootFsID cannot be specified if imageURL is not specified")),
+				validation.Nil.Error("rootFsID cannot be specified unless OS is image-based")),
 			validation.Field(&osur.RootFsLabel,
-				validation.Nil.Error("rootFsLabel cannot be specified if imageURL is not specified")),
+				validation.Nil.Error("rootFsLabel cannot be specified unless OS is image-based")),
 		)
 	}
 

--- a/rest-api/cli/tui/commands.go
+++ b/rest-api/cli/tui/commands.go
@@ -4,10 +4,13 @@
 package tui
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"sort"
 	"strconv"
@@ -1298,7 +1301,36 @@ func cmdOSList(s *Session, _ []string) error {
 	if err != nil {
 		return err
 	}
-	return printResourceTable(os.Stdout, "NAME", "STATUS", "ID", items)
+	fmt.Fprintf(os.Stderr, "%d items\n", len(items))
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 3, ' ', 0)
+	fmt.Fprintln(tw, "NAME\tSTATUS\tTYPE\tID")
+	for _, item := range items {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", item.Name, item.Status, item.Extra["type"], item.ID)
+	}
+	return tw.Flush()
+}
+
+const (
+	operatingSystemTypeIPXE             = "iPXE"
+	operatingSystemTypeImage            = "Image"
+	operatingSystemTypeTemplatedIPXE    = "Templated iPXE"
+	operatingSystemAPITypeTemplatedIPXE = "TemplatedIpxe"
+	rootFilesystemTypeID                = "ID"
+	rootFilesystemTypeLabel             = "Label"
+	authTypeNone                        = "None"
+	authTypeBasic                       = "Basic"
+	authTypeBearer                      = "Bearer"
+	artifactCacheStrategyAsNeeded       = "Cache as needed"
+	artifactCacheStrategyLocalOnly      = "Local only"
+	artifactCacheStrategyCachedOnly     = "Cached only"
+	artifactCacheStrategyRemoteOnly     = "Remote only"
+)
+
+var artifactCacheStrategyValues = map[string]string{
+	artifactCacheStrategyAsNeeded:   "CacheAsNeeded",
+	artifactCacheStrategyLocalOnly:  "LocalOnly",
+	artifactCacheStrategyCachedOnly: "CachedOnly",
+	artifactCacheStrategyRemoteOnly: "RemoteOnly",
 }
 
 func cmdOSCreate(s *Session, _ []string) error {
@@ -1310,14 +1342,257 @@ func cmdOSCreate(s *Session, _ []string) error {
 	if err != nil {
 		return err
 	}
-	tenantID, err := s.getTenantID(context.Background())
-	if err != nil {
-		return fmt.Errorf("resolving tenant id: %w", err)
+	body := map[string]interface{}{
+		"name": name,
 	}
+	if strings.TrimSpace(desc) != "" {
+		body["description"] = strings.TrimSpace(desc)
+	}
+
+	ctx := context.Background()
+	osType, err := promptOperatingSystemType(s, ctx)
+	if err != nil {
+		return err
+	}
+	switch osType {
+	case operatingSystemTypeIPXE:
+		err = promptRawIPXEOperatingSystem(body)
+	case operatingSystemTypeTemplatedIPXE:
+		err = promptTemplatedIPXEOperatingSystem(s, ctx, body)
+	case operatingSystemTypeImage:
+		err = promptImageOperatingSystem(s, ctx, body)
+	default:
+		err = fmt.Errorf("unsupported operating system type %q", osType)
+	}
+	if err != nil {
+		return err
+	}
+	err = promptOperatingSystemOptions(body)
+	if err != nil {
+		return err
+	}
+
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encoding operating system request: %w", err)
+	}
+	logBodyJSON, err := redactAuthTokenJSON(bodyJSON)
+	if err != nil {
+		return fmt.Errorf("redacting operating system request for logging: %w", err)
+	}
+	logBody := shellQuoteCLIArg(string(logBodyJSON))
+	LogCmd(s, "operating-system", "create", "--data", logBody)
+	resp, _, err := s.Client.Do("POST", apiPath(s, "operating-system"), nil, nil, bodyJSON)
+	if err != nil {
+		return fmt.Errorf("creating operating system: %w", err)
+	}
+	s.Cache.Invalidate("operating-system")
+	created, err := parseMutationResponseRequiringID(resp, "created operating system")
+	if err != nil {
+		return err
+	}
+	fmt.Printf("%s Operating system created: %s (%s)\n", Green("OK"), str(created, "name"), str(created, "id"))
+	return nil
+}
+
+func promptOperatingSystemType(s *Session, ctx context.Context) (string, error) {
+	_, err := s.getTenantID(ctx)
+	if err == nil {
+		return PromptChoice(
+			"Operating system type",
+			[]string{
+				operatingSystemTypeIPXE,
+				operatingSystemTypeImage,
+				operatingSystemTypeTemplatedIPXE,
+			},
+			"",
+		)
+	}
+
+	apiErr := &cli.APIError{}
+	if !errors.As(err, &apiErr) || apiErr.StatusCode != http.StatusForbidden {
+		return "", fmt.Errorf("determining operating system owner type: %w", err)
+	}
+	_, err = s.getInfrastructureProviderID(ctx)
+	if err != nil {
+		return "", fmt.Errorf("determining operating system owner type: %w", err)
+	}
+	fmt.Printf(
+		"%s %s %s\n",
+		Bold("Operating system type:"),
+		Green(operatingSystemTypeTemplatedIPXE),
+		Dim("(default for providers)"),
+	)
+	return operatingSystemTypeTemplatedIPXE, nil
+}
+
+func promptRawIPXEOperatingSystem(body map[string]interface{}) error {
 	ipxeScript, err := PromptText("iPXE script or URL", true)
 	if err != nil {
 		return err
 	}
+	body["ipxeScript"] = ipxeScript
+	return nil
+}
+
+func promptTemplatedIPXEOperatingSystem(
+	s *Session,
+	ctx context.Context,
+	body map[string]interface{},
+) error {
+	site, err := s.Resolver.Resolve(ctx, "site", "Site")
+	if err != nil {
+		return err
+	}
+	templates, err := s.fetchIPXETemplatesForSite(site.ID)
+	if err != nil {
+		return fmt.Errorf("fetching ipxe-template: %w", err)
+	}
+	template, err := s.Resolver.SelectFromItems("iPXE template", templates)
+	if err != nil {
+		return err
+	}
+	body["siteIds"] = []string{site.ID}
+	body["ipxeTemplateId"] = template.ID
+	err = promptIPXETemplateRequirements(template, body)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func promptIPXETemplateRequirements(template *NamedItem, body map[string]interface{}) error {
+	parameters, err := promptIPXETemplateParameters(template)
+	if err != nil {
+		return err
+	}
+	if len(parameters) > 0 {
+		body["ipxeTemplateParameters"] = parameters
+	}
+	artifacts, err := promptIPXETemplateArtifacts(template)
+	if err != nil {
+		return err
+	}
+	if len(artifacts) > 0 {
+		body["ipxeTemplateArtifacts"] = artifacts
+	}
+	return nil
+}
+
+func promptIPXETemplateParameters(template *NamedItem) ([]map[string]interface{}, error) {
+	requiredParameters, err := namedItemStringList(template, "requiredParams")
+	if err != nil {
+		return nil, fmt.Errorf("reading required iPXE template parameters: %w", err)
+	}
+	parameters := make([]map[string]interface{}, 0, len(requiredParameters))
+	for _, parameterName := range requiredParameters {
+		value, promptErr := PromptText(fmt.Sprintf("Value for parameter %s", parameterName), true)
+		if promptErr != nil {
+			return nil, promptErr
+		}
+		parameters = append(parameters, map[string]interface{}{
+			"name":  parameterName,
+			"value": value,
+		})
+	}
+	return parameters, nil
+}
+
+func promptIPXETemplateArtifacts(template *NamedItem) ([]map[string]interface{}, error) {
+	requiredArtifacts, err := namedItemStringList(template, "requiredArtifacts")
+	if err != nil {
+		return nil, fmt.Errorf("reading required iPXE template artifacts: %w", err)
+	}
+	artifacts := make([]map[string]interface{}, 0, len(requiredArtifacts))
+	for _, artifactName := range requiredArtifacts {
+		artifact, promptErr := promptIPXETemplateArtifact(artifactName)
+		if promptErr != nil {
+			return nil, promptErr
+		}
+		artifacts = append(artifacts, artifact)
+	}
+	return artifacts, nil
+}
+
+func namedItemStringList(item *NamedItem, field string) ([]string, error) {
+	raw, ok := item.Raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("selected item has no response object")
+	}
+	value, exists := raw[field]
+	if !exists || value == nil {
+		return nil, nil
+	}
+
+	stringsValue, ok := value.([]string)
+	if ok {
+		return append([]string(nil), stringsValue...), nil
+	}
+	interfaceValue, ok := value.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("field %q is not a string list", field)
+	}
+	result := make([]string, 0, len(interfaceValue))
+	for index, entry := range interfaceValue {
+		name, entryOK := entry.(string)
+		if !entryOK {
+			return nil, fmt.Errorf("field %q entry %d is not a string", field, index)
+		}
+		result = append(result, name)
+	}
+	return result, nil
+}
+
+func promptIPXETemplateArtifact(name string) (map[string]interface{}, error) {
+	artifactURL, err := PromptText(fmt.Sprintf("URL for artifact %s", name), true)
+	if err != nil {
+		return nil, err
+	}
+	artifactSHA, err := PromptText(fmt.Sprintf("SHA for artifact %s (optional)", name), false)
+	if err != nil {
+		return nil, err
+	}
+	authType, authToken, err := promptOptionalAuth(
+		fmt.Sprintf("Auth type for artifact %s", name),
+		fmt.Sprintf("Auth token for artifact %s", name),
+	)
+	if err != nil {
+		return nil, err
+	}
+	cacheStrategyLabel, err := PromptChoice(
+		fmt.Sprintf("Cache strategy for artifact %s", name),
+		[]string{
+			artifactCacheStrategyAsNeeded,
+			artifactCacheStrategyLocalOnly,
+			artifactCacheStrategyCachedOnly,
+			artifactCacheStrategyRemoteOnly,
+		},
+		"",
+	)
+	if err != nil {
+		return nil, err
+	}
+	cacheStrategy, ok := artifactCacheStrategyValues[cacheStrategyLabel]
+	if !ok {
+		return nil, fmt.Errorf("unsupported artifact cache strategy %q", cacheStrategyLabel)
+	}
+
+	artifact := map[string]interface{}{
+		"name":          name,
+		"url":           artifactURL,
+		"cacheStrategy": cacheStrategy,
+	}
+	if artifactSHA != "" {
+		artifact["sha"] = artifactSHA
+	}
+	if authType != "" {
+		artifact["authType"] = authType
+		artifact["authToken"] = authToken
+	}
+	return artifact, nil
+}
+
+func promptOperatingSystemOptions(body map[string]interface{}) error {
 	userData, err := PromptText("User data (optional)", false)
 	if err != nil {
 		return err
@@ -1330,37 +1605,154 @@ func cmdOSCreate(s *Session, _ []string) error {
 	if err != nil {
 		return err
 	}
-	body := map[string]interface{}{
-		"name":             name,
-		"tenantId":         tenantID,
-		"ipxeScript":       ipxeScript,
-		"allowOverride":    allowOverride,
-		"phoneHomeEnabled": phoneHomeEnabled,
-	}
-	if strings.TrimSpace(desc) != "" {
-		body["description"] = strings.TrimSpace(desc)
-	}
+	body["allowOverride"] = allowOverride
+	body["phoneHomeEnabled"] = phoneHomeEnabled
 	if strings.TrimSpace(userData) != "" {
 		body["userData"] = strings.TrimSpace(userData)
 	}
-	LogCmd(s, "operating-system", "create", "--name", name)
-	bodyJSON, _ := json.Marshal(body)
-	resp, _, err := s.Client.Do("POST", apiPath(s, "operating-system"), nil, nil, bodyJSON)
-	if err != nil {
-		return fmt.Errorf("creating operating system: %w", err)
-	}
-	s.Cache.Invalidate("operating-system")
-	s.Cache.InvalidateFiltered()
-	created, err := parseMutationResponseRequiringID(resp, "created operating system")
-	if err != nil {
-		return err
-	}
-	fmt.Printf("%s Operating system created: %s (%s)\n", Green("OK"), str(created, "name"), str(created, "id"))
 	return nil
 }
 
+func promptImageOperatingSystem(
+	s *Session,
+	ctx context.Context,
+	body map[string]interface{},
+) error {
+	site, err := s.Resolver.Resolve(ctx, "site", "Site")
+	if err != nil {
+		return err
+	}
+	imageURL, err := PromptText("Image URL", true)
+	if err != nil {
+		return err
+	}
+	imageSHA, err := PromptText("Image SHA", true)
+	if err != nil {
+		return err
+	}
+	body["siteIds"] = []string{site.ID}
+	body["imageUrl"] = imageURL
+	body["imageSha"] = imageSHA
+	err = promptRootFilesystem(body)
+	if err != nil {
+		return err
+	}
+	imageAuthType, imageAuthToken, err := promptOptionalAuth(
+		"Image authentication type",
+		"Image auth token",
+	)
+	if err != nil {
+		return err
+	}
+	if imageAuthType != "" {
+		body["imageAuthType"] = imageAuthType
+		body["imageAuthToken"] = imageAuthToken
+	}
+	imageDisk, err := PromptText("Image disk (optional)", false)
+	if err != nil {
+		return err
+	}
+	if imageDisk != "" {
+		body["imageDisk"] = imageDisk
+	}
+	return nil
+}
+
+func promptRootFilesystem(body map[string]interface{}) error {
+	rootFilesystemType, err := PromptChoice(
+		"Specify root filesystem by",
+		[]string{
+			rootFilesystemTypeID,
+			rootFilesystemTypeLabel,
+		},
+		"",
+	)
+	if err != nil {
+		return err
+	}
+	if rootFilesystemType == rootFilesystemTypeID {
+		rootFilesystemID, promptErr := PromptText("Root filesystem ID", true)
+		if promptErr != nil {
+			return promptErr
+		}
+		body["rootFsId"] = rootFilesystemID
+		return nil
+	}
+	rootFilesystemLabel, err := PromptText("Root filesystem label", true)
+	if err != nil {
+		return err
+	}
+	body["rootFsLabel"] = rootFilesystemLabel
+	return nil
+}
+
+func promptOptionalAuth(authTypeLabel string, authTokenLabel string) (string, string, error) {
+	authType, err := PromptChoice(
+		authTypeLabel,
+		[]string{
+			authTypeNone,
+			authTypeBasic,
+			authTypeBearer,
+		},
+		authTypeNone,
+	)
+	if err != nil {
+		return "", "", err
+	}
+	if authType == authTypeNone {
+		return "", "", nil
+	}
+	authToken, err := PromptSecret(authTokenLabel, true)
+	if err != nil {
+		return "", "", err
+	}
+	return authType, authToken, nil
+}
+
+func redactAuthTokenJSON(bodyJSON []byte) ([]byte, error) {
+	var body interface{}
+	decoder := json.NewDecoder(bytes.NewReader(bodyJSON))
+	decoder.UseNumber()
+	err := decoder.Decode(&body)
+	if err != nil {
+		return nil, err
+	}
+	redactAuthTokenValues(body)
+
+	var redacted bytes.Buffer
+	encoder := json.NewEncoder(&redacted)
+	encoder.SetEscapeHTML(false)
+	err = encoder.Encode(body)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(redacted.Bytes()), nil
+}
+
+func redactAuthTokenValues(value interface{}) {
+	switch typedValue := value.(type) {
+	case map[string]interface{}:
+		for key, nestedValue := range typedValue {
+			if key == "authToken" || key == "imageAuthToken" {
+				typedValue[key] = "<redacted>"
+				continue
+			}
+			redactAuthTokenValues(nestedValue)
+		}
+	case []interface{}:
+		for _, nestedValue := range typedValue {
+			redactAuthTokenValues(nestedValue)
+		}
+	}
+}
+
 func cmdOSUpdate(s *Session, args []string) error {
-	item, err := s.Resolver.ResolveWithArgs(context.Background(), "operating-system", "Operating System to update", args)
+	ctx := context.Background()
+	item, err := s.Resolver.ResolveWithArgs(ctx, "operating-system", "Operating System to update", args)
+	if err != nil {
+		return err
+	}
+	osType, err := operatingSystemTypeFromItem(item)
 	if err != nil {
 		return err
 	}
@@ -1372,27 +1764,6 @@ func cmdOSUpdate(s *Session, args []string) error {
 	if err != nil {
 		return err
 	}
-	ipxeScript, err := PromptText("iPXE script or URL (optional)", false)
-	if err != nil {
-		return err
-	}
-	userData, err := PromptText("User data (optional)", false)
-	if err != nil {
-		return err
-	}
-	allowOverrideText, err := PromptText("Allow override? (true/false, blank to keep)", false)
-	if err != nil {
-		return err
-	}
-	phoneHomeText, err := PromptText("Phone home enabled? (true/false, blank to keep)", false)
-	if err != nil {
-		return err
-	}
-	activeText, err := PromptText("Set active? (true/false, blank to keep)", false)
-	if err != nil {
-		return err
-	}
-
 	body := map[string]interface{}{}
 	if strings.TrimSpace(name) != "" {
 		body["name"] = strings.TrimSpace(name)
@@ -1400,21 +1771,50 @@ func cmdOSUpdate(s *Session, args []string) error {
 	if strings.TrimSpace(desc) != "" {
 		body["description"] = strings.TrimSpace(desc)
 	}
-	if strings.TrimSpace(ipxeScript) != "" {
-		body["ipxeScript"] = strings.TrimSpace(ipxeScript)
+
+	switch osType {
+	case operatingSystemTypeIPXE:
+		err = promptRawIPXEOperatingSystemUpdate(body)
+	case operatingSystemTypeImage:
+		err = promptImageOperatingSystemUpdate(body)
+	case operatingSystemTypeTemplatedIPXE:
+		err = promptTemplatedIPXEOperatingSystemUpdate(s, item, body)
+	default:
+		err = fmt.Errorf("unsupported operating system type %q", osType)
 	}
+	if err != nil {
+		return err
+	}
+
+	userData, err := PromptText("User data (optional)", false)
+	if err != nil {
+		return err
+	}
+	allowOverride, hasAllowOverride, err := PromptOptionalBool("Allow override?")
+	if err != nil {
+		return err
+	}
+	phoneHomeEnabled, hasPhoneHomeEnabled, err := PromptOptionalBool("Phone home enabled?")
+	if err != nil {
+		return err
+	}
+	isActive, hasIsActive, err := PromptOptionalBool("Set active?")
+	if err != nil {
+		return err
+	}
+
 	if strings.TrimSpace(userData) != "" {
 		body["userData"] = strings.TrimSpace(userData)
 	}
-	if v, ok := parseOptionalBool(allowOverrideText); ok {
-		body["allowOverride"] = v
+	if hasAllowOverride {
+		body["allowOverride"] = allowOverride
 	}
-	if v, ok := parseOptionalBool(phoneHomeText); ok {
-		body["phoneHomeEnabled"] = v
+	if hasPhoneHomeEnabled {
+		body["phoneHomeEnabled"] = phoneHomeEnabled
 	}
-	if v, ok := parseOptionalBool(activeText); ok {
-		body["isActive"] = v
-		if !v {
+	if hasIsActive {
+		body["isActive"] = isActive
+		if !isActive {
 			note, err := PromptText("Deactivation note (optional)", false)
 			if err != nil {
 				return err
@@ -1427,8 +1827,16 @@ func cmdOSUpdate(s *Session, args []string) error {
 	if len(body) == 0 {
 		return fmt.Errorf("no updates provided")
 	}
-	LogCmd(s, "operating-system", "update", item.ID)
-	bodyJSON, _ := json.Marshal(body)
+	bodyJSON, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("encoding operating system update request: %w", err)
+	}
+	logBodyJSON, err := redactAuthTokenJSON(bodyJSON)
+	if err != nil {
+		return fmt.Errorf("redacting operating system update request for logging: %w", err)
+	}
+	logBody := shellQuoteCLIArg(string(logBodyJSON))
+	LogCmd(s, "operating-system", "update", item.ID, "--data", logBody)
 	resp, _, err := s.Client.Do("PATCH", apiPath(s, "operating-system/{id}"), map[string]string{"id": item.ID}, nil, bodyJSON)
 	if err != nil {
 		return fmt.Errorf("updating operating system: %w", err)
@@ -1440,6 +1848,148 @@ func cmdOSUpdate(s *Session, args []string) error {
 		return err
 	}
 	fmt.Printf("%s Operating system updated: %s (%s)\n", Green("OK"), str(updated, "name"), str(updated, "id"))
+	return nil
+}
+
+func operatingSystemTypeFromItem(item *NamedItem) (string, error) {
+	osType := ""
+	if item.Extra != nil {
+		osType = strings.TrimSpace(item.Extra["type"])
+	}
+	if osType == "" {
+		raw, err := operatingSystemRaw(item)
+		if err != nil {
+			return "", err
+		}
+		osType = strings.TrimSpace(str(raw, "type"))
+	}
+
+	switch {
+	case strings.EqualFold(osType, operatingSystemTypeIPXE):
+		return operatingSystemTypeIPXE, nil
+	case strings.EqualFold(osType, operatingSystemTypeImage):
+		return operatingSystemTypeImage, nil
+	case strings.EqualFold(osType, operatingSystemTypeTemplatedIPXE),
+		strings.EqualFold(osType, operatingSystemAPITypeTemplatedIPXE):
+		return operatingSystemTypeTemplatedIPXE, nil
+	default:
+		return "", fmt.Errorf("operating system %q has unsupported type %q", item.Name, osType)
+	}
+}
+
+func operatingSystemRaw(item *NamedItem) (map[string]interface{}, error) {
+	raw, ok := item.Raw.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("operating system %q has no response object", item.Name)
+	}
+	return raw, nil
+}
+
+func promptRawIPXEOperatingSystemUpdate(body map[string]interface{}) error {
+	ipxeScript, err := PromptText("iPXE script or URL (optional)", false)
+	if err != nil {
+		return err
+	}
+	if strings.TrimSpace(ipxeScript) != "" {
+		body["ipxeScript"] = strings.TrimSpace(ipxeScript)
+	}
+	return nil
+}
+
+func promptImageOperatingSystemUpdate(body map[string]interface{}) error {
+	updateAuth, err := PromptConfirm("Update image authentication?")
+	if err != nil {
+		return err
+	}
+	if updateAuth {
+		authType, authToken, promptErr := promptOptionalAuth(
+			"Image authentication type",
+			"Image auth token",
+		)
+		if promptErr != nil {
+			return promptErr
+		}
+		body["imageAuthType"] = authType
+		body["imageAuthToken"] = authToken
+	}
+
+	updateDisk, err := PromptConfirm("Update image disk?")
+	if err != nil {
+		return err
+	}
+	if updateDisk {
+		imageDisk, promptErr := PromptText("Image disk (blank to clear)", false)
+		if promptErr != nil {
+			return promptErr
+		}
+		body["imageDisk"] = imageDisk
+	}
+
+	return nil
+}
+
+func promptTemplatedIPXEOperatingSystemUpdate(
+	s *Session,
+	item *NamedItem,
+	body map[string]interface{},
+) error {
+	updateParameters, err := PromptConfirm("Update iPXE template parameters?")
+	if err != nil {
+		return err
+	}
+	var template *NamedItem
+	loadTemplate := func() error {
+		if template != nil {
+			return nil
+		}
+		raw, loadErr := operatingSystemRaw(item)
+		if loadErr != nil {
+			return loadErr
+		}
+		templateID := strings.TrimSpace(str(raw, "ipxeTemplateId"))
+		if templateID == "" {
+			return fmt.Errorf("templated iPXE operating system %q has no ipxeTemplateId", item.Name)
+		}
+		templates, loadErr := s.fetchIPXETemplatesForSite("")
+		if loadErr != nil {
+			return fmt.Errorf("fetching ipxe-template: %w", loadErr)
+		}
+		for index := range templates {
+			if templates[index].ID == templateID {
+				template = &templates[index]
+				return nil
+			}
+		}
+		return fmt.Errorf("iPXE template %q used by operating system %q is unavailable", templateID, item.Name)
+	}
+
+	if updateParameters {
+		err = loadTemplate()
+		if err != nil {
+			return err
+		}
+		parameters, promptErr := promptIPXETemplateParameters(template)
+		if promptErr != nil {
+			return promptErr
+		}
+		body["ipxeTemplateParameters"] = parameters
+	}
+
+	updateArtifacts, err := PromptConfirm("Update iPXE template artifacts?")
+	if err != nil {
+		return err
+	}
+	if updateArtifacts {
+		err = loadTemplate()
+		if err != nil {
+			return err
+		}
+		artifacts, promptErr := promptIPXETemplateArtifacts(template)
+		if promptErr != nil {
+			return promptErr
+		}
+		body["ipxeTemplateArtifacts"] = artifacts
+	}
 	return nil
 }
 

--- a/rest-api/cli/tui/commands_test.go
+++ b/rest-api/cli/tui/commands_test.go
@@ -358,6 +358,54 @@ func TestCmdMachineListRendersIPAddresses(t *testing.T) {
 	assert.Empty(t, strings.TrimSpace(blank[ipAddressColumn:statusColumn]))
 }
 
+func TestCmdOSListRendersType(t *testing.T) {
+	cache := NewCache()
+	cache.Set("operating-system", []NamedItem{
+		{
+			Name:   "template-os",
+			ID:     "os-1",
+			Status: "Ready",
+			Extra: map[string]string{
+				"type": "Templated iPXE",
+			},
+		},
+	})
+	session := &Session{
+		Cache: cache,
+	}
+	session.Resolver = NewResolver(cache)
+
+	var runErr error
+	output := captureStdout(func() {
+		runErr = cmdOSList(session, nil)
+	})
+	require.NoError(t, runErr)
+
+	lines := strings.Split(output, "\n")
+	var header string
+	var row string
+	for _, line := range lines {
+		switch {
+		case strings.HasPrefix(line, "NAME"):
+			header = line
+		case strings.HasPrefix(line, "template-os"):
+			row = line
+		}
+	}
+	require.NotEmpty(t, header)
+	require.NotEmpty(t, row)
+
+	statusColumn := strings.Index(header, "STATUS")
+	typeColumn := strings.Index(header, "TYPE")
+	idColumn := strings.Index(header, "ID")
+	require.Greater(t, statusColumn, 0)
+	require.Greater(t, typeColumn, statusColumn)
+	require.Greater(t, idColumn, typeColumn)
+	assert.Equal(t, "Ready", strings.TrimSpace(row[statusColumn:typeColumn]))
+	assert.Equal(t, "Templated iPXE", strings.TrimSpace(row[typeColumn:idColumn]))
+	assert.Equal(t, "os-1", strings.TrimSpace(row[idColumn:]))
+}
+
 // --- VPC scope coverage tests ---
 
 func TestAppendScopeFlags_SiteOnly(t *testing.T) {
@@ -1385,6 +1433,52 @@ func TestPromptSequenceDoesNotConsumeLaterPipedLines(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, "value:true", got)
+}
+
+func TestPromptOptionalBool(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		expected    bool
+		hasExpected bool
+	}{
+		{
+			name:        "blank keeps existing value",
+			input:       "\n",
+			expected:    false,
+			hasExpected: false,
+		},
+		{
+			name:        "yes updates to true",
+			input:       "y\n",
+			expected:    true,
+			hasExpected: true,
+		},
+		{
+			name:        "no updates to false",
+			input:       "n\n",
+			expected:    false,
+			hasExpected: true,
+		},
+		{
+			name:        "invalid input retries",
+			input:       "maybe\nyes\n",
+			expected:    true,
+			hasExpected: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			result, err := withStdin(t, test.input, func() (string, error) {
+				value, hasValue, promptErr := PromptOptionalBool("Update value?")
+				return fmt.Sprintf("%t:%t", value, hasValue), promptErr
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("%t:%t", test.expected, test.hasExpected), result)
+		})
+	}
 }
 
 func TestReadPromptLinePreservesNonEOFReadError(t *testing.T) {

--- a/rest-api/cli/tui/prompt.go
+++ b/rest-api/cli/tui/prompt.go
@@ -65,29 +65,72 @@ func PromptConfirm(label string) (bool, error) {
 	return answer == "y" || answer == "yes", nil
 }
 
-// PromptChoice displays a label with a list of options and reads a selection.
-// If the user enters an empty string and a default is provided, the default is
-// returned. Input matching is case-insensitive and the canonical option value
-// is returned. A non-empty defaultValue must appear in options (case
-// insensitively) or PromptChoice returns an error before prompting -- a
-// misconfigured default must not be able to bypass choice validation.
+// PromptOptionalBool displays a yes/no prompt where blank means no update.
+func PromptOptionalBool(label string) (bool, bool, error) {
+	for {
+		fmt.Printf("%s [y/n, blank to keep] ", Bold(label))
+		input, err := readPromptLine()
+		if err != nil {
+			return false, false, err
+		}
+		answer := strings.TrimSpace(strings.ToLower(input))
+		switch answer {
+		case "":
+			return false, false, nil
+		case "y", "yes":
+			return true, true, nil
+		case "n", "no":
+			return false, true, nil
+		default:
+			fmt.Println(Red("  (enter y, n, or leave blank to keep)"))
+		}
+	}
+}
+
+// PromptChoice displays an interactive selector when attached to a terminal.
+// Piped input uses a line-oriented prompt so commands remain scriptable and
+// tests can supply deterministic input. Input matching is case-insensitive and
+// returns the canonical option value. When provided, the default is selected
+// initially in the menu and accepted for empty piped input.
 func PromptChoice(label string, options []string, defaultValue string) (string, error) {
 	if len(options) == 0 {
 		return "", fmt.Errorf("no options provided")
 	}
+	defaultIndex := -1
 	if defaultValue != "" {
-		canonical := ""
-		for _, opt := range options {
+		for index, opt := range options {
 			if strings.EqualFold(defaultValue, opt) {
-				canonical = opt
+				defaultIndex = index
+				defaultValue = opt
 				break
 			}
 		}
-		if canonical == "" {
+		if defaultIndex < 0 {
 			return "", fmt.Errorf("default value %q is not in allowed options %v", defaultValue, options)
 		}
-		defaultValue = canonical
 	}
+
+	if term.IsTerminal(int(os.Stdin.Fd())) && term.IsTerminal(int(os.Stdout.Fd())) {
+		menuOptions := append([]string(nil), options...)
+		if defaultIndex > 0 {
+			defaultOption := menuOptions[defaultIndex]
+			copy(menuOptions[1:defaultIndex+1], menuOptions[:defaultIndex])
+			menuOptions[0] = defaultOption
+		}
+		items := make([]SelectItem, len(menuOptions))
+		for index, option := range menuOptions {
+			items[index] = SelectItem{
+				Label: option,
+				ID:    option,
+			}
+		}
+		selected, err := Select(label, items)
+		if err != nil {
+			return "", err
+		}
+		return selected.ID, nil
+	}
+
 	display := strings.Join(options, "/")
 	suffix := fmt.Sprintf("[%s]", display)
 	if defaultValue != "" {

--- a/rest-api/cli/tui/regression_specialized_test.go
+++ b/rest-api/cli/tui/regression_specialized_test.go
@@ -6,6 +6,7 @@ package tui
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -315,6 +316,883 @@ func TestSpecializedCommands_MutationsRequireConfirmation(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPromptOperatingSystemTypePrefersTenantRole(t *testing.T) {
+	var providerCalls atomic.Int32
+	var tenantCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/org/acme/nico/infrastructure-provider/current":
+			providerCalls.Add(1)
+			_, _ = io.WriteString(w, `{"id":"provider-1"}`)
+		case "/v2/org/acme/nico/tenant/current":
+			tenantCalls.Add(1)
+			_, _ = io.WriteString(w, `{"id":"tenant-1"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := appcli.NewClient(server.URL, "acme", "token", nil, false)
+	session := NewSession(client, "acme", "")
+	output, err := runSpecializedCommandWithInput(t, operatingSystemTypeImage+"\n", func() error {
+		operatingSystemType, promptErr := promptOperatingSystemType(session, context.Background())
+		assert.Equal(t, operatingSystemTypeImage, operatingSystemType)
+		return promptErr
+	})
+
+	require.NoError(t, err)
+	assert.Contains(t, output, "[iPXE/Image/Templated iPXE]")
+	assert.Equal(t, int32(0), providerCalls.Load())
+	assert.Equal(t, int32(1), tenantCalls.Load())
+}
+
+func TestPromptOperatingSystemTypeStopsOnUnexpectedTenantError(t *testing.T) {
+	var providerCalls atomic.Int32
+	var tenantCalls atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v2/org/acme/nico/infrastructure-provider/current":
+			providerCalls.Add(1)
+			_, _ = io.WriteString(w, `{"id":"provider-1"}`)
+		case "/v2/org/acme/nico/tenant/current":
+			tenantCalls.Add(1)
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = io.WriteString(w, `{"message":"unauthorized"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := appcli.NewClient(server.URL, "acme", "token", nil, false)
+	session := NewSession(client, "acme", "")
+	_, err := promptOperatingSystemType(session, context.Background())
+
+	require.Error(t, err)
+	assert.ErrorContains(t, err, "determining operating system owner type")
+	apiErr := &appcli.APIError{}
+	require.ErrorAs(t, err, &apiErr)
+	assert.Equal(t, http.StatusUnauthorized, apiErr.StatusCode)
+	assert.Equal(t, int32(0), providerCalls.Load())
+	assert.Equal(t, int32(1), tenantCalls.Load())
+}
+
+func TestCmdOSCreate(t *testing.T) {
+	const (
+		siteID         = "497f6eca-6276-4993-bfeb-53cbbbba6f08"
+		templateID     = "6c2ac315-3040-4728-94eb-b66d320206c1"
+		rootFSID       = "666c2eee-193d-42db-a490-4c444342bd4e"
+		imageSHA       = "a1efca12ea51069abb123bf9c77889fcc2a31cc5483fc14d115e44fdf07c7980"
+		createdOSReply = `{"id":"os-1","name":"created-os"}`
+	)
+	tests := []struct {
+		name                      string
+		provider                  bool
+		tenantForbidden           bool
+		input                     string
+		expectedBody              string
+		expectedSiteCalls         int32
+		expectedTemplateCalls     int32
+		templateRequiredParams    []string
+		templateRequiredArtifacts []string
+		expectedOutput            []string
+		unexpectedOutput          []string
+	}{
+		{
+			name:     "tenant raw iPXE prompts for script and shared options",
+			provider: false,
+			input: strings.Join([]string{
+				"raw-ipxe-os",
+				"Raw iPXE description",
+				operatingSystemTypeIPXE,
+				"#!ipxe",
+				"#cloud-config",
+				"y",
+				"n",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"raw-ipxe-os",
+				"description":"Raw iPXE description",
+				"ipxeScript":"#!ipxe",
+				"userData":"#cloud-config",
+				"allowOverride":true,
+				"phoneHomeEnabled":false
+			}`,
+			expectedOutput: []string{
+				"[iPXE/Image/Templated iPXE]",
+				"iPXE script or URL",
+				"User data (optional)",
+			},
+			unexpectedOutput: []string{
+				"Site One",
+				"Image URL",
+			},
+		},
+		{
+			name:     "tenant templated iPXE selects site and template then shared options",
+			provider: false,
+			input: strings.Join([]string{
+				"templated-ipxe-os",
+				"Templated iPXE description",
+				operatingSystemTypeTemplatedIPXE,
+				"#cloud-config",
+				"n",
+				"y",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"templated-ipxe-os",
+				"description":"Templated iPXE description",
+				"siteIds":["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+				"ipxeTemplateId":"6c2ac315-3040-4728-94eb-b66d320206c1",
+				"userData":"#cloud-config",
+				"allowOverride":false,
+				"phoneHomeEnabled":true
+			}`,
+			expectedSiteCalls:     1,
+			expectedTemplateCalls: 1,
+			expectedOutput: []string{
+				"[iPXE/Image/Templated iPXE]",
+				"Site One",
+				"Ubuntu Template",
+				"User data (optional)",
+			},
+			unexpectedOutput: []string{
+				"iPXE script or URL",
+				"Image URL",
+			},
+		},
+		{
+			name:     "tenant templated iPXE collects required parameters and artifacts",
+			provider: false,
+			input: strings.Join([]string{
+				"templated-ipxe-requirements-os",
+				"",
+				operatingSystemTypeTemplatedIPXE,
+				"",
+				"console=ttyS0",
+				"install",
+				"https://example.com/kernel",
+				imageSHA,
+				authTypeBearer,
+				"",
+				"artifact-secret",
+				artifactCacheStrategyAsNeeded,
+				"https://example.com/initrd",
+				"",
+				authTypeNone,
+				artifactCacheStrategyRemoteOnly,
+				"",
+				"n",
+				"y",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"templated-ipxe-requirements-os",
+				"siteIds":["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+				"ipxeTemplateId":"6c2ac315-3040-4728-94eb-b66d320206c1",
+				"ipxeTemplateParameters":[
+					{"name":"kernel_args","value":"console=ttyS0"},
+					{"name":"mode","value":"install"}
+				],
+				"ipxeTemplateArtifacts":[
+					{
+						"name":"kernel",
+						"url":"https://example.com/kernel",
+						"sha":"a1efca12ea51069abb123bf9c77889fcc2a31cc5483fc14d115e44fdf07c7980",
+						"authType":"Bearer",
+						"authToken":"artifact-secret",
+						"cacheStrategy":"CacheAsNeeded"
+					},
+					{
+						"name":"initrd",
+						"url":"https://example.com/initrd",
+						"cacheStrategy":"RemoteOnly"
+					}
+				],
+				"allowOverride":false,
+				"phoneHomeEnabled":true
+			}`,
+			expectedSiteCalls:         1,
+			expectedTemplateCalls:     1,
+			templateRequiredParams:    []string{"kernel_args", "mode"},
+			templateRequiredArtifacts: []string{"kernel", "initrd"},
+			expectedOutput: []string{
+				"Value for parameter kernel_args",
+				"Value for parameter mode",
+				"URL for artifact kernel",
+				"SHA for artifact kernel (optional)",
+				"Auth type for artifact kernel",
+				"Auth token for artifact kernel",
+				"Cache strategy for artifact kernel",
+				"URL for artifact initrd",
+				"SHA for artifact initrd (optional)",
+				"Auth type for artifact initrd",
+				"Cache strategy for artifact initrd",
+				"(required)",
+				`"name":"templated-ipxe-requirements-os"`,
+				`"authToken":"<redacted>"`,
+				`"cacheStrategy":"CacheAsNeeded"`,
+			},
+			unexpectedOutput: []string{
+				"Auth token for artifact initrd",
+				"artifact-secret",
+				"--data '<redacted>'",
+			},
+		},
+		{
+			name:            "provider defaults to templated iPXE",
+			provider:        true,
+			tenantForbidden: true,
+			input: strings.Join([]string{
+				"provider-template-os",
+				"",
+				"",
+				"y",
+				"n",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"provider-template-os",
+				"siteIds":["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+				"ipxeTemplateId":"6c2ac315-3040-4728-94eb-b66d320206c1",
+				"allowOverride":true,
+				"phoneHomeEnabled":false
+			}`,
+			expectedSiteCalls:     1,
+			expectedTemplateCalls: 1,
+			expectedOutput: []string{
+				"default for providers",
+				"Site One",
+				"Ubuntu Template",
+				"User data (optional)",
+			},
+			unexpectedOutput: []string{
+				"[iPXE/Image/Templated iPXE]",
+				"iPXE script or URL",
+				"Image URL",
+			},
+		},
+		{
+			name:     "tenant image selects root filesystem ID",
+			provider: false,
+			input: strings.Join([]string{
+				"image-id-os",
+				"Image description",
+				operatingSystemTypeImage,
+				"https://example.com/images/os.qcow2",
+				imageSHA,
+				rootFilesystemTypeID,
+				rootFSID,
+				authTypeNone,
+				"",
+				"hostname: image-host",
+				"y",
+				"y",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"image-id-os",
+				"description":"Image description",
+				"siteIds":["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+				"imageUrl":"https://example.com/images/os.qcow2",
+				"imageSha":"a1efca12ea51069abb123bf9c77889fcc2a31cc5483fc14d115e44fdf07c7980",
+				"rootFsId":"666c2eee-193d-42db-a490-4c444342bd4e",
+				"userData":"hostname: image-host",
+				"allowOverride":true,
+				"phoneHomeEnabled":true
+			}`,
+			expectedSiteCalls: 1,
+			expectedOutput: []string{
+				"Site One",
+				"Image URL",
+				"Image SHA",
+				"Specify root filesystem by",
+				"Root filesystem ID",
+				"Image authentication type",
+				"Image disk (optional)",
+				"User data (optional)",
+				"Allow override at instance creation?",
+				"Enable phone home?",
+			},
+			unexpectedOutput: []string{
+				"Root filesystem label",
+				"Image auth token",
+			},
+		},
+		{
+			name:     "tenant image selects root filesystem label",
+			provider: false,
+			input: strings.Join([]string{
+				"image-label-os",
+				"",
+				operatingSystemTypeImage,
+				"https://example.com/images/os.qcow2",
+				imageSHA,
+				rootFilesystemTypeLabel,
+				"rootfs",
+				authTypeNone,
+				"",
+				"",
+				"n",
+				"n",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"image-label-os",
+				"siteIds":["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+				"imageUrl":"https://example.com/images/os.qcow2",
+				"imageSha":"a1efca12ea51069abb123bf9c77889fcc2a31cc5483fc14d115e44fdf07c7980",
+				"rootFsLabel":"rootfs",
+				"allowOverride":false,
+				"phoneHomeEnabled":false
+			}`,
+			expectedSiteCalls: 1,
+			expectedOutput: []string{
+				"Site One",
+				"Root filesystem label",
+				"Image authentication type",
+				"Image disk (optional)",
+				"User data (optional)",
+			},
+			unexpectedOutput: []string{
+				"Root filesystem ID",
+				"Image auth token",
+			},
+		},
+		{
+			name:     "tenant image requires Basic auth token and accepts image disk",
+			provider: false,
+			input: strings.Join([]string{
+				"image-basic-os",
+				"",
+				operatingSystemTypeImage,
+				"https://example.com/images/os.qcow2",
+				imageSHA,
+				rootFilesystemTypeID,
+				rootFSID,
+				authTypeBasic,
+				"",
+				"basic-secret",
+				"/dev/sda",
+				"",
+				"n",
+				"n",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"image-basic-os",
+				"siteIds":["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+				"imageUrl":"https://example.com/images/os.qcow2",
+				"imageSha":"a1efca12ea51069abb123bf9c77889fcc2a31cc5483fc14d115e44fdf07c7980",
+				"rootFsId":"666c2eee-193d-42db-a490-4c444342bd4e",
+				"imageAuthType":"Basic",
+				"imageAuthToken":"basic-secret",
+				"imageDisk":"/dev/sda",
+				"allowOverride":false,
+				"phoneHomeEnabled":false
+			}`,
+			expectedSiteCalls: 1,
+			expectedOutput: []string{
+				"Image authentication type",
+				"Image auth token",
+				"(required)",
+				"Image disk (optional)",
+				`"name":"image-basic-os"`,
+				`"imageAuthToken":"<redacted>"`,
+				`"imageDisk":"/dev/sda"`,
+			},
+			unexpectedOutput: []string{
+				"basic-secret",
+				"--data '<redacted>'",
+			},
+		},
+		{
+			name:     "tenant image accepts Bearer auth without image disk",
+			provider: false,
+			input: strings.Join([]string{
+				"image-bearer-os",
+				"",
+				operatingSystemTypeImage,
+				"https://example.com/images/os.qcow2",
+				imageSHA,
+				rootFilesystemTypeLabel,
+				"rootfs",
+				authTypeBearer,
+				"bearer-secret",
+				"",
+				"",
+				"n",
+				"n",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"image-bearer-os",
+				"siteIds":["497f6eca-6276-4993-bfeb-53cbbbba6f08"],
+				"imageUrl":"https://example.com/images/os.qcow2",
+				"imageSha":"a1efca12ea51069abb123bf9c77889fcc2a31cc5483fc14d115e44fdf07c7980",
+				"rootFsLabel":"rootfs",
+				"imageAuthType":"Bearer",
+				"imageAuthToken":"bearer-secret",
+				"allowOverride":false,
+				"phoneHomeEnabled":false
+			}`,
+			expectedSiteCalls: 1,
+			expectedOutput: []string{
+				"Image authentication type",
+				"Image auth token",
+				"Image disk (optional)",
+				`"name":"image-bearer-os"`,
+				`"imageAuthToken":"<redacted>"`,
+				`"rootFsLabel":"rootfs"`,
+			},
+			unexpectedOutput: []string{
+				"bearer-secret",
+				"--data '<redacted>'",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var providerCalls atomic.Int32
+			var tenantCalls atomic.Int32
+			var siteCalls atomic.Int32
+			var templateCalls atomic.Int32
+			var createCalls atomic.Int32
+			createdBodies := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/org/acme/nico/infrastructure-provider/current":
+					providerCalls.Add(1)
+					if test.provider {
+						_, _ = io.WriteString(w, `{"id":"provider-1"}`)
+						return
+					}
+					w.WriteHeader(http.StatusForbidden)
+					_, _ = io.WriteString(w, `{"message":"not a provider"}`)
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/org/acme/nico/tenant/current":
+					tenantCalls.Add(1)
+					if test.tenantForbidden {
+						w.WriteHeader(http.StatusForbidden)
+						_, _ = io.WriteString(w, `{"message":"not a tenant"}`)
+						return
+					}
+					_, _ = io.WriteString(w, `{"id":"tenant-1"}`)
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/org/acme/nico/site":
+					siteCalls.Add(1)
+					_, _ = io.WriteString(w, `[{"id":"`+siteID+`","name":"Site One","status":"Registered"}]`)
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/org/acme/nico/ipxe-template":
+					templateCalls.Add(1)
+					assert.Equal(t, siteID, r.URL.Query().Get("siteId"))
+					templateResponse := map[string]interface{}{
+						"id":                templateID,
+						"name":              "Ubuntu Template",
+						"visibility":        "Public",
+						"requiredParams":    test.templateRequiredParams,
+						"requiredArtifacts": test.templateRequiredArtifacts,
+					}
+					encodeErr := json.NewEncoder(w).Encode([]map[string]interface{}{templateResponse})
+					require.NoError(t, encodeErr)
+				case r.Method == http.MethodPost && r.URL.Path == "/v2/org/acme/nico/operating-system":
+					createCalls.Add(1)
+					requestBody, readErr := io.ReadAll(r.Body)
+					if readErr != nil {
+						http.Error(w, readErr.Error(), http.StatusInternalServerError)
+						return
+					}
+					createdBodies <- string(requestBody)
+					w.WriteHeader(http.StatusCreated)
+					_, _ = io.WriteString(w, createdOSReply)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			session := NewSession(
+				appcli.NewClient(server.URL, "acme", "token", nil, false),
+				"acme",
+				"",
+			)
+			output, err := runSpecializedCommandWithInput(t, test.input, func() error {
+				return cmdOSCreate(session, nil)
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, int32(1), tenantCalls.Load())
+			if test.tenantForbidden {
+				assert.Equal(t, int32(1), providerCalls.Load())
+			} else {
+				assert.Equal(t, int32(0), providerCalls.Load())
+			}
+			assert.Equal(t, test.expectedSiteCalls, siteCalls.Load())
+			assert.Equal(t, test.expectedTemplateCalls, templateCalls.Load())
+			assert.Equal(t, int32(1), createCalls.Load())
+			assert.JSONEq(t, test.expectedBody, <-createdBodies)
+			assert.Contains(t, output, "Operating system created: created-os (os-1)")
+			for _, expected := range test.expectedOutput {
+				assert.Contains(t, output, expected)
+			}
+			for _, unexpected := range test.unexpectedOutput {
+				assert.NotContains(t, output, unexpected)
+			}
+		})
+	}
+}
+
+func TestCmdOSUpdatePromptsForTypeSpecificFields(t *testing.T) {
+	const (
+		operatingSystemID = "9c8f3d62-7c95-4d1c-9f91-924a7e0f31c4"
+		templateID        = "6c2ac315-3040-4728-94eb-b66d320206c1"
+	)
+	tests := []struct {
+		name                  string
+		osType                string
+		templateID            string
+		input                 string
+		expectedBody          string
+		expectedTemplateCalls int32
+		expectedOutput        []string
+		unexpectedOutput      []string
+	}{
+		{
+			name:   "raw iPXE offers script update only",
+			osType: operatingSystemTypeIPXE,
+			input: strings.Join([]string{
+				"",
+				"",
+				"#!ipxe updated",
+				"",
+				"",
+				"",
+				"",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"ipxeScript":"#!ipxe updated"
+			}`,
+			expectedOutput: []string{
+				"iPXE script or URL (optional)",
+			},
+			unexpectedOutput: []string{
+				"Update image authentication?",
+				"Update iPXE template parameters?",
+			},
+		},
+		{
+			name:   "boolean updates accept yes and no while blank keeps the field",
+			osType: operatingSystemTypeIPXE,
+			input: strings.Join([]string{
+				"",
+				"",
+				"",
+				"",
+				"y",
+				"n",
+				"",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"allowOverride":true,
+				"phoneHomeEnabled":false
+			}`,
+			expectedOutput: []string{
+				"Allow override?",
+				"Phone home enabled?",
+				"Set active?",
+				"[y/n, blank to keep]",
+			},
+			unexpectedOutput: []string{
+				`"isActive"`,
+			},
+		},
+		{
+			name:   "image offers supported image-specific update fields",
+			osType: operatingSystemTypeImage,
+			input: strings.Join([]string{
+				"",
+				"",
+				"y",
+				authTypeBasic,
+				"rotated-token",
+				"y",
+				"/dev/sdb",
+				"",
+				"",
+				"",
+				"",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"imageAuthType":"Basic",
+				"imageAuthToken":"rotated-token",
+				"imageDisk":"/dev/sdb"
+			}`,
+			expectedOutput: []string{
+				"Update image authentication?",
+				"Image authentication type",
+				"Image auth token",
+				"Update image disk?",
+				"Image disk (blank to clear)",
+				`"imageAuthToken":"<redacted>"`,
+			},
+			unexpectedOutput: []string{
+				"iPXE script or URL (optional)",
+				"Update iPXE template parameters?",
+				"Update root filesystem?",
+				"Specify root filesystem by",
+				"Root filesystem ID",
+				"Root filesystem label",
+				"rotated-token",
+				"--data '<redacted>'",
+			},
+		},
+		{
+			name:       "templated iPXE offers template parameters and artifacts",
+			osType:     operatingSystemAPITypeTemplatedIPXE,
+			templateID: templateID,
+			input: strings.Join([]string{
+				"",
+				"",
+				"y",
+				"https://example.com/kernel",
+				"y",
+				"https://example.com/initrd",
+				"",
+				authTypeNone,
+				artifactCacheStrategyRemoteOnly,
+				"",
+				"",
+				"",
+				"",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"ipxeTemplateParameters":[
+					{"name":"kernel_url","value":"https://example.com/kernel"}
+				],
+				"ipxeTemplateArtifacts":[
+					{
+						"name":"initrd",
+						"url":"https://example.com/initrd",
+						"cacheStrategy":"RemoteOnly"
+					}
+				]
+			}`,
+			expectedTemplateCalls: 1,
+			expectedOutput: []string{
+				"Update iPXE template parameters?",
+				"Value for parameter kernel_url",
+				"Update iPXE template artifacts?",
+				"URL for artifact initrd",
+				"Cache strategy for artifact initrd",
+			},
+			unexpectedOutput: []string{
+				"iPXE script or URL (optional)",
+				"Update image authentication?",
+			},
+		},
+		{
+			name:       "templated iPXE updates parameters independently",
+			osType:     operatingSystemAPITypeTemplatedIPXE,
+			templateID: templateID,
+			input: strings.Join([]string{
+				"",
+				"",
+				"y",
+				"https://example.com/kernel",
+				"n",
+				"",
+				"",
+				"",
+				"",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"ipxeTemplateParameters":[
+					{"name":"kernel_url","value":"https://example.com/kernel"}
+				]
+			}`,
+			expectedTemplateCalls: 1,
+			expectedOutput: []string{
+				"Update iPXE template parameters?",
+				"Value for parameter kernel_url",
+				"Update iPXE template artifacts?",
+			},
+			unexpectedOutput: []string{
+				"URL for artifact initrd",
+				`"ipxeTemplateArtifacts"`,
+			},
+		},
+		{
+			name:       "templated iPXE updates artifacts independently",
+			osType:     operatingSystemAPITypeTemplatedIPXE,
+			templateID: templateID,
+			input: strings.Join([]string{
+				"",
+				"",
+				"n",
+				"y",
+				"https://example.com/initrd",
+				"",
+				authTypeNone,
+				artifactCacheStrategyRemoteOnly,
+				"",
+				"",
+				"",
+				"",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"ipxeTemplateArtifacts":[
+					{
+						"name":"initrd",
+						"url":"https://example.com/initrd",
+						"cacheStrategy":"RemoteOnly"
+					}
+				]
+			}`,
+			expectedTemplateCalls: 1,
+			expectedOutput: []string{
+				"Update iPXE template parameters?",
+				"Update iPXE template artifacts?",
+				"URL for artifact initrd",
+				"Cache strategy for artifact initrd",
+			},
+			unexpectedOutput: []string{
+				"Value for parameter kernel_url",
+				`"ipxeTemplateParameters"`,
+			},
+		},
+		{
+			name:       "templated iPXE skips template lookup when updates are declined",
+			osType:     operatingSystemAPITypeTemplatedIPXE,
+			templateID: templateID,
+			input: strings.Join([]string{
+				"renamed-template-os",
+				"",
+				"n",
+				"n",
+				"",
+				"",
+				"",
+				"",
+			}, "\n") + "\n",
+			expectedBody: `{
+				"name":"renamed-template-os"
+			}`,
+			expectedOutput: []string{
+				"Update iPXE template parameters?",
+				"Update iPXE template artifacts?",
+			},
+			unexpectedOutput: []string{
+				"Value for parameter kernel_url",
+				"URL for artifact initrd",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var templateCalls atomic.Int32
+			var updateCalls atomic.Int32
+			updatedBodies := make(chan string, 1)
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				switch {
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/org/acme/nico/operating-system":
+					response := map[string]interface{}{
+						"id":     operatingSystemID,
+						"name":   "update-os",
+						"status": "Ready",
+						"type":   test.osType,
+					}
+					if test.templateID != "" {
+						response["ipxeTemplateId"] = test.templateID
+					}
+					encodeErr := json.NewEncoder(w).Encode([]map[string]interface{}{response})
+					require.NoError(t, encodeErr)
+				case r.Method == http.MethodGet && r.URL.Path == "/v2/org/acme/nico/ipxe-template":
+					templateCalls.Add(1)
+					assert.Empty(t, r.URL.Query().Get("siteId"))
+					response := map[string]interface{}{
+						"id":                templateID,
+						"name":              "Ubuntu Template",
+						"visibility":        "Public",
+						"requiredParams":    []string{"kernel_url"},
+						"requiredArtifacts": []string{"initrd"},
+					}
+					encodeErr := json.NewEncoder(w).Encode([]map[string]interface{}{response})
+					require.NoError(t, encodeErr)
+				case r.Method == http.MethodPatch && r.URL.Path == "/v2/org/acme/nico/operating-system/"+operatingSystemID:
+					updateCalls.Add(1)
+					requestBody, readErr := io.ReadAll(r.Body)
+					require.NoError(t, readErr)
+					updatedBodies <- string(requestBody)
+					_, _ = io.WriteString(w, `{"id":"`+operatingSystemID+`","name":"update-os"}`)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
+
+			session := NewSession(
+				appcli.NewClient(server.URL, "acme", "token", nil, false),
+				"acme",
+				"",
+			)
+			output, err := runSpecializedCommandWithInput(t, test.input, func() error {
+				return cmdOSUpdate(session, []string{"update-os"})
+			})
+
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedTemplateCalls, templateCalls.Load())
+			assert.Equal(t, int32(1), updateCalls.Load())
+			assert.JSONEq(t, test.expectedBody, <-updatedBodies)
+			expectedLogBody, redactErr := redactAuthTokenJSON([]byte(test.expectedBody))
+			require.NoError(t, redactErr)
+			assert.Contains(t, output, "--data "+shellQuoteCLIArg(string(expectedLogBody)))
+			assert.Contains(t, output, "Operating system updated: update-os ("+operatingSystemID+")")
+			for _, expected := range test.expectedOutput {
+				assert.Contains(t, output, expected)
+			}
+			for _, unexpected := range test.unexpectedOutput {
+				assert.NotContains(t, output, unexpected)
+			}
+		})
+	}
+}
+
+func TestRedactAuthTokenJSON(t *testing.T) {
+	original := []byte(`{
+		"name":"visible-name",
+		"imageAuthToken":"image-secret",
+		"unrelated":"image-secret",
+		"ipxeTemplateArtifacts":[
+			{
+				"name":"kernel",
+				"url":"https://example.com/kernel",
+				"authType":"Bearer",
+				"authToken":"artifact-secret"
+			}
+		]
+	}`)
+
+	redacted, err := redactAuthTokenJSON(original)
+	require.NoError(t, err)
+	assert.JSONEq(t, `{
+		"name":"visible-name",
+		"imageAuthToken":"<redacted>",
+		"unrelated":"image-secret",
+		"ipxeTemplateArtifacts":[
+			{
+				"name":"kernel",
+				"url":"https://example.com/kernel",
+				"authType":"Bearer",
+				"authToken":"<redacted>"
+			}
+		]
+	}`, string(redacted))
+	assert.Contains(t, string(original), `"imageAuthToken":"image-secret"`)
+	assert.Contains(t, string(original), `"authToken":"artifact-secret"`)
+
+	redacted, err = redactAuthTokenJSON([]byte(`{"name":`))
+	assert.Nil(t, redacted)
+	assert.Error(t, err)
 }
 
 func TestSpecializedScopeSelection_ClearsDependentScopeAndCache(t *testing.T) {

--- a/rest-api/cli/tui/session.go
+++ b/rest-api/cli/tui/session.go
@@ -543,7 +543,12 @@ func (s *Session) fetchOperatingSystems(_ context.Context) ([]NamedItem, error) 
 	}
 	result := make([]NamedItem, len(items))
 	for i, m := range items {
-		result[i] = NamedItem{Name: str(m, "name"), ID: str(m, "id"), Status: str(m, "status"), Raw: m}
+		result[i] = NamedItem{
+			Name:   str(m, "name"),
+			ID:     str(m, "id"),
+			Status: str(m, "status"),
+			Extra:  map[string]string{"type": str(m, "type")}, Raw: m,
+		}
 	}
 	return result, nil
 }
@@ -1056,9 +1061,13 @@ func (s *Session) fetchDPUExtensionServices(_ context.Context) ([]NamedItem, err
 }
 
 func (s *Session) fetchIPXETemplates(_ context.Context) ([]NamedItem, error) {
+	return s.fetchIPXETemplatesForSite(s.Scope.SiteID)
+}
+
+func (s *Session) fetchIPXETemplatesForSite(siteID string) ([]NamedItem, error) {
 	q := map[string]string{}
-	if s.Scope.SiteID != "" {
-		q["siteId"] = s.Scope.SiteID
+	if siteID != "" {
+		q["siteId"] = siteID
 	}
 	items, err := s.fetchAll(apiPath(s, "ipxe-template"), q)
 	if err != nil {


### PR DESCRIPTION
When tenant users create a new operating system via the TUI, after specifying the name and description, they are now asked to choose the OS type (iPXE, template-based iPXE, or image-based). Provider users are only allowed to create template-based iPXE operating systems. Depending upon which OS type is selected, the user is then guided to fill out additional fields.

For image-based OSes, the list of additional fields is:
- Image URL
- Image SHA
- Root filesystem ID OR root filesystem label
- Image authentication type (dropdown list of None, Bearer, or Basic)
- Image auth token (input is hidden)
- Image disk
- siteIds (single valued, inferred from context)
- user data
- phone home enabled
- allow override (of user data)

The flow looks like this:
```
nico:test-org> operating-system create
Operating system name: new image-based OS
Description (optional): test description
Operating system type Image
Site: local-dev-site (auto-selected)
Image URL: https://saimei.ftp.acc.umu.se/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2 
Image SHA: 2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae
Specify root filesystem by ID
Root filesystem ID: 6c2ac315-3040-4728-94eb-b66d320206c1
Image authentication type Bearer
Image auth token: 
Image disk (optional): /dev/sda
User data (optional): 
Allow override at instance creation? [y/N] y
Enable phone home? [y/N] N
```

For template-based OSes, the list of additional fields is:
- iPXE template Id (dropdown select with names of templates)
- value of each required parameter within the selected iPXE template
- for each required artifact in the selected iPXE template
        * URL of artifact
        * SHA of artifact (optional)
        * authentication type for artifact (dropdown list of None, Bearer, or Basic)
        *  auth token for artifact (input is hidden)
        * cache strategy for artifact (dropdown list of Cache as needed, Local only, cached only, and remote only)
- user data
- phone home enabled
- allow override (of user data)
- siteIds (single valued, inferred from context)

The flow looks like this for a template with two required parameters (kernel_url and initrd_url) and two required artifacts (kernel and initrd).
```
nico:test-org> operating-system create
Operating system name: new os from ipxe template
Description (optional): a description here
Operating system type Templated iPXE
Site: local-dev-site (auto-selected)
iPXE template: ubuntu-autoinstall  Public
Value for parameter kernel_url: www.junkvalue.com
Value for parameter initrd_url: www.othervalue.com
URL for artifact kernel: https://www.testkernel.com
SHA for artifact kernel (optional): 
Auth type for artifact kernel None
Cache strategy for artifact kernel Cache as needed
URL for artifact initrd: https://www.testing.org
SHA for artifact initrd (optional): 2cf24dba4f21d4288094c30e2ede82c380cac19544bb5c4ab02f5b2db38500d3
Auth type for artifact initrd Basic
Auth token for artifact initrd: 
Cache strategy for artifact initrd Cached only
User data (optional): 
Allow override at instance creation? [y/N] y
Enable phone home? [y/N] N
```

Options for iPXE-based templates remain the same.

During the `operating-system update` operation, which fields the user is given the option to update will depend on the OS type of the selected OS.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/5727

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The following minor changes were also added:
- The REST API errors for specifying fields specific to image-based OSes while updating an iPXE or templated OS are now more accurate, no longer implying that the user specified `imageURL` when they may not have done so.
- 
- The `operating-system list` command output now has a new column that has the type of the operating system (iPXE, templated iPXE, or Image). The result looks like this:
```
NAME                      STATUS    TYPE            ID
tui-test-os               Ready     iPXE            084f1d37-d7a0-4d3f-ad85-acd3ac3f0992
testing only              Ready     iPXE            3c953ebf-8407-4397-a94d-bc59643bd0d0
templated-ipxe-cli-test   Syncing   TemplatedIpxe   ca37e3ed-f84c-4d0e-b3be-81d52d5d8b18
test new name             Syncing   TemplatedIpxe   ec8967f9-2517-4c8a-8f43-4f97a92469e1
sdf                       Syncing   TemplatedIpxe   7dc53aac-9046-4dc1-8835-6da71212c48e
new os                    Ready     iPXE            25b4791c-d2fd-42bd-89cb-d17abbcf954d
new template              Error     TemplatedIpxe   cd6c03ba-11ff-4ca6-81e8-e9f95efbcf60
```
- The `operating-system create` command no longer sends the deprecated `tenantId` parameter because the REST API infers it from the organization.
- The `operating-system create`  and `operating-system update` commands now list the full set of information (minus auth tokens, which are redacted) sent to the REST API as part of its logging output, whereas before it just sent the name.

before:
```
INFO: cli --config ~/.nico/config.prod.yaml operating-system create --name new iPXE OS
```

after:
```
INFO: cli --config ~/.nico/config.prod.yaml operating-system create --data '{"description":"test description","imageAuthToken":"<redacted>","imageAuthType":"Bearer","imageDisk":"/dev/sda","imageSha":"2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae","imageUrl":"https://saimei.ftp.acc.umu.se/images/cloud/bookworm/latest/debian-12-generic-amd64.qcow2","name":"new image-based OS","rootFsId":"6c2ac315-3040-4728-94eb-b66d320206c1","siteIds":["bffe764c-fdd4-4f42-a42e-05c3100e17f3"]}'
```
