### PR TITLE
chore(api): retire unused rack management flag

### DIFF
--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -194,7 +194,6 @@ explicitly enabled in the TOML.
 | `[vmaas_config]` | VM system integration / VM-aware traffic intercept | Requires `public_prefixes`. |
 | `[rms]` | Rack Manager Service (mTLS connectivity to external RMS) | |
 | `[dpf]` | DPU Platform Framework — Kubernetes DPU workload deployment | Requires the DPF operator deployed in-cluster (`helm-prereqs/setup.sh` installs it by default; `--skip-dpf` to opt out). |
-| `rack_management_enabled` | Standalone infrastructure manager mode (GB200/GB300/VR144) | Top-level boolean, not a sub-section. |
 
 For RMS component-manager backends, NICo builds RMS node descriptors from rack
 profiles. Each descriptor contains three attributes:
@@ -1470,7 +1469,6 @@ on or off.
 | Machine Identity (SPIFFE JWT-SVID) | siteConfig | `[machine_identity].enabled` | off | Per-org JWT signing for machine identity tokens. See [Day 0](../../../docs/getting-started/installation-options/day0-machine-identity.md) and [Day 1](../../../docs/configuration/machine_identity.md) docs. |
 | Machine Validation | siteConfig | `[machine_validation_config].enabled` | off | Pre-ingestion validation tests. |
 | SPDM | siteConfig | `[spdm].enabled` | off | Hardware attestation via NRAS. |
-| Rack Management | siteConfig | `rack_management_enabled = true` | off | Standalone infrastructure manager mode (GB200/GB300/VR144). |
 | Site Explorer machine auto-creation | siteConfig | `[site_explorer].create_machines` | on | Disable for manual-onboarding environments. |
 | Site Explorer switch / power shelf auto-creation | siteConfig | `[site_explorer].create_switches` / `[site_explorer].create_power_shelves` | on | Ingests only declared hardware (`expected_switches` / `expected_power_shelves` records). Disable to pause switch or power shelf ingestion site-wide. |
 | Firmware autoupdate | siteConfig | `[firmware_global].autoupdate` | off | Enable once the fleet's firmware baseline is stable. |

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -13,9 +13,14 @@ the invalid key's full section path and source. Names inside intentionally
 dynamic maps, such as pool names and rack-profile IDs, remain user-defined;
 fields within each map value must still match the documented schema.
 
