### PR TITLE
 fix(dns): make OTLP trace export in nico-dns opt-in and configurable

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1732,6 +1732,7 @@ dependencies = [
  "eyre",
  "hickory-resolver",
  "hickory-server",
+ "logfmt",
  "lru",
  "metrics-endpoint",
  "opentelemetry 0.32.0",
@@ -11789,16 +11790,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing-serde"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704b1aeb7be0d0a84fc9828cae51dab5970fee5088f83d1dd7ee6f6246fc6ff1"
-dependencies = [
- "serde",
- "tracing-core",
-]
-
-[[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11808,8 +11799,6 @@ dependencies = [
  "nu-ansi-term",
  "once_cell",
  "regex-automata",
- "serde",
- "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
@@ -11817,7 +11806,6 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
- "tracing-serde",
 ]
 
 [[package]]

--- a/crates/dns/Cargo.toml
+++ b/crates/dns/Cargo.toml
@@ -29,6 +29,7 @@ path = "src/main.rs"
 
 [dependencies]
 carbide-instrument = { path = "../instrument" }
+logfmt = { path = "../logfmt" }
 async-trait = { workspace = true }
 clap = { workspace = true }
 eyre = { workspace = true }
@@ -38,7 +39,6 @@ tracing = { workspace = true }
 tracing-subscriber = { features = [
   "env-filter",
   "local-time",
-  "json",
 ], workspace = true }
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry_sdk = { workspace = true }

--- a/crates/dns/src/config.rs
+++ b/crates/dns/src/config.rs
@@ -58,14 +58,15 @@ pub struct Config {
     /// Default: `/var/run/secrets/spiffe.io/tls.key`.
     #[serde(default = "Defaults::client_key_path")]
     pub client_key_path: PathBuf,
-    /// OTLP gRPC endpoint that traces are exported to.
-    /// Default: the in-cluster OpenTelemetry collector.
+    /// OTLP gRPC endpoint that traces are exported to. When unset, trace
+    /// export is disabled.
+    /// Default: unset (tracing disabled).
     #[serde(
-        default = "Defaults::otlp_endpoint",
-        serialize_with = "serialize_uri",
-        deserialize_with = "deserialize_uri"
+        default,
+        serialize_with = "serialize_optional_uri",
+        deserialize_with = "deserialize_optional_uri"
     )]
-    pub otlp_endpoint: http::Uri,
+    pub otlp_endpoint: Option<http::Uri>,
     /// How long to cache NXDomain and Refused responses, in seconds.
     /// Default: `120`.
     #[serde(default = "Defaults::negative_cache_ttl_secs")]
@@ -127,12 +128,6 @@ impl Defaults {
             .expect("BUG: default carbide URI is invalid")
     }
 
-    pub fn otlp_endpoint() -> http::Uri {
-        "http://opentelemetry-collector.otel.svc.cluster.local:4317"
-            .try_into()
-            .expect("BUG: default OTLP endpoint URI is invalid")
-    }
-
     pub fn root_ca_path() -> PathBuf {
         "/var/run/secrets/spiffe.io/ca.crt".into()
     }
@@ -165,7 +160,7 @@ impl Default for Config {
             root_ca_path: Defaults::root_ca_path(),
             client_cert_path: Defaults::client_cert_path(),
             client_key_path: Defaults::client_key_path(),
-            otlp_endpoint: Defaults::otlp_endpoint(),
+            otlp_endpoint: None,
             negative_cache_ttl_secs: Defaults::negative_cache_ttl_secs(),
             negative_cache_servfail_ttl_secs: Defaults::negative_cache_servfail_ttl_secs(),
             negative_cache_entries_max_count: Defaults::negative_cache_entries_max_count(),
@@ -188,6 +183,26 @@ where
 {
     let uri_str: String = Deserialize::deserialize(deserializer)?;
     uri_str.parse().map_err(serde::de::Error::custom)
+}
+
+fn serialize_optional_uri<S>(uri: &Option<http::Uri>, serializer: S) -> Result<S::Ok, S::Error>
+where
+    S: serde::Serializer,
+{
+    match uri {
+        Some(uri) => serializer.serialize_some(&format!("{uri}")),
+        None => serializer.serialize_none(),
+    }
+}
+
+fn deserialize_optional_uri<'de, D>(deserializer: D) -> Result<Option<http::Uri>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let uri_str: Option<String> = Deserialize::deserialize(deserializer)?;
+    uri_str
+        .map(|uri_str| uri_str.parse().map_err(serde::de::Error::custom))
+        .transpose()
 }
 
 impl Config {

--- a/crates/dns/src/main.rs
+++ b/crates/dns/src/main.rs
@@ -28,7 +28,6 @@ use opentelemetry_otlp::WithExportConfig;
 use tonic::codegen::http::uri::InvalidUri;
 use tracing::metadata::LevelFilter;
 use tracing_subscriber::filter::EnvFilter;
-use tracing_subscriber::fmt;
 use tracing_subscriber::prelude::*;
 
 #[tokio::main]
@@ -65,38 +64,60 @@ async fn main() -> Result<(), eyre::Report> {
         Command::Run(run_command) => {
             let config: Config = run_command.try_into()?;
 
-            let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
-                .with_tonic()
-                .with_endpoint(config.otlp_endpoint.to_string())
-                .build()?;
+            // Tracing is opt-in: an env var takes precedence over the config
+            // file so operators can override it without redeploying, and no
+            // endpoint (the default) disables trace export entirely.
+            let otlp_endpoint =
+                std::env::var(opentelemetry_otlp::OTEL_EXPORTER_OTLP_TRACES_ENDPOINT)
+                    .ok()
+                    .or_else(|| config.otlp_endpoint.as_ref().map(|uri| uri.to_string()));
 
-            let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
-                .with_batch_exporter(otlp_exporter)
-                .with_resource(
-                    opentelemetry_sdk::Resource::builder()
-                        .with_attributes([opentelemetry::KeyValue::new(
-                            "service.name",
-                            "carbide-dns",
-                        )])
-                        .build(),
-                )
-                .build();
+            let otel_layer = match &otlp_endpoint {
+                None => None,
+                Some(endpoint) => {
+                    let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
+                        .with_tonic()
+                        .with_endpoint(endpoint)
+                        .build()?;
 
-            let otel_layer =
-                tracing_opentelemetry::layer().with_tracer(tracer_provider.tracer("carbide-dns"));
+                    let tracer_provider = opentelemetry_sdk::trace::SdkTracerProvider::builder()
+                        .with_batch_exporter(otlp_exporter)
+                        .with_resource(
+                            opentelemetry_sdk::Resource::builder()
+                                .with_attributes([opentelemetry::KeyValue::new(
+                                    "service.name",
+                                    "nico-dns",
+                                )])
+                                .build(),
+                        )
+                        .build();
+
+                    Some(
+                        tracing_opentelemetry::layer()
+                            .with_tracer(tracer_provider.tracer("nico-dns")),
+                    )
+                }
+            };
 
             let log_events = carbide_instrument::LogEventsMetric::new("nico-dns");
             tracing_subscriber::registry()
                 .with(log_events.layer())
-                .with(fmt::layer().json())
+                .with(
+                    logfmt::layer().with_event_fields([logfmt::EventField::with_default(
+                        "component",
+                        "nico-dns",
+                    )]),
+                )
                 .with(env_filter)
                 .with(otel_layer)
                 .try_init()?;
 
-            tracing::info!(
-                endpoint = %config.otlp_endpoint,
-                "OpenTelemetry tracing enabled",
-            );
+            match &otlp_endpoint {
+                Some(endpoint) => tracing::info!(%endpoint, "OpenTelemetry tracing enabled"),
+                None => {
+                    tracing::info!("OpenTelemetry tracing disabled: no OTLP endpoint configured")
+                }
+            }
 
             DnsServer::run(config)
                 .await
@@ -155,6 +176,15 @@ pub struct RunCommand {
 
     #[clap(short = 'k', long, help = "Path to the client key for the API server")]
     pub client_key_path: Option<PathBuf>,
+
+    /// OTLP gRPC endpoint that traces are exported to. Trace export is
+    /// disabled by default (this is unset). If the `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`
+    /// environment variable is set, its value takes precedence over this flag.
+    #[clap(
+        long,
+        help = "OTLP gRPC endpoint that traces are exported to (e.g., http://otel-collector:4317). Defaults to unset, which disables trace export. Overridden by OTEL_EXPORTER_OTLP_TRACES_ENDPOINT."
+    )]
+    pub otlp_endpoint: Option<String>,
 
     // Backward compatibility alias
     #[clap(
@@ -234,6 +264,17 @@ impl TryInto<Config> for RunCommand {
         }
         if let Some(client_key_path) = self.client_key_path {
             config.client_key_path = client_key_path;
+        }
+        if let Some(otlp_endpoint) = self.otlp_endpoint {
+            config.otlp_endpoint =
+                Some(
+                    otlp_endpoint
+                        .parse()
+                        .map_err(|error| CommandError::InvalidUri {
+                            uri: otlp_endpoint,
+                            error,
+                        })?,
+                );
         }
 
         Ok(config)

--- a/deploy/nico-base/dns/statefulset.yaml
+++ b/deploy/nico-base/dns/statefulset.yaml
@@ -46,6 +46,9 @@ spec:
               value: "full"
             - name: RUST_LIB_BACKTRACE # See https://doc.rust-lang.org/std/backtrace/index.html#environment-variables
               value: "0"
+            # Uncomment to export DNS traces; trace export is disabled when unset.
+            # - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+            #   value: "http://opentelemetry-collector.otel.svc.cluster.local:4317"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:

--- a/docs/observability/logging.md
+++ b/docs/observability/logging.md
@@ -9,7 +9,7 @@ How NICo components emit logs, where they go, what format they use and how to tu
 - All NICo components log to **stdout**. In Kubernetes the kubelet writes container stdout to
   files under `/var/log/pods/`, where a collector (typically an OpenTelemetry Collector DaemonSet)
   picks them up.
-- Most components use **logfmt** (key=value pairs). **nico-dns** uses JSON. **nico-ssh-console**
+- Most components, including **nico-dns**, use **logfmt** (key=value pairs). **nico-ssh-console**
   uses a compact single-line format. **nico-pxe** uses plain text.
 - Default log level is **INFO**. Override at startup with `RUST_LOG` or the `--debug` flag.
 - **nico-api** supports **runtime log-level changes** via `nico-admin-cli set log-filter`. Changes
@@ -37,7 +37,7 @@ sidecar - just configure your collector to read pod logs.
 > **Note**: nico-ssh-console is an exception - in addition to stdout, it writes **machine
 > console output** (BMC serial console streams) to local files. These are not service logs
 <Note>
-nico-ssh-console is an exception - in addition to stdout, it writes **machine console output** (BMC serial console streams) to local files. These are not service logs but captured output from managed machines. See [Machine console logs](#25-machine-console-logs-nico-ssh-console) for details.
+nico-ssh-console is an exception - in addition to stdout, it writes **machine console output** (BMC serial console streams) to local files. These are not service logs but captured output from managed machines. See [Machine console logs](#24-machine-console-logs-nico-ssh-console) for details.
 </Note>
 
 ---
@@ -47,12 +47,12 @@ nico-ssh-console is an exception - in addition to stdout, it writes **machine co
 | Component | Binary | Log format | Notes |
 |-----------|--------|------------|-------|
 | **nico-api** | `carbide-api` | logfmt | Primary control plane. Supports runtime level changes. |
-| **nico-dns** | `carbide-dns` | JSON | DNS resolution service. |
-| **nico-dhcp** | Kea + `libdhcp.so` | Kea format | See [Kea DHCP format](#26-kea-dhcp-format-nico-dhcp). |
+| **nico-dns** | `carbide-dns` | logfmt | DNS resolution service. |
+| **nico-dhcp** | Kea + `libdhcp.so` | Kea format | See [Kea DHCP format](#25-kea-dhcp-format-nico-dhcp). |
 | **nico-pxe** | `carbide` | plain text | iPXE boot service. Hand-rolled `println!`, no log levels. |
 | **nico-bmc-proxy** | `carbide-bmc-proxy` | logfmt | BMC credential proxy. |
 | **nico-hardware-health** | `forge-hw-health` | logfmt | Hardware health monitoring. |
-| **nico-ssh-console** | `ssh-console` | compact | SSH console access. Also captures machine/DPU console output to files (see [Machine console logs](#25-machine-console-logs-nico-ssh-console)). |
+| **nico-ssh-console** | `ssh-console` | compact | SSH console access. Also captures machine/DPU console output to files (see [Machine console logs](#24-machine-console-logs-nico-ssh-console)). |
 | **nico-dsx-exchange-consumer** | `carbide-dsx-exchange-consumer` | logfmt | DSX message consumer. |
 | **nico-dpu-otel-agent** | `forge-dpu-otel-agent` | full | mTLS cert renewal agent on DPUs. See note below. |
 
@@ -109,6 +109,7 @@ nico-api                       — API handlers, DB, startup: anything not in a 
 └── attestation_controller
 nico-bmc-proxy
 nico-dhcp
+nico-dns
 nico-dsx-exchange-consumer
 nico-fmds
 nico-hardware-health
@@ -135,21 +136,12 @@ Components that **do not** use the logfmt layer and carry no `component` field:
 
 | Component | Binary | Format | Notes |
 |-----------|--------|--------|-------|
-| nico-dns | `carbide-dns` | JSON | Uses tracing-subscriber JSON formatter |
 | nico-pxe | `carbide` | plain text | Hand-rolled `println!`, no log levels |
 | nico-ssh-console | `ssh-console` | compact | Uses tracing-subscriber compact formatter |
 | nico-dpu-otel-agent | `forge-dpu-otel-agent` | full | Default tracing-subscriber formatter. Ignores `RUST_LOG`. |
-| nico-dhcp | Kea + `libdhcp.so` | Kea | Production uses Kea logger, not Rust tracing (see [Kea DHCP format](#26-kea-dhcp-format-nico-dhcp)) |
+| nico-dhcp | Kea + `libdhcp.so` | Kea | Production uses Kea logger, not Rust tracing (see [Kea DHCP format](#25-kea-dhcp-format-nico-dhcp)) |
 
-### 2.2 JSON format (nico-dns)
-
-nico-dns uses `tracing-subscriber`'s JSON formatter. Each line is a self-contained JSON object:
-
-```json
-{"timestamp":"2026-01-15T10:23:45.123Z","level":"INFO","target":"carbide_dns","message":"DNS query","query_type":"A","name":"host1.example.com"}
-```
-
-### 2.3 Compact format (nico-ssh-console)
+### 2.2 Compact format (nico-ssh-console)
 
 nico-ssh-console uses `tracing-subscriber`'s compact formatter - a human-readable single-line
 format similar to traditional log output:
@@ -158,12 +150,12 @@ format similar to traditional log output:
 2026-01-15T10:23:45.123Z  INFO carbide_ssh_console: Session started session_id=abc-123
 ```
 
-### 2.4 Plain text (nico-pxe)
+### 2.3 Plain text (nico-pxe)
 
 nico-pxe uses `println!` for startup messages and request logging middleware. Output is
 unstructured plain text.
 
-### 2.5 Machine console logs (nico-ssh-console)
+### 2.4 Machine console logs (nico-ssh-console)
 
 In addition to its own service logs (compact format on stdout), nico-ssh-console captures
 **machine and DPU serial console output** to local files. This is separate from the service's
@@ -202,7 +194,7 @@ hardware issues.
 The nico-ssh-console Helm chart includes an optional OpenTelemetry Collector sidecar (`lokiLogCollector.enabled: true`) that ships console logs to Loki. The sidecar reads from `/var/log/consoles/*.log`, extracts the machine ID and BMC IP from filenames, and exports to your Loki endpoint. To use a different backend, customize the `configFiles.otelcolConfig` value in the chart. See [Machine and DPU Logs](machine-dpu-logs.md) for detailed collection workflows.
 </Tip>
 
-### 2.6 Kea DHCP format (nico-dhcp)
+### 2.5 Kea DHCP format (nico-dhcp)
 
 The nico-dhcp Helm chart runs [Kea DHCP](https://www.isc.org/kea/), with NICo's DHCP logic
 loaded as a Kea hook library (`libdhcp.so`). All logging from the hook routes through Kea's

--- a/docs/observability/tracing.md
+++ b/docs/observability/tracing.md
@@ -7,7 +7,7 @@ How NICo component tracing works, what it covers, how to turn it on and off and 
 ## TL;DR
 
 - **nico-api** (the `carbide-api` binary) is NICo's primary tracing source and the subject of this
-  document. **nico-dns** also emits traces, but with a separate simpler always-on setup.
+  document. **nico-dns** also emits traces, but with a separate simpler opt-in setup.
   **nico-bmc-proxy** emits traces for each proxied BMC request when configured (see
   [nico-bmc-proxy tracing](#nico-bmc-proxy-tracing)).
 - **nico-api traces are off by default**; two things must both be true before any spans are emitted:
@@ -48,7 +48,7 @@ The following binaries build an OTLP span exporter:
 
 - **nico-api** (`crates/api-core/src/logging/setup.rs`) - the rich, control-plane tracing this
   document is mostly about, off by default behind endpoint plus enabled-flag configuration
-- **nico-dns** (`crates/dns/src/main.rs`) - a separate, much simpler **always-on** setup.
+- **nico-dns** (`crates/dns/src/main.rs`) - a separate, much simpler **opt-in** setup.
 - **nico-bmc-proxy** (`crates/bmc-proxy/src/setup.rs`) - one span per proxied BMC request, off by
   default behind endpoint plus `[tracing] enabled` (see
   [nico-bmc-proxy tracing](#nico-bmc-proxy-tracing)).
@@ -58,7 +58,7 @@ nico-dsx-exchange-consumer) carry the OpenTelemetry crates in the workspace but 
 exporter, so they do not emit traces.
 
 Unless noted otherwise, the rest of this document describes **nico-api** tracing.
-nico-dns differs as described in [NICO DNS tracing](#nico-dns-tracing-separate-and-always-on).
+nico-dns differs as described in [nico-dns tracing](#nico-dns-tracing-separate-opt-in).
 
 ### What operations are covered
 
@@ -104,21 +104,24 @@ discover or get injected with anything - it simply connects out to the endpoint 
 `[tracing] otlp_endpoint` or, if set, `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`. The environment
 variable overrides the TOML value. The transport details: gRPC-only, plaintext.
 
-### nico-dns tracing (separate and always-on)
+### nico-dns tracing (separate, opt-in)
 
 nico-dns has its own tracing setup (`crates/dns/src/main.rs`), independent of and simpler than
 nico-api's:
 
-- **Always on.** nico-dns builds the span exporter unconditionally at startup - there is no
-  endpoint env-var check and no `tracing-enabled` switch. If the process runs, it is exporting.
-- **Endpoint from config, with a default.** The target is the `otlp_endpoint` config field
-  (`crates/dns/src/config.rs`), which defaults to
-  `http://opentelemetry-collector.otel.svc.cluster.local:4317`. Because of that default, nico-dns
-  tries to export out of the box
+- **Off by default.** nico-dns builds the span exporter only when an OTLP endpoint is configured
+  - via `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, the `--otlp-endpoint` CLI flag, or the `otlp_endpoint`
+  config field (`crates/dns/src/config.rs`). With none of those set, no exporter is built and no
+  traces are sent. The env var takes precedence over the CLI flag/config file.
+- **No hardcoded default endpoint.** Earlier versions defaulted to
+  `http://opentelemetry-collector.otel.svc.cluster.local:4317` and exported unconditionally, which
+  meant every deployment silently exported traces to that address whether or not a collector was
+  listening there for OTLP/gRPC (see NVBUG 6717563). That default has been removed; set the
+  endpoint explicitly to enable tracing.
 - **Default sampler.** It uses the OpenTelemetry SDK's default sampler (no `CarbideSpanSampler`),
   so it records broadly, filtered only by the log-level directives in its `EnvFilter`. It
   instruments `retrieve_records`, among others.
-- **Resource / output:** `service.name = carbide-dns`; logs are JSON on stdout (not logfmt).
+- **Resource / output:** `service.name = nico-dns`; logs are logfmt on stdout, matching nico-api.
 - **Same transport constraints:** OTLP/gRPC, plaintext (`with_tonic`, no `tls` feature)
 
 ### nico-bmc-proxy tracing

--- a/helm-prereqs/observability/README.md
+++ b/helm-prereqs/observability/README.md
@@ -133,12 +133,16 @@ endpoint; `enabled` must come from the TOML, or at runtime without a pod roll:
   endpoint and the flag off, overhead is near zero. Tracing IS expensive when on — treat it as
   a debug-session tool (toggle on, investigate, toggle off); for sustained use add a
   tail-sampling policy at the collector (`docs/observability/tracing.md` §2.1 has one);
-- `nico-dns` also emits spans — always-on, defaulting to
-  `opentelemetry-collector.otel.svc.cluster.local:4317` (no standard deploy values override
-  it); the installer ships an ExternalName alias with that name onto the agent so those spans
-  land instead of blackholing. The other services (pxe, dhcp, bmc-proxy, …) build no exporter
-  today;
-- spans arrive in Tempo tagged `service.name=carbide-api`; the Grafana Tempo datasource is
+- `nico-dns` can also emit spans, but is off by default (no hardcoded endpoint): set
+  `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` (the `nico-dns` chart's `otlpEndpoint` value sets this),
+  or `--otlp-endpoint`/`otlp_endpoint` in its config file, to enable it. Earlier versions
+  exported unconditionally to a hardcoded
+  `opentelemetry-collector.otel.svc.cluster.local:4317` default; the installer's ExternalName
+  alias with that name still resolves for deployments relying on that address, but new
+  deployments should point `otlpEndpoint` at the agent explicitly. The other services (pxe,
+  dhcp, …) build no exporter today;
+- spans arrive in Tempo tagged `service.name=carbide-api` (`service.name=nico-dns` for `nico-dns`
+  spans); the Grafana Tempo datasource is
   pre-provisioned with trace-to-logs linking into Loki (one direction only: NICo log lines
   carry `span_id` but no `trace_id`, so Loki→Tempo derived fields aren't wired).
 

--- a/helm/charts/nico-dns/templates/statefulset.yaml
+++ b/helm/charts/nico-dns/templates/statefulset.yaml
@@ -42,6 +42,10 @@ spec:
                 configMapKeyRef:
                   name: {{ include "nico-dns.name" . }}
                   key: NICO_API
+            {{- if .Values.otlpEndpoint }}
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: {{ .Values.otlpEndpoint | quote }}
+            {{- end }}
             {{- range $key, $value := .Values.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/helm/charts/nico-dns/values.yaml
+++ b/helm/charts/nico-dns/values.yaml
@@ -55,6 +55,11 @@ resources:
   limits:
     memory: 256Mi
 
+## OTLP gRPC endpoint that DNS traces are exported to (e.g.
+## "http://opentelemetry-collector.otel.svc.cluster.local:4317"). Empty by
+## default, which disables trace export.
+otlpEndpoint: ""
+
 ## PodMonitor for the Prometheus Operator to scrape the metrics container port
 ## (8053) directly off each pod. Disabled by default; requires the Prometheus
 ## Operator CRDs (monitoring.coreos.com/v1).


### PR DESCRIPTION
nico-dns previously built its OTLP/gRPC span exporter unconditionally at startup, pointed at a hardcoded default
(opentelemetry-collector.otel.svc.cluster.local:4317), with no CLI flag, env var, or way to disable it. Every deployment therefore exported traces to that fixed address regardless of whether a collector was actually listening there for OTLP/gRPC, and operators had no way to point it elsewhere or turn it off (NVBUG 6717563: both carbide-dns replicas in pdx-qa6 continuously failed to export with `Unimplemented` while logging tracing as enabled).

Bring nico-dns's OTLP configuration up to parity with nico-api's pattern: `otlp_endpoint` is now optional (`Option<Uri>`, no hardcoded default), resolved in priority order from the OTEL_EXPORTER_OTLP_TRACES_ENDPOINT env var, the new --otlp-endpoint CLI flag, and the config file. The tracer/exporter is only constructed when an endpoint resolves; otherwise tracing is skipped and logged as disabled rather than falsely claimed as enabled.

Wire the endpoint through as an optional otlpEndpoint Helm value (nico-dns chart) and document it as a commented example in the Kustomize base manifest, both disabled by default. Update docs/observability/tracing.md and helm-prereqs/observability/README.md, which had documented the old always-on/hardcoded-default behavior.

NV 6717563

## Related issues:
- Closes #5888

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)


## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)


