### PR TITLE
fix(dpf): wire service VPC slots

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,6 +1837,7 @@ dependencies = [
  "carbide-uuid",
  "clap",
  "dashmap",
+ "derive_builder",
  "eyre",
  "futures",
  "hex",

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -3180,6 +3180,14 @@ impl CarbideConfig {
         Ok(())
     }
 
+    pub(crate) fn validate_service_vpc_slots(&self) -> eyre::Result<()> {
+        eyre::ensure!(
+            self.dpu_config.service_vpc_slot_count == 0 || self.site_global_vpc_vni.is_none(),
+            "dpu_config.service_vpc_slot_count requires site_global_vpc_vni to be unset because service VPCs require distinct HBN VRFs"
+        );
+        Ok(())
+    }
+
     /// validate_supernic_firmware_profiles checks that each profile's inner
     /// part_number and psid match the HashMap keys they are nested under.
     /// Logs a warning for any mismatches (the inner values are authoritative
@@ -5570,6 +5578,26 @@ path = "credentials.yaml"
             url: BAD_URL.to_string(),
         }];
         assert!(config.validate_web_ui_sidebar_tools().is_err());
+    }
+
+    #[test]
+    fn validate_service_vpc_slots_rejects_site_global_vpc_vni() {
+        let mut config: CarbideConfig = Figment::new()
+            .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
+            .extract()
+            .unwrap();
+
+        config.dpu_config.service_vpc_slot_count = 1;
+        assert!(config.validate_service_vpc_slots().is_ok());
+
+        config.site_global_vpc_vni = Some(6_000);
+        assert!(
+            config
+                .validate_service_vpc_slots()
+                .unwrap_err()
+                .to_string()
+                .contains("requires site_global_vpc_vni to be unset")
+        );
     }
 
     #[test]

