### PR TITLE
fix(health): recognize RMS-selected NMX-C primary

### DIFF
--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -313,7 +313,7 @@ fn switch_endpoint_metadata(
             .filter(|domain_uuid| domain_uuid != &NvLinkDomainId::nil()),
         endpoint_role,
         is_primary: switch.is_primary,
-        nmxc_enabled: config.enable_nmxc,
+        nmxc_enabled: config.enable_nmxc || switch.is_primary,
         nmxt_enabled,
     }))
 }
@@ -966,6 +966,29 @@ mod tests {
                 switch.nvlink_domain_uuid
             },
         );
+    }
+
+    #[test]
+    fn switch_endpoint_metadata_enables_nmxc_for_primary_switch() {
+        let metadata = switch_endpoint_metadata(
+            &rpc::forge::Switch {
+                config: Some(rpc::forge::SwitchConfig {
+                    name: "switch-a".to_string(),
+                    ..Default::default()
+                }),
+                is_primary: true,
+                ..Default::default()
+            },
+            SwitchEndpointRole::Host,
+            false,
+        )
+        .expect("switch metadata");
+
+        let EndpointMetadata::Switch(switch) = metadata else {
+            panic!("expected switch metadata");
+        };
+
+        assert!(switch.nmxc_enabled);
     }
 
     #[test]


### PR DESCRIPTION
RMS V2 selects the NMX-C primary and NICo persists that result in `switch.is_primary`, but health endpoint metadata only considers the legacy `config.enable_nmxc` field. This leaves the active RMS-selected primary ineligible for NMX-C health collection when the legacy field is false.

Treat either the legacy configuration flag or the persisted primary status as evidence that NMX-C is enabled. A focused unit test covers the RMS V2 case.

## Related issues

Resolves #5788

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

```bash
cargo test -p carbide-health
cargo +nightly-2026-06-16 fmt --all -- --check
cargo clippy -p carbide-health --all-targets --all-features -- -D warnings
```

All 500 `carbide-health` tests pass.