-The removed `force_dpu_nic_mode` key is explicitly recognized at the top level
-and under `[site_explorer]`, ignored, and reported as a deprecation warning.
-Use `site_explorer.dpu_policy` instead.
+The removed `force_dpu_nic_mode` and `rack_management_enabled` keys are
+explicitly recognized, ignored, and reported as deprecation warnings. Use
+`site_explorer.dpu_policy` instead of `force_dpu_nic_mode`.
+`rack_management_enabled` lost its last runtime consumer when
+[PR #1583](https://github.com/NVIDIA/infra-controller/pull/1583) made Expected
+Machine lookup during DHCP discovery unconditional. Remove both deprecated keys
+from site configuration; compatibility parsing does not restore their former
+behavior.
 
 ---
 
@@ -111,7 +116,6 @@ Use `site_explorer.dpu_policy` instead.
 | `auto_machine_repair_plugin` | `AutoMachineRepairPluginConfig` | *(default)* | `machines` | Auto-repair configuration for failed machines. |
 | `vmaas_config` | `Option<VmaasConfig>` | — | `integrations` | VMaaS configuration for VM system integration (see [VmaasConfig](#vmaasconfig)). |
 | `mlxconfig_profiles` | `Option<HashMap<String, MlxConfigProfile>>` | — | `machines` | Named Mellanox NIC register configuration profiles for superNIC firmware flashing. TOML key: `mlx-config-profiles`. |
-| `rack_management_enabled` | `bool` | `false` | `hardware` | Standalone infrastructure manager mode for GB200/GB300/VR144. See doc comment for full behavioral changes. |
 | `rms` | `RmsConfig` | *(see below)* | `hardware` | Rack Manager Service configuration for API connectivity and mTLS (see [RmsConfig](#rmsconfig)). |
 | `rack_profiles` | `RackProfileConfig` | *(default)* | `hardware` | Rack profile definitions referenced by expected racks. |
 | `spdm` | `SpdmConfig` | *(see below)* | `security` | SPDM hardware attestation (see [SpdmConfig](#spdmconfig)). |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -729,39 +729,13 @@ pub struct CarbideConfig {
     )]
     pub mlxconfig_profiles: Option<HashMap<String, MlxConfigProfile>>,
 
-    /// The intent of this config option is to use the NICo site controller as a standalone
-    /// (disconnected / air-gapped) infrastructure manager for racks of GB200/GB300/VR144.
-    /// Only set this if using NICo site controller with Rack Manager to manage GB200/300/VR144.
-    /// It will change site controller behavior significantly in the following ways, etc.:
-    /// 1. skip DPU management and use DPUs as NICs (set the site-wide `[site_explorer] dpu_policy = "nic"`, or per-host `ExpectedMachine.dpu_policy`)
-    ///    a. no dpu bfb upgrade and host power cycle
-    ///    b. no firmware upgrade and host power cycle
-    ///    c. no hbn deployment (no ecmp, etc)
-    ///    d. no dpu agent deployment
-    ///    e. no restricted mode configuration
-    ///    f. no tenant overlay network via L2 vxlan/evpn or L3 vni (fnn)
-    /// 2. support any other nic interface on the compute nodes including the onboard 3p nic
-    /// 3. require expected machines table rows to have other/all mac addresses for each machine
-    /// 4. restrict dhcp service to only provide ip address to known mac addresses
-    ///    a. for additional mac addresses, use HostInband network segment when dpu is in nic mode
-    /// 5. disable compute host individual firmware upgrades
-    ///    a. only rack level firmware upgrades are allowed
-    /// 6. enable nvlink switch and power shelf discovery and ingestion
-    ///    a. site explorer changes to explore switch and power shelf bmc
-    ///    b. state machine for ingestion workflow
-    ///    c. nvlink switch nvos deployment/upgrade via onie
-    ///    d. nvlink switch default configuration and machine validation
-    /// 7. enable rack state machine and calls to rack manager
-    ///    a. depend on rack manager for firmware upgrades of the rack
-    ///    b. depend on rack manager for all power sequencing of the rack and components
-    ///    c. override/suspend component level state machine state transitions as needed
-    /// 8. enable nvlink control plane integration with nmx-c
-    ///    a. export nmx-c apis via site controller
-    ///    b. hardware health daemon polling of switch telemetry and collection into site controller
-    ///    prometheus instance
-    /// 9. enable domain power service integration
-    #[serde(default)]
-    pub rack_management_enabled: bool,
+    /// Deprecated compatibility key. This setting no longer affects runtime
+    /// behavior now that expected-machine DHCP lookup is unconditional. It
+    /// remains accepted so strict unknown-field validation does not block
+    /// upgrades from configurations that still contain the key.
+    #[doc(hidden)]
+    #[serde(default, rename = "rack_management_enabled", skip_serializing)]
+    pub deprecated_rack_management_enabled: Option<bool>,
 
     /// Rack Manager Service configuration for rack-level firmware upgrades,
     /// power sequencing, and mTLS connectivity.

--- a/crates/api-core/src/cfg/load.rs
+++ b/crates/api-core/src/cfg/load.rs
@@ -264,6 +264,21 @@ pub fn parse_carbide_config(
         );
     }
 
+    if config.deprecated_rack_management_enabled.is_some() {
+        let path = "rack_management_enabled";
+        let source = config
+            .config_ctx
+            .as_ref()
+            .and_then(|figment| figment.find_metadata(path))
+            .map(super::provenance::source_label)
+            .unwrap_or_else(|| "configuration".to_string());
+        tracing::warn!(
+            config_key = path,
+            config_source = %source,
+            "Ignoring deprecated configuration key"
+        );
+    }
+
     for (label, _) in config
         .host_models
         .iter()
@@ -368,7 +383,49 @@ pub fn parse_carbide_config(
 
 #[cfg(test)]
 mod tests {
+    use tracing_subscriber::prelude::*;
+
     use super::*;
+    use crate::logging::stream::{LogStream, LogStreamLayer};
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn legacy_rack_management_key_is_accepted_warned_and_omitted() {
+        figment::Jail::expect_with(|jail| {
+            let config_text = format!(
+                "{}\ndeny_unknown_fields = true\nrack_management_enabled = true\n",
+                include_str!("test_data/min_config.toml")
+            );
+            jail.create_file("config.toml", &config_text)?;
+
+            let stream = LogStream::new(16, 64 * 1024);
+            let mut logs = stream.subscribe();
+            let subscriber = tracing_subscriber::registry().with(LogStreamLayer::new(stream));
+            let config = tracing::subscriber::with_default(subscriber, || {
+                parse_carbide_config(Path::new("config.toml"), None)
+            })
+            .expect("strict configuration with the deprecated key must load");
+
+            assert_eq!(config.deprecated_rack_management_enabled, Some(true));
+            let serialized =
+                toml::to_string(config.as_ref()).expect("loaded configuration must serialize");
+            assert!(!serialized.contains("rack_management_enabled"));
+
+            let warning = std::iter::from_fn(|| logs.try_recv().ok())
+                .find(|line| line.message == "Ignoring deprecated configuration key")
+                .expect("deprecated key warning");
+            assert_eq!(warning.level, "WARN");
+            assert_eq!(
+                warning.fields.get("config_key").map(String::as_str),
+                Some("rack_management_enabled")
+            );
+            assert_eq!(
+                warning.fields.get("config_source").map(String::as_str),
+                Some("config.toml")
+            );
+            Ok(())
+        })
+    }
 
     #[test]
     #[allow(clippy::result_large_err)]

--- a/crates/api-core/src/test_support/default_config.rs
+++ b/crates/api-core/src/test_support/default_config.rs
@@ -339,7 +339,7 @@ pub fn get() -> CarbideConfig {
             bridging: None,
         }),
         mlxconfig_profiles: None,
-        rack_management_enabled: false,
+        deprecated_rack_management_enabled: None,
         rms: RmsConfig::default(),
         rack_profiles: Default::default(),
         spdm_state_controller: SpdmStateControllerConfig {

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -16,9 +16,7 @@
  */
 use std::default::Default;
 
-use common::api_fixtures::{
-    TestEnvOverrides, create_test_env, create_test_env_with_overrides, get_config,
-};
+use common::api_fixtures::create_test_env;
 use db::{self};
 use mac_address::MacAddress;
 use model::expected_machine::{
@@ -3183,14 +3181,7 @@ async fn test_update_preserves_bmc_retain_credentials(
 async fn test_dhcp_honors_primary_host_nic(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // rack_management_enabled is required for discover_dhcp to consult
-    // ExpectedMachine records for unknown MACs -- that's the path that
-    // reads the matched interface's `primary` flag.
-    let env = {
-        let mut config = get_config();
-        config.rack_management_enabled = true;
-        create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await
-    };
+    let env = create_test_env(pool).await;
     let bmc_mac: MacAddress = "9A:9B:9C:9D:9E:01".parse().unwrap();
     let primary_mac: MacAddress = "9A:9B:9C:9D:9E:02".parse().unwrap();
 
@@ -3249,11 +3240,7 @@ async fn test_dhcp_honors_primary_host_nic(
 async fn test_dhcp_marks_non_primary_mac_as_non_primary(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = {
-        let mut config = get_config();
-        config.rack_management_enabled = true;
-        create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await
-    };
+    let env = create_test_env(pool).await;
     let bmc_mac: MacAddress = "9A:9B:9C:9D:9E:10".parse().unwrap();
     let primary_mac: MacAddress = "9A:9B:9C:9D:9E:11".parse().unwrap();
     let other_mac: MacAddress = "9A:9B:9C:9D:9E:12".parse().unwrap();
@@ -3432,11 +3419,7 @@ async fn test_batch_update_rejects_multiple_primary_host_nics(
 async fn test_declared_primary_survives_dhcp_arrival_order(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = {
-        let mut config = get_config();
-        config.rack_management_enabled = true;
-        create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await
-    };
+    let env = create_test_env(pool).await;
     let bmc_mac: MacAddress = "9A:9B:9C:9D:9F:10".parse().unwrap();
     let primary_mac: MacAddress = "9A:9B:9C:9D:9F:11".parse().unwrap();
     let other_mac: MacAddress = "9A:9B:9C:9D:9F:12".parse().unwrap();

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -512,9 +512,7 @@ async fn test_multiple_machines_dhcp_with_api(
 async fn test_machine_dhcp_declared_admin_nic_allocates_from_relay_admin_segment(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = get_config();
-    config.rack_management_enabled = true;
-    let env = create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await;
+    let env = create_test_env(pool).await;
 
     // Create a second admin segment so the relay determines which admin segment is used.
     let second_admin_segment = create_network_segment(
@@ -586,9 +584,7 @@ async fn test_machine_dhcp_declared_admin_nic_allocates_from_relay_admin_segment
 async fn test_machine_dhcp_declared_segment_type_allocates_from_relay_admin_segment(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let mut config = get_config();
-    config.rack_management_enabled = true;
-    let env = create_test_env_with_overrides(pool, TestEnvOverrides::with_config(config)).await;
+    let env = create_test_env(pool).await;
 
     // A second admin segment, so the relay -- not the declaration -- decides
     // which admin segment is used once selection is narrowed to Admin.

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -174,7 +174,7 @@ A VPC virtualization type for tenant instances on zero-DPU hosts. A Flat VPC is 
 
 ### Zero-DPU Host
 
-A managed host that NICo operates without a NICo-managed DPU — either a host whose DPU policy is `ignore`, or a host whose BlueField DPU is run as a plain NIC through `nic`. NICo does not build an overlay for a zero-DPU host; its tenant instances attach directly to HostInband underlay segments and belong to Flat VPCs. DPU policy is set site-wide in the API server configuration or per host on its Expected Machine. `rack_management_enabled` does not itself make a host zero-DPU; rack-manager deployments must also resolve the applicable DPU policy to `nic`.
+A managed host that NICo operates without a NICo-managed DPU — either a host whose DPU policy is `ignore`, or a host whose BlueField DPU is run as a plain NIC through `nic`. NICo does not build an overlay for a zero-DPU host; its tenant instances attach directly to HostInband underlay segments and belong to Flat VPCs. DPU policy is set site-wide in the API server configuration or per host on its Expected Machine. Rack-manager deployments must resolve the applicable DPU policy to `nic` to run DPUs as plain NICs.
 
 ### HBN in NICo
 

--- a/docs/manuals/vpc/flat_vpcs_zero_dpu.md
+++ b/docs/manuals/vpc/flat_vpcs_zero_dpu.md
@@ -148,18 +148,13 @@ JSON vocabulary rather than Forge protobuf symbols. Responses translate
 non-default policies back through `dpu_mode`; the default `manage` policy might
 leave that field unset.
 
-Two related Day-0 settings matter for zero-DPU sites:
+The related `[site_explorer] admin_segment_type_non_dpu` Day-0 setting defaults
+to `false`. When `true`, non-DPU hosts use the `HostInband` admin segment type
+instead of the regular `Admin` segment type for their admin-network attachment.
 
-- **`[site_explorer] admin_segment_type_non_dpu`** (default `false`). When
-  `true`, non-DPU hosts use the `HostInband` admin segment type instead of the
-  regular `Admin` segment type for their admin-network attachment.
-- **`rack_management_enabled`** (top-level, default `false`). This is the
-  standalone / air-gapped rack-manager mode for GB200/GB300/VR144 deployments.
-  It is not a DPU-policy override: rack-manager deployments that run DPUs as
-  NICs must also set `[site_explorer] dpu_policy = "nic"` (or set that
-  policy per host). The resulting `nic` policy produces zero-DPU hosts;
-  the rack-management flag alone does not. Enable the flag only when running
-  NICo with Rack Manager for those platforms.
+Rack management does not override DPU policy. Rack-manager deployments that run
+DPUs as NICs must set `[site_explorer] dpu_policy = "nic"` or set that policy
+per host.
 
 Because a zero-DPU host has no DPU to DHCP and identify host NICs for it, the
 host's data-NIC **MAC addresses must be registered** on its `ExpectedMachine`

--- a/docs/provisioning/boot-interfaces-and-dpu-modes.md
+++ b/docs/provisioning/boot-interfaces-and-dpu-modes.md
@@ -63,12 +63,9 @@ Boot and DPU configuration is **declarative**: you describe the host in the Expe
 
 So a standard DPU host is handled entirely by defaults. A host without DPU hardware must instead use `dpu_policy: ignore` and declare a primary HostInband NIC as described in [3.2](#32-zero-dpu-host-no-dpu-hardware). The knobs below exist for the hosts that *don't* fit the standard-DPU mold.
 
-`rack_management_enabled` is a separate deployment-mode setting, not another
-DPU policy, and it does not override this resolution. Rack-manager deployments
-that operate DPUs as NICs must also set the site-wide `dpu_policy` (or each
-host's policy) to `nic`. If rack management is enabled while both policy
-levels remain unset, the effective policy is still `manage` and the Admin-network
-default above still applies.
+Rack management does not override this resolution. Rack-manager deployments
+that operate DPUs as NICs must set the site-wide `dpu_policy` (or each host's
+policy) to `nic`.
 
 ### `dpu_policy`
 


### PR DESCRIPTION
`rack_management_enabled` no longer controls runtime behavior. Its last consumer was removed when #1583 made Expected Machine lookup during DHCP discovery unconditional, but the field remained in the public configuration, documentation, and test setup. That incorrectly suggests operators must enable it for rack management and zero-DPU DHCP behavior.

This change removes the active field and those stale claims. It retains `rack_management_enabled` as a deprecated, ignored, deserialization-only compatibility key so existing strict configurations continue to load during upgrades. The loader emits a deprecation warning with source metadata, and serialization omits the key. Operators should remove it from site configuration because compatibility parsing does not restore its former behavior.

## Related issues

- Follow-up to #1583

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

Existing `rack_management_enabled` configuration remains accepted under both unknown-field policies, is ignored, and emits a deprecation warning. Its runtime behavior had already been removed by #1583.

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 
