### PR TITLE
fix(api-core): add TLS handshake timeout in API listener

### DIFF
--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -28,10 +28,11 @@ use hyper_util::service::TowerToHyperService;
 use model::ConfigValidationError;
 use opentelemetry::metrics::Meter;
 use rustls::server::WebPkiClientVerifier;
-use tokio::net::TcpListener;
+use tokio::net::{TcpListener, TcpStream};
 use tokio::task::JoinSet;
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls::rustls::{RootCertStore, ServerConfig};
+use tokio_rustls::server::TlsStream;
 use tokio_util::sync::CancellationToken;
 use tonic_reflection::server::Builder;
 use tower_http::add_extension::AddExtensionLayer;
@@ -82,6 +83,12 @@ const TLS_REFRESH_INTERVAL: Duration = Duration::from_secs(5 * 60);
 /// zero: retrying on every accepted connection would let a persistently broken
 /// identity file amplify inbound traffic into a rebuild per connection.
 const TLS_REFRESH_RETRY_DELAY: Duration = Duration::from_secs(15);
+
+/// Overall deadline for an accepted TCP connection to complete its TLS
+/// handshake. A handshake needs only a few network round trips; ten seconds
+/// tolerates transient delay while preventing a silent peer from retaining a
+/// socket indefinitely.
+const TLS_HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// Reads the client-CA bundle. Split out so one read can feed both the TLS
 /// acceptor and the node-auth validator: each building from its own read lets a
@@ -231,18 +238,16 @@ struct TlsConnectionAttempted;
 struct TlsConnectionSucceeded;
 
 /// Why an inbound connection failed, as the bounded `reason` label. The
-/// rendered strings are the metric's contract: each variant renders to the
-/// snake_case value the counter has always reported, byte for byte.
-// The shared `ConnectionFailure` postfix is deliberate: the derived snake_case
-// is exactly the `reason` label value the counter reports, so the variant
-// names are the metric contract rather than a naming slip.
-#[allow(clippy::enum_variant_names)]
+/// rendered strings are the metric's contract. Existing variants preserve the
+/// snake_case values the counter previously reported, byte for byte.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, carbide_instrument::LabelValue)]
 enum ConnectionFailReason {
     /// The TCP accept itself errored.
     TcpConnectionFailure,
     /// The TLS handshake errored.
     TlsConnectionFailure,
+    /// The TLS handshake did not complete before its deadline.
+    TlsHandshakeTimeout,
 }
 
 /// The one metric the Events below record.
@@ -274,9 +279,10 @@ struct TcpAcceptFailed {
     error: String,
 }
 
-/// `TlsConnectionFailed` records a handshake error after the listener knows
-/// the peer. It shares the failure counter with [`TcpAcceptFailed`], while
-/// `peer_address` and `error` remain available only on the diagnostic record.
+/// `TlsConnectionFailed` records a handshake error or deadline expiry after
+/// the listener knows the peer. It shares the failure counter with
+/// [`TcpAcceptFailed`], while `peer_address` and `error` remain available only
+/// on the diagnostic record.
 #[derive(carbide_instrument::Event)]
 #[event(
     event_name = "api_tls_connection_failed",
