### PR TITLE
fix(dpf): permit NVUE logrotate config locking

### DIFF
--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -899,7 +899,7 @@ fn hbn_apparmor_config_files() -> [DpuFlavorConfigFiles; 2] {
                     "signal (receive) peer=runc,\n",
                     "capability chown,\n",
                     "/usr/{bin,sbin}/* ixr,\n",
-                    "/etc/logrotate.d/* r,\n",
+                    "/etc/logrotate.d/* rk,\n",
                     "/var/lib/logrotate/{,**} rwk,\n",
                 )
                 .to_string(),
@@ -2988,7 +2988,7 @@ mod tests {
                         "signal (receive) peer=runc,\n",
                         "capability chown,\n",
                         "/usr/{bin,sbin}/* ixr,\n",
-                        "/etc/logrotate.d/* r,\n",
+                        "/etc/logrotate.d/* rk,\n",
                         "/var/lib/logrotate/{,**} rwk,\n",
                     ),
                 ) && has_file(


### PR DESCRIPTION
DPF HBN's rsyslogd AppArmor profile lets logrotate read `/etc/logrotate.d/nvued`, but logrotate 3.21 also takes an advisory read lock before parsing it. Rotation succeeds, but every cycle emits `apparmor="DENIED" operation="file_lock" profile="rsyslogd" name="/etc/logrotate.d/nvued" comm="logrotate"`.

This adds `k` only to the existing configuration read rule, so logrotate can take the lock without receiving write access or access to any other paths. The existing flavor assertion covers every DPF deployment type.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5769

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 3 | 1 | 2 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **3** | **1** | **2** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- Include the observed AppArmor denial in the PR explanation. **Resolution:** The opening identifies the reported profile, operation, configuration path, and command.
2. **Declined** -- Add other observed AppArmor permissions to this change. **Reason:** The current flavor has no other recurring permission gap. A one-time `fsetid` denial did not prevent ownership normalization or rotation, and the exec and signal denials came from older flavors without the current policy.
3. **Declined** -- Add an inline comment for the `k` permission. **Reason:** The helper Rustdoc already explains that this policy permits the rotation chain, and `k` is the exact AppArmor permission.

### common-nits-reviewer

No findings.

</details>


Closes #5769
