### PR TITLE
patch(v2.2): retry failed custom boot scripts

### DIFF
--- a/crates/api-core/src/ipxe.rs
+++ b/crates/api-core/src/ipxe.rs
@@ -524,15 +524,17 @@ exit ||
                         .run_provisioning_instructions_on_every_boot
                         || instance.use_custom_pxe_on_boot
                     {
-                        // For non-always-PXE instances, clear the use_custom_pxe_on_boot flag
-                        // now that we're serving the script. Always-PXE instances don't use
-                        // this flag (they rely on run_provisioning_instructions_on_every_boot).
-                        if instance.use_custom_pxe_on_boot {
+                        let retry_on_failure = instance.use_custom_pxe_on_boot;
+
+                        // Clear the flag now that we're serving this one-time request. Instances
+                        // configured for every boot continue through
+                        // `run_provisioning_instructions_on_every_boot`.
+                        if retry_on_failure {
                             db::instance::use_custom_ipxe_on_next_boot(&machine_id, false, txn)
                                 .await?;
                         }
 
-                        match instance.config.os.variant {
+                        let provisioning_script = match instance.config.os.variant {
                             model::os::OperatingSystemVariant::Ipxe(ipxe) => {
                                 let mut tenant_ipxe = ipxe.ipxe_script;
                                 let vendor_serial_console = format!(" console={console}");
@@ -608,6 +610,14 @@ exit ||
                                     qcow_imaging_ipxe
                                 }
                             }
+                        };
+
+                        if retry_on_failure {
+                            // Tell the embedded iPXE menu to retry this one-time script from
+                            // memory if it returns an error; the database flag is now consumed.
+                            format!("set nico-retry-provisioning 1\n{provisioning_script}")
+                        } else {
+                            provisioning_script
                         }
                     } else {
                         exit_instructions(machine_id, target.interface_id, machine.current_state())

--- a/crates/api-core/src/tests/instance_ipxe_behaviors.rs
+++ b/crates/api-core/src/tests/instance_ipxe_behaviors.rs
@@ -26,6 +26,8 @@ use crate::tests::common::api_fixtures::instance::{
     TestInstance, default_os_config, default_tenant_config, single_interface_network_config,
 };
 
+const RETRYABLE_CUSTOM_IPXE: &str = "set nico-retry-provisioning 1\nSomeRandomiPxe";
+
 #[crate::sqlx_test]
 async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
@@ -47,9 +49,9 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
             .run_provisioning_instructions_on_every_boot
     );
 
-    // First boot should return custom iPXE instructions
+    // The one-time custom script is marked for retries within this iPXE session.
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
-    assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
+    assert_eq!(pxe.pxe_script, RETRYABLE_CUSTOM_IPXE);
 
     // Second boot should return "exit"
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
@@ -121,7 +123,7 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
     })
     .await;
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
-    assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
+    assert_eq!(pxe.pxe_script, RETRYABLE_CUSTOM_IPXE);
     env.run_machine_state_controller_iteration().await;
 
     // The next reboot should again lead to returning "exit"
@@ -174,11 +176,12 @@ async fn test_instance_always_boot_with_custom_ipxe(pool: sqlx::PgPool) {
             .run_provisioning_instructions_on_every_boot
     );
 
-    // First boot should return custom iPXE instructions
+    // The allocation's one-time request is marked for retries within this iPXE session.
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
-    assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
+    assert_eq!(pxe.pxe_script, RETRYABLE_CUSTOM_IPXE);
 
-    // Second boot should also return custom iPXE instructions
+    // Later requests use `run_provisioning_instructions_on_every_boot` without the
+    // one-time retry marker.
     let pxe = host_interface.get_pxe_instructions(host_arch).await;
     assert_eq!(pxe.pxe_script, "SomeRandomiPxe");
 

--- a/crates/api-core/src/tests/ipxe.rs
+++ b/crates/api-core/src/tests/ipxe.rs
@@ -453,7 +453,10 @@ async fn test_pxe_instance(pool: sqlx::PgPool) {
         .get_pxe_instructions(rpc::forge::MachineArchitecture::X86)
         .await;
 
-    assert_eq!(instructions.pxe_script, "SomeRandomiPxe".to_string());
+    assert_eq!(
+        instructions.pxe_script,
+        "set nico-retry-provisioning 1\nSomeRandomiPxe"
+    );
 }
 
 #[crate::sqlx_test]

--- a/crates/ipxe-renderer/src/lib.rs
+++ b/crates/ipxe-renderer/src/lib.rs
@@ -1253,6 +1253,29 @@ mod tests {
     }
 
     #[test]
