### PR TITLE
patch(v2.1): predict DPU OOB interfaces before DHCP

### DIFF
--- a/crates/api-core/tests/integration/connected_device.rs
+++ b/crates/api-core/tests/integration/connected_device.rs
@@ -35,14 +35,14 @@ async fn init(pool: PgPool) -> (TestHarness, TestManagedHost) {
     let network_controller = env.network_controller();
     let domain = env.test_domain().await;
     let underlay_segment = network_controller.create_underlay_segment(&domain).await;
-    let admin_segment = network_controller.create_admin_segment(&domain).await;
+    network_controller.create_admin_segment(&domain).await;
     let site_explorer = env.default_test_site_explorer();
     let (mh, _) = env
         .managed_host_builder(&site_explorer, underlay_segment)
         .with_config(ManagedHostConfig::default().with_dpu_count(1))
         .build()
         .await;
-    mh.first_dpu().discover_oob_iface(admin_segment).await;
+    mh.first_dpu().discover_oob_iface(underlay_segment).await;
     (env, mh)
 }
 

--- a/crates/api-core/tests/integration/network_device.rs
+++ b/crates/api-core/tests/integration/network_device.rs
@@ -34,7 +34,7 @@ async fn init(pool: PgPool) -> TestHarness {
     let network_controller = env.network_controller();
     let domain = env.test_domain().await;
     let underlay_segment = network_controller.create_underlay_segment(&domain).await;
-    let admin_segment = network_controller.create_admin_segment(&domain).await;
+    network_controller.create_admin_segment(&domain).await;
     let site_explorer = env.default_test_site_explorer();
     let (managed_host, _) = env
         .managed_host_builder(&site_explorer, underlay_segment)
@@ -43,7 +43,7 @@ async fn init(pool: PgPool) -> TestHarness {
         .await;
     managed_host
         .first_dpu()
-        .discover_oob_iface(admin_segment)
+        .discover_oob_iface(underlay_segment)
         .await;
     env
 }

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -2584,7 +2584,7 @@ pub async fn move_predicted_machine_interface_to_machine(
         != predicted_machine_interface.expected_network_segment_type
     {
         return Err(DatabaseError::internal(format!(
-            "Got DHCP for predicted host with MAC address {0} on network segment {1}, which is not of the expected type {2}",
+            "Got DHCP for predicted interface with MAC address {0} on network segment {1}, which is not of the expected type {2}",
             predicted_machine_interface.mac_address,
             network_segment.id,
             predicted_machine_interface.expected_network_segment_type,
@@ -2683,6 +2683,22 @@ pub async fn move_predicted_machine_interface_to_machine(
         txn,
     )
     .await?;
+
+    if predicted_machine_interface
+        .machine_id
+        .machine_type()
+        .is_dpu()
+    {
+        // Site Explorer is the trusted source for a DPU's OOB MAC. Preserve that trust when DHCP
+        // materializes the predicted row so anonymous DiscoverMachine can authenticate the DPU on
+        // its first attempt without being allowed to claim an arbitrary existing machine.
+        associate_interface_with_dpu_machine(
+            &machine_interface_id,
+            &predicted_machine_interface.machine_id,
+            txn,
+        )
+        .await?;
+    }
 
     // Resolve the promoted row's boot interface id. The prediction's value
     // comes from the live report and outranks an existing row value: that

--- a/crates/api-integration-tests/tests/lib.rs
+++ b/crates/api-integration-tests/tests/lib.rs
@@ -41,6 +41,8 @@ use sqlx::{Postgres, Row};
 use tokio::time::sleep;
 use tokio_util::sync::CancellationToken;
 
+const DPU_UNDERLAY_DHCP_RELAY_ADDRESS: Ipv4Addr = Ipv4Addr::new(172, 20, 1, 1);
+
 #[ctor::ctor(unsafe)]
 fn setup() {
     api_test_helper::setup_logging()
@@ -147,8 +149,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -156,8 +157,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -165,8 +165,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -174,8 +173,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -183,8 +181,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_multidpu(
@@ -192,8 +189,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &managed_segment_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_zerodpu(
@@ -247,8 +243,7 @@ async fn test_integration() -> eyre::Result<()> {
             tenant_org_id,
             &v4_vpc_prefix_id,
             &v6_vpc_prefix_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
         test_machine_a_tron_dual_stack_l2(
@@ -256,8 +251,7 @@ async fn test_integration() -> eyre::Result<()> {
             &test_env,
             &bmc_address_registry,
             &dual_stack_l2_segment_id,
-            // Relay IP in admin net
-            Ipv4Addr::new(172, 20, 0, 2),
+            DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         )
         .boxed(),
     ]);
@@ -323,7 +317,8 @@ async fn test_machine_a_tron_rack_integration() -> eyre::Result<()> {
     test_machine_a_tron_rack(
         &test_env,
         &bmc_address_registry,
-        Ipv4Addr::new(172, 20, 0, 2),
+        // MAT currently uses admin_dhcp_relay_address for DPU OS DHCP.
+        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
     )
     .await?;
 
@@ -527,7 +522,7 @@ async fn test_metrics_integration() -> eyre::Result<()> {
         None,
         &test_env,
         &bmc_address_registry,
-        Ipv4Addr::new(172, 20, 0, 1),
+        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let db_pool = db_pool.clone();
             let carbide_api_addrs = carbide_api_addrs.to_vec();
@@ -830,7 +825,7 @@ async fn test_machine_a_tron_zerodpu(
         None,
         test_env,
         bmc_mock_registry,
-        Ipv4Addr::new(172, 20, 0, 2),
+        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             let flat_vpc_id = flat_vpc_id.to_string();
@@ -893,7 +888,7 @@ async fn test_machine_a_tron_nic_mode(
         None,
         test_env,
         bmc_mock_registry,
-        Ipv4Addr::new(172, 20, 0, 2),
+        DPU_UNDERLAY_DHCP_RELAY_ADDRESS,
         |machine_handle| {
             let carbide_api_addrs = &test_env.carbide_api_addrs;
             let flat_vpc_id = flat_vpc_id.to_string();
@@ -1522,9 +1517,11 @@ where
                 dpu_per_host_count,
                 dpu_reboot_delay: 1,
                 host_reboot_delay: 1,
+                // MAT currently uses this legacy-named field for DPU OS DHCP. Route that
+                // request through Underlay so it matches the predicted DPU interface.
                 admin_dhcp_relay_address,
-                // Keep this distinct from the Admin relay so NIC-mode tests
-                // fail if machine-a-tron sends host DHCP through Admin.
+                // Keep this distinct from the DPU Underlay relay so NIC-mode tests fail if
+                // machine-a-tron sends direct host DHCP through the DPU network.
                 host_inband_dhcp_relay_address: Some(Ipv4Addr::new(10, 10, 11, 2)),
                 oob_dhcp_relay_address: Ipv4Addr::new(172, 20, 1, 1),
                 vpc_count: 0,

--- a/crates/api-model/src/predicted_machine_interface.rs
+++ b/crates/api-model/src/predicted_machine_interface.rs
@@ -32,11 +32,10 @@ pub struct PredictedMachineInterface {
     /// MAC, handed to the `machine_interfaces` row at DHCP promotion so
     /// the host's boot target is a full pair from its first owned interface.
     pub boot_interface_id: Option<String>,
-    /// The declared `ExpectedInterface.primary` intent, stored so promotion
-    /// into `machine_interfaces` lands the operator's chosen boot interface as
-    /// `primary_interface`. `false` when nothing is declared -- promotion then
-    /// leaves the row non-primary and the boot interface falls to the
-    /// `pick_boot_interface` automation.
+    /// Whether promotion should make this the machine's primary interface.
+    ///
+    /// For hosts this carries the declared `ExpectedInterface.primary` intent. For DPUs the
+    /// trusted OOB prediction is always primary because it is the DPU OS data interface.
     pub primary_interface: bool,
 }
 

--- a/crates/api-web/src/tests/env.rs
+++ b/crates/api-web/src/tests/env.rs
@@ -78,7 +78,7 @@ impl TestEnv {
 
         host.host.discover_primary_iface(self.admin_segment).await;
         for dpu in &host.dpus {
-            dpu.discover_oob_iface(self.admin_segment).await;
+            dpu.discover_oob_iface(self.underlay_segment).await;
         }
         host.report_dpu_network_status().await;
         host.insert_empty_host_health_report("test-harness-health")

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -1025,9 +1025,10 @@ impl MachineCreator {
         .await
     }
 
-    // configure_dpu_interface checks the machine_interfaces table to see if the DPU's machine interface has its machine id set.
-    // If the machine ID is already configured appropriately for the DPU's machine interface, configure_dpu_interface will return false
-    // If the DPU's machine interface was missing the machine ID in the table, configure_dpu_interface will set the machine ID and return true.
+    // Ensure the DPU's OOB interface is owned as soon as it appears. If DHCP has already created
+    // the interface, associate it directly. Otherwise record a trusted prediction that DHCP can
+    // promote atomically. DiscoverMachine requires this ownership before returning credentials, so
+    // deferring the association to a later Site Explorer sweep would strand the DPU in discovery.
     async fn configure_dpu_interface(
         &self,
         txn: &mut PgConnection,
@@ -1071,6 +1072,39 @@ impl MachineCreator {
                     txn,
                 )
                 .await?;
+                return Ok(true);
+            }
+
+            if mi.is_empty() {
+                if let Some(prediction) =
+                    db::predicted_machine_interface::find_by_mac_address(&mut *txn, oob_net0_mac)
+                        .await?
+                {
+                    if prediction.machine_id != *dpu_machine_id {
+                        return Err(SiteExplorerError::AlreadyFoundError {
+                            kind: "PredictedMachineInterface",
+                            id: oob_net0_mac.to_string(),
+                        });
+                    }
+                    return Ok(false);
+                }
+
+                db::predicted_machine_interface::create(
+                    NewPredictedMachineInterface {
+                        machine_id: dpu_machine_id,
+                        mac_address: oob_net0_mac,
+                        expected_network_segment_type: NetworkSegmentType::Underlay,
+                        boot_interface_id: None,
+                        primary_interface: true,
+                    },
+                    txn,
+                )
+                .await?;
+                tracing::info!(
+                    machine_id = %dpu_machine_id,
+                    mac_address = %oob_net0_mac,
+                    "Created predicted DPU OOB interface"
+                );
                 return Ok(true);
             }
         }

--- a/crates/site-explorer/tests/integration/machine_creator.rs
+++ b/crates/site-explorer/tests/integration/machine_creator.rs
@@ -32,7 +32,6 @@ use carbide_utils::arch::CpuArchitecture;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::rack::{RackId, RackProfileId};
 use db::ObjectFilter;
-use itertools::Itertools;
 use librms::protos::rack_manager as rms;
 use mac_address::MacAddress;
 use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
@@ -961,18 +960,34 @@ async fn test_mi_attach_dpu_if_mi_exists_during_machine_creation(
 }
 
 #[sqlx_test]
-async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
+async fn test_dpu_interface_predictions_apply_when_dhcp_follows_machine_creation(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = Env::new(pool).await;
+    // v2.1 still allocates a secondary VTEP while accepting DPU discovery. Seed that release-only
+    // prerequisite so this test reaches the authenticated DiscoverMachine response.
+    let resource_pools = ResourcePoolBuilder::default()
+        .with_secondary_vtep_ip("172.21.0.0/29")
+        .build();
+    let test_harness = TestHarness::builder(pool.clone())
+        .with_resource_pools(resource_pools)
+        .build()
+        .await;
+    let domain = test_harness.test_domain().await;
+    let network_controller = test_harness.network_controller();
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    network_controller.create_admin_segment(&domain).await;
+    let env = Env {
+        pool,
+        underlay_segment,
+        test_harness,
+    };
     let creator = machine_creator(&env, machine_creator_config(false));
     let mock_host = ManagedHostConfig::default();
     let mock_dpu = mock_host.dpus.first().unwrap();
     let mut fixture = explored_host_fixture(&env, &mock_host).await;
     let dpu_machine_id = fixture.dpu_machine_ids[&0];
 
-    // No way to find a machine_interface using machine id as machine id is not yet associated with
-    // interface (right now no machine interface is created yet).
+    // The DPU machine exists before its first DHCP request, so there is no real interface yet.
     let mut txn = env.pool.begin().await?;
     let mi = db::machine_interface::find_by_machine_ids(&mut txn, &[dpu_machine_id]).await?;
     assert!(mi.is_empty());
@@ -989,8 +1004,8 @@ async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
             .await?
     );
 
-    // At this point, create_managed_host must have created machine but can not associate it with to
-    // any interface as interface does not exist.
+    // Site Explorer cannot associate an interface that does not exist yet, but it must leave a
+    // trusted MAC claim for DHCP to promote without waiting for another exploration sweep.
     let mut txn = env.pool.begin().await?;
     let machine = db::machine::find_one(
         txn.as_mut(),
@@ -1003,42 +1018,61 @@ async fn test_mi_attach_dpu_if_mi_created_after_machine_creation(
     .await?;
     assert!(machine.is_some());
 
-    // No way to find a machine_interface using machine id as machine id is not yet associated with
-    // interface (right now no machine interface is created yet).
     let mi = db::machine_interface::find_by_machine_ids(&mut txn, &[dpu_machine_id]).await?;
     assert!(mi.is_empty());
+    let prediction =
+        db::predicted_machine_interface::find_by_mac_address(&mut txn, mock_dpu.oob_mac_address)
+            .await?
+            .expect("DPU OOB prediction should exist");
+    assert_eq!(prediction.machine_id, dpu_machine_id);
+    assert_eq!(
+        prediction.expected_network_segment_type,
+        model::network_segment::NetworkSegmentType::Underlay
+    );
+    assert!(prediction.primary_interface);
     txn.rollback().await?;
 
-    // Create MI now.
+    // DHCP must consume the trusted prediction and create an already-owned interface.
     dhcp_discover_dpu_oob_iface(env.api(), env.underlay_segment, mock_dpu.oob_mac_address).await;
 
-    // Machine is already created, create_managed_host should return false.
+    let mut txn = env.pool.begin().await?;
+    let interfaces =
+        db::machine_interface::find_by_mac_address(txn.as_mut(), mock_dpu.oob_mac_address).await?;
+    let [interface] = interfaces.as_slice() else {
+        panic!("expected one promoted DPU OOB interface, got {interfaces:#?}");
+    };
+    assert_eq!(interface.machine_id, Some(dpu_machine_id));
+    assert_eq!(interface.attached_dpu_machine_id, Some(dpu_machine_id));
+    assert!(interface.primary_interface);
     assert!(
-        !creator
-            .create_managed_host(
-                &fixture.host,
-                &mut EndpointExplorationReport::default(),
-                Some(&expected_machine(&mock_host)),
-                &env.pool,
-            )
+        db::predicted_machine_interface::find_by_mac_address(&mut txn, mock_dpu.oob_mac_address,)
             .await?
+            .is_none()
     );
 
-    // At this point, create_managed_host must have updated the associated machine id in
-    // machine_interfaces table.
-    let mut txn = env.pool.begin().await?;
-    let mi = db::machine_interface::find_by_machine_ids(&mut txn, &[dpu_machine_id]).await?;
-    assert!(!mi.is_empty());
-    let value = mi.values().collect_vec()[0].clone()[0].clone();
-    assert_eq!(value.attached_dpu_machine_id.unwrap(), dpu_machine_id);
-    assert_eq!(value.machine_id.unwrap(), dpu_machine_id);
-    txn.rollback().await?;
+    let topologies = db::machine_topology::find_by_machine_ids(&mut txn, &[dpu_machine_id]).await?;
+    let topology = &topologies[&dpu_machine_id][0];
+    let discovery_info = DiscoveryInfo::try_from(topology.topology().discovery_data.info.clone())?;
+    let interface_id = interface.id;
+    txn.commit().await?;
+
+    let response = env
+        .api()
+        .discover_machine(Request::new(MachineDiscoveryInfo {
+            machine_interface_id: Some(interface_id),
+            discovery_data: Some(DiscoveryData::Info(discovery_info)),
+            create_machine: true,
+            ..Default::default()
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(response.machine_id, Some(dpu_machine_id));
 
     Ok(())
 }
 
 #[sqlx_test]
-async fn test_all_dpu_interfaces_attach_if_created_after_multi_dpu_machine_creation(
+async fn test_dpu_interface_predictions_apply_when_dhcp_follows_multi_dpu_machine_creation(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     const NUM_DPUS: usize = 2;
@@ -1062,17 +1096,6 @@ async fn test_all_dpu_interfaces_attach_if_created_after_multi_dpu_machine_creat
     for dpu in &mock_host.dpus {
         dhcp_discover_dpu_oob_iface(env.api(), env.underlay_segment, dpu.oob_mac_address).await;
     }
-
-    assert!(
-        !creator
-            .create_managed_host(
-                &fixture.host,
-                &mut EndpointExplorationReport::default(),
-                Some(&expected_machine(&mock_host)),
-                &env.pool,
-            )
-            .await?
-    );
 
     let mut txn = env.pool.begin().await?;
     for (dpu_index, dpu) in mock_host.dpus.iter().enumerate() {


### PR DESCRIPTION
This backports #5084 to `release/v2.1`. Site Explorer can create a DPU machine before its OOB interface sends DHCP. The first DHCP request then materializes an anonymous interface, and `DiscoverMachine` cannot authenticate it because only Site Explorer can create the DPU machine.

This records the trusted OOB MAC as a `PredictedMachineInterface` during DPU creation. DHCP promotes that prediction and sets both `machine_id` and `attached_dpu_machine_id` in the same transaction, so the first discovery request sees the DPU identity. Existing interfaces are still associated directly, and interfaces without a trusted prediction keep the anonymous discovery path.

The production/API patch is byte-identical to #5084. The release test adaptation keeps the rack fixture in `tests/lib.rs`, uses the v2.1 Site Explorer configuration signature, and seeds the `secondary-vtep-ip` pool that the v2.1 `DiscoverMachine` handler still consumes.

## Related issues

- This supports https://github.com/NVIDIA/infra-controller/issues/5784
- Backports https://github.com/NVIDIA/infra-controller/pull/5084

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- Both focused Site Explorer prediction and promotion tests (`2 passed; 0 failed`) and the release branch's relocated machine-a-tron rack integration scenario (`1 passed; 0 failed`) pass with isolated PostgreSQL instances.
- Nightly Rust formatting, full workspace Clippy, custom Carbide lints, and `git diff --check` pass.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

The merged source patch was reviewed in #5084. Four local passes also reviewed the stable adapted release diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 2 | 0 | 2 |
| Claude CLI | 5 | 0 | 5 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | 7 | 0 | 7 |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

1. **Declined** -- Add tests used only on the release branch for reusing a prediction for the same machine and rejecting conflicting prediction ownership. **Reason:** The focused regression covers prediction creation, promotion by the first DHCP request, and immediate discovery. The two simple guard branches are unchanged from the reviewed source patch and are not release compatibility adaptations.
2. **Declined** -- Lowercase the existing `Got DHCP` diagnostic. **Reason:** The backport changes only `host` to `interface` in that pre-existing text, exactly as merged in #5084; a style-only production deviation is outside this backport.

### Claude CLI

1. **Declined** -- Avoid the `Underlay` prediction or update every machine-a-tron configuration. **Reason:** Repository documentation defines DPU OOB as Underlay, and #5229 confirms the historically named shared relay supports both DPU OOB boot and switch NVOS. The production hunk remains identical to #5084.
2. **Declined** -- Split the legacy machine-a-tron relay and run broad MAT coverage. **Reason:** The shared Underlay behavior is intentional. The release branch's relocated rack integration scenario passes with the adapted fixture.
3. **Declined** -- Replace a prediction owned by a different DPU instead of returning `AlreadyFoundError`. **Reason:** Silently transferring a trusted MAC claim would weaken the ownership boundary; the explicit conflict is the reviewed source behavior.
4. **Declined** -- Restore a second Site Explorer pass in both focused tests. **Reason:** The regression is the first-DHCP window, and the tests intentionally prove ownership and discovery without a second reconciliation.
5. **Declined** -- Move the secondary VTEP setup used only on the release branch into a shared helper. **Reason:** Keeping this prerequisite local makes the v2.1 compatibility adaptation explicit and avoids unrelated fixture changes.

### common-nits-reviewer

No findings.

</details>


Closes #5784
