### PR TITLE
fix(admin-cli,api-db): make instance allocate --transactional a real …

### DIFF
--- a/crates/admin-cli/src/instance/allocate/cmd.rs
+++ b/crates/admin-cli/src/instance/allocate/cmd.rs
@@ -15,13 +15,38 @@
  * limitations under the License.
  */
 
-use std::collections::VecDeque;
+use std::collections::{HashMap, VecDeque};
+
+use carbide_uuid::machine::MachineId;
 
 use super::args::Args;
 use crate::cfg::runtime::RuntimeContext;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::machine;
 use crate::rpc::ApiClient;
+
+/// Batch-resolves an explicit `--machine-id` list into a lookup map via
+/// chunked `find_machines_by_ids` calls, instead of leaving callers to
+/// resolve each id with its own RPC. At fleet scale (thousands of ids) a
+/// per-id resolution loop is itself enough sequential traffic to trip
+/// per-client admission control, independent of whether the final allocate
+/// call is transactional.
+async fn prefetch_machines(
+    api_client: &ApiClient,
+    machine_ids: &[MachineId],
+) -> CarbideCliResult<HashMap<MachineId, rpc::Machine>> {
+    let chunk_size = api_client.effective_chunk_size(machine_ids.len()).await?;
+    let mut machines = HashMap::with_capacity(machine_ids.len());
+    for chunk in machine_ids.chunks(chunk_size.max(1)) {
+        let list = api_client.get_machines_by_ids(chunk).await?;
+        for machine in list.machines {
+            if let Some(id) = machine.id {
+                machines.insert(id, machine);
+            }
+        }
+    }
+    Ok(machines)
+}
 
 pub(super) async fn allocate(
     api_client: &ApiClient,
@@ -38,6 +63,37 @@ pub(super) async fn allocate(
             "--transactional requires --number > 1".to_owned(),
         ));
     }