--- a/crates/api-core/src/cfg/load.rs
+++ b/crates/api-core/src/cfg/load.rs
@@ -307,6 +307,7 @@ pub fn parse_carbide_config(
 
     // Validate that admin-UI tool entries have unique names.
     config.validate_web_ui_sidebar_tools()?;
+    config.validate_service_vpc_slots()?;
     config.api_admission_control.validate()?;
 
     if let Some(config) = &config.dsx_exchange_event_bus {

--- a/crates/api-core/src/dpf_services.rs
+++ b/crates/api-core/src/dpf_services.rs
@@ -21,13 +21,14 @@ use std::collections::BTreeMap;
 use std::fmt::Write;
 
 use carbide_dpf::types::{
-    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DOCA_WEAVE_DHCP_AGENT_SERVICE_NAME,
-    DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_NAME, DOCA_XPLANE_SERVICE_NAME, DPU_AGENT_SERVICE_NAME,
-    DTS_SERVICE_NAME, DpuServiceInterfaceTemplateDefinition, FMDS_SERVICE_NAME,
-    OTEL_COLLECTOR_SERVICE_NAME,
+    DHCP_SERVER_SERVICE_NAME, DOCA_HBN_SERVICE_NAME, DOCA_HBN_SERVICE_NETWORK,
+    DOCA_WEAVE_DHCP_AGENT_SERVICE_NAME, DOCA_WEAVE_FLOW_CONTROLLER_SERVICE_NAME,
+    DOCA_XPLANE_SERVICE_NAME, DPU_AGENT_SERVICE_NAME, DTS_SERVICE_NAME,
+    DpuServiceInterfaceTemplateDefinition, FMDS_SERVICE_NAME, OTEL_COLLECTOR_SERVICE_NAME,
 };
 use carbide_dpf::{
     IntOrString, ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType,
+    ServiceVpcSlots,
 };
 
 use crate::cfg::file::{
@@ -59,7 +60,6 @@ pub(crate) const DOCA_HBN_SERVICE_HELM_NAME: &str = "doca-hbn";
 pub(crate) const DOCA_HBN_SERVICE_HELM_VERSION: &str = "3.4.0";
 pub(crate) const DOCA_HBN_SERVICE_IMAGE_NAME: &str = "doca_hbn";
 pub(crate) const DOCA_HBN_SERVICE_IMAGE_TAG: &str = "3.4.0-doca3.4.0";
-pub(crate) const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 
 /// DHCP Service Definitions
 pub(crate) const DHCP_SERVER_SERVICE_HELM_NAME: &str = "nico-dhcp-server";
@@ -132,48 +132,14 @@ pub(crate) const COMPILE_TIME_IMAGE_TAG: &str = match option_env!("CARBIDE_BUILD
 
 fn doca_hbn_service_interfaces(
     interfaces: &[DpuServiceInterfaceTemplateDefinition],
-    extra_interfaces: &[String],
+    service_vpc_slots: ServiceVpcSlots,
 ) -> Vec<ServiceInterface> {
     let mut service_interfaces =
         dpu_service_interfaces(interfaces, DOCA_HBN_SERVICE_NAME, DOCA_HBN_SERVICE_NETWORK);
-    service_interfaces.extend(extra_interfaces.iter().map(|name| ServiceInterface {
-        name: name.clone(),
-        network: DOCA_HBN_SERVICE_NETWORK.to_string(),
-    }));
+    service_vpc_slots.append_hbn_interfaces(&mut service_interfaces);
     service_interfaces
 }
 
-/// Generates deterministic service-VPC interface names after checking HBN capacity.
-pub(crate) fn service_vpc_interfaces(
-    interfaces: &[DpuServiceInterfaceTemplateDefinition],
-    slot_count: u32,
-) -> Result<Vec<String>, String> {
-    let mut hbn_interface_names = doca_hbn_service_interfaces(interfaces, &[])
-        .into_iter()
-        .map(|interface| interface.name)
-        .collect::<std::collections::BTreeSet<_>>();
-
-    let total = usize::try_from(slot_count)
-        .ok()
-        .and_then(|slot_count| hbn_interface_names.len().checked_add(slot_count))
-        .ok_or_else(|| "HBN interface count exceeds usize".to_string())?;
-    if total > 32 {
-        return Err(format!(
-            "HBN interface count {total} exceeds the supported maximum of 32"
-        ));
-    }
-
-    let generated = (0..slot_count)
-        .map(|slot| format!("iface_svc_{slot}"))
-        .collect::<Vec<_>>();
-    for name in &generated {
-        if !hbn_interface_names.insert(name.clone()) {
-            return Err(format!("HBN interface name {name:?} is not unique"));
-        }
-    }
-
-    Ok(generated)
-}
 fn dhcp_server_service_interfaces(
     interfaces: &[DpuServiceInterfaceTemplateDefinition],
 ) -> Vec<ServiceInterface> {
@@ -482,9 +448,9 @@ fn reassert_api_owned_value(
 pub(crate) fn doca_hbn_service(
     cfg: &DpfServiceConfig,
     dpu_interfaces: &[DpuServiceInterfaceTemplateDefinition],
-    extra_interfaces: &[String],
+    service_vpc_slots: ServiceVpcSlots,
 ) -> ServiceDefinition {
-    let interfaces = doca_hbn_service_interfaces(dpu_interfaces, extra_interfaces);
+    let interfaces = doca_hbn_service_interfaces(dpu_interfaces, service_vpc_slots);
     let mut helm_values = serde_json::json!({
         "image": {
             "repository": cfg.docker_repo_url,
@@ -892,12 +858,12 @@ pub(crate) fn mandatory_services(
     resolved: &DpfResolvedMandatoryServicesConfig,
     bootstrap_ca: &DpfDpuAgentBootstrapCa,
     interfaces: &[DpuServiceInterfaceTemplateDefinition],
-    service_vpc_interfaces: &[String],
+    service_vpc_slots: ServiceVpcSlots,
     node_auth: &NodeAuthConfig,
 ) -> Vec<ServiceDefinition> {
     let mut service_vec = vec![
         dts_service(&resolved.base.dts),
-        doca_hbn_service(&resolved.base.doca_hbn, interfaces, service_vpc_interfaces),
+        doca_hbn_service(&resolved.base.doca_hbn, interfaces, service_vpc_slots),
         dhcp_server_service(&resolved.base.dhcp_server, interfaces),
         dpu_agent_service(&resolved.base.dpu_agent, bootstrap_ca),
         // Not `node_auth.enabled` directly: an operator staging a disable
@@ -974,12 +940,8 @@ mod tests {
 
         // HBN receives p0, p1, the PF, the VF, and the configured external attachment; its SF
         // count and startup YAML agree.
-        let service_vpc_interfaces = service_vpc_interfaces(&interfaces, 1).unwrap();
-        let hbn = doca_hbn_service(
-            &default_doca_hbn_service(),
-            &interfaces,
-            &service_vpc_interfaces,
-        );
+        let service_vpc_slots = ServiceVpcSlots::new(1).unwrap();
+        let hbn = doca_hbn_service(&default_doca_hbn_service(), &interfaces, service_vpc_slots);
         assert_eq!(hbn.interfaces.len(), 5);
         assert_eq!(
             hbn.helm_values.as_ref().unwrap()["resources"]["nvidia.com/bf_sf"],
@@ -1013,16 +975,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn service_vpc_interfaces_are_deterministic_and_capacity_checked() {
-        let interfaces = build_effective_dpu_interfaces(16, None);
-        assert_eq!(
-            service_vpc_interfaces(&interfaces, 2).unwrap(),
-            ["iface_svc_0".to_string(), "iface_svc_1".to_string()]
-        );
-        assert!(service_vpc_interfaces(&interfaces, 15).is_err());
-    }
-
     /// Verifies operator Helm values cannot disconnect HBN's SF request from its interfaces.
     #[test]
     fn hbn_sf_count_remains_topology_derived() {
@@ -1039,7 +991,7 @@ mod tests {
         let interfaces = build_dpu_interfaces_vec();
 
         // Ordinary resource overrides remain effective, while the SF count follows inventory.
-        let hbn = doca_hbn_service(&config, &interfaces, &[]);
+        let hbn = doca_hbn_service(&config, &interfaces, ServiceVpcSlots::default());
         let helm_values = hbn.helm_values.unwrap();
         assert_eq!(helm_values["resources"]["memory"], "8Gi");
         assert_eq!(
@@ -1159,7 +1111,11 @@ mod tests {
     fn hbn_and_dts_omit_image_pull_secrets_by_default() {
         // HBN and DTS pull from the public DOCA registry: no imagePullSecrets unless configured.
         let interfaces = build_dpu_interfaces_vec();
-        let hbn = doca_hbn_service(&default_doca_hbn_service(), &interfaces, &[]);
+        let hbn = doca_hbn_service(
+            &default_doca_hbn_service(),
+            &interfaces,
+            ServiceVpcSlots::default(),
+        );
         assert!(
             hbn.helm_values.unwrap().get("imagePullSecrets").is_none(),
             "HBN must not emit imagePullSecrets without a configured secret"
@@ -1180,7 +1136,7 @@ mod tests {
         let mut hbn_cfg = default_doca_hbn_service();
         hbn_cfg.docker_image_pull_secret = Some("private-pull-secret".to_string());
         assert_eq!(
-            doca_hbn_service(&hbn_cfg, &interfaces, &[])
+            doca_hbn_service(&hbn_cfg, &interfaces, ServiceVpcSlots::default())
                 .helm_values
                 .unwrap()["imagePullSecrets"],
             expected
@@ -1646,12 +1602,18 @@ mod tests {
         let bootstrap_ca = DpfDpuAgentBootstrapCa::default();
 
         let fmds_mode = |node_auth: &NodeAuthConfig| {
-            mandatory_services(&resolved, &bootstrap_ca, &[], &[], node_auth)
-                .into_iter()
-                .find(|s| s.name == FMDS_SERVICE_NAME)
-                .and_then(|s| s.helm_values)
-                .and_then(|v| v.get("useNodeTokens").and_then(serde_json::Value::as_bool))
-                .expect("fmds renders useNodeTokens")
+            mandatory_services(
+                &resolved,
+                &bootstrap_ca,
+                &[],
+                ServiceVpcSlots::default(),
+                node_auth,
+            )
+            .into_iter()
+            .find(|s| s.name == FMDS_SERVICE_NAME)
+            .and_then(|s| s.helm_values)
+            .and_then(|v| v.get("useNodeTokens").and_then(serde_json::Value::as_bool))
+            .expect("fmds renders useNodeTokens")
         };
 
         let derived_on = NodeAuthConfig {

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -697,6 +697,8 @@ async fn initialize_dpf_sdk(
     // Reject unsafe global ServiceInterfaces even when DPF is disabled so a dormant Astra
     // configuration cannot become unsafe merely by enabling DPF later.
     carbide_config.dpf.validate_service_interface_scoping()?;
+    // Reject incompatible service-VPC topology even when DPF is disabled.
+    carbide_config.validate_service_vpc_slots()?;
 
     if !carbide_config.dpf.enabled {
         tracing::warn!(
@@ -733,25 +735,10 @@ async fn initialize_dpf_sdk(
 
     let astra_interfaces = carbide_dpf::sdk::build_dpu_interfaces_vec();
 
-    // SDK construction writes the shared BMC Secret, so capacity validation must remain on the
-    // pure configuration path and finish before Kubernetes repository construction.
-    let service_vpc_interfaces = crate::dpf_services::service_vpc_interfaces(
-        &effective_interfaces,
-        carbide_config.dpu_config.service_vpc_slot_count,
-    )
-    .map_err(|error| eyre::eyre!("invalid DPF HBN interface configuration: {error}"))?;
-    let additional_managed_sf = carbide_config
-        .dpu_config
-        .service_vpc_slot_count
-        .checked_add(carbide_config.dpu_config.additional_managed_sf)
-        .ok_or_else(|| eyre::eyre!("dpu_config managed SF count exceeds u32"))?;
-    carbide_dpf::calculate_pf_total_sf(
-        &effective_interfaces,
-        intercept_bridging.as_ref(),
-        carbide_config.dpf.pf_total_sf_reserved,
-        additional_managed_sf,
-    )
-    .map_err(|error| eyre::eyre!("invalid DPF SF configuration: {error}"))?;
+    let service_vpc_slots =
+        carbide_dpf::ServiceVpcSlots::new(carbide_config.dpu_config.service_vpc_slot_count)
+            .map_err(|error| eyre::eyre!("invalid DPF service-VPC configuration: {error}"))?;
+    let additional_managed_sf = carbide_config.dpu_config.additional_managed_sf;
 
     let repo = carbide_dpf::KubeRepository::new()
         .await
@@ -762,8 +749,6 @@ async fn initialize_dpf_sdk(
     if !carbide_config.dpf.deployment_scoped_service_interfaces {
         reject_unscoped_initialization_with_scoped_interfaces(&repo).await?;
     }
-
-    let provider = CarbideBmcPasswordProvider::new(credential_manager, db_pool.clone());
 
     carbide_config
         .dpf
@@ -781,17 +766,6 @@ async fn initialize_dpf_sdk(
     // Soon v2 flag will be removed and will become only mode for dpf handling.
     let deployment_type_labels = build_deployment_type_labels(carbide_config);
 
-    let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)
-        .with_labeler(
-            CarbideDPFLabeler::new(carbide_config.dpf.deployments.bf3.node_label_key.clone())
-                .with_deployment_type_labels(deployment_type_labels),
-        )
-        .with_bmc_password_refresh_interval(std::time::Duration::from_secs(60))
-        .with_join_set(join_set)
-        .build_without_resources()
-        .await
-        .map_err(|err| eyre::eyre!("failed to initialize DPF SDK: {err}"))?;
-
     // Builds the SDK init config for one DPUDeployment. BF4 uses a single
     // `BlueFieldSoftware` source (the CR itself carries the PSID→PLDM mapping);
     // config validation guarantees exactly one PSID entry.
@@ -808,60 +782,66 @@ async fn initialize_dpf_sdk(
                 | DpuDeploymentType::Bf3Gb200
                 | DpuDeploymentType::Bf4Generic => &effective_interfaces,
             };
-            let (service_vpc_interfaces, additional_managed_sf) = match deployment_type {
-                DpuDeploymentType::Bf4Astra => (&[][..], 0),
+            let (service_vpc_slots, additional_managed_sf) = match deployment_type {
+                DpuDeploymentType::Bf4Astra => (carbide_dpf::ServiceVpcSlots::default(), 0),
                 DpuDeploymentType::Bf3
                 | DpuDeploymentType::Bf3Gb200
-                | DpuDeploymentType::Bf4Generic => {
-                    (service_vpc_interfaces.as_slice(), additional_managed_sf)
-                }
+                | DpuDeploymentType::Bf4Generic => (service_vpc_slots, additional_managed_sf),
             };
-            carbide_dpf::InitDpfResourcesConfig {
-                bfb_url: deployment.bfb_url.clone().unwrap_or_default(),
-                bluefield_software,
-                flavor_name: deployment.flavor_name.clone(),
-                deployment_name: deployment.deployment_name.clone(),
-                deployment_scoped_service_interfaces: carbide_config
-                    .dpf
-                    .deployment_scoped_service_interfaces,
-                services: crate::dpf_services::mandatory_services(
+            let mut builder = carbide_dpf::InitDpfResourcesConfigBuilder::default()
+                .bfb_url(deployment.bfb_url.clone().unwrap_or_default())
+                .flavor_name(deployment.flavor_name.clone())
+                .deployment_name(deployment.deployment_name.clone())
+                .deployment_scoped_service_interfaces(
+                    carbide_config.dpf.deployment_scoped_service_interfaces,
+                )
+                .services(crate::dpf_services::mandatory_services(
                     &services,
                     &carbide_config.dpf.dpu_agent_bootstrap_ca,
                     interfaces,
-                    service_vpc_interfaces,
+                    service_vpc_slots,
                     &carbide_config.node_auth,
-                ),
-                num_of_vfs: carbide_config.dpu_config.num_of_vfs,
-                pf_total_sf_reserved: carbide_config.dpf.pf_total_sf_reserved,
-                additional_managed_sf,
-                intercept_bridging: match deployment_type {
-                    DpuDeploymentType::Bf4Astra => None,
-                    DpuDeploymentType::Bf3
-                    | DpuDeploymentType::Bf3Gb200
-                    | DpuDeploymentType::Bf4Generic => intercept_bridging.clone(),
-                },
-                interfaces: interfaces.clone(),
-                proxy: carbide_config.dpf.proxy.clone(),
-                extra_bfcfg_parameters: carbide_config
-                    .dpf
-                    .resolved_bfcfg_parameters_for(deployment),
-                deployment_type,
+                ))
+                .num_of_vfs(carbide_config.dpu_config.num_of_vfs)
+                .pf_total_sf_reserved(carbide_config.dpf.pf_total_sf_reserved)
+                .additional_managed_sf(additional_managed_sf)
+                .service_vpc_slots(service_vpc_slots)
+                .interfaces(interfaces.clone())
+                .extra_bfcfg_parameters(
+                    carbide_config.dpf.resolved_bfcfg_parameters_for(deployment),
+                )
+                .deployment_type(deployment_type);
+            if let Some(bluefield_software) = bluefield_software {
+                builder = builder.bluefield_software(bluefield_software);
             }
+            if let Some(intercept_bridging) = match deployment_type {
+                DpuDeploymentType::Bf4Astra => None,
+                DpuDeploymentType::Bf3
+                | DpuDeploymentType::Bf3Gb200
+                | DpuDeploymentType::Bf4Generic => intercept_bridging.clone(),
+            } {
+                builder = builder.intercept_bridging(intercept_bridging);
+            }
+            if let Some(proxy) = carbide_config.dpf.proxy.clone() {
+                builder = builder.proxy(proxy);
+            }
+            builder.build().map_err(|err| {
+                eyre::eyre!(
+                    "invalid {} DPF initialization configuration: {err}",
+                    deployment.deployment_name
+                )
+            })
         };
 
     let bf3 = &carbide_config.dpf.deployments.bf3;
-    sdk.create_initialization_objects(&make_init_config(bf3, DpuDeploymentType::Bf3, None))
-        .await
-        .map_err(|err| eyre::eyre!("failed to initialize bf3 DPF deployment: {err}"))?;
-
     let bf3_gb200 = bf3.bf3_gb200();
-    sdk.create_initialization_objects(&make_init_config(
-        &bf3_gb200,
-        DpuDeploymentType::Bf3Gb200,
-        None,
-    ))
-    .await
-    .map_err(|err| eyre::eyre!("failed to initialize bf3 GB200 DPF deployment: {err}"))?;
+    let mut init_configs = vec![
+        ("bf3", make_init_config(bf3, DpuDeploymentType::Bf3, None)?),
+        (
+            "bf3 GB200",
+            make_init_config(&bf3_gb200, DpuDeploymentType::Bf3Gb200, None)?,
+        ),
+    ];
 
     if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
         // Validation guarantees `bluefield_software` is set with exactly one PSID
@@ -877,13 +857,10 @@ async fn initialize_dpf_sdk(
             os_iso: bfs.os_iso.clone(),
             pldm_fw_bundle: Some(pldm_url.clone()),
         };
-        sdk.create_initialization_objects(&make_init_config(
-            bf4,
-            DpuDeploymentType::Bf4Generic,
-            Some(params),
-        ))
-        .await
-        .map_err(|err| eyre::eyre!("failed to initialize bf4_generic DPF deployment: {err}"))?;
+        init_configs.push((
+            "bf4_generic",
+            make_init_config(bf4, DpuDeploymentType::Bf4Generic, Some(params))?,
+        ));
     }
 
     if let Some(bf4_astra) = &carbide_config.dpf.deployments.bf4_astra {
@@ -899,13 +876,29 @@ async fn initialize_dpf_sdk(
             os_iso: bfs.os_iso.clone(),
             pldm_fw_bundle: Some(pldm_url.clone()),
         };
-        sdk.create_initialization_objects(&make_init_config(
-            bf4_astra,
-            DpuDeploymentType::Bf4Astra,
-            Some(params),
-        ))
+        init_configs.push((
+            "bf4_astra",
+            make_init_config(bf4_astra, DpuDeploymentType::Bf4Astra, Some(params))?,
+        ));
+    }
+
+    // Build every validated configuration before SDK construction writes the shared BMC Secret.
+    let provider = CarbideBmcPasswordProvider::new(credential_manager, db_pool.clone());
+    let sdk = carbide_dpf::DpfSdkBuilder::new(repo, carbide_dpf::NAMESPACE, provider)
+        .with_labeler(
+            CarbideDPFLabeler::new(carbide_config.dpf.deployments.bf3.node_label_key.clone())
+                .with_deployment_type_labels(deployment_type_labels),
+        )
+        .with_bmc_password_refresh_interval(std::time::Duration::from_secs(60))
+        .with_join_set(join_set)
+        .build_without_resources()
         .await
-        .map_err(|err| eyre::eyre!("failed to initialize bf4_astra DPF deployment: {err}"))?;
+        .map_err(|err| eyre::eyre!("failed to initialize DPF SDK: {err}"))?;
+
+    for (name, config) in init_configs {
+        sdk.create_initialization_objects(&config)
+            .await
+            .map_err(|err| eyre::eyre!("failed to initialize {name} DPF deployment: {err}"))?;
     }
 
     Ok(Some(Arc::new(DpfSdkOps::new(

--- a/crates/dpf/Cargo.toml
+++ b/crates/dpf/Cargo.toml
@@ -41,6 +41,7 @@ eyre = { workspace = true }
 tracing = { workspace = true }
 uuid = { features = ["v4"], workspace = true }
 async-trait = { workspace = true }
+derive_builder = { workspace = true }
 futures = { workspace = true }
 tokio-util = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/dpf/src/bin/api_harness.rs
+++ b/crates/dpf/src/bin/api_harness.rs
@@ -29,7 +29,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use carbide_dpf::repository::{DpuRepository, K8sConfigRepository};
 use carbide_dpf::{
     DpfError, DpfSdk, DpfSdkBuilder, DpuDeploymentType, DpuDeviceInfo, DpuNodeInfo,
-    InitDpfResourcesConfig, KubeRepository, NAMESPACE, ServiceDefinition, dpu_node_cr_name,
+    InitDpfResourcesConfigBuilder, KubeRepository, NAMESPACE, ServiceDefinition, dpu_node_cr_name,
 };
 use clap::{Parser, Subcommand};
 use libredfish::model::BootProgressTypes;
@@ -713,11 +713,10 @@ async fn run_provisioning_flow(
     tracing::info!(host_bmc_ip_address = %host_bmc_ip, dpu_count = dpus.len(), timeout_seconds = timeout_secs, "Starting provisioning");
 
     tracing::info!("[1/4] Initializing DPF resources...");
-    let init_config = InitDpfResourcesConfig {
-        bfb_url: bfb_url.to_string(),
-        services: services.to_vec(),
-        ..Default::default()
-    };
+    let init_config = InitDpfResourcesConfigBuilder::default()
+        .bfb_url(bfb_url)
+        .services(services.to_vec())
+        .build()?;
     sdk.create_initialization_objects(&init_config).await?;
     tracing::info!("BFB, DPUFlavor, and DPUDeployment created");
 

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -36,6 +36,7 @@ use crate::crds::dpuflavors_generated::{
     DpuFlavorSystemdServices, DpuFlavorSystemdServicesOperation,
 };
 use crate::crds::dpuflavortemplates_generated::{DPUFlavorTemplate, DpuFlavorTemplateSpec};
+use crate::service_vpc_slot::ServiceVpcSlots;
 use crate::types::{
     DEFAULT_DPU_NUM_OF_VFS, DEFAULT_PF_TOTAL_SF_RESERVED, DOCA_HBN_SERVICE_NAME,
     DpfInterceptBridge, DpfInterceptBridging, DpfProxyDetails, DpuDeploymentType,
@@ -185,7 +186,10 @@ fn get_bf4_ovs_defaults_base() -> String {
 }
 
 /// Builds the BF3 OVS bootstrap with deterministic configured peer bridges.
-fn get_default_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging>) -> String {
+fn get_default_ovs_defaults_with_topology(
+    topology: Option<&DpfInterceptBridging>,
+    service_vpc_slots: ServiceVpcSlots,
+) -> String {
     // Retain the BF3 base verbatim, then append normalized intercept-bridge state.
     let mut script = get_default_ovs_defaults_base();
     if let Some(topology) = topology {
@@ -193,12 +197,16 @@ fn get_default_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging
             format!("'{}'", interface.identity.bf3_raw_netdev_name())
         });
     }
+    service_vpc_slots.append_ovs_bridges(&mut script);
     append_ovn_encap_ip_bootstrap(&mut script);
     script
 }
 
 /// Builds the generic-BF4 OVS bootstrap after preflighting every configured PF.
-fn get_bf4_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging>) -> String {
+fn get_bf4_ovs_defaults_with_topology(
+    topology: Option<&DpfInterceptBridging>,
+    service_vpc_slots: ServiceVpcSlots,
+) -> String {
     // Explicit bash, as on Astra: the base uses `export -f`, which errors under dash.
     let mut script = String::from("#!/bin/bash\n");
     append_pre_ovs_hook(&mut script);
@@ -215,6 +223,7 @@ fn get_bf4_ovs_defaults_with_topology(topology: Option<&DpfInterceptBridging>) -
             }
         });
     }
+    service_vpc_slots.append_ovs_bridges(&mut script);
     append_ovn_encap_ip_bootstrap(&mut script);
     append_post_ovs_hook(&mut script);
     script
@@ -469,6 +478,7 @@ pub fn default_flavor_for(
         pf_total_sf,
         None,
         None,
+        ServiceVpcSlots::default(),
         &[],
     )
 }
@@ -490,6 +500,7 @@ pub(crate) fn default_flavor_for_with_topology(
     pf_total_sf: u32,
     intercept_bridging: Option<&DpfInterceptBridging>,
     dhcp_acl_interfaces: Option<&[DpuServiceInterfaceTemplateDefinition]>,
+    service_vpc_slots: ServiceVpcSlots,
     extra_bfcfg_parameters: &[String],
 ) -> Result<DPUFlavor, crate::error::DpfError> {
     match deployment_type {
@@ -500,6 +511,7 @@ pub(crate) fn default_flavor_for_with_topology(
             pf_total_sf,
             intercept_bridging,
             dhcp_acl_interfaces,
+            service_vpc_slots,
             extra_bfcfg_parameters,
         ),
         DpuDeploymentType::Bf4Astra => Err(crate::error::DpfError::ConfigError(
@@ -513,6 +525,7 @@ pub(crate) fn default_flavor_for_with_topology(
             pf_total_sf,
             intercept_bridging,
             dhcp_acl_interfaces,
+            service_vpc_slots,
             extra_bfcfg_parameters,
         ),
     }
@@ -538,11 +551,14 @@ pub fn flavor_bf4(
         DEFAULT_PF_TOTAL_SF_RESERVED,
         None,
         None,
+        ServiceVpcSlots::default(),
         &[],
     )
 }
 
 /// Builds generic BF4 flavor state from the validated site VF count and intercept-bridging topology.
+// Each argument is an independent site input; a struct would move the same list one level out.
+#[allow(clippy::too_many_arguments)]
 fn flavor_bf4_with_topology(
     namespace: &str,
     proxy: &Option<DpfProxyDetails>,
@@ -550,6 +566,7 @@ fn flavor_bf4_with_topology(
     pf_total_sf: u32,
     intercept_bridging: Option<&DpfInterceptBridging>,
     dhcp_acl_interfaces: Option<&[DpuServiceInterfaceTemplateDefinition]>,
+    service_vpc_slots: ServiceVpcSlots,
     extra_bfcfg_parameters: &[String],
 ) -> Result<DPUFlavor, crate::error::DpfError> {
     reject_template_delimiters(extra_bfcfg_parameters)?;
@@ -579,7 +596,10 @@ fn flavor_bf4_with_topology(
             host_network_interface_configs: None,
             nvconfig: Some(vec![get_bf4_nvconfig(num_of_vfs, pf_total_sf)]),
             ovs: Some(crate::crds::dpuflavors_generated::DpuFlavorOvs {
-                raw_config_script: Some(get_bf4_ovs_defaults_with_topology(intercept_bridging)),
+                raw_config_script: Some(get_bf4_ovs_defaults_with_topology(
+                    intercept_bridging,
+                    service_vpc_slots,
+                )),
             }),
             sysctl: None,
             system_reserved_resources: None,
@@ -802,6 +822,7 @@ pub fn default_flavor(
         DEFAULT_PF_TOTAL_SF_RESERVED,
         None,
         None,
+        ServiceVpcSlots::default(),
         &[],
     )
 }
@@ -817,6 +838,7 @@ fn default_flavor_with_topology(
     pf_total_sf: u32,
     intercept_bridging: Option<&DpfInterceptBridging>,
     dhcp_acl_interfaces: Option<&[DpuServiceInterfaceTemplateDefinition]>,
+    service_vpc_slots: ServiceVpcSlots,
     extra_bfcfg_parameters: &[String],
 ) -> Result<DPUFlavor, crate::error::DpfError> {
     reject_template_delimiters(extra_bfcfg_parameters)?;
@@ -846,7 +868,10 @@ fn default_flavor_with_topology(
             host_network_interface_configs: None,
             nvconfig: Some(vec![get_nvconfig(num_of_vfs, pf_total_sf, deployment_type)]),
             ovs: Some(crate::crds::dpuflavors_generated::DpuFlavorOvs {
-                raw_config_script: Some(get_default_ovs_defaults_with_topology(intercept_bridging)),
+                raw_config_script: Some(get_default_ovs_defaults_with_topology(
+                    intercept_bridging,
+                    service_vpc_slots,
+                )),
             }),
             sysctl: None,
             system_reserved_resources: None,
@@ -1819,7 +1844,8 @@ mod tests {
     fn bf3_intercept_bridging_bootstrap_renders_expected_raw_representors() {
         // Render BF3 bootstrap for one configured PF and VF.
         let topology = intercept_bridging();
-        let script = get_default_ovs_defaults_with_topology(Some(&topology));
+        let script =
+            get_default_ovs_defaults_with_topology(Some(&topology), ServiceVpcSlots::default());
 
         // BF3 drops controller only from its platform raw-netdev convention.
         assert!(script.contains("host_representor='pf3hpf'"));
@@ -1854,7 +1880,8 @@ mod tests {
         assert_eq!(String::from_utf8_lossy(&output.stdout), "en8f2");
 
         // VF discovery is intentionally absent; the expected VF is the PF netdev plus its suffix.
-        let script = get_bf4_ovs_defaults_with_topology(Some(&topology));
+        let script =
+            get_bf4_ovs_defaults_with_topology(Some(&topology), ServiceVpcSlots::default());
         assert!(script.contains("host_representor=\"${dpf_c2p3_netdev}vf4\""));
         assert!(script.contains("external_ids='{}' || true"));
         assert!(!script.contains("phys_port_name 'c2pf3vf4'"));
@@ -1920,7 +1947,8 @@ mod tests {
     fn bf4_intercept_bridging_preflight_precedes_all_ovs_mutation() {
         // Locate the final preflight call and the first inherited OVS cleanup operation.
         let topology = intercept_bridging();
-        let script = get_bf4_ovs_defaults_with_topology(Some(&topology));
+        let script =
+            get_bf4_ovs_defaults_with_topology(Some(&topology), ServiceVpcSlots::default());
 
         let final_resolution = script
             .find("resolve_dpf_pf 'c2pf3'")
@@ -1948,14 +1976,26 @@ mod tests {
                 61,
                 None,
                 None,
+                ServiceVpcSlots::default(),
                 &[],
             )
             .unwrap(),
         );
         assert!(bf3.contains(&"NUM_OF_VFS=3".to_string()));
         assert!(bf3.contains(&"PF_TOTAL_SF=61".to_string()));
-        let generic_bf4 =
-            parameters(flavor_bf4_with_topology("ns", &None, 5, 63, None, None, &[]).unwrap());
+        let generic_bf4 = parameters(
+            flavor_bf4_with_topology(
+                "ns",
+                &None,
+                5,
+                63,
+                None,
+                None,
+                ServiceVpcSlots::default(),
+                &[],
+            )
+            .unwrap(),
+        );
         assert!(generic_bf4.contains(&"NUM_OF_VFS=5".to_string()));
         assert!(generic_bf4.contains(&"PF_TOTAL_SF=63".to_string()));
 
@@ -2033,6 +2073,7 @@ mod tests {
             DEFAULT_PF_TOTAL_SF_RESERVED,
             None,
             None,
+            ServiceVpcSlots::default(),
             &extra,
         )
         .unwrap()
@@ -2124,6 +2165,7 @@ mod tests {
             DEFAULT_PF_TOTAL_SF_RESERVED,
             None,
             None,
+            ServiceVpcSlots::default(),
             &extra,
         )
         .map(drop)
@@ -2184,6 +2226,7 @@ mod tests {
                 DEFAULT_PF_TOTAL_SF_RESERVED,
                 None,
                 None,
+                ServiceVpcSlots::default(),
                 &extra,
             )
             .unwrap()
@@ -2232,6 +2275,7 @@ mod tests {
                 DEFAULT_PF_TOTAL_SF_RESERVED + 7,
                 Some(topology),
                 Some(&interfaces),
+                ServiceVpcSlots::default(),
                 &[],
             )
             .unwrap()
@@ -2281,16 +2325,36 @@ mod tests {
         value_scenarios!(
             run = |script: String| script.ends_with(&expected);
             "BF3 provisioning" {
-                get_default_ovs_defaults_with_topology(None) => true,
+                get_default_ovs_defaults_with_topology(None, ServiceVpcSlots::default()) => true,
             }
 
             // BF4 runs the operator's post-OVS hook last, so the encap-IP block is
             // the final NICo-authored step rather than the final line.
             "generic BF4 provisioning" {
-                get_bf4_ovs_defaults_with_topology(None) => false,
+                get_bf4_ovs_defaults_with_topology(None, ServiceVpcSlots::default()) => false,
             }
         );
-        assert!(get_bf4_ovs_defaults_with_topology(None).contains(&expected));
+        assert!(
+            get_bf4_ovs_defaults_with_topology(None, ServiceVpcSlots::default())
+                .contains(&expected)
+        );
+    }
+
+    #[test]
+    fn ovs_bootstrap_creates_service_vpc_slot_bridges() {
+        let expected = concat!(
+            "_ovs-vsctl --may-exist add-br br-svc-0\n",
+            "_ovs-vsctl set bridge br-svc-0 datapath_type=netdev\n",
+            "_ovs-vsctl set bridge br-svc-0 fail_mode=standalone\n",
+        );
+
+        let slots = ServiceVpcSlots::new(1).unwrap();
+        assert!(get_default_ovs_defaults_with_topology(None, slots).contains(expected));
+        assert!(get_bf4_ovs_defaults_with_topology(None, slots).contains(expected));
+        assert!(
+            !get_default_ovs_defaults_with_topology(None, ServiceVpcSlots::default())
+                .contains("br-svc-")
+        );
     }
 
     /// Every BF4 script must run the pre hook before any OVS work and the post
@@ -2302,11 +2366,14 @@ mod tests {
         // also occurs inside the pre-hook's own filename.
         for (script, first_ovs_operation) in [
             (
-                get_bf4_ovs_defaults_with_topology(None),
+                get_bf4_ovs_defaults_with_topology(None, ServiceVpcSlots::default()),
                 "ovs-vsctl --if-exists del-br",
             ),
             (
-                get_bf4_ovs_defaults_with_topology(Some(&intercept_bridging())),
+                get_bf4_ovs_defaults_with_topology(
+                    Some(&intercept_bridging()),
+                    ServiceVpcSlots::default(),
+                ),
                 "ovs-vsctl --if-exists del-br",
             ),
             (get_bf4_astra_ovs_defaults(), "/etc/mellanox/ovs-script.sh"),
@@ -3386,7 +3453,7 @@ mod tests {
             [Case {
                 scenario: "doca/offload/br-sfc setup lines present",
                 input: (
-                    get_default_ovs_defaults_with_topology(None),
+                    get_default_ovs_defaults_with_topology(None, ServiceVpcSlots::default()),
                     &[
                         "other_config:doca-init=true",
                         "other_config:hw-offload=true",

--- a/crates/dpf/src/lib.rs
+++ b/crates/dpf/src/lib.rs
@@ -34,12 +34,12 @@
 //! ## Example
 //!
 //! ```rust,ignore
-//! use dpf::{DpfSdkBuilder, KubeRepository, InitDpfResourcesConfig};
+//! use dpf::{DpfSdkBuilder, KubeRepository, InitDpfResourcesConfigBuilder};
 //!
 //! #[tokio::main]
 //! async fn main() -> Result<(), Box<dyn std::error::Error>> {
 //!     let repo = KubeRepository::new().await?;
-//!     let config = InitDpfResourcesConfig::default();
+//!     let config = InitDpfResourcesConfigBuilder::default().build()?;
 //!     let sdk = DpfSdkBuilder::new(repo, "dpf-operator-system", "secret".to_string())
 //!         .initialize(&config)
 //!         .await?;
@@ -62,6 +62,7 @@ pub mod error;
 pub mod flavor;
 pub mod repository;
 pub mod sdk;
+mod service_vpc_slot;
 pub mod services;
 pub mod types;
 pub mod watcher;
@@ -79,6 +80,7 @@ pub use sdk::{
     build_service_nad, build_service_template, calculate_pf_total_sf, dpu_cr_name,
     dpu_device_cr_name, dpu_node_cr_name, node_id_from_dpu_node_cr_name,
 };
+pub use service_vpc_slot::ServiceVpcSlots;
 pub use services::{DEFAULT_DOCA_HELM_REGISTRY, ServiceRegistryConfig};
 pub use types::{
     BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DEFAULT_DPU_NUM_OF_VFS,
@@ -86,9 +88,10 @@ pub use types::{
     DetachedDpuServiceDefinition, DetachedHelmChart, DpfInterceptBridge, DpfInterceptBridging,
     DpfInterfaceIdentity, DpuDeploymentType, DpuDeviceInfo, DpuErrorEvent, DpuEvent, DpuMismatch,
     DpuNodeInfo, DpuPhase, DpuReadyEvent, DpuServiceHelmChartObservation, DpuServiceObservation,
-    DpuServiceVersion, InitDpfResourcesConfig, MaintenanceEvent, PF_TOTAL_SF_BF4_ASTRA_FUDGE,
-    RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort, ServiceConfigPortProtocol,
-    ServiceDefinition, ServiceInterface, ServiceNAD, ServiceNADResourceType,
+    DpuServiceVersion, InitDpfResourcesConfig, InitDpfResourcesConfigBuilder, MaintenanceEvent,
+    PF_TOTAL_SF_BF4_ASTRA_FUDGE, RebootRequiredEvent, ServiceChainSwitch, ServiceConfigPort,
+    ServiceConfigPortProtocol, ServiceDefinition, ServiceInterface, ServiceNAD,
+    ServiceNADResourceType,
 };
 pub use watcher::{DpuWatcher, DpuWatcherBuilder};
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -98,8 +98,7 @@ use crate::repository::{
     DpuServiceConfigurationRepository, DpuServiceNADRepository, DpuServiceRepository,
     DpuServiceTemplateRepository, K8sConfigRepository,
 };
-#[cfg(test)]
-use crate::types::DEFAULT_PF_TOTAL_SF_RESERVED;
+use crate::service_vpc_slot::MAX_HBN_SERVICE_INTERFACES;
 use crate::types::{
     BlueFieldSoftwareParams, BmcPasswordProvider, ConfigPortsServiceType, DHCP_SERVER_SERVICE_NAME,
     DOCA_HBN_SERVICE_NAME, DOCA_WEAVE_DHCP_AGENT_PF_TOTAL_SF, DPU_AGENT_SERVICE_NAME,
@@ -111,12 +110,13 @@ use crate::types::{
     MAX_BLUEFIELD_VFS_PER_PF, OTEL_COLLECTOR_SERVICE_NAME, PF_TOTAL_SF_BF4_ASTRA_FUDGE,
     ServiceConfigPortProtocol, ServiceDefinition, ServiceNADResourceType, ServiceTemplateVersion,
 };
+#[cfg(test)]
+use crate::types::{DEFAULT_PF_TOTAL_SF_RESERVED, InitDpfResourcesConfigBuilder};
 use crate::watcher::DpuWatcherBuilder;
 
 const SECRET_NAME: &str = "bmc-shared-password";
 const BFB_NAME_PREFIX: &str = "bf-bundle";
 const BLUEFIELD_SOFTWARE_NAME_PREFIX: &str = "bf-software";
-const MAX_HBN_SERVICE_INTERFACES: usize = 32;
 /// Label set by DPF on deployment-owned resources and propagated to the corresponding
 /// DPU-cluster Node. Value format: `<namespace>_<deployment_name>`.
 const DPU_OWNED_BY_DEPLOYMENT_LABEL: &str = "svc.dpu.nvidia.com/owned-by-dpudeployment";
@@ -715,6 +715,7 @@ async fn create_dpu_flavor<R: DpuFlavorRepository>(
             .intercept_bridging
             .as_ref()
             .map(|_| resolved.interfaces.as_ref()),
+        config.service_vpc_slots,
         &config.extra_bfcfg_parameters,
     )?;
     let name = flavor.unique_name(&config.flavor_name)?;
@@ -1620,6 +1621,14 @@ struct ResolvedInitialization<'a> {
     pf_total_sf: u32,
 }
 
+/// Validates initialization configuration without exposing its resolved SDK state.
+pub(crate) fn validate_initialization_config(
+    config: &InitDpfResourcesConfig,
+) -> Result<(), DpfError> {
+    resolve_initialization_inventory(config)?;
+    Ok(())
+}
+
 /// Resolves initialization interfaces and validates their SF capacity without writing resources.
 fn resolve_initialization_inventory<'a>(
     config: &'a InitDpfResourcesConfig,
@@ -1644,6 +1653,13 @@ fn resolve_initialization_inventory<'a>(
     {
         return Err(DpfError::ConfigError(
             "BF4 Astra does not support additional managed SFs".to_string(),
+        ));
+    }
+    if matches!(config.deployment_type, DpuDeploymentType::Bf4Astra)
+        && !config.service_vpc_slots.is_empty()
+    {
+        return Err(DpfError::ConfigError(
+            "BF4 Astra does not support service-VPC slots".to_string(),
         ));
     }
 
@@ -1720,6 +1736,11 @@ fn resolve_initialization_inventory<'a>(
     } else {
         Cow::Borrowed(config.interfaces.as_slice())
     };
+
+    let mut interfaces = interfaces;
+    config
+        .service_vpc_slots
+        .apply(&config.services, interfaces.to_mut())?;
 
     let pf_total_sf = match config.deployment_type {
         DpuDeploymentType::Bf4Astra => calculate_astra_pf_total_sf(interfaces.as_ref())?,
@@ -2063,7 +2084,12 @@ async fn create_flavor_services_and_deployment<
             })?;
     }
 
+    // Reducing the service-VPC slot count intentionally does not prune higher-index templates here.
+    // Deleting a DPUServiceInterface removes live per-DPU interfaces; operators must prune
+    // obsolete slot CRs only after every DPU has stopped using them.
+    //
     // Patch CRs require their peer bridge, so preserve flavor creation before interface templates.
+    // DPF may keep patch interfaces Pending until the deployment reprovisions onto that flavor.
     apply_service_interface_templates_with_scope(
         repo,
         namespace,
@@ -4027,11 +4053,10 @@ mod tests {
     }
 
     /// Provides BF3 initialization inputs for flavor persistence and conflict tests.
-    fn flavor_test_config(proxy: Option<DpfProxyDetails>) -> InitDpfResourcesConfig {
-        InitDpfResourcesConfig {
-            proxy,
-            ..Default::default()
-        }
+    fn flavor_test_config() -> InitDpfResourcesConfig {
+        InitDpfResourcesConfigBuilder::default()
+            .build()
+            .expect("default flavor test configuration must be valid")
     }
 
     /// Verifies static inventory filtering pins minimum, default, and maximum counts.
@@ -4258,15 +4283,13 @@ mod tests {
     #[test]
     fn initialization_rejects_mismatched_topology_vf_count() {
         // The shared configured topology is validated for the default population of 16 VFs.
-        let config = InitDpfResourcesConfig {
-            num_of_vfs: 8,
-            intercept_bridging: Some(configured_topology()),
-            ..Default::default()
-        };
+        let config = InitDpfResourcesConfigBuilder::default()
+            .num_of_vfs(8)
+            .intercept_bridging(configured_topology());
 
         // Pure preflight must reject the mismatch before any repository write is possible.
         assert!(matches!(
-            resolve_initialization_inventory(&config),
+            config.build(),
             Err(DpfError::ConfigError(message))
                 if message.contains("validated for num_of_vfs=16")
                     && message.contains("requested num_of_vfs=8")
@@ -4280,16 +4303,14 @@ mod tests {
         let mut interfaces =
             build_effective_dpu_interfaces(crate::DEFAULT_DPU_NUM_OF_VFS, Some(&topology));
         interfaces[1].name = "unexpected".to_string();
-        let config = InitDpfResourcesConfig {
-            intercept_bridging: Some(topology),
+        let config = InitDpfResourcesConfigBuilder::default()
+            .intercept_bridging(topology)
             // A non-empty custom inventory previously bypassed projection and could diverge from
             // the Patch-backed HBN endpoints used to generate the DHCP ACL.
-            interfaces,
-            ..Default::default()
-        };
+            .interfaces(interfaces);
 
         assert!(matches!(
-            resolve_initialization_inventory(&config),
+            config.build(),
             Err(DpfError::ConfigError(message))
                 if message.contains("first differing interface: received unexpected, expected p1")
                     && message.contains("received 4 interfaces, expected 4")
@@ -4302,30 +4323,28 @@ mod tests {
         let topology = configured_topology();
         let interfaces =
             build_effective_dpu_interfaces(crate::DEFAULT_DPU_NUM_OF_VFS, Some(&topology));
-        let config = InitDpfResourcesConfig {
-            intercept_bridging: Some(topology),
-            interfaces: interfaces.clone(),
-            ..Default::default()
-        };
-
-        let resolved = resolve_initialization_inventory(&config)
+        let config = InitDpfResourcesConfigBuilder::default()
+            .intercept_bridging(topology)
+            .interfaces(interfaces.clone())
+            .build()
             .expect("canonical custom topology projection must be accepted");
-        assert_eq!(resolved.interfaces.as_ref(), interfaces.as_slice());
+
+        assert_eq!(config.interfaces, interfaces);
     }
 
     /// Verifies explicit Astra inventories are augmented without changing non-Astra callers.
     #[test]
     fn initialization_augments_explicit_astra_interface_projection_only() {
         let base_interfaces = build_dpu_interfaces_vec();
-        let astra_config = InitDpfResourcesConfig {
-            deployment_scoped_service_interfaces: true,
-            deployment_type: DpuDeploymentType::Bf4Astra,
-            interfaces: base_interfaces.clone(),
-            ..Default::default()
-        };
-
-        let astra_resolved = resolve_initialization_inventory(&astra_config)
+        let astra_config = InitDpfResourcesConfigBuilder::default()
+            .deployment_scoped_service_interfaces(true)
+            .deployment_type(DpuDeploymentType::Bf4Astra)
+            .interfaces(base_interfaces.clone())
+            .build()
             .expect("explicit Astra inventory must be accepted");
+        let astra_resolved = resolve_initialization_inventory(&astra_config)
+            .expect("explicit Astra inventory must resolve");
+
         assert_eq!(
             &astra_resolved.interfaces.as_ref()[..base_interfaces.len()],
             base_interfaces.as_slice()
@@ -4347,13 +4366,11 @@ mod tests {
                 .any(|interface| interface.name == "p-br-xplane-r3swpln1-to-br-sfc")
         );
 
-        let bf3_config = InitDpfResourcesConfig {
-            interfaces: base_interfaces.clone(),
-            ..Default::default()
-        };
-        let bf3_resolved = resolve_initialization_inventory(&bf3_config)
+        let bf3_config = InitDpfResourcesConfigBuilder::default()
+            .interfaces(base_interfaces.clone())
+            .build()
             .expect("explicit BF3 inventory must be accepted unchanged");
-        assert_eq!(bf3_resolved.interfaces.as_ref(), base_interfaces.as_slice());
+        assert_eq!(bf3_config.interfaces, base_interfaces);
     }
 
     /// Astra's NICo-owned patch names cannot be rebound by a direct SDK caller.
@@ -4367,15 +4384,13 @@ mod tests {
             vf_id: 0,
             chained_svc_if: None,
         });
-        let config = InitDpfResourcesConfig {
-            deployment_scoped_service_interfaces: true,
-            deployment_type: DpuDeploymentType::Bf4Astra,
-            interfaces,
-            ..Default::default()
-        };
+        let config = InitDpfResourcesConfigBuilder::default()
+            .deployment_scoped_service_interfaces(true)
+            .deployment_type(DpuDeploymentType::Bf4Astra)
+            .interfaces(interfaces);
 
         assert!(matches!(
-            resolve_initialization_inventory(&config),
+            config.build(),
             Err(DpfError::ConfigError(message))
                 if message.contains("p-brcx-r0swpln0-to-br-sfc")
                     && message.contains("reserved")
@@ -4386,17 +4401,17 @@ mod tests {
     /// headroom; the BF3/generic reserve must not change the Astra flavor.
     #[test]
     fn astra_pf_total_sf_ignores_site_reserve() {
-        let config = InitDpfResourcesConfig {
-            deployment_scoped_service_interfaces: true,
-            deployment_type: DpuDeploymentType::Bf4Astra,
+        let config = InitDpfResourcesConfigBuilder::default()
+            .deployment_scoped_service_interfaces(true)
+            .deployment_type(DpuDeploymentType::Bf4Astra)
             // A value that would overflow if Astra incorrectly treated this as additional SF
             // capacity proves the reserve is not part of Astra's calculation.
-            pf_total_sf_reserved: u32::MAX,
-            ..Default::default()
-        };
-
-        let resolved = resolve_initialization_inventory(&config)
+            .pf_total_sf_reserved(u32::MAX)
+            .build()
             .expect("Astra capacity must not consume the BF3/generic SF reserve");
+        let resolved =
+            resolve_initialization_inventory(&config).expect("Astra initialization must resolve");
+
         let astra_interfaces = build_astra_dpu_interfaces_vec();
         let managed_endpoints = astra_interfaces
             .iter()
@@ -4412,14 +4427,12 @@ mod tests {
     #[test]
     fn initialization_rejects_hardware_vf_count_above_platform_limit() {
         // Direct SDK callers do not pass through api-core configuration deserialization.
-        let config = InitDpfResourcesConfig {
-            num_of_vfs: MAX_BLUEFIELD_VFS_PER_PF + 1,
-            ..Default::default()
-        };
+        let config =
+            InitDpfResourcesConfigBuilder::default().num_of_vfs(MAX_BLUEFIELD_VFS_PER_PF + 1);
 
         // Pure preflight runs before the SDK writes its shared BMC Secret.
         assert!(matches!(
-            resolve_initialization_inventory(&config),
+            config.build(),
             Err(DpfError::ConfigError(message)) if message.contains("num_of_vfs must be <= 126")
         ));
     }
@@ -6572,7 +6585,7 @@ mod tests {
     #[tokio::test]
     async fn test_create_dpu_flavor_fresh() {
         let mock = SdkMock::new();
-        let config = flavor_test_config(None);
+        let config = flavor_test_config();
         let resolved = resolve_initialization_inventory(&config).unwrap();
         let name = create_dpu_flavor(&mock, TEST_NAMESPACE, &config, &resolved)
             .await
@@ -6599,11 +6612,14 @@ mod tests {
     #[tokio::test]
     async fn test_create_dpu_flavor_fresh_with_proxy() {
         let mock = SdkMock::new();
-        let proxy = Some(DpfProxyDetails {
+        let proxy = DpfProxyDetails {
             https_proxy: "http://proxy.corp:3128".to_string(),
             no_proxy: vec!["10.0.0.0/8".to_string()],
-        });
-        let config = flavor_test_config(proxy);
+        };
+        let config = InitDpfResourcesConfigBuilder::default()
+            .proxy(proxy)
+            .build()
+            .expect("proxy flavor test configuration must be valid");
         let resolved = resolve_initialization_inventory(&config).unwrap();
         let name_with_proxy = create_dpu_flavor(&mock, TEST_NAMESPACE, &config, &resolved)
             .await
@@ -6651,7 +6667,7 @@ mod tests {
         }
 
         let mock = AlwaysConflictsMock::default();
-        let config = flavor_test_config(None);
+        let config = flavor_test_config();
         let resolved = resolve_initialization_inventory(&config).unwrap();
         let err = create_dpu_flavor(&mock, TEST_NAMESPACE, &config, &resolved)
             .await
@@ -6679,7 +6695,7 @@ mod tests {
             .unwrap()
             .insert(SdkMock::key(&terminating_flavor), terminating_flavor);
 
-        let config = flavor_test_config(None);
+        let config = flavor_test_config();
         let resolved = resolve_initialization_inventory(&config).unwrap();
         let err = create_dpu_flavor(&mock, TEST_NAMESPACE, &config, &resolved)
             .await
@@ -6707,7 +6723,7 @@ mod tests {
             .insert(SdkMock::key(&flavor), flavor);
 
         let expected_name = flavor_name.clone();
-        let config = flavor_test_config(None);
+        let config = flavor_test_config();
         let resolved = resolve_initialization_inventory(&config).unwrap();
         let returned = create_dpu_flavor(&mock, TEST_NAMESPACE, &config, &resolved)
             .await

--- a/crates/dpf/src/service_vpc_slot.rs
+++ b/crates/dpf/src/service_vpc_slot.rs
@@ -1,0 +1,546 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! NICo-managed service-VPC slot topology.
+//!
+//! Each configured slot `N` reserves the otherwise empty OVS bridge `br-svc-N`
+//! as a stable connection point between HBN and a DPU service dynamically
+//! enabled after DPU provisioning.
+//!
+//! NICo creates these resources for slot `N`:
+//!
+//! ```text
+//! DPUFlavor
+//!   OVS initialization creates br-svc-N
+//!
+//! DPUServiceConfiguration/doca-hbn
+//!   interfaces:
+//!     - name: iface_svc_N
+//!
+//! DPUServiceInterface/service-vpc-slot-N
+//!   label: interface=service-vpc-slot-N
+//!   type: Patch
+//!   peerBridge: br-svc-N
+//!   peerPatchName: svc-slot-N
+//!
+//! DPUDeployment/<provisioning deployment>
+//!   serviceChains.switches[N].ports:
+//!     - service: doca-hbn/iface_svc_N
+//!     - serviceInterface: interface=service-vpc-slot-N
+//! ```
+//!
+//! DPF materializes that desired state on each selected DPU. `br-sfc` is DPF's
+//! shared OVS service-function-chaining bridge. The Patch interface causes DPF's
+//! SFC controller to create both OVS patch ports; `p_brsfc_to_svc-slot-N` is
+//! derived from the explicitly configured peer name `svc-slot-N`.
+//!
+//! ```text
+//! doca-hbn/iface_svc_N
+//!          |
+//! DPUServiceChain switch on br-sfc
+//!          |
+//! p_brsfc_to_svc-slot-N <========> svc-slot-N
+//!                                      |
+//!                                  br-svc-N
+//!                                      |
+//!            post-provisioning dynamically enabled DPU service
+//! ```
+//!
+//! The dynamically enabled service creates its own Patch `DPUServiceInterface`
+//! terminating on `br-svc-N` and its own `DPUServiceChain` connecting that patch
+//! to the service interface.
+
+use std::collections::BTreeSet;
+use std::fmt::Write;
+
+use crate::error::DpfError;
+use crate::types::{
+    DOCA_HBN_SERVICE_NAME, DOCA_HBN_SERVICE_NETWORK, DpuServiceInterfacePatch,
+    DpuServiceInterfaceTemplateDefinition, DpuServiceInterfaceTemplateType, ServiceDefinition,
+    ServiceInterface,
+};
+
+pub(crate) const MAX_HBN_SERVICE_INTERFACES: usize = 32;
+
+/// A validated collection of NICo-managed service-VPC slots.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct ServiceVpcSlots {
+    count: u32,
+}
+
+impl ServiceVpcSlots {
+    /// Validates and constructs a service-VPC slot collection.
+    pub fn new(count: u32) -> Result<Self, DpfError> {
+        if count > MAX_HBN_SERVICE_INTERFACES as u32 {
+            return Err(DpfError::ConfigError(format!(
+                "service-VPC slot count {count} exceeds the supported HBN interface maximum of {MAX_HBN_SERVICE_INTERFACES}"
+            )));
+        }
+        Ok(Self { count })
+    }
+
+    /// Returns whether no service-VPC slots are configured.
+    pub(crate) const fn is_empty(self) -> bool {
+        self.count == 0
+    }
+
+    /// Appends this feature's HBN interfaces to the caller's base HBN inventory.
+    pub fn append_hbn_interfaces(self, interfaces: &mut Vec<ServiceInterface>) {
+        interfaces.extend(self.slots().map(|slot| ServiceInterface {
+            name: slot.hbn_interface_name(),
+            network: DOCA_HBN_SERVICE_NETWORK.to_string(),
+        }));
+    }
+
+    /// Appends the dedicated OVS bridge for every configured slot.
+    pub(crate) fn append_ovs_bridges(self, script: &mut String) {
+        // Reprovision performs a full OS installation, so OVSDB is reset before this script runs;
+        // bridges from a previous, larger slot count do not need explicit deletion here.
+        for slot in self.slots() {
+            // Each slot bridge is dedicated to one HBN patch and one consumer service patch.
+            let bridge = slot.bridge_name();
+            let _ = writeln!(
+                script,
+                "_ovs-vsctl --may-exist add-br {bridge}\n_ovs-vsctl set bridge {bridge} datapath_type=netdev\n_ovs-vsctl set bridge {bridge} fail_mode=standalone"
+            );
+        }
+    }
+
+    /// Validates and adds the complete slot topology to initialization state.
+    pub(crate) fn apply(
+        self,
+        services: &[ServiceDefinition],
+        interfaces: &mut Vec<DpuServiceInterfaceTemplateDefinition>,
+    ) -> Result<(), DpfError> {
+        if self.is_empty() {
+            return Ok(());
+        }
+
+        let hbn_interface_names = interfaces
+            .iter()
+            .flat_map(|interface| interface.chained_svc_if.iter().flatten())
+            .filter(|(service, _)| service == DOCA_HBN_SERVICE_NAME)
+            .map(|(_, name)| name.as_str())
+            .collect::<BTreeSet<_>>();
+        let remaining_hbn_interfaces =
+            MAX_HBN_SERVICE_INTERFACES.saturating_sub(hbn_interface_names.len());
+        if self.count > remaining_hbn_interfaces as u32 {
+            return Err(DpfError::ConfigError(format!(
+                "service-VPC slot count {} exceeds the remaining HBN interface capacity of {remaining_hbn_interfaces}",
+                self.count,
+            )));
+        }
+
+        let interface_names = interfaces
+            .iter()
+            .map(|interface| interface.name.as_str())
+            .collect::<BTreeSet<_>>();
+        let mut ovs_names = BTreeSet::new();
+        for interface in interfaces.iter() {
+            match &interface.iface_type {
+                DpuServiceInterfaceTemplateType::Physical => {
+                    ovs_names.insert(interface.name.clone());
+                }
+                DpuServiceInterfaceTemplateType::Patch(patch) => {
+                    ovs_names.insert(patch.peer_bridge.clone());
+                    ovs_names.insert(patch.peer_patch_name.clone());
+                    ovs_names.insert(format!("p_brsfc_to_{}", patch.peer_patch_name));
+                }
+                _ => {}
+            }
+        }
+
+        for slot in self.slots() {
+            let peer_patch_name = slot.peer_patch_name();
+            let slot_ovs_names = [
+                slot.bridge_name(),
+                peer_patch_name.clone(),
+                format!("p_brsfc_to_{peer_patch_name}"),
+            ];
+            if interface_names.contains(slot.interface_name().as_str())
+                || hbn_interface_names.contains(slot.hbn_interface_name().as_str())
+                || slot_ovs_names.iter().any(|name| ovs_names.contains(name))
+            {
+                return Err(DpfError::ConfigError(format!(
+                    "DPF interface or OVS name conflicts with reserved service-VPC slot {}",
+                    slot.interface_name(),
+                )));
+            }
+        }
+        let slot_interfaces = self
+            .slots()
+            .map(ServiceVpcSlot::dpu_interface)
+            .collect::<Vec<_>>();
+
+        let mut hbn_services = services
+            .iter()
+            .filter(|service| service.name == DOCA_HBN_SERVICE_NAME);
+        let hbn = hbn_services.next().ok_or_else(|| {
+            DpfError::ConfigError(
+                "service-VPC slots require a doca-hbn service definition".to_string(),
+            )
+        })?;
+        if hbn_services.next().is_some() {
+            return Err(DpfError::ConfigError(
+                "service-VPC slots require exactly one doca-hbn service definition".to_string(),
+            ));
+        }
+
+        let mut expected = interfaces
+            .iter()
+            .chain(&slot_interfaces)
+            .flat_map(|interface| interface.chained_svc_if.iter().flatten())
+            .filter(|(service, _)| service == DOCA_HBN_SERVICE_NAME)
+            .map(|(_, name)| (name.clone(), DOCA_HBN_SERVICE_NETWORK.to_string()))
+            .collect::<Vec<_>>();
+        expected.sort_unstable();
+        let mut actual = hbn
+            .interfaces
+            .iter()
+            .map(|interface| (interface.name.clone(), interface.network.clone()))
+            .collect::<Vec<_>>();
+        actual.sort_unstable();
+        if actual != expected {
+            return Err(DpfError::ConfigError(
+                "doca-hbn interface inventory must exactly match the resolved DPF HBN chains"
+                    .to_string(),
+            ));
+        }
+        interfaces.extend(slot_interfaces);
+        Ok(())
+    }
+
+    fn slots(self) -> impl Iterator<Item = ServiceVpcSlot> {
+        (0..self.count).map(ServiceVpcSlot)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct ServiceVpcSlot(u32);
+
+impl ServiceVpcSlot {
+    fn interface_name(self) -> String {
+        format!("service-vpc-slot-{}", self.0)
+    }
+
+    fn bridge_name(self) -> String {
+        format!("br-svc-{}", self.0)
+    }
+
+    fn peer_patch_name(self) -> String {
+        format!("svc-slot-{}", self.0)
+    }
+
+    fn hbn_interface_name(self) -> String {
+        format!("iface_svc_{}", self.0)
+    }
+
+    fn dpu_interface(self) -> DpuServiceInterfaceTemplateDefinition {
+        DpuServiceInterfaceTemplateDefinition {
+            name: self.interface_name(),
+            iface_type: DpuServiceInterfaceTemplateType::Patch(DpuServiceInterfacePatch {
+                peer_bridge: self.bridge_name(),
+                peer_patch_name: self.peer_patch_name(),
+                peer_external_ids: None,
+            }),
+            pf_id: 0,
+            vf_id: 0,
+            chained_svc_if: Some(vec![(
+                DOCA_HBN_SERVICE_NAME.to_string(),
+                self.hbn_interface_name(),
+            )]),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn physical_interface(
+        name: &str,
+        hbn_interface: Option<&str>,
+    ) -> DpuServiceInterfaceTemplateDefinition {
+        DpuServiceInterfaceTemplateDefinition {
+            name: name.to_string(),
+            iface_type: DpuServiceInterfaceTemplateType::Physical,
+            pf_id: 0,
+            vf_id: 0,
+            chained_svc_if: hbn_interface
+                .map(|name| vec![(DOCA_HBN_SERVICE_NAME.to_string(), name.to_string())]),
+        }
+    }
+
+    fn hbn_service(interfaces: Vec<ServiceInterface>) -> ServiceDefinition {
+        ServiceDefinition {
+            interfaces,
+            ..ServiceDefinition::new(DOCA_HBN_SERVICE_NAME, "repo", "chart", "1")
+        }
+    }
+
+    #[test]
+    fn generates_complete_slot_topology() {
+        let slots = ServiceVpcSlots::new(2).unwrap();
+        let mut interfaces = Vec::new();
+        let mut hbn_interfaces = Vec::new();
+        slots.append_hbn_interfaces(&mut hbn_interfaces);
+        slots
+            .apply(&[hbn_service(hbn_interfaces.clone())], &mut interfaces)
+            .unwrap();
+        let mut ovs = String::new();
+        slots.append_ovs_bridges(&mut ovs);
+
+        assert_eq!(
+            hbn_interfaces
+                .into_iter()
+                .map(|interface| interface.name)
+                .collect::<Vec<_>>(),
+            ["iface_svc_0", "iface_svc_1"]
+        );
+        assert_eq!(
+            interfaces
+                .iter()
+                .map(|interface| interface.name.as_str())
+                .collect::<Vec<_>>(),
+            ["service-vpc-slot-0", "service-vpc-slot-1"]
+        );
+        assert!(matches!(
+            &interfaces[0].iface_type,
+            DpuServiceInterfaceTemplateType::Patch(patch)
+                if patch.peer_bridge == "br-svc-0" && patch.peer_patch_name == "svc-slot-0"
+        ));
+        assert_eq!(
+            ovs,
+            concat!(
+                "_ovs-vsctl --may-exist add-br br-svc-0\n",
+                "_ovs-vsctl set bridge br-svc-0 datapath_type=netdev\n",
+                "_ovs-vsctl set bridge br-svc-0 fail_mode=standalone\n",
+                "_ovs-vsctl --may-exist add-br br-svc-1\n",
+                "_ovs-vsctl set bridge br-svc-1 datapath_type=netdev\n",
+                "_ovs-vsctl set bridge br-svc-1 fail_mode=standalone\n",
+            )
+        );
+    }
+
+    #[test]
+    fn generated_slot_participates_in_sf_capacity() {
+        let slots = ServiceVpcSlots::new(1).unwrap();
+        let mut hbn_interfaces = Vec::new();
+        slots.append_hbn_interfaces(&mut hbn_interfaces);
+        let mut interfaces = Vec::new();
+        slots
+            .apply(&[hbn_service(hbn_interfaces)], &mut interfaces)
+            .unwrap();
+
+        assert!(crate::calculate_pf_total_sf(&interfaces, None, 0, 0).is_err());
+        assert_eq!(
+            crate::calculate_pf_total_sf(&interfaces, None, 1, 0).unwrap(),
+            1
+        );
+    }
+
+    #[test]
+    fn accepts_zero_and_maximum_slots_but_rejects_excess() {
+        assert!(ServiceVpcSlots::new(0).unwrap().is_empty());
+        assert_eq!(
+            {
+                let mut interfaces = Vec::new();
+                ServiceVpcSlots::new(MAX_HBN_SERVICE_INTERFACES as u32)
+                    .unwrap()
+                    .append_hbn_interfaces(&mut interfaces);
+                interfaces.len()
+            },
+            MAX_HBN_SERVICE_INTERFACES
+        );
+        assert!(ServiceVpcSlots::new(33).is_err());
+    }
+
+    #[test]
+    fn rejects_every_generated_name_collision() {
+        let slots = ServiceVpcSlots::new(1).unwrap();
+        for (description, mut interfaces) in [
+            (
+                "interface template",
+                vec![physical_interface("service-vpc-slot-0", None)],
+            ),
+            (
+                "HBN interface",
+                vec![physical_interface("existing", Some("iface_svc_0"))],
+            ),
+            (
+                "physical OVS name",
+                vec![physical_interface("br-svc-0", None)],
+            ),
+        ] {
+            assert!(
+                slots.apply(&[], &mut interfaces).is_err(),
+                "accepted colliding {description}"
+            );
+        }
+
+        for (bridge, patch_port) in [
+            ("br-pf3", "p_brsfc_to_svc-slot-0"),
+            ("svc-slot-0", "p-pf3"),
+            ("br-pf3", "br-svc-0"),
+        ] {
+            let mut interfaces = vec![DpuServiceInterfaceTemplateDefinition {
+                name: "existing".to_string(),
+                iface_type: DpuServiceInterfaceTemplateType::Patch(DpuServiceInterfacePatch {
+                    peer_bridge: bridge.to_string(),
+                    peer_patch_name: patch_port.to_string(),
+                    peer_external_ids: None,
+                }),
+                pf_id: 0,
+                vf_id: 0,
+                chained_svc_if: None,
+            }];
+
+            assert!(
+                slots.apply(&[], &mut interfaces).is_err(),
+                "accepted colliding bridge {bridge} and patch port {patch_port}"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_slots_exceeding_remaining_hbn_capacity() {
+        let mut interfaces = (0..MAX_HBN_SERVICE_INTERFACES)
+            .map(|index| physical_interface(&format!("p{index}"), Some(&format!("hbn{index}"))))
+            .collect::<Vec<_>>();
+
+        assert!(
+            ServiceVpcSlots::new(1)
+                .unwrap()
+                .apply(&[], &mut interfaces)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn validates_exact_hbn_inventory_without_requiring_order() {
+        let slots = ServiceVpcSlots::new(1).unwrap();
+        let interfaces = vec![physical_interface("p0", Some("p0_if"))];
+        let mut expected = vec![ServiceInterface {
+            name: "p0_if".to_string(),
+            network: DOCA_HBN_SERVICE_NETWORK.to_string(),
+        }];
+        slots.append_hbn_interfaces(&mut expected);
+        expected.reverse();
+
+        let mut interfaces = interfaces;
+        assert!(
+            slots
+                .apply(&[hbn_service(expected)], &mut interfaces)
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn rejects_missing_duplicate_extra_and_wrong_network_hbn_inventory() {
+        let slots = ServiceVpcSlots::new(1).unwrap();
+        let interfaces = vec![physical_interface("p0", Some("p0_if"))];
+        let mut expected = vec![ServiceInterface {
+            name: "p0_if".to_string(),
+            network: DOCA_HBN_SERVICE_NETWORK.to_string(),
+        }];
+        slots.append_hbn_interfaces(&mut expected);
+        let mut wrong_network = expected.clone();
+        wrong_network[1].network = "wrong".to_string();
+
+        for (description, inventory) in [
+            ("missing base interface", vec![expected[1].clone()]),
+            ("missing slot interface", vec![expected[0].clone()]),
+            (
+                "duplicate interface",
+                vec![
+                    expected[0].clone(),
+                    expected[1].clone(),
+                    expected[1].clone(),
+                ],
+            ),
+            (
+                "extra interface",
+                vec![
+                    expected[0].clone(),
+                    expected[1].clone(),
+                    ServiceInterface {
+                        name: "extra".to_string(),
+                        network: DOCA_HBN_SERVICE_NETWORK.to_string(),
+                    },
+                ],
+            ),
+            ("wrong network", wrong_network),
+        ] {
+            let mut interfaces = interfaces.clone();
+            assert!(
+                slots
+                    .apply(&[hbn_service(inventory)], &mut interfaces)
+                    .is_err(),
+                "accepted {description}"
+            );
+            assert_eq!(interfaces, vec![physical_interface("p0", Some("p0_if"))]);
+        }
+    }
+
+    #[test]
+    fn rejects_an_unconfigured_second_hbn_chain_on_one_interface() {
+        let slots = ServiceVpcSlots::new(1).unwrap();
+        let mut interface = physical_interface("p0", Some("p0_if"));
+        interface
+            .chained_svc_if
+            .as_mut()
+            .expect("physical interface fixture has one HBN chain")
+            .push((DOCA_HBN_SERVICE_NAME.to_string(), "p0_if_2".to_string()));
+        let mut configured_hbn_interfaces = vec![ServiceInterface {
+            name: "p0_if".to_string(),
+            network: DOCA_HBN_SERVICE_NETWORK.to_string(),
+        }];
+        slots.append_hbn_interfaces(&mut configured_hbn_interfaces);
+
+        assert!(
+            slots
+                .apply(
+                    &[hbn_service(configured_hbn_interfaces)],
+                    &mut vec![interface],
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn rejects_missing_or_duplicate_hbn_service() {
+        let slots = ServiceVpcSlots::new(1).unwrap();
+        let interfaces = vec![physical_interface("p0", Some("p0_if"))];
+        let mut no_service_interfaces = interfaces.clone();
+        assert!(slots.apply(&[], &mut no_service_interfaces).is_err());
+        assert_eq!(no_service_interfaces, interfaces);
+
+        let mut hbn_interfaces = vec![ServiceInterface {
+            name: "p0_if".to_string(),
+            network: DOCA_HBN_SERVICE_NETWORK.to_string(),
+        }];
+        slots.append_hbn_interfaces(&mut hbn_interfaces);
+        let hbn = hbn_service(hbn_interfaces);
+        let mut duplicate_service_interfaces = interfaces.clone();
+        assert!(
+            slots
+                .apply(&[hbn.clone(), hbn], &mut duplicate_service_interfaces)
+                .is_err()
+        );
+        assert_eq!(duplicate_service_interfaces, interfaces);
+    }
+}

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -547,10 +547,10 @@ async fn conditional_dpu_delete_rejects_uid_mismatch() {
 async fn test_create_initialization_objects() {
     let mock = InitializationMock::default();
 
-    let config = InitDpfResourcesConfig {
-        bfb_url: "http://example.com/test.bfb".to_string(),
-        ..Default::default()
-    };
+    let config = InitDpfResourcesConfigBuilder::default()
+        .bfb_url("http://example.com/test.bfb")
+        .build()
+        .expect("BF3 initialization test configuration must be valid");
     let deployment_name = config.deployment_name.clone();
 
     let sdk = crate::sdk::DpfSdkBuilder::new(mock.clone(), TEST_NS, "test-password".to_string())
@@ -614,9 +614,7 @@ async fn sf_overflow_fails_before_initialization_writes() {
         .await;
     assert!(matches!(result, Err(DpfError::ConfigError(_))));
     assert!(mock.secrets.is_empty());
-    assert!(mock.bfbs.is_empty());
-    assert!(mock.flavors.is_empty());
-    assert!(mock.deployments.is_empty());
+    assert_no_initialization_crs(&mock);
 }
 
 /// Verifies one-shot Astra initialization rejects global interfaces before its first write.
@@ -674,19 +672,138 @@ async fn unscoped_astra_split_initialization_writes_no_resources() {
     assert_no_initialization_crs(&mock);
 }
 
+/// Verifies the public initialization path rejects split HBN topology and emits matching
+/// configuration and chain references when the SDK-generated service interface is supplied.
+#[tokio::test]
+async fn service_vpc_initialization_keeps_hbn_configuration_and_chain_aligned() {
+    let mock = InitializationMock::default();
+    let slots = crate::ServiceVpcSlots::new(1).unwrap();
+    let interfaces = crate::build_effective_dpu_interfaces(crate::DEFAULT_DPU_NUM_OF_VFS, None);
+    let mut hbn_interfaces = interfaces
+        .iter()
+        .filter_map(|interface| {
+            interface.chained_svc_if.as_ref().and_then(|chains| {
+                chains
+                    .iter()
+                    .find(|(service, _)| service == DOCA_HBN_SERVICE_NAME)
+                    .map(|(_, name)| ServiceInterface {
+                        name: name.clone(),
+                        network: DOCA_HBN_SERVICE_NETWORK.to_string(),
+                    })
+            })
+        })
+        .collect();
+    slots.append_hbn_interfaces(&mut hbn_interfaces);
+    let hbn = ServiceDefinition {
+        interfaces: hbn_interfaces,
+        ..ServiceDefinition::new(DOCA_HBN_SERVICE_NAME, "repo", "chart", "1")
+    };
+    let config = InitDpfResourcesConfigBuilder::default()
+        .services(vec![hbn])
+        .service_vpc_slots(slots)
+        .interfaces(interfaces)
+        .build()
+        .expect("service-VPC initialization test configuration must be valid");
+
+    crate::sdk::DpfSdkBuilder::new(mock.clone(), TEST_NS, "test-password".to_string())
+        .initialize(&config)
+        .await
+        .unwrap();
+
+    let hbn_config = DpuServiceConfigurationRepository::get(&mock, DOCA_HBN_SERVICE_NAME, TEST_NS)
+        .await
+        .unwrap()
+        .expect("HBN service configuration must exist");
+    let hbn_interfaces = hbn_config.spec.interfaces.unwrap();
+    assert!(hbn_interfaces.iter().any(|interface| {
+        interface.name == "iface_svc_0" && interface.network == DOCA_HBN_SERVICE_NETWORK
+    }));
+
+    let deployment = DpuDeploymentRepository::get(&mock, "dpu-deployment", TEST_NS)
+        .await
+        .unwrap()
+        .expect("DPU deployment must exist");
+    let slot_switch = deployment
+        .spec
+        .service_chains
+        .unwrap()
+        .switches
+        .into_iter()
+        .find(|switch| {
+            switch.ports.iter().any(|port| {
+                port.service
+                    .as_ref()
+                    .is_some_and(|service| service.interface == "iface_svc_0")
+            })
+        })
+        .expect("service-VPC chain must reference the HBN interface");
+    assert!(slot_switch.ports.iter().any(|port| {
+        port.service_interface.as_ref().is_some_and(|interface| {
+            interface.match_labels.get("interface").map(String::as_str)
+                == Some("service-vpc-slot-0")
+        })
+    }));
+}
+
+#[test]
+fn service_vpc_config_rejects_missing_hbn_interface() {
+    let result = InitDpfResourcesConfigBuilder::default()
+        .services(vec![ServiceDefinition::new(
+            DOCA_HBN_SERVICE_NAME,
+            "repo",
+            "chart",
+            "1",
+        )])
+        .service_vpc_slots(crate::ServiceVpcSlots::new(1).unwrap())
+        .build();
+
+    assert!(matches!(result, Err(DpfError::ConfigError(_))));
+}
+
+#[test]
+fn config_rejects_sf_overflow() {
+    let result = InitDpfResourcesConfigBuilder::default()
+        .intercept_bridging(configured_intercept_bridging())
+        .pf_total_sf_reserved(u32::MAX)
+        .build();
+    assert!(matches!(result, Err(DpfError::ConfigError(_))));
+}
+
+#[test]
+fn config_rejects_unscoped_astra() {
+    let result = InitDpfResourcesConfigBuilder::default()
+        .bluefield_software(BlueFieldSoftwareParams {
+            os_iso: "http://example.com/astra.iso".to_string(),
+            pldm_fw_bundle: Some("http://example.com/astra.pldm".to_string()),
+        })
+        .deployment_name("astra-deployment")
+        .deployment_type(DpuDeploymentType::Bf4Astra)
+        .build();
+
+    let Err(error) = result else {
+        panic!("unscoped Astra initialization must fail");
+    };
+    assert!(matches!(&error, DpfError::ConfigError(_)));
+    assert!(
+        error
+            .to_string()
+            .contains("BF4 Astra requires deployment_scoped_service_interfaces=true")
+    );
+}
+
 #[tokio::test]
 async fn test_create_initialization_objects_bluefield_software() {
     let mock = InitializationMock::default();
 
-    let config = InitDpfResourcesConfig {
-        bluefield_software: Some(BlueFieldSoftwareParams {
+    let config = InitDpfResourcesConfigBuilder::default()
+        .bluefield_software(BlueFieldSoftwareParams {
             os_iso: "http://example.com/os.iso".to_string(),
             pldm_fw_bundle: Some("http://example.com/fw.pldm".to_string()),
-        }),
-        deployment_name: "bf4-dep".to_string(),
-        deployment_type: DpuDeploymentType::Bf4Generic,
-        ..Default::default()
-    };
+        })
+        .deployment_name("bf4-dep")
+        .deployment_type(DpuDeploymentType::Bf4Generic)
+        .build()
+        .expect("BF4 initialization test configuration must be valid");
 
     let sdk = crate::sdk::DpfSdkBuilder::new(mock.clone(), TEST_NS, "test-password".to_string())
         .initialize(&config)
@@ -750,54 +867,54 @@ async fn scoped_bf3_gb200_bf4_and_astra_initialization_coexists() {
     let topology = configured_intercept_bridging();
     let configs = [
         // BF3 proves the configured topology through the BFB flavor path.
-        InitDpfResourcesConfig {
-            bfb_url: "http://example.com/bf3.bfb".to_string(),
-            deployment_name: "bf3-deployment".to_string(),
-            flavor_name: "bf3-flavor".to_string(),
-            services: services.clone(),
-            deployment_scoped_service_interfaces: true,
-            intercept_bridging: Some(topology.clone()),
-            deployment_type: DpuDeploymentType::Bf3,
-            ..Default::default()
-        },
+        InitDpfResourcesConfigBuilder::default()
+            .bfb_url("http://example.com/bf3.bfb")
+            .deployment_name("bf3-deployment")
+            .flavor_name("bf3-flavor")
+            .services(services.clone())
+            .deployment_scoped_service_interfaces(true)
+            .intercept_bridging(topology.clone())
+            .deployment_type(DpuDeploymentType::Bf3)
+            .build()
+            .expect("scoped BF3 test configuration must be valid"),
         // GB200 BF3 reuses the BF3 source and services but owns a distinct flavor and selector.
-        InitDpfResourcesConfig {
-            bfb_url: "http://example.com/bf3.bfb".to_string(),
-            deployment_name: "bf3-gb200-deployment".to_string(),
-            flavor_name: "bf3-gb200-flavor".to_string(),
-            services: services.clone(),
-            deployment_scoped_service_interfaces: true,
-            intercept_bridging: Some(topology.clone()),
-            deployment_type: DpuDeploymentType::Bf3Gb200,
-            ..Default::default()
-        },
+        InitDpfResourcesConfigBuilder::default()
+            .bfb_url("http://example.com/bf3.bfb")
+            .deployment_name("bf3-gb200-deployment")
+            .flavor_name("bf3-gb200-flavor")
+            .services(services.clone())
+            .deployment_scoped_service_interfaces(true)
+            .intercept_bridging(topology.clone())
+            .deployment_type(DpuDeploymentType::Bf3Gb200)
+            .build()
+            .expect("scoped GB200 test configuration must be valid"),
         // Generic BF4 proves the same topology through its BlueFieldSoftware path.
-        InitDpfResourcesConfig {
-            bluefield_software: Some(BlueFieldSoftwareParams {
+        InitDpfResourcesConfigBuilder::default()
+            .bluefield_software(BlueFieldSoftwareParams {
                 os_iso: "http://example.com/bf4.iso".to_string(),
                 pldm_fw_bundle: Some("http://example.com/bf4.pldm".to_string()),
-            }),
-            deployment_name: "bf4-deployment".to_string(),
-            flavor_name: "bf4-flavor".to_string(),
-            services: services.clone(),
-            deployment_scoped_service_interfaces: true,
-            intercept_bridging: Some(topology),
-            deployment_type: DpuDeploymentType::Bf4Generic,
-            ..Default::default()
-        },
+            })
+            .deployment_name("bf4-deployment")
+            .flavor_name("bf4-flavor")
+            .services(services.clone())
+            .deployment_scoped_service_interfaces(true)
+            .intercept_bridging(topology)
+            .deployment_type(DpuDeploymentType::Bf4Generic)
+            .build()
+            .expect("scoped generic BF4 test configuration must be valid"),
         // Astra proves its fixed BF4+CX9 inventory remains isolated from both configured classes.
-        InitDpfResourcesConfig {
-            bluefield_software: Some(BlueFieldSoftwareParams {
+        InitDpfResourcesConfigBuilder::default()
+            .bluefield_software(BlueFieldSoftwareParams {
                 os_iso: "http://example.com/astra.iso".to_string(),
                 pldm_fw_bundle: Some("http://example.com/astra.pldm".to_string()),
-            }),
-            deployment_name: "astra-deployment".to_string(),
-            flavor_name: "astra-flavor".to_string(),
-            services,
-            deployment_scoped_service_interfaces: true,
-            deployment_type: DpuDeploymentType::Bf4Astra,
-            ..Default::default()
-        },
+            })
+            .deployment_name("astra-deployment")
+            .flavor_name("astra-flavor")
+            .services(services)
+            .deployment_scoped_service_interfaces(true)
+            .deployment_type(DpuDeploymentType::Bf4Astra)
+            .build()
+            .expect("scoped Astra test configuration must be valid"),
     ];
 
     mock.configs.insert(
@@ -1452,17 +1569,17 @@ async fn reinitialization_preserves_operator_extra_scripts() {
     .into_iter()
     .map(|name| ServiceDefinition::new(name, "repo", "chart", "1.0.0"))
     .collect::<Vec<_>>();
-    let config = InitDpfResourcesConfig {
-        bluefield_software: Some(BlueFieldSoftwareParams {
+    let config = InitDpfResourcesConfigBuilder::default()
+        .bluefield_software(BlueFieldSoftwareParams {
             os_iso: "http://example.com/bf4.iso".to_string(),
             pldm_fw_bundle: Some("http://example.com/bf4.pldm".to_string()),
-        }),
-        deployment_name: "bf4-deployment".to_string(),
-        flavor_name: "bf4-flavor".to_string(),
-        services,
-        deployment_type: DpuDeploymentType::Bf4Generic,
-        ..Default::default()
-    };
+        })
+        .deployment_name("bf4-deployment")
+        .flavor_name("bf4-flavor")
+        .services(services)
+        .deployment_type(DpuDeploymentType::Bf4Generic)
+        .build()
+        .expect("extra-script test configuration must be valid");
 
     sdk.create_initialization_objects(&config).await.unwrap();
 

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -20,6 +20,7 @@
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 
+use derive_builder::Builder;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::Condition;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use serde::{Deserialize, Serialize};
@@ -45,6 +46,7 @@ impl BmcPasswordProvider for String {
 
 /// Service name constants for use across crates
 pub const DOCA_HBN_SERVICE_NAME: &str = "doca-hbn";
+pub const DOCA_HBN_SERVICE_NETWORK: &str = "mybrhbn";
 pub const DHCP_SERVER_SERVICE_NAME: &str = "carbide-dhcp-server";
 /// Shared marker applied to every DPF-managed DPUNode.
 pub const DPU_ENABLED_NODE_LABEL: &str = "feature.node.kubernetes.io/dpu-enabled";
@@ -72,38 +74,53 @@ const MAX_INSTANCE_VF_ID: u8 = 15;
 
 /// Configuration for creating DPF operator resources (BFB or
 /// BlueFieldSoftware, DPUFlavor, DPUDeployment, services, etc.).
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Builder)]
+#[builder(
+    name = "InitDpfResourcesConfigBuilder",
+    pattern = "owned",
+    public,
+    default,
+    field(private),
+    build_fn(private, name = "assemble")
+)]
+#[builder_struct_attr(must_use = "call build() to create a validated initialization configuration")]
 pub struct InitDpfResourcesConfig {
     /// URL for the BFB (BlueField Bundle) image. Used for BF3-class DPUs.
     /// Ignored when [`bluefield_software`](Self::bluefield_software) is set.
-    pub bfb_url: String,
+    #[builder(setter(into))]
+    pub(crate) bfb_url: String,
     /// BlueFieldSoftware spec for BF4-class DPUs. When set, a `BlueFieldSoftware`
     /// CR is created and referenced by the DPUDeployment instead of a BFB, and
     /// [`bfb_url`](Self::bfb_url) is ignored. Exactly one provisioning source
     /// (BFB or BlueFieldSoftware) is expected per deployment.
-    pub bluefield_software: Option<BlueFieldSoftwareParams>,
+    #[builder(setter(strip_option))]
+    pub(crate) bluefield_software: Option<BlueFieldSoftwareParams>,
     /// Name of the DPUDeployment CR.
-    pub deployment_name: String,
+    #[builder(setter(into))]
+    pub(crate) deployment_name: String,
     /// Name of the DPUFlavor CR.
-    pub flavor_name: String,
+    #[builder(setter(into))]
+    pub(crate) flavor_name: String,
     /// Service templates and configs for M4 DPUDeployment.
     /// When empty, `default_services()` is used automatically.
-    pub services: Vec<ServiceDefinition>,
+    pub(crate) services: Vec<ServiceDefinition>,
 
     /// Number of hardware VFs provisioned per DPU PF for BF3 and generic BF4.
-    pub num_of_vfs: u32,
+    pub(crate) num_of_vfs: u32,
     /// SF capacity reserved beyond configured NICo-managed service endpoints.
     /// Without intercept bridging, this remains the complete legacy `PF_TOTAL_SF` value.
-    pub pf_total_sf_reserved: u32,
+    pub(crate) pf_total_sf_reserved: u32,
     /// Managed SF capacity not represented in [`interfaces`](Self::interfaces).
     /// Added to calculated BF3/generic-BF4 capacity when intercept bridging is configured;
     /// otherwise it consumes the unchanged legacy pool. BF4 Astra rejects a non-zero value.
-    pub additional_managed_sf: u32,
+    pub(crate) additional_managed_sf: u32,
+    /// NICo-managed service-VPC slots wired from HBN to dedicated OVS bridges.
+    pub(crate) service_vpc_slots: crate::ServiceVpcSlots,
     /// Enables deployment-scoped DPUServiceInterface names and node selectors.
     /// False preserves the legacy global resource naming and selector mode for
     /// BF3 (including BF3 GB200) and generic BF4. BF4 Astra requires this to be true for the
-    /// whole namespace so
-    /// legacy match-all resources do not bind Astra nodes. When enabled, initialization removes
+    /// whole namespace so legacy match-all resources do not bind Astra nodes. When enabled,
+    /// initialization removes
     /// legacy unscoped ServiceInterfaces before creating scoped replacements. If cleanup remains
     /// incomplete for ten minutes, NICo logs an error and continues waiting. If an operator
     /// manually completes unscoped cleanup, NICo creates scoped replacements. The setting is read
@@ -111,16 +128,18 @@ pub struct InitDpfResourcesConfig {
     /// ServiceInterfaces and wait for their deletion, then restart with this disabled.
     /// API-core rejects a disabled value during DPF initialization while scoped
     /// ServiceInterfaces exist.
-    pub deployment_scoped_service_interfaces: bool,
+    pub(crate) deployment_scoped_service_interfaces: bool,
     /// Optional intercept-bridging topology for BF3 and generic BF4. `Some` replaces the
     /// ordinary static PF/VF inventory and contains exactly one configured PF.
-    pub intercept_bridging: Option<DpfInterceptBridging>,
+    #[builder(setter(strip_option))]
+    pub(crate) intercept_bridging: Option<DpfInterceptBridging>,
     /// Effective interface inventory shared by ServiceInterfaces, service chains,
     /// and caller-built service definitions. Empty asks the SDK to build it. With
     /// intercept bridging, a non-empty inventory must exactly match the SDK projection.
-    pub interfaces: Vec<DpuServiceInterfaceTemplateDefinition>,
+    pub(crate) interfaces: Vec<DpuServiceInterfaceTemplateDefinition>,
 
-    pub proxy: Option<DpfProxyDetails>,
+    #[builder(setter(strip_option))]
+    pub(crate) proxy: Option<DpfProxyDetails>,
     /// Operator-supplied bf.cfg lines appended to the flavor's built-in `bfcfgParameters`.
     ///
     /// Passed through verbatim; the SDK applies no quoting or interpretation. Entries containing
@@ -129,9 +148,9 @@ pub struct InitDpfResourcesConfig {
     ///
     /// WARNING: Changing this will generate a new DPUFlavor, reprovisioning the deployment's
     /// DPUs.
-    pub extra_bfcfg_parameters: Vec<String>,
+    pub(crate) extra_bfcfg_parameters: Vec<String>,
     /// Deployment type — determines which DPUFlavor spec to build.
-    pub deployment_type: DpuDeploymentType,
+    pub(crate) deployment_type: DpuDeploymentType,
 }
 
 /// Parameters for a `BlueFieldSoftware` CR, used to provision BF4-class DPUs.
@@ -157,6 +176,7 @@ impl Default for InitDpfResourcesConfig {
             num_of_vfs: DEFAULT_DPU_NUM_OF_VFS,
             pf_total_sf_reserved: DEFAULT_PF_TOTAL_SF_RESERVED,
             additional_managed_sf: 0,
+            service_vpc_slots: crate::ServiceVpcSlots::default(),
             deployment_scoped_service_interfaces: false,
             intercept_bridging: None,
             interfaces: Vec::new(),
@@ -164,6 +184,17 @@ impl Default for InitDpfResourcesConfig {
             extra_bfcfg_parameters: Vec::new(),
             deployment_type: DpuDeploymentType::Bf3,
         }
+    }
+}
+
+impl InitDpfResourcesConfigBuilder {
+    /// Builds an immutable configuration after validation.
+    pub fn build(self) -> Result<InitDpfResourcesConfig, crate::DpfError> {
+        let config = self
+            .assemble()
+            .map_err(|error| crate::DpfError::ConfigError(error.to_string()))?;
+        crate::sdk::validate_initialization_config(&config)?;
+        Ok(config)
     }
 }
 
@@ -1379,6 +1410,7 @@ mod tests {
                 (
                     config.num_of_vfs,
                     config.pf_total_sf_reserved,
+                    config.service_vpc_slots.is_empty(),
                     config.deployment_scoped_service_interfaces,
                     config.intercept_bridging.is_none(),
                     config.interfaces.is_empty(),
@@ -1389,6 +1421,7 @@ mod tests {
                 () => (
                     DEFAULT_DPU_NUM_OF_VFS,
                     DEFAULT_PF_TOTAL_SF_RESERVED,
+                    true,
                     false,
                     true,
                     true,


### PR DESCRIPTION
## Problem

Setting `service_vpc_slot_count` above zero adds HBN interfaces such as
`iface_svc_0`, but no DPF chain wires those interfaces. DPF intentionally keeps
the HBN `invalid-network` attachment in place until every interface has complete
chain and IPAM settings, so HBN cannot start.

The original slot implementation also split naming, capacity, and HBN interface
construction across API-core and the DPF SDK.

## Fix

- Encapsulate slot naming, validation, DPU interfaces, OVS bridges, and SF
  capacity in `ServiceVpcSlots`.
- Compose slot endpoints into the existing `doca_hbn_service_interfaces`
  inventory.
- Require SDK initialization inputs to pass the validating configuration
  builder.
- Provision one dedicated OVS bridge per service-VPC slot.
- Create a patch `DPUServiceInterface` and base chain from each HBN
  `iface_svc_N` to its slot bridge.
- Leave the bridge as the stable connection point for a later service-owned
  patch interface and chain.
- Preserve the DPF `invalid-network` readiness gate.

Changing the generated `DPUFlavor` causes existing DPUs to be reprovisioned
before they can use the new slot topology.

## Validation

- `cargo fmt --all`
- `cargo check -p carbide-api-core --no-default-features --lib`
- `cargo test -p carbide-dpf` (192 passed)
- `cargo clippy -p carbide-dpf --all-targets -- -D warnings`
- `git diff --check`
