### PR TITLE
fix(rest-api): accept prefixed metadata versions

### DIFF
--- a/.github/workflows/rest-lint-and-test.yml
+++ b/.github/workflows/rest-lint-and-test.yml
@@ -264,6 +264,7 @@ jobs:
           - nvswitch-manager
           - powershelf-manager
           - proto
+          - sdk-simple
           - site-agent
           - site-manager
           - site-workflow

--- a/rest-api/Makefile
+++ b/rest-api/Makefile
@@ -3,7 +3,7 @@
 
 .PHONY: test postgres-up postgres-down ensure-postgres postgres-wait clean check-source-headers fix-source-headers check-command-bundle
 .PHONY: build docker-build docker-build-local
-.PHONY: test-ipam test-site-agent test-site-manager test-workflow test-db test-api test-auth test-common test-cert-manager test-site-workflow test-flow test-powershelf-manager test-nvswitch-manager test-proto migrate core-mock-server-build core-mock-server-start core-mock-server-stop flow-mock-server-build flow-mock-server-start flow-mock-server-stop
+.PHONY: test-ipam test-site-agent test-site-manager test-workflow test-db test-api test-auth test-common test-cert-manager test-site-workflow test-flow test-powershelf-manager test-nvswitch-manager test-proto test-sdk-simple migrate core-mock-server-build core-mock-server-start core-mock-server-stop flow-mock-server-build flow-mock-server-start flow-mock-server-stop
 .PHONY: validate-openapi preview-openapi generate-client
 .PHONY: core-proto core-proto-clean core-proto-fetch core-proto-fmt core-protogen flow-proto flow-protogen tools-build tools-clean
 .PHONY: pre-commit-install pre-commit-run pre-commit-update
@@ -260,7 +260,10 @@ test-nvswitch-manager:
 		DB_NAME=$(POSTGRES_DB) \
 		go test -p 1 ./... -count=1
 
-test: test-ipam test-db test-api test-auth test-common test-cert-manager test-site-workflow test-site-manager test-workflow test-site-agent test-flow test-powershelf-manager test-nvswitch-manager test-proto
+test-sdk-simple:
+	go test ./sdk/simple -count=1
+
+test: test-ipam test-db test-api test-auth test-common test-cert-manager test-site-workflow test-site-manager test-workflow test-site-agent test-flow test-powershelf-manager test-nvswitch-manager test-proto test-sdk-simple
 
 build:
 	mkdir -p $(BUILD_DIR)

--- a/rest-api/sdk/simple/api.go
+++ b/rest-api/sdk/simple/api.go
@@ -345,7 +345,10 @@ func (am *ApiMetadata) Initialize(ctx context.Context, org string, apiClient *st
 			Message: fmt.Sprintf("Unable to retrieve API version for org %s.", org),
 		}
 	}
-	am.apiVersion = "v" + *metadata.Version
+	am.apiVersion = *metadata.Version
+	if !strings.HasPrefix(am.apiVersion, "v") {
+		am.apiVersion = "v" + am.apiVersion
+	}
 
 	// Fetch Infrastructure Provider
 	logger.Info().Msgf("Fetching Infrastructure Provider for org: %s", org)

--- a/rest-api/sdk/simple/client_api_name_test.go
+++ b/rest-api/sdk/simple/client_api_name_test.go
@@ -14,48 +14,88 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestAuthenticateUsesConfiguredAPIName(t *testing.T) {
-	visitedPaths := map[string]int{}
+func TestClient_Authenticate(t *testing.T) {
+	tests := []struct {
+		name              string
+		metadataVersion   string
+		normalizedVersion string
+		compatible        bool
+	}{
+		{
+			name:              "unprefixed minimum API version",
+			metadataVersion:   "0.2.86",
+			normalizedVersion: "v0.2.86",
+			compatible:        true,
+		},
+		{
+			name:              "prefixed prerelease API version",
+			metadataVersion:   "v2.3.0-pr-16-g663042ae7",
+			normalizedVersion: "v2.3.0-pr-16-g663042ae7",
+			compatible:        true,
+		},
+		{
+			name:              "prefixed API version below minimum",
+			metadataVersion:   "v0.2.85",
+			normalizedVersion: "v0.2.85",
+			compatible:        false,
+		},
+	}
 
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		visitedPaths[r.URL.Path]++
-		w.Header().Set("Content-Type", "application/json")
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			visitedPaths := map[string]int{}
 
-		switch r.URL.Path {
-		case "/v2/org/test-org/nico/metadata":
-			_, _ = io.WriteString(w, `{"version":"0.2.86"}`)
-		case "/v2/org/test-org/nico/infrastructure-provider/current":
-			_, _ = io.WriteString(w, `{"id":"provider-1"}`)
-		case "/v2/org/test-org/nico/tenant/current":
-			_, _ = io.WriteString(w, `{"id":"tenant-1"}`)
-		case "/v2/org/test-org/nico/site":
-			_, _ = io.WriteString(w, `[{"id":"site-1","name":"site-1"}]`)
-		case "/v2/org/test-org/nico/vpc":
-			_, _ = io.WriteString(w, `[]`)
-		default:
-			http.NotFound(w, r)
-		}
-	}))
-	defer server.Close()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				visitedPaths[r.URL.Path]++
+				w.Header().Set("Content-Type", "application/json")
 
