### PR TITLE
tests(api-core): move redfish actions tests to integration suite

### DIFF
--- a/crates/api-core/src/handlers/redfish.rs
+++ b/crates/api-core/src/handlers/redfish.rs
@@ -626,7 +626,7 @@ impl TestBehavior {
         }
     }
 
-    #[cfg(test)]
+    #[cfg(any(test, feature = "test-support"))]
     fn from_parameters_if_testing(parameters: &mut String) -> Option<TestBehavior> {
         let mut param_obj: serde_json::Map<String, serde_json::Value> =
             serde_json::from_str(parameters).expect("invalid parameters");
@@ -641,13 +641,13 @@ impl TestBehavior {
         }
     }
 
-    #[cfg(not(test))]
+    #[cfg(not(any(test, feature = "test-support")))]
     fn from_parameters_if_testing(_parameters: &mut String) -> Option<TestBehavior> {
         None
     }
 }
 
-#[cfg(test)]
+#[cfg(any(test, feature = "test-support"))]
 pub(crate) mod test_behavior {
     use super::TestBehavior;
 

--- a/crates/api-core/src/test_support/mod.rs
+++ b/crates/api-core/src/test_support/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod ib_guid_pool;
 pub mod mac_address_pool;
 pub mod network;
 pub mod network_segment;
+pub mod redfish;
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/api-core/src/test_support/redfish.rs
+++ b/crates/api-core/src/test_support/redfish.rs
@@ -1,0 +1,34 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+pub mod test_behavior {
+    pub fn success() -> serde_json::Value {
+        crate::handlers::redfish::test_behavior::success()
+    }
+
+    pub fn failure_at_request() -> serde_json::Value {
+        crate::handlers::redfish::test_behavior::failure_at_request()
+    }
+
+    pub fn failure_at_client_creation() -> serde_json::Value {
+        crate::handlers::redfish::test_behavior::failure_at_client_creation()
+    }
+
+    pub fn request_failure_description() -> String {
+        crate::handlers::redfish::test_behavior::request_failure_description()
+    }
+}

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -73,7 +73,6 @@ mod preingestion_dpu_nic_mode;
 mod primary_interface;
 mod rack_health;
 mod rack_state_controller;
-mod redfish_actions;
 mod resource_pool;
 mod site_explorer;
 mod site_prefix;

--- a/crates/api-core/tests/integration/main.rs
+++ b/crates/api-core/tests/integration/main.rs
@@ -50,6 +50,7 @@ mod power_shelf_health;
 mod power_shelf_maintenance;
 mod rack_find;
 mod rack_profile;
+mod redfish_actions;
 mod route_servers;
 mod scout_firmware_upgrade_status;
 mod set_primary_dpu;

--- a/crates/api-core/tests/integration/redfish_actions.rs
+++ b/crates/api-core/tests/integration/redfish_actions.rs
@@ -14,25 +14,84 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::sync::Arc;
 use std::time::Duration;
 
 use ::rpc::forge::forge_server::Forge;
+use carbide_api_core::AuthContext;
+use carbide_api_core::test_support::fixture_config::FixtureDefault as _;
+use carbide_api_core::test_support::redfish::test_behavior;
 use carbide_authn::middleware::{ExternalUserInfo, Principal};
+use carbide_secrets::credentials::Credentials;
+use carbide_secrets::test_support::credentials::TestCredentialManager;
+use carbide_site_explorer::config::SiteExplorerConfig;
+use carbide_test_harness::TestNetworkSegment;
+use carbide_test_harness::prelude::*;
+use model::test_support::ManagedHostConfig;
 use rpc::forge::{RedfishAction, RedfishActionResult};
 use sqlx::postgres::{PgConnectOptions, PgPoolOptions};
 use tokio::time::Instant;
 
-use crate::auth::AuthContext;
-use crate::handlers::redfish::test_behavior;
-use crate::tests::common::api_fixtures::{TestEnv, create_managed_host, create_test_env};
+struct TestEnv {
+    api: Arc<Api>,
+    harness: TestHarness,
+    admin_segment: TestNetworkSegment,
+    underlay_segment: TestNetworkSegment,
+    site_explorer: TestSiteExplorer,
+}
 
-#[crate::sqlx_test]
+async fn create_test_env(pool: PgPool) -> TestEnv {
+    let harness = TestHarness::builder(pool)
+        .with_api_builder_fn(|builder| {
+            builder.with_credential_manager(Arc::new(TestCredentialManager::new(
+                Credentials::UsernamePassword {
+                    username: "root".to_string(),
+                    password: "notforprod".to_string(),
+                },
+            )))
+        })
+        .build()
+        .await;
+    let domain = harness.test_domain().await;
+    let network_controller = harness.network_controller();
+    let admin_segment = network_controller.create_admin_segment(&domain).await;
+    let underlay_segment = network_controller.create_underlay_segment(&domain).await;
+    let site_explorer = harness.test_site_explorer(SiteExplorerConfig::default());
+    let api = harness.api_arc();
+
+    TestEnv {
+        api,
+        harness,
+        admin_segment,
+        underlay_segment,
+        site_explorer,
+    }
+}
+
+async fn create_managed_host(env: &TestEnv) -> TestManagedHost {
+    let mut managed_host = env
+        .harness
+        .managed_host_builder(&env.site_explorer, env.underlay_segment)
+        .with_config(ManagedHostConfig::default())
+        .with_dpu_network_status_reported()
+        .build()
+        .await
+        .0;
+    managed_host
+        .host
+        .discover_primary_iface(env.admin_segment)
+        .await;
+    managed_host.advance_to_converged_ready().await;
+    managed_host
+}
+
+#[sqlx_test]
 async fn test_create_and_approve_action(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
     let env = create_test_env(pool).await;
     let mh = create_managed_host(&env).await;
     let bmc_ip = mh
-        .host()
+        .host
         .rpc_machine()
         .await
         .bmc_info
@@ -130,7 +189,7 @@ async fn test_create_and_approve_action(_: PgPoolOptions, options: PgConnectOpti
     assert_eq!(err.message(), "user already approved request");
 
     // Test whether the raw DB query allows double insertion of approver
-    let mut txn = env.db_txn().await;
+    let mut txn = env.harness.db_txn().await;
     assert!(
         !db::redfish_actions::approve_request("user2".to_string(), request_id.into(), &mut txn)
             .await
@@ -161,13 +220,13 @@ async fn test_create_and_approve_action(_: PgPoolOptions, options: PgConnectOpti
     }
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_action_failure_at_bmc_request(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
     let env = create_test_env(pool).await;
     let mh = create_managed_host(&env).await;
     let bmc_ip = mh
-        .host()
+        .host
         .rpc_machine()
         .await
         .bmc_info
@@ -219,13 +278,13 @@ async fn test_action_failure_at_bmc_request(_: PgPoolOptions, options: PgConnect
     }
 }
 
-#[crate::sqlx_test]
+#[sqlx_test]
 async fn test_action_failure_at_client_creation(_: PgPoolOptions, options: PgConnectOptions) {
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
     let env = create_test_env(pool).await;
     let mh = create_managed_host(&env).await;
     let bmc_ip = mh
-        .host()
+        .host
         .rpc_machine()
         .await
         .bmc_info


### PR DESCRIPTION
Move Redfish actions tests to integration suite.

## Related issues

#2001 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

