### PR TITLE
fix(network-segment): stop copying IPv4 gateways to IPv6 prefixes

### DIFF
--- a/crates/admin-cli/src/network_segment/create/args.rs
+++ b/crates/admin-cli/src/network_segment/create/args.rs
@@ -15,12 +15,13 @@
  * limitations under the License.
  */
 
-use std::net::IpAddr;
+use std::net::Ipv4Addr;
 
 use carbide_uuid::domain::DomainId;
 use carbide_uuid::network::NetworkSegmentId;
 use carbide_uuid::vpc::VpcId;
-use clap::Parser;
+use clap::error::ErrorKind;
+use clap::{CommandFactory, Parser};
 use ipnet::IpNet;
 use rpc::forge;
 
@@ -35,7 +36,7 @@ Create a dual-stack host in-band segment with a chosen ID and SLAAC EUI-64 infer
     $ nico-admin-cli --cloud-unsafe-op=admin network-segment create --name host-inband-a \
     --segment-type host-inband --id 12345678-1234-5678-90ab-cdef01234567 \
     --prefix 192.0.2.0/24 --gateway 192.0.2.1 --prefix 2001:db8::/64 \
-    --dhcpv6-link-address fe80::1 --subdomain-id 3ea8d9a2-4fe3-4189-97fc-cf9134e31f8f \
+    --subdomain-id abcdef01-2345-6789-abcd-ef0123456789 \
     --infer-slaac-eui64-addresses
 
 ")]
@@ -83,18 +84,10 @@ pub(crate) struct Args {
 
     #[clap(
         long,
-        value_name = "IP-address",
+        value_name = "IPv4-address",
         help = "IPv4 gateway for the IPv4 prefix"
     )]
-    gateway: Option<IpAddr>,
-
-    #[clap(
-        long,
-        name = "dhcpv6-link-address",
-        value_name = "IPv6-address",
-        help = "DHCPv6 relay link-address for the IPv6 prefix"
-    )]
-    dhcpv6_link_address: Option<IpAddr>,
+    gateway: Option<Ipv4Addr>,
 
     #[clap(
         long,
@@ -119,20 +112,51 @@ pub(crate) struct Args {
     infer_slaac_eui64_addresses: bool,
 }
 
