### PR TITLE
Remove Hide Port2 PF from DPU Flavor

### DIFF
--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -769,10 +769,6 @@ fn bf4_astra_ew_nic_configurations() -> Vec<DpuFlavorEwNicConfigurations> {
                 name: "LINK_TYPE_P1".to_string(),
                 value: "2".to_string(),
             },
-            DpuFlavorEwNicConfigurationsRawNvConfig {
-                name: "HIDE_PORT2_PF".to_string(),
-                value: "1".to_string(),
-            },
         ]),
         spectrum_x_optimized: Some(DpuFlavorEwNicConfigurationsSpectrumXOptimized {
             enabled: true,


### PR DESCRIPTION
Remove Hide Port 2 PF from DPUFlavor for astra

## Related issues
https://github.com/NVIDIA/infra-controller/issues/3205

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
Tested on local dev environment - this config is no longer in the template
ewNicConfigurations:
      - networkBay:
          conf: conf1
        numVfs: 1
        rawNvConfig:
        - name: BOARD_CONFIGURATION_MODE
          value: '0'
      ......
        - name: NUM_OF_PF
          value: '4'
        - name: LINK_TYPE_P1
          value: '2'
        spectrumXOptimized:
          enabled: true
          multiplaneMode: hwplb
          numberOfPlanes: 4
          overlay: none
          version: RA2.2-runtime


Closes https://github.com/NVIDIA/infra-controller/issues/5758