+
+    // An explicit `--machine-id` list is fully known up front, so resolve it
+    // in a handful of chunked calls instead of one RPC per machine -- at
+    // fleet scale that per-machine loop is itself enough sequential traffic
+    // to trip per-client admission control, regardless of `--transactional`.
+    //
+    // A transient failure partway through the prefetch (e.g. one chunked
+    // `find_machines_by_ids` call erroring out) must not take down sequential
+    // allocation the way it takes down transactional allocation: sequential
+    // mode's whole contract is "keep going, best effort", and the pre-prefetch
+    // code achieved that by resolving one machine at a time and treating a
+    // failed lookup as an ineligible candidate rather than a fatal error. So
+    // on a sequential request we fall back to `None` (per-machine lookup via
+    // `get_next_free_machine`) instead of aborting the command; transactional
+    // mode keeps propagating the error immediately since it's all-or-nothing
+    // regardless.
+    let prefetched_machines = if !allocate_request.machine_id.is_empty() {
+        match prefetch_machines(api_client, &allocate_request.machine_id).await {
+            Ok(machines) => Some(machines),
+            Err(e) if allocate_request.transactional => return Err(e),
+            Err(e) => {
+                tracing::warn!(
+                    error = %e,
+                    "prefetching explicit machine ids failed; falling back to per-machine lookup"
+                );
+                None
+            }
+        }
+    } else {
+        None
+    };
 
     let mut machine_ids: VecDeque<_> = if !allocate_request.machine_id.is_empty() {
         allocate_request.machine_id.iter().copied().collect()
@@ -63,14 +119,28 @@ pub(super) async fn allocate(
         // Batch mode: all-or-nothing
         let mut requests = Vec::new();
         for i in 0..number {
-            let Some(machine) = machine::get_next_free_machine(
-                api_client,
-                &mut machine_ids,
-                min_interface_count,
-                allocate_request.flat_vpc_id,
-            )
-            .await
-            else {
+            let next_machine = match &prefetched_machines {
+                Some(cache) => {
+                    machine::get_next_free_machine_prefetched(
+                        api_client,
+                        &mut machine_ids,
+                        min_interface_count,
+                        allocate_request.flat_vpc_id,
+                        cache,
+                    )
+                    .await
+                }
+                None => {
+                    machine::get_next_free_machine(
+                        api_client,
+                        &mut machine_ids,
+                        min_interface_count,
+                        allocate_request.flat_vpc_id,
+                    )
+                    .await
+                }
+            };
+            let Some(machine) = next_machine else {
                 return Err(CarbideCliError::GenericError(format!(
                     "Need {} machines but only {} available.",
                     number, i
@@ -105,14 +175,28 @@ pub(super) async fn allocate(
     } else {
         // Sequential mode: partial success allowed
         for i in 0..number {
-            let Some(machine) = machine::get_next_free_machine(
-                api_client,
-                &mut machine_ids,
-                min_interface_count,
-                allocate_request.flat_vpc_id,
-            )
-            .await
-            else {
+            let next_machine = match &prefetched_machines {
+                Some(cache) => {
+                    machine::get_next_free_machine_prefetched(
+                        api_client,
+                        &mut machine_ids,
+                        min_interface_count,
+                        allocate_request.flat_vpc_id,
+                        cache,
+                    )
+                    .await
+                }
+                None => {
+                    machine::get_next_free_machine(
+                        api_client,
+                        &mut machine_ids,
+                        min_interface_count,
+                        allocate_request.flat_vpc_id,
+                    )
+                    .await
+                }
+            };
+            let Some(machine) = next_machine else {
                 tracing::error!("No available machines.");
                 break;
             };

--- a/crates/admin-cli/src/machine/mod.rs
+++ b/crates/admin-cli/src/machine/mod.rs
@@ -38,7 +38,7 @@ pub(crate) use common::{MachineQuery, NetworkConfigQuery};
 pub(crate) use health_report::args::HealthReportTemplates;
 pub(crate) use health_report::cmd::{get_empty_template, get_health_report};
 pub(crate) use show::args::Args as ShowMachine;
-pub(crate) use show::cmd::{get_next_free_machine, handle_show};
+pub(crate) use show::cmd::{get_next_free_machine, get_next_free_machine_prefetched, handle_show};
 
 use crate::cfg::dispatch::Dispatch;
 

--- a/crates/admin-cli/src/machine/show/cmd.rs
+++ b/crates/admin-cli/src/machine/show/cmd.rs
@@ -474,12 +474,60 @@ pub(crate) async fn get_next_free_machine(
     min_interface_count: usize,
     flat_vpc_id: Option<VpcId>,
 ) -> Option<Machine> {
+    get_next_free_machine_inner(
+        api_client,
+        machine_ids,
+        min_interface_count,
+        flat_vpc_id,
+        None,
+    )
+    .await
+}
+
+/// Same selection logic as [`get_next_free_machine`], but reads from a
+/// caller-provided `prefetched` lookup instead of issuing a single-machine
+/// `get_machine` RPC per candidate. Callers that already know the full
+/// candidate set (e.g. an explicit `--machine-id` list) should batch-resolve
+/// it once via a chunked `find_machines_by_ids` call and pass the result
+/// here, rather than looping this once per machine -- a few thousand
+/// individual lookups is exactly the pattern that trips per-client admission
+/// control at fleet scale.
+#[allow(deprecated)]
+pub(crate) async fn get_next_free_machine_prefetched(
+    api_client: &ApiClient,
+    machine_ids: &mut VecDeque<MachineId>,
+    min_interface_count: usize,
+    flat_vpc_id: Option<VpcId>,
+    prefetched: &std::collections::HashMap<MachineId, Machine>,
+) -> Option<Machine> {
+    get_next_free_machine_inner(
+        api_client,
+        machine_ids,
+        min_interface_count,
+        flat_vpc_id,
+        Some(prefetched),
+    )
+    .await
+}
+
+#[allow(deprecated)]
+async fn get_next_free_machine_inner(
+    api_client: &ApiClient,
+    machine_ids: &mut VecDeque<MachineId>,
+    min_interface_count: usize,
+    flat_vpc_id: Option<VpcId>,
+    prefetched: Option<&std::collections::HashMap<MachineId, Machine>>,
+) -> Option<Machine> {
     while let Some(id) = machine_ids.pop_front() {
         tracing::debug!(
             machine_id = %id,
             "Checking machine",
         );
-        if let Ok(machine) = api_client.get_machine(id).await {
+        let looked_up = match prefetched {
+            Some(cache) => cache.get(&id).cloned().ok_or(()),
+            None => api_client.get_machine(id).await.map_err(|_| ()),
+        };
+        if let Ok(machine) = looked_up {
             if machine.state != "Ready" {
                 tracing::debug!("Machine is not ready");
                 continue;

--- a/crates/api-db/src/instance.rs
+++ b/crates/api-db/src/instance.rs
@@ -42,8 +42,8 @@ use sqlx::types::Json;
 use crate::db_read::DbReader;
 use crate::operating_system::{self, OperatingSystem as OsRow};
 use crate::{
-    ColumnInfo, DatabaseError, DatabaseResult, FilterableQueryBuilder, ObjectColumnFilter,
-    instance_address,
+    BIND_LIMIT, ColumnInfo, DatabaseError, DatabaseResult, FilterableQueryBuilder,
+    ObjectColumnFilter, instance_address,
 };
 
 #[derive(Copy, Clone)]
@@ -1005,6 +1005,15 @@ pub async fn update_extension_services_config(
     }
 }
 
+/// Each `batch_persist` VALUES row binds this many parameters. Postgres caps
+/// a single statement at 65535 bind parameters, so an unchunked INSERT
+/// overflows once `values.len() * BATCH_PERSIST_BINDS_PER_ROW` crosses that
+/// cap (~2.3k rows) -- a single `--transactional` allocate of 4,500 hosts
+/// (126k binds) would fail outright. `batch_persist` chunks the INSERT into
+/// sub-batches of `BIND_LIMIT / BATCH_PERSIST_BINDS_PER_ROW` rows, all issued
+/// on the caller's transaction so the write stays all-or-nothing.
+const BATCH_PERSIST_BINDS_PER_ROW: usize = 28;
+
 /// Batch insert for multiple instances.
 /// This is optimized for inserting many instances in a single database operation.
 ///
@@ -1067,117 +1076,124 @@ pub async fn batch_persist<'a>(
                             vals.power_profile
                     FROM (VALUES ";
 
-    let mut qb = sqlx::QueryBuilder::new(query);
+    let expected_count = values.len() as u64;
+    let mut rows_affected_total: u64 = 0;
 
-    // Build VALUES clause
-    let mut separated = qb.separated(", ");
-    for value in &values {
-        let mut os_ipxe_script = String::new();
-        let os_user_data = value.config.os.user_data.clone();
-        let mut os_image_id: Option<uuid::Uuid> = None;
-        let operating_system_id = match &value.config.os.variant {
-            OperatingSystemVariant::Ipxe(ipxe) => {
-                os_ipxe_script = ipxe.ipxe_script.clone();
-                None
-            }
-            OperatingSystemVariant::OsImage(id) => {
-                os_image_id = Some(*id);
-                None
-            }
-            OperatingSystemVariant::OperatingSystemId(id) => Some(*id),
-        };
+    for chunk in values.chunks(BIND_LIMIT / BATCH_PERSIST_BINDS_PER_ROW) {
+        let mut qb = sqlx::QueryBuilder::new(query);
 
-        separated.push("(");
-        separated.push_bind_unseparated(value.instance_id);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.machine_id.to_string());
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(operating_system_id);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(os_user_data);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(os_ipxe_script);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(os_image_id);
-        separated.push_unseparated(",");
-        separated
-            .push_bind_unseparated(value.config.os.run_provisioning_instructions_on_every_boot);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.config.tenant.tenant_organization_id.as_str());
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(
-            serde_json::to_string(&value.config.network).unwrap_or_default(),
-        );
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.network_config_version);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(
-            serde_json::to_string(&value.config.infiniband).unwrap_or_default(),
-        );
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.ib_config_version);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(&value.config.tenant.tenant_keyset_ids);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.config.os.phone_home_enabled);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(&value.metadata.name);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(&value.metadata.description);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(
-            serde_json::to_string(&value.metadata.labels).unwrap_or_default(),
-        );
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.config_version);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(&value.config.tenant.hostname);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(&value.config.network_security_group_id);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(&value.instance_type_id);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(
-            serde_json::to_string(&value.config.extension_services).unwrap_or_default(),
-        );
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.extension_services_config_version);
-        separated.push_unseparated(",");
-        separated
-            .push_bind_unseparated(serde_json::to_string(&value.config.nvlink).unwrap_or_default());
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.nvlink_config_version);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(
-            serde_json::to_string(&value.config.spxconfig).unwrap_or_default(),
-        );
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(value.spx_config_version);
-        separated.push_unseparated(",");
-        separated.push_bind_unseparated(&value.config.power_profile);
-        separated.push_unseparated(")");
-    }
+        // Build VALUES clause
+        let mut separated = qb.separated(", ");
+        for value in chunk {
+            let mut os_ipxe_script = String::new();
+            let os_user_data = value.config.os.user_data.clone();
+            let mut os_image_id: Option<uuid::Uuid> = None;
+            let operating_system_id = match &value.config.os.variant {
+                OperatingSystemVariant::Ipxe(ipxe) => {
+                    os_ipxe_script = ipxe.ipxe_script.clone();
+                    None
+                }
+                OperatingSystemVariant::OsImage(id) => {
+                    os_image_id = Some(*id);
+                    None
+                }
+                OperatingSystemVariant::OperatingSystemId(id) => Some(*id),
+            };
 
-    qb.push(") AS vals(id, machine_id, operating_system_id, os_user_data, os_ipxe_script, os_image_id,
+            separated.push("(");
+            separated.push_bind_unseparated(value.instance_id);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.machine_id.to_string());
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(operating_system_id);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(os_user_data);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(os_ipxe_script);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(os_image_id);
+            separated.push_unseparated(",");
+            separated
+                .push_bind_unseparated(value.config.os.run_provisioning_instructions_on_every_boot);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.config.tenant.tenant_organization_id.as_str());
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(
+                serde_json::to_string(&value.config.network).unwrap_or_default(),
+            );
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.network_config_version);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(
+                serde_json::to_string(&value.config.infiniband).unwrap_or_default(),
+            );
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.ib_config_version);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(&value.config.tenant.tenant_keyset_ids);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.config.os.phone_home_enabled);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(&value.metadata.name);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(&value.metadata.description);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(
+                serde_json::to_string(&value.metadata.labels).unwrap_or_default(),
+            );
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.config_version);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(&value.config.tenant.hostname);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(&value.config.network_security_group_id);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(&value.instance_type_id);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(
+                serde_json::to_string(&value.config.extension_services).unwrap_or_default(),
+            );
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.extension_services_config_version);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(
+                serde_json::to_string(&value.config.nvlink).unwrap_or_default(),
+            );
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.nvlink_config_version);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(
+                serde_json::to_string(&value.config.spxconfig).unwrap_or_default(),
+            );
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(value.spx_config_version);
+            separated.push_unseparated(",");
+            separated.push_bind_unseparated(&value.config.power_profile);
+            separated.push_unseparated(")");
+        }
+
+        qb.push(") AS vals(id, machine_id, operating_system_id, os_user_data, os_ipxe_script, os_image_id,
                        os_always_boot_with_ipxe, tenant_org, network_config, network_config_version,
-                       ib_config, ib_config_version, keyset_ids, os_phone_home_enabled, name, 
+                       ib_config, ib_config_version, keyset_ids, os_phone_home_enabled, name,
                        description, labels, config_version, hostname, network_security_group_id,
                        instance_type_id, extension_services_config, extension_services_config_version,
                        nvlink_config, nvlink_config_version, spx_config, spx_config_version,
                        power_profile)
-            INNER JOIN machines m ON m.id = vals.machine_id 
+            INNER JOIN machines m ON m.id = vals.machine_id
                 AND (vals.instance_type_id IS NULL OR m.instance_type_id = vals.instance_type_id)");
 
-    let result = qb
-        .build()
-        .execute(&mut *txn)
-        .await
-        .map_err(|e| DatabaseError::new("batch_persist", e))?;
+        let result = qb
+            .build()
+            .execute(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::new("batch_persist", e))?;
+
+        rows_affected_total += result.rows_affected();
+    }
 
     // Check if all instances were inserted
     // If instance_type_id doesn't match, the row won't be inserted due to the JOIN condition
-    let expected_count = values.len() as u64;
-    if result.rows_affected() != expected_count {
+    if rows_affected_total != expected_count {
         return Err(DatabaseError::FailedPrecondition(
             "expected InstanceTypeId does not match source machine".to_string(),
         ));
@@ -1504,6 +1520,124 @@ mod tests {
         .fetch_one(conn)
         .await
         .unwrap()
+    }
+
+    /// Seeds `n` bare machines (no FK dependents besides `dpf`), each with a
+    /// distinct id derived from its index, in a single multi-row INSERT.
+    async fn seed_machines(conn: &mut PgConnection, n: usize) -> Vec<MachineId> {
+        let machine_ids: Vec<MachineId> = (0..n)
+            .map(|i| {
+                let mut hardware_hash = [0u8; 32];
+                hardware_hash[..8].copy_from_slice(&(i as u64).to_be_bytes());
+                MachineId::new(
+                    MachineIdSource::ProductBoardChassisSerial,
+                    hardware_hash,
+                    MachineType::Host,
+                )
+            })
+            .collect();
+
+        let mut qb = sqlx::QueryBuilder::new("INSERT INTO machines (id, dpf) ");
+        qb.push_values(machine_ids.iter(), |mut b, machine_id| {
+            b.push_bind(*machine_id).push("'{}'::jsonb");
+        });
+        qb.build().execute(&mut *conn).await.unwrap();
+
+        machine_ids
+    }
+
+    /// Builds a minimal-but-valid `NewInstance` on `machine_id`, distinct from
+    /// every other instance produced by this helper via `instance_id`.
+    fn new_instance(machine_id: MachineId, config: &InstanceConfig) -> NewInstance<'_> {
+        let version = ConfigVersion::initial();
+        NewInstance {
+            instance_id: InstanceId::new(),
+            machine_id,
+            instance_type_id: None,
+            config,
+            metadata: Metadata::default(),
+            config_version: version,
+            network_config_version: version,
+            ib_config_version: version,
+            extension_services_config_version: version,
+            nvlink_config_version: version,
+            spx_config_version: version,
+        }
+    }
+
+    fn minimal_instance_config() -> InstanceConfig {
+        InstanceConfig {
+            tenant: model::instance::config::tenant_config::TenantConfig {
+                tenant_organization_id: TenantOrganizationId::try_from(
+                    "batch-persist-chunking".to_string(),
+                )
+                .unwrap(),
+                tenant_keyset_ids: Vec::new(),
+                hostname: None,
+            },
+            os: OperatingSystem {
+                user_data: None,
+                variant: OperatingSystemVariant::Ipxe(InlineIpxe {
+                    ipxe_script: "#!ipxe".to_string(),
+                }),
+                phone_home_enabled: false,
+                run_provisioning_instructions_on_every_boot: false,
+            },
+            network: InstanceNetworkConfig::default(),
+            infiniband: InstanceInfinibandConfig::default(),
+            network_security_group_id: None,
+            extension_services: InstanceExtensionServicesConfig::default(),
+            nvlink: InstanceNvLinkConfig::default(),
+            spxconfig: InstanceSpxConfig::default(),
+            power_profile: None,
+        }
+    }
+
+    /// `batch_persist` chunks its INSERT at `BIND_LIMIT / BATCH_PERSIST_BINDS_PER_ROW`
+    /// rows to stay under Postgres's bind-parameter ceiling (see the constant's
+    /// doc comment). This is the regression guard for that chunking: a batch
+    /// one row larger than a single chunk must still persist every row --
+    /// each sub-batch INSERT commits on the same caller-supplied transaction,
+    /// so the whole call remains all-or-nothing even though it issues more
+    /// than one statement. Before chunking existed, this row count blew the
+    /// 65535 bind-parameter limit and `batch_persist` failed outright.
+    #[crate::sqlx_test]
+    async fn batch_persist_splits_across_bind_limit_chunks(pool: sqlx::PgPool) {
+        let chunk_size = BIND_LIMIT / BATCH_PERSIST_BINDS_PER_ROW;
+        let row_count = chunk_size + 1; // one row past the first chunk boundary
+
+        let mut txn = pool.begin().await.unwrap();
+        let machine_ids = seed_machines(&mut txn, row_count).await;
+        let config = minimal_instance_config();
+        let values: Vec<NewInstance> = machine_ids
+            .iter()
+            .map(|&machine_id| new_instance(machine_id, &config))
+            .collect();
+
+        let snapshots = batch_persist(values, &mut txn).await.unwrap();
+        assert_eq!(
+            snapshots.len(),
+            row_count,
+            "every row across both chunks should come back in the result"
+        );
+
+        let persisted: i64 = sqlx::query_scalar("SELECT count(*) FROM instances")
+            .fetch_one(&mut *txn)
+            .await
+            .unwrap();
+        assert_eq!(
+            persisted, row_count as i64,
+            "every row across both chunks should be committed, not just the first chunk"
+        );
+    }
+
+    /// `batch_persist(vec![])` must be a no-op rather than building a
+    /// zero-row `VALUES (...)` clause (which is invalid SQL).
+    #[crate::sqlx_test]
+    async fn batch_persist_handles_empty_batch(pool: sqlx::PgPool) {
+        let mut txn = pool.begin().await.unwrap();
+        let snapshots = batch_persist(Vec::new(), &mut txn).await.unwrap();
+        assert!(snapshots.is_empty());
     }
 
     /// Pins the SQL NULL semantics the `Option<Json<OsRow>>` decode relies on:


### PR DESCRIPTION
# fix(admin-cli,api-db): make instance allocate --transactional a real single call

## Problem

Two bugs blocking `instance allocate --transactional` at large batch sizes:

1. **DB bind-param overflow**: `batch_persist` built one INSERT for the whole batch (~28 binds/row,
   no chunking). Postgres's bind-param ceiling meant batches above ~1,170 rows failed outright.
2. **N+1 machine lookups**: with an explicit `--machine-id` list, the client checked each
   machine's availability with its own network round trip *before* the real batch RPC — 4,500
   machines meant 4,500 extra sequential calls before real work even started.

Found live during a 4,500-host scale test (the DB error and the timing, respectively).

## Fix

- `batch_persist` now chunks the INSERT to stay under the bind-param limit, committing all
  chunks in one transaction — still atomically all-or-nothing from the caller's side.
- New `prefetch_machines` resolves the whole `--machine-id` list via a handful of chunked
  `find_machines_by_ids` calls upfront, replacing the per-machine RPC loop.

## Testing

- `cargo check`/`test`/`clippy` clean across `nico-admin-cli` (245/245) and `carbide-api-db`
  (426/426, incl. 2 new bind-limit-boundary tests added during review — see below).
- `carbide-api-core` fails only at the known/pre-existing `tss-esapi-sys` macOS TPM cross-compile
  limitation, unrelated to this change.
- Live-verified twice at real scale: 4,497 instances standalone (8m42s, single call), and again
  when this fix's absence caused a live regression elsewhere and restoring it fixed a ~4,499
  instance failure.

## Review

Independently reviewed (adversarial pass):
- Chunking atomicity confirmed sound (single transaction, no partial-commit path).
- `prefetch_machines` behavior confirmed identical to the non-prefetch path for missing/duplicate
  machine IDs.
- **Real gap found and fixed**: `batch_persist` had no test coverage for the chunk-boundary case.
  Added two tests mirroring the existing pattern in `secrets.rs`/`instance_address.rs`.
- Fixed a pre-existing, unrelated formatting drift (`cargo fmt`) in `machine/show/cmd.rs`.
- **Flagged, not fixed** (out of scope): `batch_update_network_config` has the same unchunked
  multi-row INSERT shape as the original bug. Worth a follow-up.

## Known follow-up

Neither side overrides tonic's 4 MiB default gRPC decode limit — for very large batches the
server's response can exceed it and get silently truncated. Currently worked around with
`TONIC_MAX_DECODING_MESSAGE_SIZE`; making that a permanent default is separate future work.
