### PR TITLE
fix(api-web): give correct context for DPU versions page

### DIFF
--- a/crates/api-web/src/dpu_versions.rs
+++ b/crates/api-web/src/dpu_versions.rs
@@ -141,7 +141,7 @@ pub(super) async fn list_html(
 
     let tmpl = DpuVersions {
         machines,
-        page: PageContext::new(info, "/admin/dpu-versions"),
+        page: PageContext::new(info, "/admin/dpu/versions"),
     };
     (StatusCode::OK, Html(tmpl.render().unwrap())).into_response()
 }


### PR DESCRIPTION
Previously all pagination links on the DPU versions page of the admin web UI directed to wrong URL, giving 404 errors. This PR fixes that problem.

## Related issues
(https://github.com/NVIDIA/infra-controller/issues/5441)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


