### PR TITLE
tests(api-core): move machine metadata tests to integration suite

### DIFF
--- a/crates/api-core/src/test_support/metadata.rs
+++ b/crates/api-core/src/test_support/metadata.rs
@@ -21,7 +21,7 @@
 /// The function returns a tuple of
 /// 1. Metadata to check
 /// 2. Expected part of error message
-pub(in crate::tests) fn invalid_metadata_testcases(
+pub fn invalid_metadata_testcases(
     include_min_length_test_cases: bool,
 ) -> Vec<(rpc::forge::Metadata, String)> {
     let mut results = [

--- a/crates/api-core/src/test_support/mod.rs
+++ b/crates/api-core/src/test_support/mod.rs
@@ -22,6 +22,7 @@ pub mod health;
 pub(crate) mod ib_fabric;
 pub(crate) mod ib_guid_pool;
 pub mod mac_address_pool;
+pub mod metadata;
 pub mod network;
 pub mod network_segment;
 

--- a/crates/api-core/src/tests/common/mod.rs
+++ b/crates/api-core/src/tests/common/mod.rs
@@ -24,10 +24,6 @@ pub(in crate::tests) mod api_fixtures;
 #[cfg(test)]
 pub(in crate::tests) mod attestation;
 pub(in crate::tests) mod endpoint;
-// Only this crate's own `#[cfg(test)]` health-override tests drive these shared CRUD
-// helpers; gate them out of test-support-only builds to keep dead-code detection honest.
-#[cfg(test)]
-pub(in crate::tests) mod metadata;
 pub(in crate::tests) mod network_segment;
 pub(in crate::tests) mod overlay_address;
 pub(in crate::tests) mod postgres;

--- a/crates/api-core/src/tests/expected_machine.rs
+++ b/crates/api-core/src/tests/expected_machine.rs
@@ -31,6 +31,7 @@ use uuid::Uuid;
 
 use crate::CarbideError;
 use crate::test_support::fixture_config::FixtureDefault as _;
+use crate::test_support::metadata;
 use crate::tests::common;
 
 async fn create_fixture_expected_machines(pool: &sqlx::PgPool) {
@@ -766,7 +767,7 @@ async fn test_add_and_update_expected_machine_with_invalid_metadata(pool: sqlx::
     let env = create_test_env(pool).await;
     let bmc_mac_address: MacAddress = "3A:3B:3C:3D:3E:3F".parse().unwrap();
     // Start adding an expected-machine with invalid metadata
-    for (invalid_metadata, expected_err) in common::metadata::invalid_metadata_testcases(false) {
+    for (invalid_metadata, expected_err) in metadata::invalid_metadata_testcases(false) {
         let expected_machine = rpc::forge::ExpectedMachine {
             bmc_mac_address: bmc_mac_address.to_string(),
             bmc_username: "ADMIN".into(),
@@ -822,7 +823,7 @@ async fn test_add_and_update_expected_machine_with_invalid_metadata(pool: sqlx::
         .await
         .expect("Expected addition to succeed");
 
-    for (invalid_metadata, expected_err) in common::metadata::invalid_metadata_testcases(false) {
+    for (invalid_metadata, expected_err) in metadata::invalid_metadata_testcases(false) {
         let expected_machine = rpc::forge::ExpectedMachine {
             bmc_mac_address: bmc_mac_address.to_string(),
             bmc_username: "ADMIN".into(),

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -85,6 +85,7 @@ use crate::cfg::file::VmaasConfig;
 use crate::instance::{allocate_instance, allocate_network};
 use crate::network_segment::allocate::PrefixAllocator;
 use crate::test_support::fixture_config::FixtureDefault as _;
+use crate::test_support::metadata;
 use crate::test_support::network_segment::FIXTURE_TENANT_ORG_ID;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::instance::single_interface_network_config_with_vfs;
@@ -930,7 +931,7 @@ async fn test_allocate_instance_with_invalid_metadata(_: PgPoolOptions, options:
     let segment_id = env.create_vpc_and_tenant_segment().await;
     let (host_machine_id, _dpu_machine_id) = create_managed_host(&env).await.into();
 
-    for (invalid_metadata, expected_err) in common::metadata::invalid_metadata_testcases(true) {
+    for (invalid_metadata, expected_err) in metadata::invalid_metadata_testcases(true) {
         let tenant_config = default_tenant_config();
         let config = InstanceConfig::builder()
             .tenant(tenant_config)

--- a/crates/api-core/src/tests/instance_config_update.rs
+++ b/crates/api-core/src/tests/instance_config_update.rs
@@ -37,6 +37,7 @@ use tonic::Request;
 
 use crate::cfg::file::{FnnConfig, FnnRoutingProfileConfig, PrefixFilterPolicyEntry};
 use crate::test_support::fixture_config::ManagedHostConfigExt as _;
+use crate::test_support::metadata;
 use crate::test_support::network_segment::FIXTURE_TENANT_ORG_ID;
 use crate::tests::common::api_fixtures::instance::advance_created_instance_into_ready_state;
 use crate::tests::common::api_fixtures::{create_managed_host_multi_dpu, get_vpc_fixture_id};
@@ -853,7 +854,7 @@ async fn test_reject_invalid_instance_config_updates(_: PgPoolOptions, options: 
     );
 
     // Try to update to invalid metadata
-    for (invalid_metadata, expected_err) in common::metadata::invalid_metadata_testcases(true) {
+    for (invalid_metadata, expected_err) in metadata::invalid_metadata_testcases(true) {
         let err = env
             .api
             .update_instance_config(tonic::Request::new(

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -53,7 +53,6 @@ mod machine_find;
 mod machine_health;
 mod machine_history;
 mod machine_interfaces;
-mod machine_metadata;
 mod machine_network;
 mod machine_states;
 mod machine_topology;

--- a/crates/api-core/src/tests/vpc.rs
+++ b/crates/api-core/src/tests/vpc.rs
@@ -32,6 +32,7 @@ use model::vpc::{
 };
 use rpc::forge::forge_server::Forge;
 
+use crate::test_support::metadata;
 use crate::test_support::network_segment::FIXTURE_TENANT_ORG_ID;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::tenant::create_fixture_tenant;
@@ -372,7 +373,7 @@ async fn create_vpc(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>
     assert_eq!(status.code(), tonic::Code::NotFound);
 
     // Try to update to invalid metadata
-    for (invalid_metadata, expected_err) in common::metadata::invalid_metadata_testcases(true) {
+    for (invalid_metadata, expected_err) in metadata::invalid_metadata_testcases(true) {
         let invalid_updated_vpc = env
             .api
             .update_vpc(tonic::Request::new(rpc::forge::VpcUpdateRequest {
@@ -1554,7 +1555,7 @@ async fn create_vpc_with_invalid_metadata(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = create_test_env(pool).await;
 
-    for (invalid_metadata, expected_err) in common::metadata::invalid_metadata_testcases(true) {
+    for (invalid_metadata, expected_err) in metadata::invalid_metadata_testcases(true) {
         let result = env
             .api
             .create_vpc(

--- a/crates/api-core/tests/integration/machine_metadata.rs
+++ b/crates/api-core/tests/integration/machine_metadata.rs
@@ -15,18 +15,33 @@
  * limitations under the License.
  */
 
-use common::api_fixtures::{create_managed_host, create_test_env};
+use carbide_api_core::CarbideError;
+use carbide_api_core::test_support::metadata::invalid_metadata_testcases;
+use carbide_test_harness::prelude::*;
+use carbide_test_harness::test_support::fixture_config::FixtureDefault as _;
+use model::test_support::ManagedHostConfig;
 use rpc::forge::forge_server::Forge;
 
-use crate::CarbideError;
-use crate::tests::common;
+#[sqlx_test]
+async fn test_machine_metadata(pool: PgPool) -> Result<(), Box<dyn std::error::Error>> {
+    let env = TestHarness::builder(pool)
+        .with_resource_pools(ResourcePoolBuilder::default().build())
+        .build()
+        .await;
+    let network_controller = env.network_controller();
+    let domain = env.test_domain().await;
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    let admin_segment = network_controller.create_admin_segment(&domain).await;
+    let site_explorer = env.default_test_site_explorer();
+    let mut mh = env
+        .managed_host_builder(&site_explorer, underlay_segment)
+        .with_config(ManagedHostConfig::default())
+        .build()
+        .await
+        .0;
+    mh.host.discover_primary_iface(admin_segment).await;
 
-#[crate::sqlx_test]
-async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
-    let mh = create_managed_host(&env).await;
-
-    let host_machine = mh.host().rpc_machine().await;
+    let host_machine = mh.host.rpc_machine().await;
     let version1: config_version::ConfigVersion = host_machine.version.parse().unwrap();
 
     let expected_metadata = rpc::forge::Metadata {
@@ -40,11 +55,11 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
         name: "ASDF".to_string(),
         description: "LL1".to_string(),
         labels: vec![
-            ::rpc::forge::Label {
+            rpc::forge::Label {
                 key: "A".to_string(),
                 value: None,
             },
-            ::rpc::forge::Label {
+            rpc::forge::Label {
                 key: "B".to_string(),
                 value: Some("BB".to_string()),
             },
@@ -53,9 +68,9 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
 
     // Update with missing Metadata fails
     let err = env
-        .api
+        .api()
         .update_machine_metadata(tonic::Request::new(
-            ::rpc::forge::MachineMetadataUpdateRequest {
+            rpc::forge::MachineMetadataUpdateRequest {
                 machine_id: host_machine.id,
                 if_version_match: None,
                 metadata: None,
@@ -66,9 +81,9 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
     assert_eq!(err.code(), tonic::Code::InvalidArgument);
 
     // Update succeeds
-    env.api
+    env.api()
         .update_machine_metadata(tonic::Request::new(
-            ::rpc::forge::MachineMetadataUpdateRequest {
+            rpc::forge::MachineMetadataUpdateRequest {
                 machine_id: host_machine.id,
                 if_version_match: None,
                 metadata: Some(new_metadata.clone()),
@@ -77,7 +92,7 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
         .await
         .unwrap();
 
-    let mut host_machine = mh.host().rpc_machine().await;
+    let mut host_machine = mh.host.rpc_machine().await;
     let version2: config_version::ConfigVersion = host_machine.version.parse().unwrap();
     assert_eq!(version2.version_nr(), version1.version_nr() + 1);
     host_machine
@@ -93,16 +108,16 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
     let new_metadata = rpc::forge::Metadata {
         name: "CONDITIONAL".to_string(),
         description: "".to_string(),
-        labels: vec![::rpc::forge::Label {
+        labels: vec![rpc::forge::Label {
             key: "D".to_string(),
             value: None,
         }],
     };
 
     let err = env
-        .api
+        .api()
         .update_machine_metadata(tonic::Request::new(
-            ::rpc::forge::MachineMetadataUpdateRequest {
+            rpc::forge::MachineMetadataUpdateRequest {
                 machine_id: host_machine.id,
                 if_version_match: Some(version1.to_string()),
                 metadata: Some(new_metadata.clone()),
@@ -116,9 +131,9 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
         CarbideError::ConcurrentModificationError("machine", version1.to_string()).to_string()
     );
 
-    env.api
+    env.api()
         .update_machine_metadata(tonic::Request::new(
-            ::rpc::forge::MachineMetadataUpdateRequest {
+            rpc::forge::MachineMetadataUpdateRequest {
                 machine_id: host_machine.id,
                 if_version_match: Some(version2.to_string()),
                 metadata: Some(new_metadata.clone()),
@@ -127,7 +142,7 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
         .await
         .unwrap();
 
-    let mut host_machine = mh.host().rpc_machine().await;
+    let mut host_machine = mh.host.rpc_machine().await;
     let version3: config_version::ConfigVersion = host_machine.version.parse().unwrap();
     assert_eq!(version3.version_nr(), version2.version_nr() + 1);
     host_machine
@@ -140,11 +155,11 @@ async fn test_machine_metadata(pool: sqlx::PgPool) -> Result<(), Box<dyn std::er
     assert_eq!(host_machine.metadata.as_ref().unwrap(), &new_metadata);
 
     // Updates with invalid metadata fail
-    for (invalid_metadata, expected_err) in common::metadata::invalid_metadata_testcases(true) {
+    for (invalid_metadata, expected_err) in invalid_metadata_testcases(true) {
         let err = env
-            .api
+            .api()
             .update_machine_metadata(tonic::Request::new(
-                ::rpc::forge::MachineMetadataUpdateRequest {
+                rpc::forge::MachineMetadataUpdateRequest {
                     machine_id: host_machine.id,
                     if_version_match: None,
                     metadata: Some(invalid_metadata.clone()),

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -39,6 +39,7 @@ mod ib_fabric_find;
 mod level_filter;
 mod machine_bmc_metadata;
 mod machine_boot_interfaces;
+mod machine_metadata;
 mod nvlink_domain_health;
 mod operating_system;
 mod power_options;


### PR DESCRIPTION
Move machine metadata test to integration suite. Make invalid metadata test cases shared in test_support.

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

