### PR TITLE
fix(hw-health): Ensure the presence of an otel collector does not remove prometheus metrics

### DIFF
--- a/helm-prereqs/observability/README.md
+++ b/helm-prereqs/observability/README.md
@@ -8,7 +8,7 @@ An optional, self-contained monitoring stack for any cluster installed with `hel
 ```text
                      ┌───────────────────────────── monitoring ns ─────────────────────────────┐
  NICo /metrics ──────► Prometheus (kube-prometheus-stack, release `obs`) ◄── ServiceMonitors    │
- (carbide_*)         │        │                                                                 │
+ hw /telemetry ──────►        │                                                                 │
                      │        ▼                                                                 │
                      │     Grafana ── datasources: Prometheus, Loki, Tempo; dashboard sidecar   │
                      └────────▲───────────────────────▲─────────────────────────────────────────┘
@@ -22,7 +22,7 @@ An optional, self-contained monitoring stack for any cluster installed with `hel
 
 | Signal | Source | Store | How |
 |---|---|---|---|
-| Metrics | every NICo service's `/metrics` (`carbide_*`) | Prometheus | the NICo charts' ServiceMonitors — auto-enabled in the setup.sh flow, see [Scraping the NICo metrics](#scraping-the-nico-metrics) |
+| Metrics | every NICo service's `/metrics` and hardware-health `/telemetry` (`carbide_*`) | Prometheus | the NICo charts' ServiceMonitors — auto-enabled in the setup.sh flow, see [Scraping the NICo metrics](#scraping-the-nico-metrics) |
 | Metrics | nodes, cadvisor, kube-state | Prometheus | kube-prometheus-stack defaults |
 | Logs | ALL pod stdout (nico-\*, nico-rest, flow, temporal, vault, CP static pods, …) | Loki | otel-agent DaemonSet tails `/var/log/pods/*` |
 | Traces | NICo OTLP spans (opt-in, see [Enabling traces](#enabling-traces)) | Tempo | services → otel-agent `:4317` → Tempo |
@@ -77,34 +77,48 @@ kubectl -n monitoring port-forward svc/obs-grafana 3000:80   # -> http://localho
 | `OTEL_RECEIVER_VIP` | *(required if `WITH_DPU`)* | MetalLB VIP the DPUs dial |
 | `OTEL_RECEIVER_DNS` | `otel-receiver.forge` | SAN on the gateway cert = the name DPUs dial |
 | `SITE_CA_ISSUER` | `site-issuer` | ClusterIssuer for the gateway cert — **must be the CA the DPUs trust** |
-| `NICO_SERVICEMONITORS` | `hint` (standalone), `true` (from setup.sh) | `true` = enable the NICo charts' ServiceMonitors via a release upgrade with this tree's chart; `hint` = print the enable command instead; `false` = skip (see [Scraping the NICo metrics](#scraping-the-nico-metrics)) |
+| `NICO_SERVICEMONITORS` | `hint` (standalone or setup without a Core install), `true` (setup after installing Core) | `true` = apply the NICo metrics overlay via a release upgrade with this tree's chart; `hint` = print the command instead; `false` = skip (see [Scraping the NICo metrics](#scraping-the-nico-metrics)) |
 | `NICO_RELEASE` / `NICO_NS` | `nico` / `nico-system` | NICo Core release name / namespace |
 | `LOKI_CHART_VER` `TEMPO_CHART_VER` `OTEL_CHART_VER` `KPS_CHART_VER` | see [pins](#components-and-pins) | chart version overrides |
 
 Per-site values are applied as `helm --set-string` overrides — the `values-*.yaml` files keep
 validated defaults and never need editing for a new site.
 
+Within `setup.sh`, `NICO_SERVICEMONITORS=true` is honored only after that run successfully
+installs Core. If Core is skipped or declined, setup forces the safe `hint` behavior. To
+deliberately reconcile an existing release, run the standalone installer with the override.
+
 ## Scraping the NICo metrics
 
 The NICo subcharts ship ServiceMonitor templates but **default them off**, and the standard
 deploy values do not enable them — a fresh site exposes `carbide_*` metrics that nothing
-scrapes. In the `setup.sh --with-observability` flow **the installer closes this
-automatically**: Core was just installed from the same tree, so it safely applies the bundled
-`values-nico-servicemonitors.yaml` overlay to the release (`--reuse-values`; adds monitor
-objects only, no pod changes). Prometheus discovers them cluster-wide within a scrape interval
-(`*SelectorNilUsesHelmValues: false` — no labels to coordinate).
+scrapes. In the `setup.sh --with-observability` flow, when Core was successfully installed in
+the same run, the installer safely applies the bundled `values-nico-servicemonitors.yaml`
+overlay to the release (`--reuse-values`; for hardware-health, this enables its Prometheus sink
+and both monitor endpoints). Prometheus discovers the resulting monitors cluster-wide within a
+scrape interval (`*SelectorNilUsesHelmValues: false` — no labels to coordinate).
 
-Running **standalone** the default is `hint`: upgrading a release with a chart tree that may
-differ from what is deployed could apply more than the monitors, so the installer prints the
-enable command instead. Apply it with the chart ref your site was actually installed from:
+Hardware health serves both paths on port `9009`: `/metrics` contains service-owned metrics,
+including the optional BMC request-latency histogram, while `/telemetry` contains the original
+per-hardware samples. The latter is high-cardinality; size Prometheus retention and scrape
+capacity accordingly.
+
+An enabled hardware-health OTLP target remains an analyzer input and does not replace either
+direct scrape.
+
+Running **standalone**, using `--skip-core`, or declining the Core install uses `hint`: upgrading
+an existing release with a chart tree that may differ from what is deployed could apply more
+than the monitors, so the installer prints the enable command instead. Apply it with the chart
+ref your site was actually installed from:
 
 ```bash
 helm upgrade nico <your-chart-ref> -n nico-system --reuse-values \
     -f helm-prereqs/observability/values-nico-servicemonitors.yaml
 ```
 
-(or re-run with `NICO_SERVICEMONITORS=true` when this checkout matches the deployed chart).
-If Core is not installed at all (infra-only cluster), the step defers with the same hint.
+(or run `NICO_SERVICEMONITORS=true helm-prereqs/observability/install-observability.sh` when this
+checkout matches the deployed chart). If Core is not installed at all (infra-only cluster), the
+step defers with the same hint.
 
 ## Enabling traces
 
@@ -121,7 +135,7 @@ or set `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT=http://otel-agent.otel.svc.cluster.lo
 the chart's generic `extraEnv:` (the env var wins over the config key — but it sets ONLY the
 endpoint; `enabled` must come from the TOML, or at runtime without a pod roll:
 `nico-admin-cli set tracing-enabled true`). Details, verified from `crates/api/src/logging.rs`
-+ `crates/api-core/src/cfg/file.rs` (see also `docs/observability/tracing.md`):
+and `crates/api-core/src/cfg/file.rs` (see also `docs/observability/tracing.md`):
 
 - transport is OTLP **gRPC, plaintext only** — never point nico-api at `:4318` or an `https://`
   endpoint; keep the hop in-cluster (the collector is the TLS boundary);
@@ -175,8 +189,9 @@ kubectl -n loki get pods && kubectl -n tempo get pods && kubectl -n otel get pod
 kubectl -n loki exec sts/loki -- wget -qO- \
   'http://localhost:3100/loki/api/v1/query?query=count_over_time({forge_site="<site>"}[5m])' | head -c 400
 
-# NICo metrics scraped (after enabling ServiceMonitors): Grafana -> Explore -> Prometheus ->
-#   up{job=~"nico-.*"}     and     carbide_api_ready
+# NICo hardware-health metrics scraped: Grafana -> Explore -> Prometheus ->
+#   carbide_hardware_health_bmc_latency_ms_count
+#   carbide_hardware_health_hw_metric_capacity_utilization_percent
 
 # traces (after enabling span export): Grafana -> Explore -> Tempo -> search service carbide-api
 ```

--- a/helm-prereqs/observability/install-observability.sh
+++ b/helm-prereqs/observability/install-observability.sh
@@ -17,8 +17,9 @@
 # install-observability.sh — site-local metrics + logs + traces for a NICo cluster:
 #   Loki (logs) + Tempo (traces) + OTEL collector agent (DaemonSet: pod logs -> Loki,
 #   OTLP spans -> Tempo) + kube-prometheus-stack (Prometheus scraping the carbide_* /metrics
-#   via the NICo charts' ServiceMonitors + Grafana with Prometheus/Loki/Tempo datasources and
-#   auto-loaded dashboards). Optional: an OTLP/mTLS gateway for sites with real DPUs.
+#   endpoints and hardware-health /telemetry via the NICo charts' ServiceMonitors + Grafana
+#   with Prometheus/Loki/Tempo datasources and auto-loaded dashboards). Optional: an OTLP/mTLS
+#   gateway for sites with real DPUs.
 #
 # Fully self-contained: everything runs and stays on the site; nothing leaves the cluster.
 #
@@ -47,9 +48,9 @@
 #                      zone); change it only together with the DPU-side configuration.
 #   SITE_CA_ISSUER     ClusterIssuer for the gateway server cert — MUST be the ca-issuer backed
 #                      by the CA the DPUs trust. Default site-issuer.
-#   NICO_SERVICEMONITORS  Default true: when the NICo Core release is installed, enable its
-#                      charts' ServiceMonitors automatically (carbide_* metrics scrape). Set
-#                      false on clusters installed from a different checkout (chart drift).
+#   NICO_SERVICEMONITORS  Default hint when run standalone. setup.sh supplies true only after
+#                      successfully installing Core from this tree in the same run. true applies
+#                      the NICo Core metrics overlay. Set false to skip reconciliation.
 #   NICO_RELEASE / NICO_NS   NICo Core release name/namespace. Default nico / nico-system.
 #   LOKI_CHART_VER / TEMPO_CHART_VER / OTEL_CHART_VER / KPS_CHART_VER   Chart pin overrides.
 set -euo pipefail
@@ -246,51 +247,62 @@ kubectl -n loki get pods
 kubectl -n otel get pods
 kubectl -n monitoring get pods | head -8
 
-# --- NICo metrics: enable the charts' ServiceMonitors -------------------------------------
+# --- NICo metrics --------------------------------------------------------------------------
 # The NICo subcharts ship ServiceMonitor templates but default them OFF — nothing scrapes the
-# carbide_* metrics until they exist. When the nico release is present and monitors are
-# missing, enable them via the bundled overlay (adds monitor objects only — no pod changes;
-# Prometheus discovers them cluster-wide within a scrape interval).
-# NICO_SERVICEMONITORS: true = enable via a release upgrade with THIS tree's chart (setup.sh
-# passes true — Core was just installed from the same tree); hint (standalone default) = print
-# the command instead, because upgrading with a checkout that differs from what is deployed
-# would apply more than the monitors; false = skip silently.
+# carbide_* metrics until they exist. The bundled overlay enables all required metrics endpoints.
+# NICO_SERVICEMONITORS: true = apply it via a release upgrade with THIS tree's chart (setup.sh
+# passes true only when this run installed Core from the same tree); hint (standalone and
+# setup.sh --skip-core default) = print the command instead, because upgrading with a checkout
+# that differs from what is deployed could change more than metrics collection; false = skip
+# silently. Reapply it unconditionally because existing monitors may not cover all current
+# endpoints.
+_inspect_nico_release() {
+    local status_output
+    local status_code
+
+    if status_output="$(helm status "${NICO_RELEASE}" -n "${NICO_NS}" 2>&1)"; then
+        _NICO_RELEASE_PRESENT=true
+        return 0
+    else
+        status_code=$?
+    fi
+
+    # Helm returns this storage-driver sentinel only when the named release is absent.
+    if [[ "${status_output}" == *"release: not found"* ]]; then
+        _NICO_RELEASE_PRESENT=false
+        return 0
+    fi
+
+    echo "ERROR: unable to inspect NICo release '${NICO_RELEASE}' in ${NICO_NS}:" >&2
+    printf '%s\n' "${status_output}" >&2
+    return "${status_code}"
+}
+
 NICO_SERVICEMONITORS="${NICO_SERVICEMONITORS:-hint}"
 NICO_RELEASE="${NICO_RELEASE:-nico}"
 NICO_NS="${NICO_NS:-nico-system}"
+_NICO_RELEASE_PRESENT=false
+if [[ "${NICO_SERVICEMONITORS}" != "false" ]]; then
+    _inspect_nico_release || exit $?
+fi
+
 if [[ "${NICO_SERVICEMONITORS}" == "false" ]]; then
-    echo "--- NICo ServiceMonitors skipped (NICO_SERVICEMONITORS=false)"
-elif ! helm status "${NICO_RELEASE}" -n "${NICO_NS}" >/dev/null 2>&1; then
-    echo "--- NICo release '${NICO_RELEASE}' not found in ${NICO_NS} — ServiceMonitors deferred."
+    echo "--- NICo direct metrics reconciliation skipped (NICO_SERVICEMONITORS=false)"
+elif [[ "${_NICO_RELEASE_PRESENT}" != "true" ]]; then
+    echo "--- NICo release '${NICO_RELEASE}' not found in ${NICO_NS} — metrics collection deferred."
     echo "    After installing NICo Core, re-run this script (idempotent) or:"
     echo "      helm upgrade ${NICO_RELEASE} <chart-ref> -n ${NICO_NS} --reuse-values \\"
     echo "        -f ${SCRIPT_DIR}/values-nico-servicemonitors.yaml"
+elif [[ "${NICO_SERVICEMONITORS}" == "true" ]]; then
+    echo "--- reconciling NICo direct metrics collection (ServiceMonitors + hardware-health sink)"
+    helm upgrade "${NICO_RELEASE}" "${PREREQS_DIR}/../helm" -n "${NICO_NS}" --reuse-values \
+        -f "${SCRIPT_DIR}/values-nico-servicemonitors.yaml"
 else
-    # A failed API call must read as "unknown", not "absent" — retry briefly.
-    _SM_LIST=""; _SM_KNOWN=false
-    for _i in 1 2 3; do
-        if _SM_LIST="$(kubectl get servicemonitors.monitoring.coreos.com -n "${NICO_NS}" -o name 2>/dev/null)"; then
-            _SM_KNOWN=true; break
-        fi
-        sleep 2
-    done
-    if [[ "${_SM_KNOWN}" == "true" ]] && grep -q nico <<< "${_SM_LIST}"; then
-        echo "--- NICo ServiceMonitors already present"
-    elif [[ "${_SM_KNOWN}" != "true" ]]; then
-        echo "--- could not verify NICo ServiceMonitors (API error) — re-run this script, or enable manually:"
-        echo "      helm upgrade ${NICO_RELEASE} <chart-ref> -n ${NICO_NS} --reuse-values \\"
-        echo "        -f ${SCRIPT_DIR}/values-nico-servicemonitors.yaml"
-    elif [[ "${NICO_SERVICEMONITORS}" == "true" ]]; then
-        echo "--- enabling NICo ServiceMonitors (carbide_* metrics scrape)"
-        helm upgrade "${NICO_RELEASE}" "${PREREQS_DIR}/../helm" -n "${NICO_NS}" --reuse-values \
-            -f "${SCRIPT_DIR}/values-nico-servicemonitors.yaml"
-    else
-        echo "--- NICo ServiceMonitors are NOT enabled — Prometheus is not scraping the carbide_*"
-        echo "    metrics. Enable them with YOUR deployed chart ref (adds monitor objects only):"
-        echo "      helm upgrade ${NICO_RELEASE} <chart-ref> -n ${NICO_NS} --reuse-values \\"
-        echo "        -f ${SCRIPT_DIR}/values-nico-servicemonitors.yaml"
-        echo "    Or re-run with NICO_SERVICEMONITORS=true if this checkout matches the deployed chart."
-    fi
+    echo "--- NICo direct metrics collection was not reconciled (standalone safety default)."
+    echo "    Apply the overlay with YOUR deployed chart ref:"
+    echo "      helm upgrade ${NICO_RELEASE} <chart-ref> -n ${NICO_NS} --reuse-values \\"
+    echo "        -f ${SCRIPT_DIR}/values-nico-servicemonitors.yaml"
+    echo "    Or re-run with NICO_SERVICEMONITORS=true if this checkout matches the deployed chart."
 fi
 
 echo ""

--- a/helm-prereqs/observability/values-nico-servicemonitors.yaml
+++ b/helm-prereqs/observability/values-nico-servicemonitors.yaml
@@ -1,7 +1,8 @@
 # NICo Core overlay — turn on the primary /metrics ServiceMonitor/PodMonitor of every subchart
 # that ships one, so the observability stack's Prometheus scrapes the carbide_* metrics.
-# (High-cardinality extras — nico-api per-object state metrics, hardware-health telemetry —
-# are separately gated and stay opt-in.)
+# Hardware-health additionally enables its Prometheus sink and /telemetry monitor. An OTLP target
+# remains an analyzer input; it must not relay those input metrics to the metrics backend. Other
+# high-cardinality extras, such as nico-api per-object state metrics, stay opt-in.
 #
 # The subcharts ship the monitor TEMPLATES but default them OFF, and none of the standard deploy
 # values enable them — without this overlay Prometheus discovers nothing from NICo. Apply it as
@@ -10,8 +11,8 @@
 #   helm upgrade nico <chart-ref> -n nico-system --reuse-values \
 #       -f observability/values-nico-servicemonitors.yaml
 #
-# (install-observability.sh applies this automatically in the setup.sh flow, and prints the
-# command above when running standalone.)
+# (install-observability.sh applies this automatically only when the same setup.sh run installed
+# Core, and prints the command above when running standalone or with --skip-core.)
 nico-api:
   serviceMonitor:
     enabled: true
@@ -28,7 +29,11 @@ nico-dsx-exchange-consumer:
   serviceMonitor:
     enabled: true
 nico-hardware-health:
+  env:
+    CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED: "true"
   serviceMonitor:
+    enabled: true
+  telemetryServiceMonitor:
     enabled: true
 nico-machine-a-tron:
   serviceMonitor:

--- a/helm-prereqs/setup.sh
+++ b/helm-prereqs/setup.sh
@@ -1392,6 +1392,7 @@ fi
 # ---------------------------------------------------------------------------
 # NICo Core
 # ---------------------------------------------------------------------------
+_CORE_INSTALLED_THIS_RUN=false
 if "${SKIP_CORE}"; then
     echo "=== [6/6] NICo Core ==="
     echo "Skipped (--skip-core flag set)."
@@ -1670,6 +1671,7 @@ else
             kubectl rollout status deployment/nico-api -n nico-system --timeout=300s
             echo "DPF enabled in carbide-api"
         fi
+        _CORE_INSTALLED_THIS_RUN=true
     elif "${INSTALL_DPF}"; then
         # The DPF path deploys from a mktemp values file that the EXIT trap
         # deletes, and enablement is a two-phase flow (deploy DPF-off, set the
@@ -1704,16 +1706,33 @@ fi
 #   helm-prereqs/observability/install-observability.sh
 # Docs: helm-prereqs/observability/README.md
 # ---------------------------------------------------------------------------
+_resolve_nico_servicemonitors_mode() {
+    local core_installed_this_run="$1"
+    local requested_mode="${NICO_SERVICEMONITORS:-}"
+
+    if [[ "${core_installed_this_run}" == "true" ]]; then
+        printf '%s\n' "${requested_mode:-true}"
+    elif [[ "${requested_mode}" == "false" ]]; then
+        printf 'false\n'
+    else
+        # Never upgrade an existing Core release from this checkout unless the
+        # same setup run successfully installed it. This also covers a declined
+        # Core prompt in addition to --skip-core.
+        printf 'hint\n'
+    fi
+}
+
 _OBSERVABILITY_INSTALLED=false
 if "${WITH_OBSERVABILITY}"; then
     echo ""
     _SETUP_PHASE="observability"
     echo "=== Observability (--with-observability) ==="
     # The stack is optional: a failure here must not abort the rest of the install.
-    # NICO_SERVICEMONITORS=true is safe in this integrated path — Core was just installed
-    # from this same tree, so the release upgrade the installer performs is a no-op apart
-    # from adding the monitor objects.
-    if NICO_SERVICEMONITORS="${NICO_SERVICEMONITORS:-true}" \
+    # Reconcile Core metrics only when this run installed Core from the same tree.
+    # Otherwise use the standalone-safe hint path and leave any existing release untouched.
+    _nico_servicemonitors_mode="$(_resolve_nico_servicemonitors_mode \
+        "${_CORE_INSTALLED_THIS_RUN}")"
+    if NICO_SERVICEMONITORS="${_nico_servicemonitors_mode}" \
         "${SCRIPT_DIR}/observability/install-observability.sh"; then
         _OBSERVABILITY_INSTALLED=true
     else

--- a/helm-prereqs/tests/install-observability-release-status_test.sh
+++ b/helm-prereqs/tests/install-observability-release-status_test.sh
@@ -1,0 +1,92 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INSTALLER="${SCRIPT_DIR}/../observability/install-observability.sh"
+TEST_TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "${TEST_TMP_DIR}"' EXIT
+TEST_LOG="${TEST_TMP_DIR}/helm.log"
+
+inspect_definition="$(
+    sed -n '/^_inspect_nico_release()/,/^}/p' "${INSTALLER}"
+)"
+if [[ -z "${inspect_definition}" ]]; then
+    echo "could not extract NICo release inspection helper" >&2
+    exit 1
+fi
+eval "${inspect_definition}"
+
+helm() {
+    printf '%s\n' "$*" >> "${TEST_LOG}"
+    case "${TEST_SCENARIO}" in
+        present)
+            printf 'NAME: nico\nSTATUS: deployed\n'
+            ;;
+        missing)
+            printf 'Error: release: not found\n' >&2
+            return 1
+            ;;
+        forbidden)
+            printf 'Error: query: failed to query with labels: secrets is forbidden\n' >&2
+            return 7
+            ;;
+        unreachable)
+            printf 'Error: Kubernetes cluster unreachable: connection refused\n' >&2
+            return 9
+            ;;
+    esac
+}
+
+NICO_RELEASE=nico
+NICO_NS=nico-system
+
+_NICO_RELEASE_PRESENT=false
+TEST_SCENARIO=present _inspect_nico_release
+[[ "${_NICO_RELEASE_PRESENT}" == "true" ]] || {
+    echo "deployed release was not marked present" >&2
+    exit 1
+}
+
+_NICO_RELEASE_PRESENT=true
+TEST_SCENARIO=missing _inspect_nico_release
+[[ "${_NICO_RELEASE_PRESENT}" == "false" ]] || {
+    echo "missing release was not classified as absent" >&2
+    exit 1
+}
+
+assert_status_failure() {
+    local scenario="$1"
+    local expected_status="$2"
+    local expected_error="$3"
+    local error_log="${TEST_TMP_DIR}/${scenario}.err"
+    local actual_status
+
+    if TEST_SCENARIO="${scenario}" _inspect_nico_release 2> "${error_log}"; then
+        echo "${scenario} helm status failure was accepted" >&2
+        exit 1
+    else
+        actual_status=$?
+    fi
+
+    [[ "${actual_status}" == "${expected_status}" ]] || {
+        echo "${scenario} status ${actual_status} did not preserve ${expected_status}" >&2
+        exit 1
+    }
+    grep -Fq -- "${expected_error}" "${error_log}" || {
+        echo "${scenario} error output was not retained" >&2
+        exit 1
+    }
+}
+
+assert_status_failure forbidden 7 'secrets is forbidden'
+assert_status_failure unreachable 9 'Kubernetes cluster unreachable'
+
+if [[ "$(grep -Fc -- 'status nico -n nico-system' "${TEST_LOG}")" -ne 4 ]]; then
+    echo "release inspection did not call helm status for every scenario" >&2
+    exit 1
+fi
+
+echo "install-observability release status tests passed"

--- a/helm-prereqs/tests/setup-observability-core-gate_test.sh
+++ b/helm-prereqs/tests/setup-observability-core-gate_test.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SETUP_SH="${SCRIPT_DIR}/../setup.sh"
+
+mode_definition="$(
+    sed -n '/^_resolve_nico_servicemonitors_mode()/,/^}/p' "${SETUP_SH}"
+)"
+if [[ -z "${mode_definition}" ]]; then
+    echo "could not extract NICo ServiceMonitor mode resolver" >&2
+    exit 1
+fi
+eval "${mode_definition}"
+
+assert_mode() {
+    local expected="$1"
+    local core_installed_this_run="$2"
+    local requested_mode="${3-__unset__}"
+    local actual
+
+    if [[ "${requested_mode}" == "__unset__" ]]; then
+        actual="$(unset NICO_SERVICEMONITORS; \
+            _resolve_nico_servicemonitors_mode "${core_installed_this_run}")"
+    else
+        actual="$(NICO_SERVICEMONITORS="${requested_mode}" \
+            _resolve_nico_servicemonitors_mode "${core_installed_this_run}")"
+    fi
+
+    if [[ "${actual}" != "${expected}" ]]; then
+        echo "expected mode ${expected}, got ${actual} " \
+            "(core_installed=${core_installed_this_run}, requested=${requested_mode})" >&2
+        exit 1
+    fi
+}
+
+# A Core release installed from this checkout can be reconciled automatically,
+# while callers can still request the existing hint or false modes explicitly.
+assert_mode true true
+assert_mode true true true
+assert_mode hint true hint
+assert_mode false true false
+
+# An existing or skipped Core release must never be upgraded from this checkout.
+# Even an inherited true value is reduced to the safe hint behavior.
+assert_mode hint false
+assert_mode hint false true
+assert_mode hint false hint
+assert_mode false false false
+
+marker_init_line="$(grep -nF '_CORE_INSTALLED_THIS_RUN=false' "${SETUP_SH}" | cut -d: -f1)"
+core_upgrade_line="$(grep -nF '(cd "${SCRIPT_DIR}/.." && "${NICO_CORE_CMD[@]}")' \
+    "${SETUP_SH}" | cut -d: -f1)"
+marker_set_line="$(grep -nF '_CORE_INSTALLED_THIS_RUN=true' "${SETUP_SH}" | cut -d: -f1)"
+mode_call_line="$(grep -nF '"${_CORE_INSTALLED_THIS_RUN}")"' "${SETUP_SH}" | cut -d: -f1)"
+
+if ! (( marker_init_line < core_upgrade_line && core_upgrade_line < marker_set_line && \
+        marker_set_line < mode_call_line )); then
+    echo "Core installation state must gate observability after the Core phase" >&2
+    exit 1
+fi
+
+echo "setup observability Core gate tests passed"

--- a/helm/charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
+++ b/helm/charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
@@ -1,13 +1,19 @@
 {{- if .Values.telemetryServiceMonitor.enabled }}
+{{- $prometheusSinkEnabled := "true" }}
+{{- if and (kindIs "map" .Values.env) (hasKey .Values.env "CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED") }}
+{{- $prometheusSinkEnabled = lower (toString (index .Values.env "CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED")) }}
+{{- end }}
+{{- if eq $prometheusSinkEnabled "true" }}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: nico-hardware-health-telemetry
+  name: {{ include "nico-hardware-health.name" . }}-telemetry
   namespace: {{ include "nico-hardware-health.namespace" . }}
   labels:
     {{- include "nico-hardware-health.labels" . | nindent 4 }}
-    app: nico-hardware-health
+    app: {{ include "nico-hardware-health.name" . }}
     prometheus: nico-monitoring
 spec:
-  {{- include "nico-hardware-health.telemetryServiceMonitorSpec" (dict "name" "nico-hardware-health" "port" "metrics" "monitor" .Values.telemetryServiceMonitor "namespace" (include "nico-hardware-health.namespace" .)) | nindent 2 }}
+  {{- include "nico-hardware-health.telemetryServiceMonitorSpec" (dict "name" (include "nico-hardware-health.name" .) "port" "metrics" "monitor" .Values.telemetryServiceMonitor "namespace" (include "nico-hardware-health.namespace" .)) | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/helm/charts/nico-hardware-health/tests/metrics_collection_test.yaml
+++ b/helm/charts/nico-hardware-health/tests/metrics_collection_test.yaml
@@ -1,0 +1,102 @@
+suite: hardware-health metrics collection
+templates:
+  - templates/deployment.yaml
+  - templates/service-monitor.yaml
+  - templates/telemetry-service-monitor.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: keeps the direct Prometheus sink enabled by default
+    template: templates/deployment.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED
+            value: "true"
+
+  - it: scrapes BMC latency and other service metrics from /metrics
+    template: templates/service-monitor.yaml
+    set:
+      serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/metrics"]
+          value: nico-hardware-health
+
+  - it: scrapes raw hardware samples from /telemetry
+    template: templates/telemetry-service-monitor.yaml
+    set:
+      telemetryServiceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /telemetry
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/metrics"]
+          value: nico-hardware-health
+
+  - it: follows nameOverride when selecting the hardware-health Service
+    template: templates/telemetry-service-monitor.yaml
+    set:
+      nameOverride: carbide-hardware-health
+      telemetryServiceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: carbide-hardware-health-telemetry
+      - equal:
+          path: metadata.labels.app
+          value: carbide-hardware-health
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/metrics"]
+          value: carbide-hardware-health
+
+  - it: suppresses the telemetry monitor when the Prometheus sink is false
+    template: templates/telemetry-service-monitor.yaml
+    set:
+      telemetryServiceMonitor.enabled: true
+      env.CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED: "false"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: suppresses the telemetry monitor when the Prometheus sink is empty
+    template: templates/telemetry-service-monitor.yaml
+    set:
+      telemetryServiceMonitor.enabled: true
+      env.CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED: ""
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: suppresses the telemetry monitor when the Prometheus sink is zero
+    template: templates/telemetry-service-monitor.yaml
+    set:
+      telemetryServiceMonitor.enabled: true
+      env.CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED: "0"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: suppresses the telemetry monitor when the Prometheus sink is misspelled
+    template: templates/telemetry-service-monitor.yaml
+    set:
+      telemetryServiceMonitor.enabled: true
+      env.CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED: "ture"
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: uses the binary's enabled default when the environment map is null
+    template: templates/telemetry-service-monitor.yaml
+    set:
+      telemetryServiceMonitor.enabled: true
+      env: null
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /telemetry

--- a/helm/charts/nico-hardware-health/values.yaml
+++ b/helm/charts/nico-hardware-health/values.yaml
@@ -55,6 +55,8 @@ env:
   RUST_BACKTRACE: "full"
   RUST_LIB_BACKTRACE: "0"
   NICO_HEALTH__COLLECTORS__LOGS__ENABLED: "true"
+  ## Keep direct Prometheus collection independent of optional OTLP analyzer targets.
+  CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED: "true"
 
 livenessProbe:
   httpGet:
@@ -66,7 +68,8 @@ livenessProbe:
   failureThreshold: 3
   successThreshold: 1
 
-## Scrapes /metrics: service operational metrics (discovery, collectors, components).
+## Scrapes /metrics: service operational metrics (discovery, collectors, components,
+## including the optional BMC latency histogram).
 serviceMonitor:
   enabled: false
   interval: 30s
@@ -74,7 +77,8 @@ serviceMonitor:
 
 ## Scrapes /telemetry: hardware sensor samples exported by the Prometheus sink
 ## (temperature, power, fans, and other Redfish-derived gauge readings per endpoint).
-## High cardinality; enable only when Prometheus retention and scrape budget allow it.
+## Requires CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED=true. High cardinality;
+## enable only when Prometheus retention and scrape budget allow it.
 telemetryServiceMonitor:
   enabled: false
   interval: 30s

--- a/helm/tests/fixtures/hardware-health-otlp-values.yaml
+++ b/helm/tests/fixtures/hardware-health-otlp-values.yaml
@@ -1,0 +1,10 @@
+nico-hardware-health:
+  env:
+    CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED: "false"
+    CARBIDE_HEALTH__SINKS__OTLP__ENABLED: "true"
+    CARBIDE_HEALTH__SINKS__OTLP__TARGETS: >-
+      [ {endpoint="http://otlp-receiver.observability.svc.cluster.local:4317"} ]
+  serviceMonitor:
+    enabled: false
+  telemetryServiceMonitor:
+    enabled: false

--- a/helm/tests/hardware_health_observability_test.yaml
+++ b/helm/tests/hardware_health_observability_test.yaml
@@ -1,0 +1,49 @@
+suite: hardware-health direct observability
+templates:
+  - charts/nico-hardware-health/templates/deployment.yaml
+  - charts/nico-hardware-health/templates/service-monitor.yaml
+  - charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
+release:
+  namespace: nico-system
+tests:
+  - it: observability overlay restores Prometheus without disabling the configured OTLP target
+    template: charts/nico-hardware-health/templates/deployment.yaml
+    values:
+      - fixtures/hardware-health-otlp-values.yaml
+      - ../../helm-prereqs/observability/values-nico-servicemonitors.yaml
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CARBIDE_HEALTH__SINKS__PROMETHEUS__ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CARBIDE_HEALTH__SINKS__OTLP__ENABLED
+            value: "true"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: CARBIDE_HEALTH__SINKS__OTLP__TARGETS
+            value: '[ {endpoint="http://otlp-receiver.observability.svc.cluster.local:4317"} ]'
+
+  - it: observability overlay scrapes hardware-health service metrics
+    template: charts/nico-hardware-health/templates/service-monitor.yaml
+    values:
+      - fixtures/hardware-health-otlp-values.yaml
+      - ../../helm-prereqs/observability/values-nico-servicemonitors.yaml
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /metrics
+
+  - it: observability overlay scrapes original hardware telemetry
+    template: charts/nico-hardware-health/templates/telemetry-service-monitor.yaml
+    values:
+      - fixtures/hardware-health-otlp-values.yaml
+      - ../../helm-prereqs/observability/values-nico-servicemonitors.yaml
+    asserts:
+      - equal:
+          path: spec.endpoints[0].path
+          value: /telemetry


### PR DESCRIPTION
Enabling an external OTEL collector currently disables direct Prometheus collection from nico-hardware-health. As a result, metrics available only on /
metrics, such as the BMC latency histogram, are missing, while hardware samples forwarded through an OTEL collector still appear with altered
OTLP-derived labels.

Hardware-health should always expose and directly scrape /metrics and /telemetry, regardless of whether an OTEL collector is enabled. The OTEL Collector should
consume hardware telemetry only as analyzer input and must not relay the original metrics to the observability backend, avoiding
missing or duplicated series.

## Related issues
#5766 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [X] Unit tests added/updated
- [X] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