@@ -291,6 +297,45 @@ struct TlsConnectionFailed {
     error: String,
     #[context]
     peer_address: SocketAddr,
+}
+
+#[derive(Debug, thiserror::Error)]
+enum TlsAcceptError {
+    #[error(transparent)]
+    Handshake(#[from] std::io::Error),
+    #[error("TLS handshake timed out after {timeout:?}")]
+    Timeout { timeout: Duration },
+}
+
+impl TlsAcceptError {
+    fn failure_reason(&self) -> ConnectionFailReason {
+        match self {
+            Self::Handshake(_) => ConnectionFailReason::TlsConnectionFailure,
+            Self::Timeout { .. } => ConnectionFailReason::TlsHandshakeTimeout,
+        }
+    }
+
+    fn record(self, peer_address: SocketAddr) {
+        let reason = self.failure_reason();
+        carbide_instrument::emit(TlsConnectionFailed {
+            reason,
+            error: self.to_string(),
+            peer_address,
+        });
+    }
+}
+
+async fn accept_tls_connection(
+    tls_acceptor: &TlsAcceptor,
+    connection: TcpStream,
+    handshake_timeout: Duration,
+) -> Result<TlsStream<TcpStream>, TlsAcceptError> {
+    tokio::time::timeout(handshake_timeout, tls_acceptor.accept(connection))
+        .await
+        .map_err(|_| TlsAcceptError::Timeout {
+            timeout: handshake_timeout,
+        })?
+        .map_err(TlsAcceptError::from)
 }
 
 /// Start listening for requests, spawning the listener task into `join_set`.
@@ -618,7 +663,9 @@ pub(crate) async fn start(
                     .name("http conn handler")
                     .spawn(async move {
                         if let Some(tls_acceptor) = tls_acceptor {
-                            match tls_acceptor.accept(conn).await {
+                            match accept_tls_connection(&tls_acceptor, conn, TLS_HANDSHAKE_TIMEOUT)
+                                .await
+                            {
                                 Ok(conn) => {
                                     let conn = TokioIo::new(conn);
                                     carbide_instrument::emit(TlsConnectionSucceeded);
@@ -657,11 +704,7 @@ pub(crate) async fn start(
                                     }
                                 }
                                 Err(error) => {
-                                    carbide_instrument::emit(TlsConnectionFailed {
-                                        reason: ConnectionFailReason::TlsConnectionFailure,
-                                        error: error.to_string(),
-                                        peer_address: addr,
-                                    });
+                                    error.record(addr);
                                 }
                             }
                         } else {
@@ -725,12 +768,22 @@ async fn root_url() -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use std::net::SocketAddr;
+    use std::net::{Ipv4Addr, SocketAddr};
+    use std::sync::Arc;
+    use std::time::Duration;
 
     use carbide_instrument::testing::{MetricsCapture, capture_logs};
     use carbide_test_support::{Check, check_values};
+    use rcgen::{CertifiedKey, generate_simple_self_signed};
+    use tokio::io::AsyncReadExt;
+    use tokio::net::{TcpListener, TcpStream};
+    use tokio_rustls::TlsAcceptor;
+    use tokio_rustls::rustls::ServerConfig;
 
-    use super::{ConnectionFailReason, TcpAcceptFailed, TlsCertsRefreshed, TlsConnectionFailed};
+    use super::{
+        ConnectionFailReason, TcpAcceptFailed, TlsAcceptError, TlsCertsRefreshed,
+        accept_tls_connection,
+    };
 
     const FAILURE_METRIC: &str = "carbide_api_tls_connection_fail_total";
     const TLS_CERT_REFRESH_METRIC: &str = "carbide_api_tls_cert_refreshes_total";
@@ -766,13 +819,22 @@ mod tests {
     }
 
     fn emit_tls_connection_failure() {
-        carbide_instrument::emit(TlsConnectionFailed {
-            reason: ConnectionFailReason::TlsConnectionFailure,
-            error: "handshake failed".to_string(),
-            peer_address: "192.0.2.10:443"
+        TlsAcceptError::Handshake(std::io::Error::other("handshake failed")).record(
+            "192.0.2.10:443"
                 .parse::<SocketAddr>()
                 .expect("test peer address is valid"),
-        });
+        );
+    }
+
+    fn emit_tls_handshake_timeout() {
+        TlsAcceptError::Timeout {
+            timeout: Duration::from_secs(10),
+        }
+        .record(
+            "192.0.2.11:443"
+                .parse::<SocketAddr>()
+                .expect("test peer address is valid"),
+        );
     }
 
     fn observe_failure(input: FailureInput) -> FailureObservation {
@@ -826,8 +888,52 @@ mod tests {
         }
     }
 
+    fn test_tls_acceptor() -> TlsAcceptor {
+        let CertifiedKey { cert, signing_key } =
+            generate_simple_self_signed(vec!["localhost".to_string()])
+                .expect("test certificate generation succeeds");
+        let private_key =
+            rustls_pki_types::PrivateKeyDer::Pkcs8(signing_key.serialize_der().into());
+        let config = ServerConfig::builder_with_provider(Arc::new(
+            rustls::crypto::aws_lc_rs::default_provider(),
+        ))
+        .with_safe_default_protocol_versions()
+        .expect("default protocol versions are supported")
+        .with_no_client_auth()
+        .with_single_cert(vec![cert.der().clone()], private_key)
+        .expect("test certificate and key form a valid server identity");
+
+        TlsAcceptor::from(Arc::new(config))
+    }
+
+    /// A peer that opens TCP but sends no TLS bytes cannot retain the server
+    /// socket beyond the handshake deadline.
+    #[tokio::test(start_paused = true)]
+    async fn incomplete_tls_handshake_is_closed_after_timeout() {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("test listener binds");
+        let listener_address = listener.local_addr().expect("test listener has an address");
+        let mut client = TcpStream::connect(listener_address)
+            .await
+            .expect("test client connects");
+        let (server, _) = listener.accept().await.expect("test listener accepts");
+
+        let error = accept_tls_connection(&test_tls_acceptor(), server, Duration::from_millis(10))
+            .await
+            .expect_err("an incomplete TLS handshake must time out");
+        assert!(matches!(error, TlsAcceptError::Timeout { .. }));
+
+        let mut byte = [0];
+        let bytes_read = client
+            .read(&mut byte)
+            .await
+            .expect("server closes the timed-out connection cleanly");
+        assert_eq!(bytes_read, 0);
+    }
+
     /// Each accept or handshake failure writes one ERROR record and increments
-    /// exactly one existing `reason` series.
+    /// exactly one bounded `reason` series.
     #[test]
     fn connection_failures_emit_their_metric_and_historical_log() {
         check_values(
@@ -858,6 +964,20 @@ mod tests {
                         "tls_connection_failure",
                         "handshake failed",
                         Some("192.0.2.10:443"),
+                    ),
+                },
+                Check {
+                    scenario: "tls handshake timeout",
+                    input: FailureInput {
+                        reason: "tls_handshake_timeout",
+                        emit: emit_tls_handshake_timeout,
+                    },
+                    expect: expected_failure(
+                        "api_tls_connection_failed",
+                        "error accepting tls connection",
+                        "tls_handshake_timeout",
+                        "TLS handshake timed out after 10s",
+                        Some("192.0.2.11:443"),
                     ),
                 },
             ],


### PR DESCRIPTION
Before this fix accepting of TLS connection could have taken infinite time because no timeout on await. It could cause leak of memory and file descriptors in case when remote TCP connection was not properly closed or aborted.

The fix is to add hard-coded 10 seconds timeout for a TLS handshakes.  

## Related issues

#5712 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

