### PR TITLE
feat(admin-cli): expose slaac for vpc create/show

### DIFF
--- a/crates/admin-cli/src/jump/cmd.rs
+++ b/crates/admin-cli/src/jump/cmd.rs
@@ -250,6 +250,7 @@ pub(super) async fn jump(args: Cmd, ctx: &mut RuntimeContext) -> color_eyre::Res
                             label_value: None,
                         },
                         ctx.config.format,
+                        &mut ctx.output_file,
                         &ctx.api_client,
                         1,
                     )

--- a/crates/admin-cli/src/vpc/create/args.rs
+++ b/crates/admin-cli/src/vpc/create/args.rs
@@ -29,6 +29,9 @@ Create a tenant VPC:
 Create a tenant VPC with flat virtualization and a chosen ID:
     $ nico-admin-cli --cloud-unsafe-op=my_username vpc create --name tenant-vpc-1 --org-id tenant-org-1 --id ad1f9fd5-8438-4407-b259-72fdb7896d42 --virtualization-type flat
 
+Create an FNN VPC with SLAAC enabled:
+    $ nico-admin-cli --cloud-unsafe-op=admin vpc create --name tenant-vpc-1 --org-id fds34511233a --virtualization-type fnn --slaac-enabled true
+
 ")]
 pub(crate) struct Args {
     #[clap(long, help = "Name to give the new VPC")]
@@ -57,6 +60,14 @@ pub(crate) struct Args {
         help = "Network virtualization type"
     )]
     virtualization_type: forge::VpcVirtualizationType,
