### PR TITLE
fix(tests): fix FMDs flaky tests

### DIFF
--- a/crates/fmds/src/rest_server.rs
+++ b/crates/fmds/src/rest_server.rs
@@ -386,6 +386,7 @@ mod tests {
     use std::net::{Ipv4Addr, Ipv6Addr, SocketAddr};
 
     use axum::http;
+    use carbide_instrument::testing::MetricsCapture;
     use forge_dpu_fmds_shared::machine_identity::MachineIdentityParams;
     use http_body_util::{BodyExt, Full};
     use hyper::body::Bytes;
@@ -831,12 +832,17 @@ mod tests {
             asn: 12345,
             machine_identity: Some(MachineIdentityParams::default().into()),
         };
-        grpc_server
-            .update_config(Request::new(UpdateConfigRequest {
-                config_update: Some(update),
-            }))
-            .await
-            .unwrap();
+        {
+            // The gRPC handler emits into the process-global test registry, so
+            // participate in the metric-capture lock while driving it.
+            let _metrics = MetricsCapture::start();
+            grpc_server
+                .update_config(Request::new(UpdateConfigRequest {
+                    config_update: Some(update),
+                }))
+                .await
+                .unwrap();
+        }
 
         // Read via REST
         let (server, port) = setup_server(state).await;


### PR DESCRIPTION
Use MetricsCaputre lock to prevent flakiness. 

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

