### PR TITLE
feat(bmc-proxy): add NICO_BMC_PROXY__ env var prefix

### DIFF
--- a/crates/bmc-proxy/src/config.rs
+++ b/crates/bmc-proxy/src/config.rs
@@ -154,7 +154,8 @@ impl Config {
     pub(crate) fn parse(s: &str) -> Result<Config, ConfigError> {
         Figment::new()
             .merge(Toml::string(s))
-            .merge(Env::prefixed("CARBIDE_BMC_PROXY_"))
+            .merge(Env::prefixed("CARBIDE_BMC_PROXY_")) // legacy, will be deprecated
+            .merge(Env::prefixed("NICO_BMC_PROXY__").split("__"))
             .extract()
             .map_err(Into::into)
     }

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -132,6 +132,10 @@ DPS stays one trace across the proxy hop (issue
 - **Off by default.** Spans are exported only when an OTLP endpoint is configured **and**
   `[tracing] enabled = true` (or the process is started with `--debug`). There is no runtime
   toggle on this binary.
+- **Environment variable override.** Tracing can be enabled via environment variable using the
+  `NICO_BMC_PROXY__TRACING__ENABLED=true`. The double underscore (`__`) maps to nested TOML sections,
+  so `NICO_BMC_PROXY__TRACING__ENABLED` overrides `[tracing] enabled`. This prefix takes precedence
+  over TOML configuration.
 - **Endpoint.** Set the standard `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, or
   `OTEL_EXPORTER_OTLP_ENDPOINT` to cover every signal at once; the trace-specific variable wins when
   both are set. `[tracing] otlp_endpoint` in the proxy TOML is the fallback for when neither variable

--- a/helm/charts/nico-bmc-proxy/templates/deployment.yaml
+++ b/helm/charts/nico-bmc-proxy/templates/deployment.yaml
@@ -105,7 +105,7 @@ spec:
             # Both names so chart works with either carbide or nico image.
             - name: CARBIDE_BMC_PROXY_DATABASE_URL
               value: "postgres://$(DATASTORE_USER):$(DATASTORE_PASSWORD)@$(DATASTORE_HOST):$(DATASTORE_PORT)/$(DATASTORE_NAME)"
-            - name: NICO_BMC_PROXY_DATABASE_URL
+            - name: NICO_BMC_PROXY__DATABASE_URL
               value: "postgres://$(DATASTORE_USER):$(DATASTORE_PASSWORD)@$(DATASTORE_HOST):$(DATASTORE_PORT)/$(DATASTORE_NAME)"
             - name: RUST_BACKTRACE
               value: {{ .Values.env.RUST_BACKTRACE | quote }}


### PR DESCRIPTION
Add support for `NICO_BMC_PROXY__` env var prefix with nested field support. This enables configuring nested config fields like `tracing.enabled` via env vars without modifying the TOML config file

## Related issues
- Closes #5752

## Type of Change
- [x] **Add** - New feature or capability

## Testing
- [x] Manual testing performed

## Additional Notes
The legacy `CARBIDE_BMC_PROXY_` prefix (single underscore, flat fields only) is preserved for backward compatibility but will be deprecated in a future release (added comment)