+    fn static_ipxe_menu_retries_only_marked_boot_scripts() {
+        assert!(STATIC_IPXE_MENU_TEMPLATE.contains(
+            "imgfree nico-boot ||\n\
+             set nico-retry-provisioning 0\n\
+             time chain --name nico-boot http://${next-server}/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto retry_nico_boot"
+        ));
+        assert!(STATIC_IPXE_MENU_TEMPLATE.contains(
+            ":retry_nico_boot\n\
+             iseq ${nico-retry-provisioning} 1 || goto error_handler\n\
+             imgstat nico-boot || goto error_handler\n\
+             prompt --key p --timeout 30000 Hit the ${bold}p${boldoff} key to open NICo menu; retrying in 30 seconds... && goto nico_menu ||\n\
+             time imgexec nico-boot && exit 1 || goto retry_nico_boot"
+        ));
+        assert_eq!(
+            STATIC_IPXE_MENU_TEMPLATE
+                .matches("/api/v0/pxe/boot?")
+                .count(),
+            1,
+            "retrying should reuse the served script instead of requesting it again"
+        );
+    }
+
+    #[test]
     fn test_get_template_by_name() {
         let renderer = DefaultIpxeScriptRenderer::new();
 

--- a/pxe/ipxe/local/embed.ipxe
+++ b/pxe/ipxe/local/embed.ipxe
@@ -26,7 +26,16 @@ goto nico_menu
 
 :nico
 ifconf -c dhcp
-time chain --autofree http://${next-server}/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto error_handler
+imgfree nico-boot ||
+set nico-retry-provisioning 0
+time chain --name nico-boot http://${next-server}/api/v0/pxe/boot?buildarch=${buildarch}&platform=${platform}&manufacturer=${manufacturer}&product=${product}&serial=${serial} && exit 1 || goto retry_nico_boot
+
+# Core sets this flag to 1 when the response consumes a one-time custom PXE request.
+:retry_nico_boot
+iseq ${nico-retry-provisioning} 1 || goto error_handler
+imgstat nico-boot || goto error_handler
+prompt --key p --timeout 30000 Hit the ${bold}p${boldoff} key to open NICo menu; retrying in 30 seconds... && goto nico_menu ||
+time imgexec nico-boot && exit 1 || goto retry_nico_boot
 
 :nico_menu
 menu NICo - ${hostname}


### PR DESCRIPTION
This backports #5749 to `release/v2.2`. `nico-api` clears `use_custom_pxe_on_boot` in `GetPxeInstructions` when it serves a requested custom boot script. If an artifact download fails and the script returns, another request to `/api/v0/pxe/boot` gets normal boot instructions and exits to disk before provisioning finishes.

The patch marks the response that clears the flag so the embedded iPXE menu keeps that script and retries it from memory after 30 seconds. The source patch applied without conflicts or release-specific changes. A reset or power loss can still require another custom PXE request.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/5728
- Backports https://github.com/NVIDIA/infra-controller/pull/5749

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Renderer and database-backed API tests verify the retry marker, in-memory retry, and later boot instructions.
- `cargo make format-nightly` and `cargo make clippy` pass, and the source and backport stable patch IDs match. Refreshed Carbide lints stop on two existing `txn-held-across-await` findings in the unchanged `dns_resolution.rs` integration test.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the source patch in #5749. This backport applies the same stable patch without conflicts or release changes; a focused v2.2 review found no adjustment was needed.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 11 | 6 | 5 |
| common-nits-reviewer | 1 | 0 | 1 |
| **Total** | **12** | **6** | **6** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Declined** -- Move retries into the machine controller. **Reason:** Instances without phone home and those using `operator_managed_networking` do not enter that branch, which also requires a full BMC restart.
2. **Adopted** -- Explain why the retry belongs in the active iPXE session. **Resolution:** The commit, PR, and script comment now state that only the current session retries the loaded script.
3. **Declined** -- Add retry telemetry or a bounded fallback to server requests. **Reason:** That requires a new reporting contract or gives up the requested recovery after an arbitrary limit.
4. **Adopted** -- Avoid calling `isset` with an empty expansion. **Resolution:** The marker is initialized to `0` and checked with `iseq`.
5. **Adopted** -- Restore an exact endpoint response assertion. **Resolution:** The API test compares the complete marker and script.
6. **Adopted** -- Correct a test comment that implied an unmodeled failure. **Resolution:** The comment now describes the `run_provisioning_instructions_on_every_boot` response that the test exercises.
7. **Declined** -- Add a special case for `create_volume` exit instructions. **Reason:** The exit script succeeds and does not enter the new retry branch.
8. **Adopted** -- Clarify local names and remove a repeated field read. **Resolution:** The implementation uses `retry_on_failure`, `provisioning_script`, and the captured flag.
9. **Declined** -- Replace the exact renderer assertion with smaller substring checks. **Reason:** The exact assertion protects the command order required to retain and rerun the image.
10. **Declined** -- Suppress the `imgfree` result when no image exists. **Reason:** The cleanup prevents the next request from using a stale named image, and iPXE has no separate output redirection for this command.
11. **Adopted** -- Explain where the script marker is set. **Resolution:** The embedded script comment identifies the `nico-api` response that sets it.

### common-nits-reviewer

1. **Declined** -- Add a native iPXE runtime harness. **Reason:** The API and renderer tests cover the changed repository contracts; new harness infrastructure is outside this fix.

</details>

Closes #5728