+impl Args {
+    /// Validates cross-field constraints that clap cannot express.
+    pub(super) fn validate(&self) -> Result<(), clap::Error> {
+        // `no_gateway_on_ipv6` means the request's gateway needs an IPv4
+        // prefix to carry it.
+        if self.gateway.is_some()
+            && !self
+                .prefix
+                .iter()
+                .any(|prefix| matches!(prefix, IpNet::V4(_)))
+        {
+            return Err(Self::command()
+                .bin_name("nico-admin-cli network-segment create")
+                .error(
+                    ErrorKind::ArgumentConflict,
+                    "--gateway requires an IPv4 --prefix",
+                ));
+        }
+
+        Ok(())
+    }
+}
+
 impl From<Args> for forge::NetworkSegmentCreationRequest {
     fn from(args: Args) -> Self {
         let prefixes = args
             .prefix
             .into_iter()
-            .map(|prefix| forge::NetworkPrefix {
-                id: None,
-                prefix: prefix.to_string(),
-                gateway: args.gateway.map(|gw| gw.to_string()),
-                reserve_first: args.reserve_first,
-                free_ip_count: 0,
-                svi_ip: None,
-                free_ip_count_v2: None,
-                free_ip_count_saturated: false,
+            .map(|prefix| {
+                let gateway = if matches!(prefix, IpNet::V4(_)) {
+                    args.gateway.map(|gateway| gateway.to_string())
+                } else {
+                    None
+                };
+
+                forge::NetworkPrefix {
+                    id: None,
+                    prefix: prefix.to_string(),
+                    gateway,
+                    reserve_first: args.reserve_first,
+                    free_ip_count: 0,
+                    svi_ip: None,
+                    free_ip_count_v2: None,
+                    free_ip_count_saturated: false,
+                }
             })
             .collect();
 
@@ -146,5 +170,66 @@ impl From<Args> for forge::NetworkSegmentCreationRequest {
             id: args.id,
             infer_slaac_eui64_addresses: args.infer_slaac_eui64_addresses,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::Outcome::*;
+    use carbide_test_support::scenarios;
+
+    use super::*;
+
+    #[test]
+    fn validate_gateway_by_prefix_family() {
+        #[derive(Debug, PartialEq)]
+        struct ValidationFailure {
+            kind: clap::error::ErrorKind,
+            exit_code: i32,
+            names_conflict: bool,
+            shows_create_usage: bool,
+        }
+
+        scenarios!(
+            run = |argv| {
+                Args::try_parse_from(argv.iter().copied())
+                    .expect("scenario must parse as network-segment create")
+                    .validate()
+                    .map_err(|err| {
+                        let rendered = err.to_string();
+                        ValidationFailure {
+                            kind: err.kind(),
+                            exit_code: err.exit_code(),
+                            names_conflict: rendered
+                                .contains("--gateway requires an IPv4 --prefix"),
+                            shows_create_usage: rendered
+                                .contains("Usage: nico-admin-cli network-segment create"),
+                        }
+                    })
+            };
+            "dual-stack prefix accepts an IPv4 gateway" {
+                &[
+                    "network-segment-create",
+                    "--name=segment",
+                    "--prefix=192.0.2.0/24",
+                    "--gateway=192.0.2.1",
+                    "--prefix=2001:db8::/64",
+                ][..] => Yields(()),
+            }
+
+            "IPv6-only prefix rejects an IPv4 gateway" {
+                &[
+                    "network-segment-create",
+                    "--name=segment",
+                    "--prefix=2001:db8::/64",
+                    "--gateway=192.0.2.1",
+                ][..] => FailsWith(ValidationFailure {
+                    kind: clap::error::ErrorKind::ArgumentConflict,
+                    exit_code: 2,
+                    names_conflict: true,
+                    shows_create_usage: true,
+                }),
+            }
+        );
     }
 }

--- a/crates/admin-cli/src/network_segment/create/mod.rs
+++ b/crates/admin-cli/src/network_segment/create/mod.rs
@@ -26,6 +26,10 @@ use crate::errors::CarbideCliResult;
 
 impl Run for Args {
     async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        if let Err(err) = self.validate() {
+            err.exit();
+        }
+
         ctx.assert_cloud_unsafe_op_message()?;
         cmd::create(self, ctx.config.format, &ctx.api_client).await
     }

--- a/crates/admin-cli/src/network_segment/tests.rs
+++ b/crates/admin-cli/src/network_segment/tests.rs
@@ -115,6 +115,36 @@ fn parse_create_controls_slaac_eui64_inference() {
     );
 }
 
+#[test]
+fn create_request_maps_gateway_by_prefix_family() {
+    let command = Cmd::try_parse_from([
+        "network-segment",
+        "create",
+        "--name=segment",
+        "--prefix=192.0.2.0/24",
+        "--gateway=192.0.2.1",
+        "--prefix=2001:db8::/64",
+    ])
+    .expect("dual-stack create command should parse");
+
+    let Cmd::Create(args) = command else {
+        unreachable!("command should parse as network-segment create");
+    };
+    let request = forge::NetworkSegmentCreationRequest::from(args);
+
+    assert_eq!(
+        request
+            .prefixes
+            .into_iter()
+            .map(|prefix| (prefix.prefix, prefix.gateway))
+            .collect::<Vec<_>>(),
+        vec![
+            ("192.0.2.0/24".to_string(), Some("192.0.2.1".to_string())),
+            ("2001:db8::/64".to_string(), None),
+        ]
+    );
+}
+
 // Every malformed invocation is rejected at parse time.
 #[test]
 fn invalid_invocations_are_rejected() {
@@ -126,6 +156,34 @@ fn invalid_invocations_are_rejected() {
         };
         "delete without --id" {
             &["network-segment", "delete"][..] => Fails,
+        }
+
+        "create with an IPv6 gateway" {
+            &[
+                "network-segment",
+                "create",
+                "--name",
+                "segment",
+                "--prefix",
+                "2001:db8::/64",
+                "--gateway",
+                "2001:db8::1",
+            ][..] => Fails,
+        }
+
+        // The creation RPC has no DHCPv6 link-address field, so keep the
+        // former no-op rejected.
+        "create with unsupported --dhcpv6-link-address" {
+            &[
+                "network-segment",
+                "create",
+                "--name",
+                "segment",
+                "--prefix",
+                "2001:db8::/64",
+                "--dhcpv6-link-address",
+                "fe80::1",
+            ][..] => Fails,
         }
     );
 }


### PR DESCRIPTION
`nico-admin-cli network-segment create` copies its optional `--gateway` value onto every requested prefix. In a dual-stack request, the IPv4 gateway is therefore also set on the IPv6 prefix, and the database rejects the request under `no_gateway_on_ipv6`. The command also accepts `--dhcpv6-link-address`, although the creation RPC has no field for it and discards the value.

This changes `--gateway` to accept IPv4 addresses only and applies it only to the IPv4 prefix. Supplying a gateway without an IPv4 prefix now produces a normal clap invocation error before any RPC. IPv6 prefixes remain supported without a value in `NetworkPrefix.gateway`; this does not remove IPv6 routing support. The `--dhcpv6-link-address` option is removed until the RPC can represent it.

The generated admin CLI reference on `main` does not yet contain the `network-segment create` page, and regenerating the full reference also adds unrelated missing command pages. Those unrelated generated files remain outside this PR; the command's live `--help` output was exercised at this revision.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5400

Part of https://github.com/NVIDIA/infra-controller/issues/2415

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [x] **This PR contains breaking changes**

Scripts that supply `--dhcpv6-link-address` will now receive an unknown argument error. The option was previously accepted but its value never crossed the CLI boundary, so no supported DHCPv6 link-address behavior is removed.

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The local review covered the CLI input boundary, request conversion, clap error behavior, compatibility, and generated reference scope. Eight findings were adopted, and nine were declined after checking them against the existing database and RPC contracts. Final Rust and common-nits closure reviews found no remaining issue in the change across three files.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 1 | 0 | 1 |
| Claude CLI | 11 | 4 | 7 |
| common-nits-reviewer | 4 | 3 | 1 |
| **Total** | **17** | **8** | **9** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- Clarified that the database permits a gateway only on the IPv4 prefix row.

### CodeRabbit CLI

1. **Declined** -- Extra single-family and omitted-gateway conversion rows would repeat the two family branches already exercised together by the dual-stack request assertion. Parser and cross-field tests separately cover rejected inputs.

### Claude CLI

1. **Adopted (4 findings)** -- Documented the database invariant and removed-option coverage, replaced an opaque validation-test tuple with named fields, and added the compatibility explanation to the PR.
2. **Declined (7 findings)** -- `ArgumentConflict` describes a gateway paired only with IPv6 prefixes more accurately than a missing-prefix error. The remaining suggestions covered speculative command renames, pre-existing host-inband and gateway-containment errors, a new server validation layer, unrelated show output, and the existing generated-reference backlog.

### common-nits-reviewer

1. **Adopted (3 findings)** -- Rejected a gateway with no IPv4 prefix before runtime work, used a native clap error with exit code 2, and rendered the complete `nico-admin-cli network-segment create` usage path.
2. **Declined (1 finding)** -- The generated-reference backlog remains outside this PR instead of waiting for or absorbing the unrelated baseline refresh.

</details>

Closes #5400