+
+    #[clap(
+        long,
+        action = clap::ArgAction::Set,
+        value_name = "SLAAC_ENABLED",
+        help = "Whether Core should allocate an IPv6 /64 for each IPv6-enabled instance interface. Supported only for FNN VPCs; NICo does not configure router advertisements. Enabling requires the connected Core to advertise VPC SLAAC support and fails otherwise. Omit or set false to disable. This setting cannot be changed after creation"
+    )]
+    slaac_enabled: Option<bool>,
 }
 
 impl From<Args> for forge::VpcCreationRequest {
@@ -77,7 +88,41 @@ impl From<Args> for forge::VpcCreationRequest {
             routing_profile_type: None,
             routing_profile_overrides: None,
             power_resource_group: None,
-            slaac_enabled: None,
+            slaac_enabled: args.slaac_enabled,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use carbide_test_support::value_scenarios;
+
+    use super::*;
+
+    #[test]
+    fn vpc_creation_request_preserves_slaac_presence() {
+        value_scenarios!(
+            run = |slaac_enabled: Option<&str>| {
+                let mut argv = vec![
+                    "vpc-create",
+                    "--name",
+                    "tenant-vpc",
+                    "--org-id",
+                    "tenant-org",
+                ];
+                if let Some(slaac_enabled) = slaac_enabled {
+                    argv.extend(["--slaac-enabled", slaac_enabled]);
+                }
+                let request: forge::VpcCreationRequest = Args::try_parse_from(argv)
+                    .expect("valid VPC create arguments")
+                    .into();
+                request.slaac_enabled
+            };
+            "presence" {
+                None => None,
+                Some("false") => Some(false),
+                Some("true") => Some(true),
+            }
+        );
     }
 }

--- a/crates/admin-cli/src/vpc/create/cmd.rs
+++ b/crates/admin-cli/src/vpc/create/cmd.rs
@@ -16,17 +16,35 @@
  */
 
 use ::rpc::admin_cli::output::OutputFormat;
+use ::rpc::forge;
+use eyre::WrapErr;
 
 use super::args::Args;
-use crate::errors::CarbideCliResult;
+use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
+
+trait VpcCreateClient {
+    async fn version(&self) -> CarbideCliResult<forge::BuildInfo>;
+    async fn create_vpc(&self, request: forge::VpcCreationRequest) -> CarbideCliResult<forge::Vpc>;
+}
+
+impl VpcCreateClient for ApiClient {
+    async fn version(&self) -> CarbideCliResult<forge::BuildInfo> {
+        Ok(self.0.version(false).await?)
+    }
+
+    async fn create_vpc(&self, request: forge::VpcCreationRequest) -> CarbideCliResult<forge::Vpc> {
+        Ok(self.0.create_vpc(request).await?)
+    }
+}
 
 pub(super) async fn create(
     args: Args,
     output_format: OutputFormat,
     api_client: &ApiClient,
 ) -> CarbideCliResult<()> {
-    let vpc = api_client.0.create_vpc(args).await?;
+    let request: forge::VpcCreationRequest = args.into();
+    let vpc = create_vpc(request, api_client).await?;
 
     match output_format {
         OutputFormat::Json => println!("{}", serde_json::to_string_pretty(&vpc)?),
@@ -40,4 +58,127 @@ pub(super) async fn create(
     }
 
     Ok(())
+}
+
+async fn create_vpc(
+    request: forge::VpcCreationRequest,
+    api_client: &impl VpcCreateClient,
+) -> CarbideCliResult<forge::Vpc> {
+    // Older Core versions ignore the unknown protobuf field. Check the
+    // advertised capability before creation so `true` cannot silently create
+    // a VPC with SLAAC disabled.
+    if request.slaac_enabled == Some(true) {
+        let build_info = api_client.version().await.wrap_err(
+            "while attempting to query core capabilities before creating a VPC with SLAAC enabled",
+        )?;
+        if !build_info
+            .capabilities
+            .contains(&(forge::BuildCapability::VpcSlaac as i32))
+        {
+            return Err(CarbideCliError::UnsupportedOperation(
+                "the connected Core does not support VPC SLAAC; upgrade Core or omit --slaac-enabled true",
+            ));
+        }
+    }
+
+    api_client.create_vpc(request).await
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+
+    #[derive(Clone, Copy, Debug, Eq, PartialEq)]
+    enum Call {
+        Version,
+        Create(Option<bool>),
+    }
+
+    struct FakeVpcCreateClient {
+        capabilities: Vec<i32>,
+        version_fails: bool,
+        calls: RefCell<Vec<Call>>,
+    }
+
+    impl VpcCreateClient for FakeVpcCreateClient {
+        async fn version(&self) -> CarbideCliResult<forge::BuildInfo> {
+            self.calls.borrow_mut().push(Call::Version);
+            if self.version_fails {
+                return Err(tonic::Status::unavailable("version unavailable").into());
+            }
+            Ok(forge::BuildInfo {
+                capabilities: self.capabilities.clone(),
+                ..Default::default()
+            })
+        }
+
+        async fn create_vpc(
+            &self,
+            request: forge::VpcCreationRequest,
+        ) -> CarbideCliResult<forge::Vpc> {
+            self.calls
+                .borrow_mut()
+                .push(Call::Create(request.slaac_enabled));
+            Ok(forge::Vpc::default())
+        }
+    }
+
+    async fn check_create(
+        slaac_enabled: Option<bool>,
+        capabilities: &[i32],
+        succeeds: bool,
+        expected_calls: &[Call],
+    ) {
+        let client = FakeVpcCreateClient {
+            capabilities: capabilities.to_vec(),
+            version_fails: false,
+            calls: RefCell::new(Vec::new()),
+        };
+        let result = create_vpc(
+            forge::VpcCreationRequest {
+                slaac_enabled,
+                ..Default::default()
+            },
+            &client,
+        )
+        .await;
+
+        assert_eq!(result.is_ok(), succeeds);
+        assert_eq!(client.calls.into_inner(), expected_calls);
+    }
+
+    #[tokio::test]
+    async fn slaac_capability_check_controls_creation() {
+        check_create(
+            Some(true),
+            &[forge::BuildCapability::VpcSlaac as i32],
+            true,
+            &[Call::Version, Call::Create(Some(true))],
+        )
+        .await;
+        check_create(Some(true), &[i32::MAX], false, &[Call::Version]).await;
+        check_create(Some(false), &[], true, &[Call::Create(Some(false))]).await;
+        check_create(None, &[], true, &[Call::Create(None)]).await;
+
+        let client = FakeVpcCreateClient {
+            capabilities: Vec::new(),
+            version_fails: true,
+            calls: RefCell::new(Vec::new()),
+        };
+        let error = create_vpc(
+            forge::VpcCreationRequest {
+                slaac_enabled: Some(true),
+                ..Default::default()
+            },
+            &client,
+        )
+        .await
+        .expect_err("a failed capability query must stop creation");
+        assert!(error.to_string().contains(
+            "while attempting to query core capabilities before creating a VPC with SLAAC enabled"
+        ));
+        assert_eq!(client.calls.into_inner(), [Call::Version]);
+    }
 }

--- a/crates/admin-cli/src/vpc/show/cmd.rs
+++ b/crates/admin-cli/src/vpc/show/cmd.rs
@@ -25,51 +25,60 @@ use prettytable::{Table, row};
 use super::args::Args;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
+use crate::{async_write, async_writeln};
+
+pub(crate) trait VpcShowClient {
+    async fn list_vpcs(&self, args: Args, page_size: usize) -> CarbideCliResult<forgerpc::VpcList>;
+
+    async fn find_vpcs_by_ids(&self, vpc_ids: Vec<VpcId>) -> CarbideCliResult<forgerpc::VpcList>;
+}
+
+impl VpcShowClient for ApiClient {
+    async fn list_vpcs(&self, args: Args, page_size: usize) -> CarbideCliResult<forgerpc::VpcList> {
+        ApiClient::get_all_vpcs(
+            self,
+            args.tenant_org_id,
+            args.name,
+            page_size,
+            args.label_key,
+            args.label_value,
+        )
+        .await
+    }
+
+    async fn find_vpcs_by_ids(&self, vpc_ids: Vec<VpcId>) -> CarbideCliResult<forgerpc::VpcList> {
+        Ok(self.0.find_vpcs_by_ids(vpc_ids).await?)
+    }
+}
 
 pub(crate) async fn show(
     args: Args,
     output_format: OutputFormat,
-    api_client: &ApiClient,
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    api_client: &impl VpcShowClient,
     page_size: usize,
 ) -> CarbideCliResult<()> {
     let is_json = output_format == OutputFormat::Json;
     if let Some(id) = args.id {
-        show_vpc_details(id, is_json, api_client).await?;
+        show_vpc_details(id, is_json, output_file, api_client).await?;
     } else {
-        show_vpcs(
-            is_json,
-            api_client,
-            page_size,
-            args.tenant_org_id,
-            args.name,
-            args.label_key,
-            args.label_value,
-        )
-        .await?;
+        show_vpcs(is_json, output_file, api_client, page_size, args).await?;
     }
     Ok(())
 }
 
 async fn show_vpcs(
     json: bool,
-    api_client: &ApiClient,
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    api_client: &impl VpcShowClient,
     page_size: usize,
-    tenant_org_id: Option<String>,
-    name: Option<String>,
-    label_key: Option<String>,
-    label_value: Option<String>,
+    args: Args,
 ) -> CarbideCliResult<()> {
-    let all_vpcs = match api_client
-        .get_all_vpcs(tenant_org_id, name, page_size, label_key, label_value)
-        .await
-    {
-        Ok(all_vpcs) => all_vpcs,
-        Err(e) => return Err(e),
-    };
+    let all_vpcs = api_client.list_vpcs(args, page_size).await?;
     if json {
-        println!("{}", serde_json::to_string_pretty(&all_vpcs)?);
+        async_writeln!(output_file, "{}", serde_json::to_string_pretty(&all_vpcs)?)?;
     } else {
-        convert_vpcs_to_nice_table(all_vpcs).printstd();
+        async_write!(output_file, "{}", convert_vpcs_to_nice_table(all_vpcs))?;
     }
     Ok(())
 }
@@ -77,9 +86,10 @@ async fn show_vpcs(
 async fn show_vpc_details(
     vpc_id: VpcId,
     json: bool,
-    api_client: &ApiClient,
+    output_file: &mut Box<dyn tokio::io::AsyncWrite + Unpin>,
+    api_client: &impl VpcShowClient,
 ) -> CarbideCliResult<()> {
-    let vpcs = api_client.0.find_vpcs_by_ids(vec![vpc_id]).await?;
+    let vpcs = api_client.find_vpcs_by_ids(vec![vpc_id]).await?;
 
     if vpcs.vpcs.len() != 1 {
         return Err(CarbideCliError::GenericError("Unknown VPC ID".to_string()));
@@ -88,12 +98,13 @@ async fn show_vpc_details(
     let vpcs = &vpcs.vpcs[0];
 
     if json {
-        println!("{}", serde_json::to_string_pretty(vpcs)?);
+        async_writeln!(output_file, "{}", serde_json::to_string_pretty(vpcs)?)?;
     } else {
-        println!(
+        async_writeln!(
+            output_file,
             "{}",
             convert_vpc_to_nice_format(vpcs).unwrap_or_else(|x| x.to_string())
-        );
+        )?;
     }
     Ok(())
 }
@@ -109,6 +120,7 @@ fn convert_vpcs_to_nice_table(vpcs: forgerpc::VpcList) -> Box<Table> {
         "Version",
         "Created",
         "Virt Type",
+        "SLAAC Enabled",
         "Labels",
     ]);
     let default_metadata = Default::default();
@@ -131,6 +143,7 @@ fn convert_vpcs_to_nice_table(vpcs: forgerpc::VpcList) -> Box<Table> {
             vpc.version,
             vpc.created.unwrap_or_default(),
             virt_type,
+            format_slaac_enabled(config.slaac_enabled),
             metadata
                 .labels
                 .iter()
@@ -223,6 +236,10 @@ pub(in crate::vpc) fn convert_vpc_to_nice_format(vpc: &forgerpc::Vpc) -> Carbide
                 .into(),
         ),
         (
+            "SLAAC ENABLED",
+            format_slaac_enabled(config.slaac_enabled).into(),
+        ),
+        (
             "ROUTING PROFILE TYPE",
             config
                 .routing_profile_type
@@ -247,15 +264,49 @@ pub(in crate::vpc) fn convert_vpc_to_nice_format(vpc: &forgerpc::Vpc) -> Carbide
     Ok(lines)
 }
 
+fn format_slaac_enabled(slaac_enabled: Option<bool>) -> &'static str {
+    match slaac_enabled {
+        Some(true) => "true",
+        Some(false) => "false",
+        // `None` means Core predates the response field.
+        None => "Unknown",
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::async_write::CapturedOutput;
+
+    struct FakeVpcShowClient {
+        vpcs: forgerpc::VpcList,
+    }
+
+    impl VpcShowClient for FakeVpcShowClient {
+        async fn list_vpcs(
+            &self,
+            _args: Args,
+            _page_size: usize,
+        ) -> CarbideCliResult<forgerpc::VpcList> {
+            Ok(self.vpcs.clone())
+        }
+
+        async fn find_vpcs_by_ids(
+            &self,
+            _vpc_ids: Vec<VpcId>,
+        ) -> CarbideCliResult<forgerpc::VpcList> {
+            Err(CarbideCliError::GenericError(
+                "unexpected VPC detail request".to_string(),
+            ))
+        }
+    }
 
     #[test]
-    fn vpc_details_include_routing_profiles() {
+    fn vpc_details_include_slaac_and_routing_profiles() {
         let vpc = forgerpc::Vpc {
             config: Some(forgerpc::VpcConfig {
                 tenant_organization_id: "tenant".to_string(),
+                slaac_enabled: Some(true),
                 routing_profile_type: Some("INTERNAL".to_string()),
                 routing_profile_overrides: Some(forgerpc::VpcRoutingProfileOverrides {
                     leak_default_route_from_underlay: Some(false),
@@ -275,6 +326,7 @@ mod tests {
         };
 
         let display = convert_vpc_to_nice_format(&vpc).expect("VPC display");
+        assert!(display.contains("SLAAC ENABLED            : true"));
         assert!(display.contains("ROUTING PROFILE TYPE"));
         assert!(display.contains("INTERNAL"));
         let (_, routing_profiles) = display
@@ -288,5 +340,68 @@ mod tests {
         assert!(!overrides.contains("\"access_tier\""));
         assert!(effective.contains("\"internal\": true"));
         assert!(effective.contains("\"access_tier\": 2"));
+    }
+
+    #[tokio::test]
+    async fn vpc_list_command_includes_slaac_presence_and_empty_cells() {
+        let client = FakeVpcShowClient {
+            vpcs: forgerpc::VpcList {
+                vpcs: [
+                    ("enabled", Some(true)),
+                    ("disabled", Some(false)),
+                    ("older-core", None),
+                ]
+                .into_iter()
+                .map(|(name, slaac_enabled)| forgerpc::Vpc {
+                    metadata: Some(forgerpc::Metadata {
+                        name: name.to_string(),
+                        ..Default::default()
+                    }),
+                    config: Some(forgerpc::VpcConfig {
+                        slaac_enabled,
+                        ..Default::default()
+                    }),
+                    ..Default::default()
+                })
+                .collect(),
+            },
+        };
+
+        let mut captured = CapturedOutput::new();
+        show(
+            Args {
+                id: None,
+                tenant_org_id: None,
+                name: None,
+                label_key: None,
+                label_value: None,
+            },
+            OutputFormat::AsciiTable,
+            captured.writer(),
+            &client,
+            100,
+        )
+        .await
+        .expect("VPC list should render");
+
+        let display = String::from_utf8(captured.into_bytes().await).expect("UTF-8 output");
+        let cells_for = |name| {
+            display
+                .lines()
+                .find(|line| line.contains(name))
+                .unwrap_or_else(|| panic!("missing row for {name}"))
+                .trim_matches('|')
+                .split('|')
+                .map(str::trim)
+                .collect::<Vec<_>>()
+        };
+
+        let header = cells_for("SLAAC Enabled");
+        assert_eq!(header[7], "SLAAC Enabled");
+        assert_eq!(cells_for("enabled")[7], "true");
+        assert_eq!(cells_for("disabled")[7], "false");
+        let older_core = cells_for("older-core");
+        assert_eq!(older_core[7], "Unknown");
+        assert_eq!(older_core[8], "");
     }
 }

--- a/crates/admin-cli/src/vpc/show/mod.rs
+++ b/crates/admin-cli/src/vpc/show/mod.rs
@@ -29,6 +29,7 @@ impl Run for Args {
         cmd::show(
             self,
             ctx.config.format,
+            &mut ctx.output_file,
             &ctx.api_client,
             ctx.config.page_size,
         )


### PR DESCRIPTION
The admin CLI sends `slaac_enabled: None` for every VPC creation request and omits the field from human-readable VPC output, even though Core already accepts and returns it.

This adds `--slaac-enabled <SLAAC_ENABLED>` to `vpc create` while preserving omitted, explicit `false`, and explicit `true` requests. When enabled, the CLI checks Core's advertised `VPC_SLAAC` capability before creation and returns an actionable error without sending the create request when the capability is absent. That keeps older Core versions from silently ignoring the unknown protobuf field and creating the VPC with SLAAC disabled. Core remains authoritative for restricting SLAAC to FNN VPCs. NICo still does not configure router advertisements; that remains tracked by [#2398](https://github.com/NVIDIA/infra-controller/issues/2398).

Human-readable VPC list and detail output now show `true`, `false`, or `Unknown` for responses from Core versions that predate the field. `vpc show` also writes through the configured output writer.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5408

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable source diff. The final diff then received a bounded closure review after the adopted changes.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 3 | 2 | 1 |
| Claude CLI | 10 | 6 | 4 |
| common-nits-reviewer | 2 | 1 | 1 |
| **Total** | **15** | **9** | **6** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

1. **Adopted** -- Use the standard username in the new CLI example. **Resolution:** The example now uses `admin`.
2. **Adopted** -- Explain the Core compatibility requirement in command help. **Resolution:** Help now states that enablement requires the advertised capability and fails when it is absent.
3. **Declined** -- Reject SLAAC in the CLI when a VPC isn't FNN. **Reason:** Core already owns this validation, and duplicating the rule would create a second policy implementation.

### Claude CLI

1. **Adopted** -- Test the compatibility check through the create flow. **Resolution:** A fake client proves Version runs before Create, and unsupported enablement never creates a VPC.
2. **Adopted** -- Describe allocation only for IPv6-enabled interfaces. **Resolution:** Help now says Core allocates one IPv6 `/64` for each IPv6-enabled instance interface.
3. **Adopted** -- Give operators a next step when Core lacks the capability. **Resolution:** The error says to upgrade Core or omit `--slaac-enabled true`.
4. **Adopted** -- Distinguish the private list client method from the existing API client method. **Resolution:** The seam now uses `list_vpcs`.
5. **Adopted** -- Explain the `Unknown` display value. **Resolution:** The formatter notes that `None` means Core predates the response field.
6. **Adopted** -- Disclose the VPC show output change. **Resolution:** The PR explains that `vpc show` now uses the configured output writer.
7. **Declined** -- Remove explicit `ArgAction::Set`. **Reason:** Keeping it makes the valued boolean contract distinct from a flag whose presence alone selects true.
8. **Declined** -- Commit regenerated CLI pages. **Reason:** Generation on `main` includes unrelated backlog owned by #4457 and produces files that fail repository checks.
9. **Declined** -- Add SLAAC display to admin-web. **Reason:** Admin-web is outside this CLI issue.
10. **Declined** -- Route `vpc create` output through the shared writer. **Reason:** Create output is separate from the VPC show behavior changed here.

### common-nits-reviewer

1. **Adopted** -- Prove the compatibility boundary for enabling SLAAC in the command path, independently matching the Claude finding. **Resolution:** The private fake client test checks call order, prevents creation without support, and preserves explicit false and omission.
2. **Declined** -- Commit regenerated CLI pages, independently matching the Claude finding. **Reason:** The #4457 baseline exception keeps unrelated generated drift out of this PR while live help and scratch generation verify the command contract.

</details>
