### PR TITLE
fix(machine-controller): restore GB200 BMC host interface address

### DIFF
--- a/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
+++ b/crates/bmc-mock/src/hw/wiwynn_gb200_nvl.rs
@@ -48,7 +48,15 @@ impl WiwynnGB200Nvl<'_> {
             managers: vec![
                 redfish::manager::SingleConfig {
                     id: "BMC_0",
-                    eth_interfaces: Some(vec![]), // TODO: eth0 / eth1 / hmcusb0 / hostusb0
+                    // TODO: Add eth0, eth1, and hmcusb0.
+                    eth_interfaces: Some(vec![
+                        redfish::ethernet_interface::builder(
+                            &redfish::ethernet_interface::manager_resource("BMC_0", "hostusb0"),
+                        )
+                        .static_ipv4_address("10.0.1.1", "255.255.255.0", "0.0.0.0")
+                        .interface_enabled(true)
+                        .build(),
+                    ]),
                     host_interfaces: Some(vec![
                         redfish::host_interface::builder(
                             &redfish::host_interface::manager_resource("BMC_0", "hostusb0"),

--- a/crates/bmc-mock/src/redfish/ethernet_interface.rs
+++ b/crates/bmc-mock/src/redfish/ethernet_interface.rs
@@ -99,6 +99,22 @@ impl Builder for EthernetInterfaceBuilder {
 }
 
 impl EthernetInterfaceBuilder {
+    /// Adds the one static IPv4 address exposed by this mock interface.
+    pub(crate) fn static_ipv4_address(
+        self,
+        address: &str,
+        subnet_mask: &str,
+        gateway: &str,
+    ) -> Self {
+        self.apply_patch(json!({
+            "IPv4StaticAddresses": [{
+                "Address": address,
+                "SubnetMask": subnet_mask,
+                "Gateway": gateway,
+            }],
+        }))
+    }
+
     pub(crate) fn mac_address(self, addr: MacAddress) -> Self {
         self.add_str_field("MACAddress", &addr.to_string())
     }

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -128,6 +128,7 @@ mod dpu_uefi_rotation;
 mod extension_services;
 mod factory_reset;
 mod firmware_artifact;
+mod gb200_host_interface;
 mod helpers;
 mod host_boot_config;
 mod host_uefi_rotation;
@@ -7828,6 +7829,15 @@ impl StateHandler for HostMachineStateHandler {
                         }
                     }
 
+                    // GB200 SBIOS can rebuild a stale UEFI HTTP option only when
+                    // `hostusb0` is configured before the platform setup reboot.
+                    gb200_host_interface::repair_gb200_host_interface_if_needed(
+                        ctx,
+                        redfish_client.as_ref(),
+                        mh_snapshot,
+                    )
+                    .await?;
+
                     handle_host_init_boot_config_stage(
                         ctx,
                         mh_snapshot,
@@ -7973,6 +7983,32 @@ impl StateHandler for HostMachineStateHandler {
                     }
                 }
                 MachineState::WaitingForDiscovery => {
+                    let discovery_pending = !discovered_after_state_transition(
+                        mh_snapshot.host_snapshot.state.version,
+                        mh_snapshot.host_snapshot.status.last_discovery_time,
+                    );
+                    if discovery_pending
+                        && gb200_host_interface::gb200_host_interface_address_is_missing(
+                            ctx,
+                            mh_snapshot,
+                        )
+                        .await?
+                    {
+                        // Persist the rewind first. The next iteration repairs
+                        // the BMC from the state that already owns platform setup.
+                        tracing::warn!(
+                            machine_id = %host_machine_id,
+                            "GB200 BMC hostusb0 static IPv4 address is missing; returning to platform configuration before another discovery boot"
+                        );
+                        return Ok(StateHandlerOutcome::transition(
+                            ManagedHostState::HostInit {
+                                machine_state: MachineState::WaitingForPlatformConfiguration {
+                                    retry_count: 0,
+                                },
+                            },
+                        ));
+                    }
+
                     // Storage cleanup is a destructive disk wipe (NVMe/HDD) that scout runs after a
                     // reset, so only a real, discovered host enters it. A predicted host waits for
                     // discovery to promote it; the promoted host then does the cleanup.
@@ -7986,10 +8022,7 @@ impl StateHandler for HostMachineStateHandler {
                         )));
                     }
 
-                    if !discovered_after_state_transition(
-                        mh_snapshot.host_snapshot.state.version,
-                        mh_snapshot.host_snapshot.status.last_discovery_time,
-                    ) {
+                    if discovery_pending {
                         tracing::trace!(
                             machine_id = %host_machine_id,
                             host_last_seen = ?mh_snapshot.host_snapshot.status.last_discovery_time,

--- a/crates/machine-controller/src/handler/gb200_host_interface.rs
+++ b/crates/machine-controller/src/handler/gb200_host_interface.rs
@@ -1,0 +1,102 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Checks and restores the BMC host interface that GB200 SBIOS uses for
+//! Redfish access.
+
+use carbide_redfish::libredfish::error::state_handler_redfish_error as redfish_error;
+use carbide_redfish::libredfish::host_interface::{
+    HostInterfaceStaticIpv4Repair, ensure_gb200_host_interface_static_ipv4,
+    gb200_host_interface_static_ipv4_is_missing,
+};
+use libredfish::Redfish;
+use model::machine::ManagedHostStateSnapshot;
+use model::rack_type::RackProductFamily;
+use state_controller::state_handler::{StateHandlerContext, StateHandlerError};
+
+use crate::context::MachineStateHandlerContextObjects;
+
+/// Reports whether a GB200 waiting for `scout` needs its BMC host interface
+/// restored before another boot can refresh the UEFI HTTP option.
+pub(super) async fn gb200_host_interface_address_is_missing(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<bool, StateHandlerError> {
+    if !is_reported_gb200(ctx, mh_snapshot).await? {
+        return Ok(false);
+    }
+
+    let redfish_client = ctx
+        .services
+        .create_redfish_client_from_machine(&mh_snapshot.host_snapshot)
+        .await?;
+    gb200_host_interface_static_ipv4_is_missing(redfish_client.as_ref())
+        .await
+        .map_err(|error| redfish_error("gb200_host_interface_static_ipv4_is_missing", error))
+}
+
+/// Restores the expected address only for hosts identified as GB200 by their
+/// persisted Site Explorer report.
+pub(super) async fn repair_gb200_host_interface_if_needed(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    redfish_client: &dyn Redfish,
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<(), StateHandlerError> {
+    if !is_reported_gb200(ctx, mh_snapshot).await? {
+        return Ok(());
+    }
+
+    match ensure_gb200_host_interface_static_ipv4(redfish_client)
+        .await
+        .map_err(|error| redfish_error("ensure_gb200_host_interface_static_ipv4", error))?
+    {
+        HostInterfaceStaticIpv4Repair::AlreadyConfigured => {}
+        HostInterfaceStaticIpv4Repair::Patched => tracing::warn!(
+            machine_id = %mh_snapshot.host_snapshot.id,
+            "Restored the GB200 BMC hostusb0 static IPv4 address before host platform configuration"
+        ),
+        HostInterfaceStaticIpv4Repair::Conflicting => {
+            return Err(StateHandlerError::ManualInterventionRequired(format!(
+                "GB200 host {} has unexpected static IPv4 configuration on hostusb0; refusing to overwrite it",
+                mh_snapshot.host_snapshot.id,
+            )));
+        }
+    }
+
+    Ok(())
+}
+
+/// Uses only the persisted Redfish report so stale or missing rack association
+/// data cannot enable this BMC write on other hardware.
+async fn is_reported_gb200(
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    mh_snapshot: &ManagedHostStateSnapshot,
+) -> Result<bool, StateHandlerError> {
+    let Some(host_bmc_ip) = mh_snapshot.host_snapshot.status.bmc_info.ip else {
+        return Ok(false);
+    };
+
+    let endpoints =
+        db::explored_endpoints::find_by_ips(&mut ctx.services.db_reader, vec![host_bmc_ip]).await?;
+    let product_family = endpoints
+        .first()
+        .and_then(|endpoint| endpoint.report.model())
+        .as_deref()
+        .and_then(RackProductFamily::from_hardware_model);
+
+    Ok(product_family == Some(RackProductFamily::Gb200))
+}

--- a/crates/machine-controller/tests/integration/gb200_host_interface.rs
+++ b/crates/machine-controller/tests/integration/gb200_host_interface.rs
@@ -1,0 +1,103 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use carbide_test_harness::prelude::*;
+use model::machine::{MachineState, ManagedHostState};
+
+use crate::env::Env;
+
+#[sqlx_test]
+async fn waiting_for_discovery_only_returns_gb200_to_platform_configuration(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut env = Env::builder(pool).build().await;
+    let domain = env.test_harness.test_domain().await;
+    let network_controller = env.test_harness.network_controller();
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    network_controller.create_admin_segment(&domain).await;
+    let site_explorer = env.test_harness.default_test_site_explorer();
+    let (managed_host, build_data) = env
+        .test_harness
+        .managed_host_builder(&site_explorer, underlay_segment)
+        .build()
+        .await;
+
+    managed_host
+        .advance_state(ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        })
+        .await;
+    env.run_single_iteration().await;
+
+    assert_eq!(
+        managed_host.host.machine().await.current_state(),
+        &ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        },
+        "a non-GB200 host must retain the existing discovery behavior"
+    );
+
+    let mut txn = env.test_harness.db_txn().await;
+    let mut endpoint =
+        db::explored_endpoints::find_by_ips(txn.as_mut(), vec![build_data.host_bmc_ip()])
+            .await?
+            .pop()
+            .expect("host Site Explorer report should exist");
+    endpoint
+        .report
+        .systems
+        .first_mut()
+        .expect("host Site Explorer report should contain a system")
+        .model = Some("GB200 NVL".to_string());
+    assert!(
+        db::explored_endpoints::try_update(
+            endpoint.address,
+            endpoint.report_version,
+            &endpoint.report,
+            endpoint.waiting_for_explorer_refresh,
+            txn.as_mut(),
+        )
+        .await?,
+        "host Site Explorer report should still have the expected version"
+    );
+    txn.commit().await?;
+
+    managed_host
+        .advance_state(ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForDiscovery,
+        })
+        .await;
+    let redfish_timepoint = env.redfish_sim.timepoint();
+
+    env.run_single_iteration().await;
+
+    assert_eq!(
+        managed_host.host.machine().await.current_state(),
+        &ManagedHostState::HostInit {
+            machine_state: MachineState::WaitingForPlatformConfiguration { retry_count: 0 },
+        },
+    );
+    assert!(
+        env.redfish_sim
+            .actions_since(&redfish_timepoint)
+            .all_hosts()
+            .is_empty(),
+        "the rewind iteration must not change BMC state or reboot the host"
+    );
+
+    Ok(())
+}

--- a/crates/machine-controller/tests/integration/main.rs
+++ b/crates/machine-controller/tests/integration/main.rs
@@ -20,6 +20,7 @@ mod bmc_rotation;
 mod dpu_uefi_rotation;
 mod env;
 mod firmware_upgrade_completion;
+mod gb200_host_interface;
 mod host_uefi_rotation;
 mod host_uefi_setup;
 mod maintenance;

--- a/crates/redfish/src/libredfish/host_interface.rs
+++ b/crates/redfish/src/libredfish/host_interface.rs
@@ -1,0 +1,339 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Checks and restores the GB200 BMC interface used to communicate with the host.
+
+use http::header::{ETAG, IF_MATCH};
+use http::{HeaderMap, Method, StatusCode};
+use libredfish::{Redfish, RedfishError};
+use serde::{Deserialize, Serialize};
+
+use super::instrumented::REDFISH_BACKEND;
+
+const GB200_HOST_INTERFACE_ID: &str = "hostusb0";
+const GB200_HOST_INTERFACE_ADDRESS: &str = "10.0.1.1";
+const GB200_HOST_INTERFACE_SUBNET_MASK: &str = "255.255.255.0";
+const GB200_HOST_INTERFACE_GATEWAY: &str = "0.0.0.0";
+
+const GET_FOR_REPAIR_OPERATION: &str = "get_manager_host_interface_for_static_ipv4_repair";
+const PATCH_OPERATION: &str = "patch_manager_host_interface_static_ipv4";
+
+/// Result of an attempt to repair the GB200 BMC host interface configuration.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum HostInterfaceStaticIpv4Repair {
+    /// The expected address was already present, so no request changed the resource.
+    AlreadyConfigured,
+    /// The missing address was patched and confirmed by reading the resource again.
+    Patched,
+    /// A nonempty configuration differs from the expected address and was not changed.
+    Conflicting,
+}
+
+/// Wire representation used to replace the static IPv4 address list.
+#[derive(Debug, Serialize)]
+struct EthernetInterfacePatch {
+    #[serde(rename = "IPv4StaticAddresses")]
+    ipv4_static_addresses: Vec<StaticIpv4Address>,
+}
+
+/// Static address values required by the GB200 BMC host interface.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "PascalCase")]
+struct StaticIpv4Address {
+    address: &'static str,
+    subnet_mask: &'static str,
+    gateway: &'static str,
+}
+
+/// Minimal manager Ethernet interface response needed for a guarded repair.
+#[derive(Debug, Deserialize)]
+struct EthernetInterfaceResponse {
+    #[serde(rename = "IPv4StaticAddresses")]
+    ipv4_static_addresses: Option<Vec<StaticIpv4AddressResponse>>,
+}
+
+/// Static IPv4 values returned by the BMC.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+struct StaticIpv4AddressResponse {
+    address: Option<String>,
+    subnet_mask: Option<String>,
+    gateway: Option<String>,
+}
+
+/// A manager Ethernet interface observation that retains the response headers
+/// needed to guard a subsequent write with the exact resource `ETag`.
+struct HostInterfaceObservation {
+    static_ipv4_status: StaticIpv4Status,
+    headers: Option<HeaderMap>,
+}
+
+/// Whether the BMC reports the expected, missing, or conflicting address.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+enum StaticIpv4Status {
+    Present,
+    Missing,
+    Conflicting,
+}
+
+/// Reports whether the GB200 BMC interface has no static IPv4 addresses.
+///
+/// The pinned libredfish model preserves the number of configured addresses,
+/// but does not deserialize their `Address` values. `WaitingForDiscovery` only
+/// needs the empty list check; the repair path reads the raw resource so it can
+/// verify every value before writing anything.
+pub async fn gb200_host_interface_static_ipv4_is_missing(
+    redfish_client: &dyn Redfish,
+) -> Result<bool, RedfishError> {
+    let interface = redfish_client
+        .get_manager_ethernet_interface(GB200_HOST_INTERFACE_ID)
+        .await?;
+
+    Ok(interface.ipv4_static_addresses.is_empty())
+}
+
+/// Restores a missing static IPv4 address on the GB200 BMC host interface.
+///
+/// An existing conflicting configuration is reported and is never replaced.
+/// The repair requires the resource's `ETag` and sends that value unchanged in
+/// `If-Match`, so a concurrent update fails instead of being overwritten.
+/// Wiwynn firmware returns HTTP 200 for the successful PATCH; HTTP 204 is
+/// accepted for Redfish implementations that omit a response body.
+pub async fn ensure_gb200_host_interface_static_ipv4(
+    redfish_client: &dyn Redfish,
+) -> Result<HostInterfaceStaticIpv4Repair, RedfishError> {
+    // The typed libredfish operation does not expose response headers. Read the
+    // resource directly so the PATCH is conditional on the same representation
+    // that was classified immediately before the change.
+    let observation = get_gb200_host_interface_for_repair(redfish_client).await?;
+    match observation.static_ipv4_status {
+        StaticIpv4Status::Present => {
+            return Ok(HostInterfaceStaticIpv4Repair::AlreadyConfigured);
+        }
+        StaticIpv4Status::Conflicting => {
+            return Ok(HostInterfaceStaticIpv4Repair::Conflicting);
+        }
+        StaticIpv4Status::Missing => {}
+    }
+
+    let url = gb200_host_interface_url(redfish_client);
+    let etag = required_etag(observation.headers.as_ref(), &url)?;
+
+    patch_gb200_host_interface(redfish_client, etag).await?;
+
+    match get_gb200_host_interface_for_repair(redfish_client)
+        .await?
+        .static_ipv4_status
+    {
+        StaticIpv4Status::Present => Ok(HostInterfaceStaticIpv4Repair::Patched),
+        StaticIpv4Status::Missing => Err(RedfishError::GenericError {
+            error: format!(
+                "manager interface {GB200_HOST_INTERFACE_ID} accepted the static IPv4 PATCH but the address is still missing"
+            ),
+        }),
+        StaticIpv4Status::Conflicting => Err(RedfishError::GenericError {
+            error: format!(
+                "manager interface {GB200_HOST_INTERFACE_ID} accepted the static IPv4 PATCH but returned a conflicting configuration"
+            ),
+        }),
+    }
+}
+
+/// Reads the raw resource because the typed API does not expose its `ETag`.
+async fn get_gb200_host_interface_for_repair(
+    redfish_client: &dyn Redfish,
+) -> Result<HostInterfaceObservation, RedfishError> {
+    let url = gb200_host_interface_url(redfish_client);
+    carbide_instrument::red::instrumented(REDFISH_BACKEND, GET_FOR_REPAIR_OPERATION, async {
+        let (_, interface, headers) = redfish_client
+            .std_redfish()
+            .client
+            .req::<EthernetInterfaceResponse, String>(
+                Method::GET,
+                &url,
+                None,
+                None,
+                None,
+                Vec::new(),
+            )
+            .await?;
+
+        let interface = interface.ok_or(RedfishError::NoContent)?;
+        let addresses = interface.ipv4_static_addresses.ok_or_else(|| {
+            RedfishError::GenericError {
+                error: format!(
+                    "manager interface {url} did not report IPv4StaticAddresses; refusing to change it"
+                ),
+            }
+        })?;
+
+        Ok(HostInterfaceObservation {
+            static_ipv4_status: host_interface_static_ipv4_status(&addresses),
+            headers,
+        })
+    })
+    .await
+}
+
+/// Writes the expected address only when the resource still has the observed `ETag`.
+async fn patch_gb200_host_interface(
+    redfish_client: &dyn Redfish,
+    etag: String,
+) -> Result<(), RedfishError> {
+    let url = gb200_host_interface_url(redfish_client);
+    let body = EthernetInterfacePatch {
+        ipv4_static_addresses: vec![StaticIpv4Address {
+            address: GB200_HOST_INTERFACE_ADDRESS,
+            subnet_mask: GB200_HOST_INTERFACE_SUBNET_MASK,
+            gateway: GB200_HOST_INTERFACE_GATEWAY,
+        }],
+    };
+
+    carbide_instrument::red::instrumented(REDFISH_BACKEND, PATCH_OPERATION, async {
+        let (status_code, _, _) = redfish_client
+            .std_redfish()
+            .client
+            .req::<serde_json::Value, _>(
+                Method::PATCH,
+                &url,
+                Some(body),
+                None,
+                None,
+                vec![(IF_MATCH, etag)],
+            )
+            .await?;
+
+        // Verification assumes the address was applied synchronously, so an
+        // asynchronous success response is not accepted here.
+        match status_code {
+            StatusCode::OK | StatusCode::NO_CONTENT => Ok(()),
+            _ => Err(RedfishError::HTTPErrorCode {
+                url,
+                status_code,
+                response_body: "expected HTTP 200 or 204 while patching the manager host interface"
+                    .to_string(),
+            }),
+        }
+    })
+    .await
+}
+
+/// Extracts an exact resource `ETag`, rejecting missing or wildcard values.
+fn required_etag(headers: Option<&HeaderMap>, url: &str) -> Result<String, RedfishError> {
+    let etag = headers
+        .and_then(|headers| headers.get(ETAG))
+        .and_then(|etag| etag.to_str().ok())
+        .filter(|etag| !etag.is_empty() && *etag != "*")
+        .ok_or_else(|| RedfishError::GenericError {
+            error: format!("manager interface {url} response is missing a usable ETag"),
+        })?;
+
+    Ok(etag.to_string())
+}
+
+/// Builds the manager Ethernet interface path for the current BMC manager.
+fn gb200_host_interface_url(redfish_client: &dyn Redfish) -> String {
+    let manager_id = redfish_client.std_redfish().manager_id();
+    format!("Managers/{manager_id}/EthernetInterfaces/{GB200_HOST_INTERFACE_ID}")
+}
+
+/// Classifies the complete static IPv4 address list without discarding conflicts.
+fn host_interface_static_ipv4_status(addresses: &[StaticIpv4AddressResponse]) -> StaticIpv4Status {
+    match addresses {
+        [] => StaticIpv4Status::Missing,
+        [address] if is_expected_gb200_host_interface_address(address) => StaticIpv4Status::Present,
+        _ => StaticIpv4Status::Conflicting,
+    }
+}
+
+/// Checks every value that must match before an existing address is accepted.
+fn is_expected_gb200_host_interface_address(address: &StaticIpv4AddressResponse) -> bool {
+    address.address.as_deref() == Some(GB200_HOST_INTERFACE_ADDRESS)
+        && address.subnet_mask.as_deref() == Some(GB200_HOST_INTERFACE_SUBNET_MASK)
+        && matches!(
+            address.gateway.as_deref(),
+            None | Some(GB200_HOST_INTERFACE_GATEWAY)
+        )
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    fn static_address(
+        address: &str,
+        subnet_mask: &str,
+        gateway: Option<&str>,
+    ) -> StaticIpv4AddressResponse {
+        StaticIpv4AddressResponse {
+            address: Some(address.to_string()),
+            gateway: gateway.map(String::from),
+            subnet_mask: Some(subnet_mask.to_string()),
+        }
+    }
+
+    #[test]
+    fn static_ipv4_status_classifies_complete_address_list() {
+        value_scenarios!(run = |addresses: Vec<StaticIpv4AddressResponse>| {
+            host_interface_static_ipv4_status(&addresses)
+        };
+            "missing" {
+                Vec::new() => StaticIpv4Status::Missing,
+            }
+
+            "present" {
+                vec![static_address(
+                    GB200_HOST_INTERFACE_ADDRESS,
+                    GB200_HOST_INTERFACE_SUBNET_MASK,
+                    None,
+                )] => StaticIpv4Status::Present,
+                vec![static_address(
+                    GB200_HOST_INTERFACE_ADDRESS,
+                    GB200_HOST_INTERFACE_SUBNET_MASK,
+                    Some(GB200_HOST_INTERFACE_GATEWAY),
+                )] => StaticIpv4Status::Present,
+            }
+
+            "conflicting" {
+                vec![StaticIpv4AddressResponse {
+                    address: None,
+                    subnet_mask: None,
+                    gateway: None,
+                }] => StaticIpv4Status::Conflicting,
+                vec![static_address("192.0.2.1", GB200_HOST_INTERFACE_SUBNET_MASK, None)]
+                    => StaticIpv4Status::Conflicting,
+                vec![static_address(GB200_HOST_INTERFACE_ADDRESS, "255.255.0.0", None)]
+                    => StaticIpv4Status::Conflicting,
+                vec![static_address(
+                    GB200_HOST_INTERFACE_ADDRESS,
+                    GB200_HOST_INTERFACE_SUBNET_MASK,
+                    Some("10.0.1.254"),
+                )] => StaticIpv4Status::Conflicting,
+                vec![
+                    static_address(
+                        GB200_HOST_INTERFACE_ADDRESS,
+                        GB200_HOST_INTERFACE_SUBNET_MASK,
+                        None,
+                    ),
+                    static_address("192.0.2.1", GB200_HOST_INTERFACE_SUBNET_MASK, None),
+                ] => StaticIpv4Status::Conflicting,
+            }
+        );
+    }
+}

--- a/crates/redfish/src/libredfish/instrumented.rs
+++ b/crates/redfish/src/libredfish/instrumented.rs
@@ -25,8 +25,9 @@
 //! ([`super::implementation`]), so the one decorator covers every consumer
 //! -- machine-controller, spdm-controller, site-explorer, preingestion, and
 //! the rest -- without touching their call sites. The `operation` label is
-//! the trait method's own name: a closed set fixed at compile time, never a
-//! URL or other wire data.
+//! the trait method's own name, or a fixed compile-time label for a direct
+//! operation that needs response metadata unavailable through the trait. It
+//! is never a URL or other wire data.
 //!
 //! This backend's `outcome` has a third value beyond the shared helper's
 //! ok/error: `unsupported`, for calls a vendor answers with a local

--- a/crates/redfish/src/libredfish/mod.rs
+++ b/crates/redfish/src/libredfish/mod.rs
@@ -22,6 +22,7 @@ pub mod auth;
 pub mod conv;
 pub mod dpu_bios;
 pub mod error;
+pub mod host_interface;
 #[cfg(feature = "test-support")]
 pub mod test_support;
 

--- a/crates/redfish/tests/host_interface.rs
+++ b/crates/redfish/tests/host_interface.rs
@@ -1,0 +1,325 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use std::net::{SocketAddr, TcpListener};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+use axum::body::Bytes;
+use axum::extract::State;
+use axum::http::header::{ETAG, IF_MATCH};
+use axum::http::{HeaderMap, HeaderValue, StatusCode, Uri};
+use axum::response::{IntoResponse, Response};
+use axum::routing::get;
+use axum::{Json, Router};
+use axum_server::tls_rustls::RustlsConfig;
+use carbide_redfish::libredfish::host_interface::{
+    HostInterfaceStaticIpv4Repair, ensure_gb200_host_interface_static_ipv4,
+};
+use libredfish::{Endpoint, Redfish, RedfishClientPool, RedfishError};
+use serde_json::{Value, json};
+
+const INTERFACE_PATH: &str = "/redfish/v1/Managers/BMC/EthernetInterfaces/hostusb0";
+const RESOURCE_ETAG: &str = "W/\"revision-7\"";
+
+#[derive(Debug)]
+struct PatchRequest {
+    path: String,
+    if_match: Option<String>,
+    body: Value,
+}
+
+#[derive(Clone)]
+struct AppState {
+    etag: Option<&'static str>,
+    initial_static_addresses: Option<Value>,
+    get_hits: Arc<AtomicUsize>,
+    patch_requests: Arc<Mutex<Vec<PatchRequest>>>,
+    patch_status: StatusCode,
+    apply_patch: bool,
+    patched: Arc<AtomicBool>,
+}
+
+impl AppState {
+    fn new(etag: Option<&'static str>, patch_status: StatusCode) -> Self {
+        Self {
+            etag,
+            initial_static_addresses: Some(json!([])),
+            get_hits: Arc::new(AtomicUsize::new(0)),
+            patch_requests: Arc::new(Mutex::new(Vec::new())),
+            patch_status,
+            apply_patch: true,
+            patched: Arc::new(AtomicBool::new(false)),
+        }
+    }
+
+    fn with_static_addresses(mut self, addresses: Value) -> Self {
+        self.initial_static_addresses = Some(addresses);
+        self
+    }
+
+    fn without_static_addresses(mut self) -> Self {
+        self.initial_static_addresses = None;
+        self
+    }
+
+    fn without_applying_patch(mut self) -> Self {
+        self.apply_patch = false;
+        self
+    }
+}
+
+async fn get_interface(State(state): State<AppState>) -> Response {
+    state.get_hits.fetch_add(1, Ordering::SeqCst);
+    let static_addresses = if state.patched.load(Ordering::SeqCst) {
+        Some(json!([{
+            "Address": "10.0.1.1",
+            "SubnetMask": "255.255.255.0",
+            "Gateway": "0.0.0.0"
+        }]))
+    } else {
+        state.initial_static_addresses.clone()
+    };
+    let mut resource = json!({
+        "@odata.id": INTERFACE_PATH,
+        "@odata.type": "#EthernetInterface.v1_9_0.EthernetInterface",
+        "Id": "hostusb0"
+    });
+    if let Some(static_addresses) = static_addresses {
+        resource["IPv4StaticAddresses"] = static_addresses;
+    }
+
+    let mut response = Json(resource).into_response();
+    if let Some(etag) = state.etag {
+        response
+            .headers_mut()
+            .insert(ETAG, HeaderValue::from_static(etag));
+    }
+    response
+}
+
+async fn patch_interface(
+    State(state): State<AppState>,
+    uri: Uri,
+    headers: HeaderMap,
+    body: Bytes,
+) -> Response {
+    let request = PatchRequest {
+        path: uri.path().to_string(),
+        if_match: headers
+            .get(IF_MATCH)
+            .and_then(|value| value.to_str().ok())
+            .map(str::to_string),
+        body: serde_json::from_slice(&body).unwrap(),
+    };
+    state.patch_requests.lock().unwrap().push(request);
+    if state.patch_status.is_success() && state.apply_patch {
+        state.patched.store(true, Ordering::SeqCst);
+    }
+
+    let mut response = Json(json!({})).into_response();
+    *response.status_mut() = state.patch_status;
+    response
+}
+
+fn spawn_mock_bmc(state: AppState) -> SocketAddr {
+    let app = Router::new()
+        .route(INTERFACE_PATH, get(get_interface).patch(patch_interface))
+        .with_state(state);
+
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.set_nonblocking(true).unwrap();
+    let addr = listener.local_addr().unwrap();
+
+    let tls = bmc_mock::tls::server_config(None::<&str>).unwrap();
+    let config = RustlsConfig::from_config(Arc::new(tls));
+    tokio::spawn(async move {
+        axum_server::from_tcp_rustls(listener, config)
+            .unwrap()
+            .serve(app.into_make_service())
+            .await
+            .unwrap();
+    });
+
+    addr
+}
+
+fn redfish_client(addr: SocketAddr) -> Box<dyn Redfish> {
+    let pool = RedfishClientPool::builder()
+        .danger_accept_invalid_certs()
+        .build()
+        .unwrap();
+    let mut client = pool
+        .create_standard_client(Endpoint {
+            host: addr.ip().to_string(),
+            port: Some(addr.port()),
+            user: Some("root".to_string()),
+            password: Some("placeholder".to_string()),
+        })
+        .unwrap();
+    client.set_manager_id("BMC").unwrap();
+    client
+}
+
+fn install_crypto_provider() {
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+}
+
+#[tokio::test]
+async fn repair_uses_resource_etag_and_accepts_success_responses() {
+    install_crypto_provider();
+    for patch_status in [StatusCode::OK, StatusCode::NO_CONTENT] {
+        let state = AppState::new(Some(RESOURCE_ETAG), patch_status);
+        let addr = spawn_mock_bmc(state.clone());
+        let client = redfish_client(addr);
+
+        let repair = ensure_gb200_host_interface_static_ipv4(client.as_ref())
+            .await
+            .unwrap();
+
+        assert_eq!(repair, HostInterfaceStaticIpv4Repair::Patched);
+        assert_eq!(state.get_hits.load(Ordering::SeqCst), 2);
+        let requests = state.patch_requests.lock().unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(requests[0].path, INTERFACE_PATH);
+        assert_eq!(requests[0].if_match.as_deref(), Some(RESOURCE_ETAG));
+        assert_eq!(
+            requests[0].body,
+            json!({
+                "IPv4StaticAddresses": [{
+                    "Address": "10.0.1.1",
+                    "SubnetMask": "255.255.255.0",
+                    "Gateway": "0.0.0.0"
+                }]
+            })
+        );
+    }
+}
+
+#[tokio::test]
+async fn repair_does_not_patch_an_already_configured_address() {
+    install_crypto_provider();
+    let state = AppState::new(Some(RESOURCE_ETAG), StatusCode::OK).with_static_addresses(json!([{
+        "Address": "10.0.1.1",
+        "SubnetMask": "255.255.255.0",
+        "Gateway": "0.0.0.0"
+    }]));
+    let addr = spawn_mock_bmc(state.clone());
+    let client = redfish_client(addr);
+
+    let repair = ensure_gb200_host_interface_static_ipv4(client.as_ref())
+        .await
+        .unwrap();
+
+    assert_eq!(repair, HostInterfaceStaticIpv4Repair::AlreadyConfigured);
+    assert_eq!(state.get_hits.load(Ordering::SeqCst), 1);
+    assert!(state.patch_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn repair_does_not_patch_without_an_etag() {
+    install_crypto_provider();
+    let state = AppState::new(None, StatusCode::OK);
+    let addr = spawn_mock_bmc(state.clone());
+    let client = redfish_client(addr);
+
+    let error = ensure_gb200_host_interface_static_ipv4(client.as_ref())
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("missing a usable ETag"));
+    assert_eq!(state.get_hits.load(Ordering::SeqCst), 1);
+    assert!(state.patch_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn repair_does_not_patch_when_static_addresses_are_not_reported() {
+    install_crypto_provider();
+    let state = AppState::new(Some(RESOURCE_ETAG), StatusCode::OK).without_static_addresses();
+    let addr = spawn_mock_bmc(state.clone());
+    let client = redfish_client(addr);
+
+    let error = ensure_gb200_host_interface_static_ipv4(client.as_ref())
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("did not report IPv4StaticAddresses")
+    );
+    assert_eq!(state.get_hits.load(Ordering::SeqCst), 1);
+    assert!(state.patch_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn repair_preserves_a_conflicting_static_address() {
+    install_crypto_provider();
+    let state = AppState::new(Some(RESOURCE_ETAG), StatusCode::OK).with_static_addresses(json!([{
+        "Address": "192.0.2.1",
+        "SubnetMask": "255.255.255.0",
+        "Gateway": "0.0.0.0"
+    }]));
+    let addr = spawn_mock_bmc(state.clone());
+    let client = redfish_client(addr);
+
+    let repair = ensure_gb200_host_interface_static_ipv4(client.as_ref())
+        .await
+        .unwrap();
+
+    assert_eq!(repair, HostInterfaceStaticIpv4Repair::Conflicting);
+    assert_eq!(state.get_hits.load(Ordering::SeqCst), 1);
+    assert!(state.patch_requests.lock().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn repair_propagates_a_stale_etag_response() {
+    install_crypto_provider();
+    let state = AppState::new(Some(RESOURCE_ETAG), StatusCode::PRECONDITION_FAILED);
+    let addr = spawn_mock_bmc(state.clone());
+    let client = redfish_client(addr);
+
+    let error = ensure_gb200_host_interface_static_ipv4(client.as_ref())
+        .await
+        .unwrap_err();
+
+    assert!(matches!(
+        error,
+        RedfishError::HTTPErrorCode { status_code, .. }
+            if status_code == StatusCode::PRECONDITION_FAILED
+    ));
+    assert_eq!(state.get_hits.load(Ordering::SeqCst), 1);
+    assert_eq!(state.patch_requests.lock().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn repair_verifies_that_an_accepted_patch_changed_the_address() {
+    install_crypto_provider();
+    let state = AppState::new(Some(RESOURCE_ETAG), StatusCode::OK).without_applying_patch();
+    let addr = spawn_mock_bmc(state.clone());
+    let client = redfish_client(addr);
+
+    let error = ensure_gb200_host_interface_static_ipv4(client.as_ref())
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("address is still missing"));
+    assert_eq!(state.get_hits.load(Ordering::SeqCst), 2);
+    assert_eq!(state.patch_requests.lock().unwrap().len(), 1);
+}


### PR DESCRIPTION
> [!IMPORTANT]
> **This is generally considered a bug in the GB200 UEFI firmware, and the idea is once the firmware is fixed, we won't need this anymore.**

> [!NOTE]
> This PR contains
> - +411/-6 lines of actual code changes + comments
> - +525/-1 lines of tests + test infrastructure

GB200 hosts can remain in `HostInitializing/WaitingForDiscovery` after the BF3 `mlxconfig` profile changes the PCI topology. If `hostusb0` has no `10.0.1.1/24` static address, SBIOS cannot reach its internal Redfish service to rebuild the UEFI HTTP boot option for the new PCI path, so later reboots return to the disk/installed OS instead of `scout`.

When discovery is still pending for a GB200, this checks `hostusb0` and returns the machine to `WaitingForPlatformConfiguration` if the static address list is empty. That state restores the expected address before the existing platform setup + boot configuration sequence. The repair uses the BMC's exact ETag, verifies the address after PATCH, and won't change an omitted or nonempty conflicting configuration.

Other hardware + correctly configured GB200 hosts retain their existing behavior.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5731

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers completely covered the same stable pre-fix tree; the active model then completed a bounded post-fix closure review of the final diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 2 | 0 | 2 |
| Claude CLI | 14 | 6 | 8 |
| common-nits-reviewer | 1 | 1 | 0 |
| **Total** | **18** | **8** | **10** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted (initial)** -- The raw response types and helper functions did not explain their safety roles. **Resolution:** Added focused comments for classification, exact ETag use, and synchronous verification.

### CodeRabbit CLI

1. **Declined** -- Persist a counter for repeated discovery rewinds. **Reason:** The repair remained configured through multiple reboots on six hosts; another rewind requires a new external removal, and new controller state is outside this recovery fix.
2. **Declined** -- Avoid the standard Redfish client because the simulator does not implement it. **Reason:** Production clients provide the standard client, while the trait has no operation that returns the response ETag; its HTTP contract is covered directly.

### Claude CLI

1. **Declined** -- Treat an address entry containing only null values as missing. **Reason:** All seven affected BMCs returned an exact empty list; an incomplete nonempty entry remains conflicting so the controller cannot overwrite unknown configuration.
2. **Adopted** -- ETag extraction also ran during verification. **Resolution:** Classification now retains headers, and only the read immediately before PATCH requires an ETag.
3. **Adopted** -- The GET status guard duplicated the client's error handling. **Resolution:** Removed it and documented why PATCH accepts only synchronous HTTP 200 or 204 responses.
4. **Adopted** -- The controller test did not prove the GB200 gate. **Resolution:** The test now checks unchanged non-GB200 behavior before exercising the GB200 rewind.
5. **Declined** -- Add the conditional PATCH to the upstream Redfish trait. **Reason:** This focused repair needs response metadata the current trait does not expose; changing the shared dependency is separate work.
6. **Declined** -- Extract the product family lookup based on the report. **Reason:** Existing callers intentionally use different fallback rules, and sharing the partial lookup is not required for this fix.
7. **Declined** -- Rename the Redfish module to avoid the separate `HostInterface` schema name. **Reason:** The module and public functions consistently identify the GB200 BMC interface, and the resource path is explicit in the implementation.
8. **Adopted** -- The discovery check ran after a fresh `scout` report. **Resolution:** The BMC check now runs only while fresh discovery remains pending.
9. **Declined** -- Add a persisted bound for repeated rewinds. **Reason:** This duplicates the CodeRabbit suggestion and would add state for a loop that requires another external removal of the address.
10. **Adopted** -- Deliberate repair branches lacked tests. **Resolution:** Added HTTP 204, already configured, incomplete entry, and PATCH verification cases.
11. **Declined** -- Falling closed without an ETag might block affected hardware. **Reason:** Each of the seven affected BMC resources returned a usable exact ETag; wildcard writes remain intentionally rejected.
12. **Declined** -- Update the Redfish endpoint documentation in this PR. **Reason:** Repository workflow keeps documentation in a separate PR, and the code change does not need that broader scope.
13. **Adopted** -- RED instrumentation documentation said every operation used a trait method name. **Resolution:** It now covers fixed labels for direct operations that need response metadata.
14. **Declined** -- Minor URL, mock reuse, and helper symmetry cleanup. **Reason:** None changes the repair behavior, and no shared HTTP test helper or trait operation that exposes an ETag exists today.

### common-nits-reviewer

1. **Adopted** -- An omitted `IPv4StaticAddresses` property deserialized as an empty list and could authorize a write. **Resolution:** Omission is now distinct from an empty list, fails without PATCH, and has HTTP coverage.

</details>

Closes #5731
