### PR TITLE
fix(build): Pin artifact image tool installs, drop redundant mold rust flag

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -37,10 +37,12 @@ rustflags = [
 #[target.x86_64-unknown-linux-gnu]
 #rustflags = ["-C", "linker=clang", "-C", "link-arg=-fuse-ld=lld"]
 
-# mold is significantly faster and more memory-efficient than ld on aarch64.
-# The build environment selects a native or cross compiler driver.
-[target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-fuse-ld=mold"]
+# mold is selected by the build environment rather than from here, through
+# CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER pointing at a driver that
+# already passes -fuse-ld=mold. Setting the flag here as well reached every
+# aarch64 build, including ones whose image predates the mold install, and cc
+# rejects a linker it does not have: "unrecognized command-line option
+# '-fuse-ld=mold'". Keep linker selection with the toolchain that provides it.
 
 [env]
 RUST_TEST_THREADS = "40"

--- a/dev/docker/Dockerfile.build-artifacts-container-aarch64
+++ b/dev/docker/Dockerfile.build-artifacts-container-aarch64
@@ -81,7 +81,7 @@ RUN printf '#!/bin/sh\nexec clang -fuse-ld=mold "$@"\n' \
 ENV CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER=/usr/local/bin/clang-mold
 
 RUN rustup component add rustfmt
-RUN cargo install cargo-cache cargo-make sccache && \
+RUN cargo install cargo-cache cargo-make sccache --locked && \
 	cargo install mdbook@0.4.52 mdbook-plantuml@0.8.0 mdbook-mermaid@0.16.2 && \
 	cargo cache -r registry-index,registry-sources
 

--- a/dev/docker/Dockerfile.build-artifacts-container-x86_64
+++ b/dev/docker/Dockerfile.build-artifacts-container-x86_64
@@ -75,7 +75,7 @@ RUN CACHEKEY=${CI_COMMIT_SHORT_SHA} apt update &&  \
 	&& rm -rf /var/lib/apt/lists/*
 
 RUN rustup component add rustfmt
-RUN cargo install cargo-cache cargo-make sccache && \
+RUN cargo install cargo-cache cargo-make sccache --locked && \
 	cargo install mdbook@0.4.52 mdbook-plantuml@0.8.0 mdbook-mermaid@0.16.2 && \
 	cargo cache -r registry-index,registry-sources
 


### PR DESCRIPTION
Four arm64 jobs fail on `main` with `unrecognized command-line option
'-fuse-ld=mold'`.
#5479 added that rustflag for the aarch64 target and installed
mold in the build images, but `build-artifacts-container-aarch64` failed on that
same merge run, so the published image never got mold while the flag went live
for every arm64 build. That image build failed because its `cargo install` is
unpinned and picked up `tinyvec 1.13.0`, which does not compile. So this PR pins
the install with `--locked`, matching what `build-container-aarch64` already
does, and removes the rustflag, which is redundant wherever the image sets
`CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER` to a driver that passes
`-fuse-ld=mold` itself.

> [!NOTE]
> The mdbook installs on the same lines stay unpinned. The comment above them
> records that `--locked` broke them before, so only the tool install changes.

## Related issues

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
* Touching these Dockerfiles is what triggers the image rebuild, so this PR's own
  CI is where the pinned install and the mold-enabled image get verified
* The x86_64 artifact image carries the identical unpinned line and has only been
  luckier, so it is pinned here too
* Developer arm64 hosts lose mold, since `prepare-ubuntu-host-for-dev.sh`
  installs the package but never sets the linker variable the images use. Worth a
  follow-up so local builds keep the speedup