-	client, err := NewClient(ClientConfig{
-		BaseURL: server.URL,
-		Org:     "test-org",
-		APIName: "nico",
-		Token:   "test-token",
-		Logger:  NewNoOpLogger(),
-	})
-	require.NoError(t, err)
+				switch r.URL.Path {
+				case "/v2/org/test-org/nico/metadata":
+					_, _ = io.WriteString(w, `{"version":"`+tt.metadataVersion+`"}`)
+				case "/v2/org/test-org/nico/infrastructure-provider/current":
+					_, _ = io.WriteString(w, `{"id":"provider-1"}`)
+				case "/v2/org/test-org/nico/tenant/current":
+					_, _ = io.WriteString(w, `{"id":"tenant-1"}`)
+				case "/v2/org/test-org/nico/site":
+					_, _ = io.WriteString(w, `[{"id":"site-1","name":"site-1"}]`)
+				case "/v2/org/test-org/nico/vpc":
+					_, _ = io.WriteString(w, `[]`)
+				default:
+					http.NotFound(w, r)
+				}
+			}))
+			defer server.Close()
 
-	err = client.Authenticate(context.Background())
-	require.NoError(t, err)
+			client, err := NewClient(ClientConfig{
+				BaseURL: server.URL,
+				Org:     "test-org",
+				APIName: "nico",
+				Token:   "test-token",
+				Logger:  NewNoOpLogger(),
+			})
+			require.NoError(t, err)
 
-	assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/metadata"])
-	assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/infrastructure-provider/current"])
-	assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/tenant/current"])
-	assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/site"])
-	assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/vpc"])
-	assert.Zero(t, visitedPaths["/v2/org/test-org/carbide/metadata"])
+			err = client.Authenticate(context.Background())
+			if tt.compatible {
+				require.NoError(t, err)
+			} else {
+				var apiErr *ApiError
+				require.ErrorAs(t, err, &apiErr)
+				assert.Equal(t, http.StatusUpgradeRequired, apiErr.Code)
+			}
+
+			version, compatible := client.IsMinimumAPIVersion("v0.2.86")
+			assert.Equal(t, tt.normalizedVersion, version)
+			assert.Equal(t, tt.compatible, compatible)
+
+			assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/metadata"])
+			assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/infrastructure-provider/current"])
+			assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/tenant/current"])
+			assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/site"])
+			assert.Equal(t, 1, visitedPaths["/v2/org/test-org/nico/vpc"])
+			assert.Zero(t, visitedPaths["/v2/org/test-org/carbide/metadata"])
+		})
+	}
 }
 
 func TestNewClientFromEnvReadsAPIName(t *testing.T) {


### PR DESCRIPTION
The simple SDK assumed metadata versions were unprefixed and always
added v.

`b26105bf` retained the `v` prefix in CI version tags. `e9ebd53c` then
embedded that tag in REST API metadata. Together, these changes made
versions such as `v2.3.0-pr-16-g663042ae7` become
`vv2.3.0-pr-16-g663042ae7`, breaking semantic-version comparison and
returning a misleading 426.

Preserve existing prefixes, normalize legacy bare versions, and run
the regression tests in aggregate and CI test suites.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated