### PR TITLE
dev(tilt): support of mat controller and use of cluster IPs for BMC

### DIFF
--- a/dev/deployment/tilt/README.md
+++ b/dev/deployment/tilt/README.md
@@ -32,7 +32,7 @@ The default stack includes:
 - cert-manager
 - the CloudNativePG operator and one PostgreSQL cluster
 - Vault in local development mode
-- NICo API, BMC proxy, DHCP server, and machine-a-tron
+- NICo API, BMC proxy, DHCP server, machine-a-tron, and mat-k8s-controller
 - Temporal and its local namespaces
 - Keycloak and the `nico-dev` realm
 - NICo REST API, database migrations, certificate manager, site manager,
@@ -113,11 +113,26 @@ All Tilt settings are in [`values.yaml`](values.yaml). NICo Core values are at
 the document root, while the `tilt` section contains the prerequisite and REST
 settings.
 
+## Machine-a-tron BMC routing
+
+Tilt runs machine-a-tron in controller mode. `mat-k8s-controller` polls the
+machine-a-tron status endpoint and creates one Kubernetes ClusterIP Service per
+simulated BMC, using the BMC address assigned by NICo as the Service IP. NICo
+therefore connects directly to each simulated BMC instead of routing every
+Redfish request through the shared machine-a-tron proxy.
+
+The Tilt BMC underlay is `10.96.64.0/18`, which lies within Kind's default
+`10.96.0.0/16` ServiceCIDR. Kubernetes rejects an explicit ClusterIP outside
+the cluster ServiceCIDR, so keep this range aligned with the Kind network
+configuration if the ServiceCIDR changes.
+
 ## Image builds
 
 Core uses the existing Dockerfiles under
-[`dev/deployment/devspace/`](../devspace). REST and MCP use the existing
-Dockerfiles under [`rest-api/docker/local/`](../../../rest-api/docker/local).
+[`dev/deployment/devspace/`](../devspace); mat-k8s-controller uses its existing
+[`Dockerfile`](../../k8s/machine-a-tron-controller/Dockerfile). REST and MCP
+use the existing Dockerfiles under
+[`rest-api/docker/local/`](../../../rest-api/docker/local).
 The Tilt setup does not add or modify a Dockerfile.
 
 Each deployable image has its own Tilt resource and rebuild control. Images build

--- a/dev/deployment/tilt/Tiltfile
+++ b/dev/deployment/tilt/Tiltfile
@@ -123,7 +123,7 @@ def helm_chart(
         namespace,
         values,
         resource_deps=[],
-        image_dep='',
+        image_deps=[],
         image_keys=[],
         port_forwards=[],
         links=[],
@@ -140,7 +140,7 @@ def helm_chart(
         namespace=namespace,
         deps=[chart, values_file],
         resource_deps=resource_deps,
-        image_deps=[image_dep] if image_dep else [],
+        image_deps=image_deps,
         image_keys=image_keys,
         labels=['application'],
         pod_readiness='wait' if wait else 'ignore',
@@ -841,6 +841,14 @@ docker_build(
     dockerfile=os.path.join(devspace_dir, 'Dockerfile.machine-a-tron'),
     ignore=['dev/deployment/tilt'],
 )
+docker_build(
+    'mat-k8s-controller',
+    os.path.join(repo_root, 'dev/k8s/machine-a-tron-controller'),
+    dockerfile=os.path.join(
+        repo_root,
+        'dev/k8s/machine-a-tron-controller/Dockerfile',
+    ),
+)
 
 rest_image(
     'nico-rest-api',
@@ -936,7 +944,7 @@ helm_chart(
     namespace=core_namespace,
     values=nico_api_values,
     resource_deps=nico_api_dependencies,
-    image_dep='nico-api',
+    image_deps=['nico-api'],
     image_keys=[('global.image.repository', 'global.image.tag')],
     port_forwards=[port_forward(1079, 1079)],
     links=[link('https://localhost:1079/admin/', 'NICo Web UI')],
@@ -948,7 +956,7 @@ helm_chart(
     namespace=core_namespace,
     values=component_values(core_global, all_values['nico-bmc-proxy']),
     resource_deps=['nico-api'],
-    image_dep='nico-bmc-proxy',
+    image_deps=['nico-bmc-proxy'],
     image_keys=[('image.repository', 'image.tag')],
     manual=True,
 )
@@ -958,7 +966,7 @@ helm_chart(
     namespace=core_namespace,
     values=component_values(core_global, nico_dhcp_values),
     resource_deps=['nico-api'],
-    image_dep='nico-dhcp',
+    image_deps=['nico-dhcp'],
     image_keys=[('global.image.repository', 'global.image.tag')],
     manual=True,
 )
@@ -1056,8 +1064,14 @@ helm_chart(
         'nico-dhcp-machine-a-tron',
         'nico-machine-a-tron-dhcp-relay',
     ],
-    image_dep='machine-a-tron',
-    image_keys=[('image.repository', 'image.tag')],
+    image_deps=['machine-a-tron', 'mat-k8s-controller'],
+    image_keys=[
+        ('image.repository', 'image.tag'),
+        (
+            'mat-k8s-controller.image.repository',
+            'mat-k8s-controller.image.tag',
+        ),
+    ],
     port_forwards=[port_forward(1266, 1266)],
     links=[link('https://localhost:1266/', 'Machine-A-Tron UI')],
     manual=True,
@@ -1074,7 +1088,7 @@ helm_chart(
         'nico-api',
         'nico-machine-a-tron-ssh',
     ],
-    image_dep='nico-api',
+    image_deps=['nico-api'],
     image_keys=[('global.image.repository', 'global.image.tag')],
     port_forwards=[
         port_forward(3222, 22),
@@ -1123,7 +1137,7 @@ helm_chart(
     namespace=rest_namespace,
     values=component_values(rest_global, rest_values['certManager']),
     resource_deps=['nico-local-config'],
-    image_dep='localhost/nico-rest-cert-manager',
+    image_deps=['localhost/nico-rest-cert-manager'],
     image_keys=rest_image_keys,
     manual=True,
 )
@@ -1133,7 +1147,7 @@ helm_chart(
     namespace=rest_namespace,
     values=component_values(rest_global, rest_values['siteManager']),
     resource_deps=['nico-rest-cert-manager'],
-    image_dep='localhost/nico-rest-site-manager',
+    image_deps=['localhost/nico-rest-site-manager'],
     image_keys=rest_image_keys,
     manual=True,
 )
@@ -1149,7 +1163,7 @@ helm_chart(
         'rest-certificate-ready',
         'temporal-namespaces',
     ],
-    image_dep='localhost/nico-rest-api',
+    image_deps=['localhost/nico-rest-api'],
     image_keys=rest_image_keys,
     port_forwards=[port_forward(18388, 8388)],
     manual=True,
@@ -1164,7 +1178,7 @@ helm_chart(
         'rest-certificate-ready',
         'temporal-namespaces',
     ],
-    image_dep='localhost/nico-rest-workflow',
+    image_deps=['localhost/nico-rest-workflow'],
     image_keys=rest_image_keys,
     manual=True,
 )
@@ -1179,7 +1193,7 @@ helm_chart(
         'nico-rest-site-manager',
         'nico-rest-workflow',
     ],
-    image_dep='localhost/nico-rest-site-agent',
+    image_deps=['localhost/nico-rest-site-agent'],
     image_keys=rest_image_keys,
     manual=True,
     wait=False,
@@ -1190,7 +1204,7 @@ helm_chart(
     namespace=rest_namespace,
     values=component_values(rest_global, rest_values['mcp']),
     resource_deps=['nico-rest-api'],
-    image_dep='localhost/nico-mcp',
+    image_deps=['localhost/nico-mcp'],
     image_keys=rest_image_keys,
     port_forwards=[port_forward(18080, 8080)],
     manual=True,

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -81,8 +81,8 @@ nico-api:
 
       [networks.DEV-K3S-X86-BMC-UNDERLAY-ACORN-X86-0]
       type = "underlay"
-      prefix = "192.168.192.0/18"
-      gateway = "192.168.192.1"
+      prefix = "10.96.64.0/18"
+      gateway = "10.96.64.1"
       mtu = 1500
       reserve_first = 2
 
@@ -115,8 +115,6 @@ nico-api:
       [site_explorer]
       enabled = true
       create_machines = true
-      allow_changing_bmc_proxy = true
-      bmc_proxy = "nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266"
       run_interval = "10s"
       machines_created_per_run = 1000
       explorations_per_run = 1000
@@ -147,7 +145,6 @@ nico-bmc-proxy:
       metrics_endpoint = "[::]:1080"
       database_url = "postgres://replaced-by-env-var"
       allowed_principals = ["trusted-certificate"]
-      bmc_proxy = "nico-machine-a-tron-mat-0-bmc-mock.nico-system.svc.cluster.local:1266"
 
       [tls]
       identity_pemfile_path = "/var/run/secrets/spiffe.io/tls.crt"
@@ -207,6 +204,10 @@ nico-machine-a-tron:
   enabled: true
   machineATron:
     nicoApiUrl: https://nico-api.nico-system.svc.cluster.local:1079
+  mat-k8s-controller:
+    enabled: true
+    config:
+      insecureSkipVerify: true
   machineDefaults:
     discoveryRetryInterval: "5s"
   persistence:
@@ -241,7 +242,7 @@ nico-machine-a-tron:
         host_reboot_delay = 10
         acceleration_factor = 0.01
         discovery_retry_interval = "5s"
-        oob_dhcp_relay_address = "192.168.192.1"
+        oob_dhcp_relay_address = "10.96.64.1"
         admin_dhcp_relay_address = "192.168.176.1"
 
         [machines.rack-machines]
@@ -256,7 +257,7 @@ nico-machine-a-tron:
         run_interval_working = "1s"
         run_interval_idle = "10s"
         network_status_run_interval = "20s"
-        oob_dhcp_relay_address = "192.168.192.1"
+        oob_dhcp_relay_address = "10.96.64.1"
         admin_dhcp_relay_address = "192.168.176.1"
         dpus_in_nic_mode = false
   pods:
@@ -269,14 +270,14 @@ nico-machine-a-tron:
             - rack-001
           dpu_reboot_delay: 20
           host_reboot_delay: 10
-          oob_dhcp_relay_address: 192.168.192.1
+          oob_dhcp_relay_address: 10.96.64.1
           admin_dhcp_relay_address: 192.168.176.1
       machines:
         rack-machines:
           hwType: wiwynn_gb200_nvl
           hostCount: 2
           dpuPerHostCount: 2
-          oobDhcpRelayAddress: 192.168.192.1
+          oobDhcpRelayAddress: 10.96.64.1
           adminDhcpRelayAddress: 192.168.176.1
 
 tilt:


### PR DESCRIPTION
Added support of deployment of machine-a-tron controller and to Tilt dev environment. Access to machine via IP address instead of BMC proxy mode on nico-api.  

## Related issues

N/A

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

