### PR TITLE
feat(credentials): support firmware artifact access tokens

### DIFF
--- a/crates/admin-cli/src/credential/add_bmc/args.rs
+++ b/crates/admin-cli/src/credential/add_bmc/args.rs
@@ -60,6 +60,7 @@ impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
             password,
             mac_address: args.mac_address.map(|mac| mac.to_string()),
             vendor: None,
+            credential_name: None,
         })
     }
 }

--- a/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_dpu_factory_default/args.rs
@@ -53,6 +53,7 @@ impl From<Args> for forgerpc::CredentialCreationRequest {
             password: args.password,
             mac_address: None,
             vendor: Some(args.model.to_string()),
+            credential_name: None,
         }
     }
 }

--- a/crates/admin-cli/src/credential/add_host_factory_default/args.rs
+++ b/crates/admin-cli/src/credential/add_host_factory_default/args.rs
@@ -44,6 +44,7 @@ impl From<Args> for forgerpc::CredentialCreationRequest {
             password: args.password,
             mac_address: None,
             vendor: Some(args.vendor.to_string()),
+            credential_name: None,
         }
     }
 }

--- a/crates/admin-cli/src/credential/add_nic_lockdown_ikm/args.rs
+++ b/crates/admin-cli/src/credential/add_nic_lockdown_ikm/args.rs
@@ -44,6 +44,7 @@ impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
             password,
             mac_address: None,
             vendor: None,
+            credential_name: None,
         })
     }
 }

--- a/crates/admin-cli/src/credential/add_uefi/args.rs
+++ b/crates/admin-cli/src/credential/add_uefi/args.rs
@@ -54,6 +54,7 @@ impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
             password,
             mac_address: None,
             vendor: None,
+            credential_name: None,
         })
     }
 }

--- a/crates/admin-cli/src/credential/add_ufm/args.rs
+++ b/crates/admin-cli/src/credential/add_ufm/args.rs
@@ -47,6 +47,7 @@ impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
             password: args.token,
             mac_address: None,
             vendor: None,
+            credential_name: None,
         })
     }
 }

--- a/crates/admin-cli/src/credential/bgp/delete_sitewide/args.rs
+++ b/crates/admin-cli/src/credential/bgp/delete_sitewide/args.rs
@@ -27,6 +27,7 @@ impl From<Args> for forgerpc::CredentialDeletionRequest {
             credential_type: CredentialType::BgpSiteWideLeafPassword.into(),
             username: None,
             mac_address: None,
+            credential_name: None,
         }
     }
 }

--- a/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
+++ b/crates/admin-cli/src/credential/bgp/set_sitewide/args.rs
@@ -44,6 +44,7 @@ impl TryFrom<Args> for forgerpc::CredentialCreationRequest {
             password: password_validator(args.password)?,
             mac_address: None,
             vendor: None,
+            credential_name: None,
         })
     }
 }

--- a/crates/admin-cli/src/credential/delete_bmc/args.rs
+++ b/crates/admin-cli/src/credential/delete_bmc/args.rs
@@ -50,6 +50,7 @@ impl From<Args> for forgerpc::CredentialDeletionRequest {
             credential_type: CredentialType::from(args.kind).into(),
             username: None,
             mac_address: args.mac_address.map(|mac| mac.to_string()),
+            credential_name: None,
         }
     }
 }

--- a/crates/admin-cli/src/credential/delete_ufm/args.rs
+++ b/crates/admin-cli/src/credential/delete_ufm/args.rs
@@ -42,6 +42,7 @@ impl TryFrom<Args> for forgerpc::CredentialDeletionRequest {
             credential_type: CredentialType::Ufm.into(),
             username: Some(username),
             mac_address: None,
+            credential_name: None,
         })
     }
 }

--- a/crates/admin-cli/src/credential/firmware_access_token/args.rs
+++ b/crates/admin-cli/src/credential/firmware_access_token/args.rs
@@ -6,6 +6,7 @@
 use std::path::PathBuf;
 
 use clap::Parser;
+use clap::builder::NonEmptyStringValueParser;
 
 #[derive(Parser, Debug, Clone)]
 pub(crate) enum Args {
@@ -27,7 +28,11 @@ Set a token from standard input:
 
 ")]
 pub(crate) struct SetArgs {
-    #[arg(long, help = "Non-secret credential name")]
+    #[arg(
+        long,
+        help = "Non-secret credential name",
+        value_parser = NonEmptyStringValueParser::new()
+    )]
     pub(super) name: String,
 
     #[arg(
@@ -46,6 +51,26 @@ Delete a token:
 
 ")]
 pub(crate) struct DeleteArgs {
-    #[arg(long, help = "Non-secret credential name")]
+    #[arg(
+        long,
+        help = "Non-secret credential name",
+        value_parser = NonEmptyStringValueParser::new()
+    )]
     pub(super) name: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn credential_name_parser_rejects_empty_values() {
+        for (name, valid) in [("repository-a", true), ("", false)] {
+            let set = SetArgs::try_parse_from(["set", "--name", name, "--token-file", "token.txt"]);
+            let delete = DeleteArgs::try_parse_from(["delete", "--name", name]);
+
+            assert_eq!(set.is_ok(), valid, "set command with name {name:?}");
+            assert_eq!(delete.is_ok(), valid, "delete command with name {name:?}");
+        }
+    }
 }

--- a/crates/admin-cli/src/credential/firmware_access_token/args.rs
+++ b/crates/admin-cli/src/credential/firmware_access_token/args.rs
@@ -19,8 +19,11 @@ pub(crate) enum Args {
 #[command(after_long_help = "\
 EXAMPLES:
 
+Set a token from a file:
+    $ nico-admin-cli credential firmware-access-token set --name repository-a --token-file ./firmware-token.txt
+
 Set a token from standard input:
-    $ printf '%s' \"$TOKEN\" | nico-admin-cli credential firmware-access-token set --name repository-a --token-file -
+    $ cat ./firmware-token.txt | nico-admin-cli credential firmware-access-token set --name repository-a --token-file -
 
 ")]
 pub(crate) struct SetArgs {

--- a/crates/admin-cli/src/credential/firmware_access_token/args.rs
+++ b/crates/admin-cli/src/credential/firmware_access_token/args.rs
@@ -1,0 +1,48 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::path::PathBuf;
+
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+pub(crate) enum Args {
+    #[clap(about = "Set or rotate a firmware artifact access token")]
+    Set(SetArgs),
+    #[clap(about = "Delete a firmware artifact access token")]
+    Delete(DeleteArgs),
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Set a token from standard input:
+    $ printf '%s' \"$TOKEN\" | nico-admin-cli credential firmware-access-token set --name repository-a --token-file -
+
+")]
+pub(crate) struct SetArgs {
+    #[arg(long, help = "Non-secret credential name")]
+    pub(super) name: String,
+
+    #[arg(
+        long,
+        help = "File containing the token, or '-' to read standard input"
+    )]
+    pub(super) token_file: PathBuf,
+}
+
+#[derive(Parser, Debug, Clone)]
+#[command(after_long_help = "\
+EXAMPLES:
+
+Delete a token:
+    $ nico-admin-cli credential firmware-access-token delete --name repository-a
+
+")]
+pub(crate) struct DeleteArgs {
+    #[arg(long, help = "Non-secret credential name")]
+    pub(super) name: String,
+}

--- a/crates/admin-cli/src/credential/firmware_access_token/cmd.rs
+++ b/crates/admin-cli/src/credential/firmware_access_token/cmd.rs
@@ -12,11 +12,11 @@ use super::args::{DeleteArgs, SetArgs};
 use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
-fn read_token(args: &SetArgs) -> CarbideCliResult<String> {
+fn read_token(args: &SetArgs, mut stdin: impl Read) -> CarbideCliResult<String> {
     let token = if args.token_file.as_os_str() == "-" {
         let mut token = String::new();
 
-        std::io::stdin().read_to_string(&mut token).wrap_err(
+        stdin.read_to_string(&mut token).wrap_err(
             "while attempting to read the firmware artifact access token from standard input",
         )?;
 
@@ -42,7 +42,7 @@ fn read_token(args: &SetArgs) -> CarbideCliResult<String> {
 }
 
 pub(super) async fn set(args: SetArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
-    let token = read_token(&args)?;
+    let token = read_token(&args, std::io::stdin())?;
     api_client
         .0
         .create_credential(CredentialCreationRequest {
@@ -88,10 +88,31 @@ mod tests {
             token_file: path.clone(),
         };
 
-        let token = read_token(&args).expect("read token");
+        let token = read_token(&args, std::io::empty()).expect("read token");
         fs::remove_file(path).expect("remove token fixture");
 
         assert_eq!(token, " token value \r\n");
+    }
+
+    #[test]
+    fn standard_input_tokens_are_preserved_and_must_not_be_empty() {
+        let args = SetArgs {
+            name: "repository-a".to_string(),
+            token_file: "-".into(),
+        };
+
+        let token = read_token(&args, " standard input token \r\n".as_bytes())
+            .expect("read token from standard input");
+
+        let error =
+            read_token(&args, "".as_bytes()).expect_err("empty standard input token must fail");
+
+        assert_eq!(token, " standard input token \r\n");
+
+        assert_eq!(
+            error.to_string(),
+            "generic error: firmware artifact access token must not be empty"
+        );
     }
 
     #[test]
@@ -108,7 +129,7 @@ mod tests {
             token_file: path.clone(),
         };
 
-        let error = read_token(&args).expect_err("missing token file must fail");
+        let error = read_token(&args, std::io::empty()).expect_err("missing token file must fail");
 
         assert_eq!(
             error.to_string(),

--- a/crates/admin-cli/src/credential/firmware_access_token/cmd.rs
+++ b/crates/admin-cli/src/credential/firmware_access_token/cmd.rs
@@ -1,0 +1,130 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+use std::io::Read;
+
+use eyre::WrapErr;
+use rpc::forge::{CredentialCreationRequest, CredentialDeletionRequest, CredentialType};
+
+use super::args::{DeleteArgs, SetArgs};
+use crate::errors::{CarbideCliError, CarbideCliResult};
+use crate::rpc::ApiClient;
+
+fn read_token(args: &SetArgs) -> CarbideCliResult<String> {
+    let token = if args.token_file.as_os_str() == "-" {
+        let mut token = String::new();
+        std::io::stdin()
+            .read_to_string(&mut token)
+            .wrap_err("failed to read firmware artifact access token from standard input")?;
+
+        token
+    } else {
+        std::fs::read_to_string(&args.token_file).wrap_err_with(|| {
+            format!(
+                "failed to read firmware artifact access token from {}",
+                args.token_file.display()
+            )
+        })?
+    };
+
+    // Artifact tokens are opaque. Preserve valid UTF-8 content exactly as supplied,
+    // including whitespace and line endings.
+    if token.is_empty() {
+        return Err(CarbideCliError::GenericError(
+            "firmware artifact access token must not be empty".to_string(),
+        ));
+    }
+
+    Ok(token)
+}
+
+pub(super) async fn set(args: SetArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
+    let token = read_token(&args)?;
+    api_client
+        .0
+        .create_credential(CredentialCreationRequest {
+            credential_type: CredentialType::FirmwareArtifactAccessToken.into(),
+            username: None,
+            password: token,
+            vendor: None,
+            mac_address: None,
+            credential_name: Some(args.name),
+        })
+        .await?;
+
+    Ok(())
+}
+
+pub(super) async fn delete(args: DeleteArgs, api_client: &ApiClient) -> CarbideCliResult<()> {
+    api_client
+        .0
+        .delete_credential(CredentialDeletionRequest {
+            credential_type: CredentialType::FirmwareArtifactAccessToken.into(),
+            username: None,
+            mac_address: None,
+            credential_name: Some(args.name),
+        })
+        .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use super::*;
+
+    #[test]
+    fn token_file_contents_are_preserved() {
+        let path = std::env::temp_dir().join(format!("nico-firmware-token-{}", std::process::id()));
+        fs::write(&path, " token value \r\n").expect("write token fixture");
+
+        let args = SetArgs {
+            name: "repository-a".to_string(),
+            token_file: path.clone(),
+        };
+
+        let token = read_token(&args).expect("read token");
+        fs::remove_file(path).expect("remove token fixture");
+
+        assert_eq!(token, " token value \r\n");
+    }
+
+    #[test]
+    fn token_file_error_identifies_the_requested_path() {
+        let path = std::env::temp_dir()
+            .join(format!(
+                "nico-firmware-token-missing-{}",
+                std::process::id()
+            ))
+            .join("token");
+
+        let args = SetArgs {
+            name: "repository-a".to_string(),
+            token_file: path.clone(),
+        };
+
+        let error = read_token(&args).expect_err("missing token file must fail");
+
+        assert_eq!(
+            error.to_string(),
+            format!(
+                "failed to read firmware artifact access token from {}",
+                path.display()
+            )
+        );
+
+        let CarbideCliError::EyreReport(report) = error else {
+            panic!("expected an EyreReport");
+        };
+
+        let io_error = report
+            .downcast_ref::<std::io::Error>()
+            .expect("I/O source should remain in the error chain");
+
+        assert_eq!(io_error.kind(), std::io::ErrorKind::NotFound);
+    }
+}

--- a/crates/admin-cli/src/credential/firmware_access_token/cmd.rs
+++ b/crates/admin-cli/src/credential/firmware_access_token/cmd.rs
@@ -15,15 +15,16 @@ use crate::rpc::ApiClient;
 fn read_token(args: &SetArgs) -> CarbideCliResult<String> {
     let token = if args.token_file.as_os_str() == "-" {
         let mut token = String::new();
-        std::io::stdin()
-            .read_to_string(&mut token)
-            .wrap_err("failed to read firmware artifact access token from standard input")?;
+
+        std::io::stdin().read_to_string(&mut token).wrap_err(
+            "while attempting to read the firmware artifact access token from standard input",
+        )?;
 
         token
     } else {
         std::fs::read_to_string(&args.token_file).wrap_err_with(|| {
             format!(
-                "failed to read firmware artifact access token from {}",
+                "while attempting to read the firmware artifact access token from {}",
                 args.token_file.display()
             )
         })?
@@ -112,7 +113,7 @@ mod tests {
         assert_eq!(
             error.to_string(),
             format!(
-                "failed to read firmware artifact access token from {}",
+                "while attempting to read the firmware artifact access token from {}",
                 path.display()
             )
         );

--- a/crates/admin-cli/src/credential/firmware_access_token/mod.rs
+++ b/crates/admin-cli/src/credential/firmware_access_token/mod.rs
@@ -1,0 +1,22 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+mod args;
+mod cmd;
+
+pub(super) use args::Args;
+
+use crate::cfg::run::Run;
+use crate::cfg::runtime::RuntimeContext;
+use crate::errors::CarbideCliResult;
+
+impl Run for Args {
+    async fn run(self, ctx: &mut RuntimeContext) -> CarbideCliResult<()> {
+        match self {
+            Self::Set(args) => cmd::set(args, &ctx.api_client).await,
+            Self::Delete(args) => cmd::delete(args, &ctx.api_client).await,
+        }
+    }
+}

--- a/crates/admin-cli/src/credential/generate_ufm_cert/args.rs
+++ b/crates/admin-cli/src/credential/generate_ufm_cert/args.rs
@@ -44,6 +44,7 @@ impl From<Args> for forgerpc::CredentialCreationRequest {
             password: "".to_string(),
             mac_address: None,
             vendor: Some(args.fabric),
+            credential_name: None,
         }
     }
 }

--- a/crates/admin-cli/src/credential/mod.rs
+++ b/crates/admin-cli/src/credential/mod.rs
@@ -27,6 +27,7 @@ mod common;
 mod delete_bmc;
 mod delete_nmxm;
 mod delete_ufm;
+mod firmware_access_token;
 mod force_bmc;
 mod force_uefi;
 mod generate_ufm_cert;
@@ -75,6 +76,8 @@ pub(crate) enum Cmd {
     Bgp(bgp::Cmd),
     #[clap(about = "Manage container registry credentials", subcommand)]
     Registry(registry::Args),
+    #[clap(about = "Manage firmware artifact access tokens", subcommand)]
+    FirmwareAccessToken(firmware_access_token::Args),
     #[clap(about = "Stage a site-wide credential rotation (auto-generate or explicit password)")]
     Rotate(rotate::Args),
     #[clap(about = "Show convergence status of a site-wide credential rotation")]

--- a/crates/api-core/src/handlers/credential.rs
+++ b/crates/api-core/src/handlers/credential.rs
@@ -48,6 +48,8 @@ const DEFAULT_FORGE_ADMIN_BMC_USERNAME: &str = "root";
 /// by FRR on the DPU.  NVUE will silently accept seemingly any length,
 /// but FRR reloads fail above this length.
 pub(crate) const MAX_BGP_PASSWORD_LENGTH: usize = 80;
+const MISSING_FIRMWARE_ARTIFACT_CREDENTIAL_NAME: &str =
+    "firmware artifact access token credential name is required";
 
 pub(crate) async fn create_credential(
     api: &Api,
@@ -315,6 +317,35 @@ pub(crate) async fn create_credential(
                     CarbideError::internal(format!("error setting BGP credential: {e:?}"))
                 })?;
         }
+        rpc::CredentialType::FirmwareArtifactAccessToken => {
+            let name = req
+                .credential_name
+                .filter(|name| !name.is_empty())
+                .ok_or_else(|| {
+                    CarbideError::InvalidArgument(MISSING_FIRMWARE_ARTIFACT_CREDENTIAL_NAME.into())
+                })?;
+
+            if password.is_empty() {
+                return Err(CarbideError::InvalidArgument(
+                    "firmware artifact access token must not be empty".to_string(),
+                )
+                .into());
+            }
+
+            let key = CredentialKey::FirmwareArtifactAccessToken { name };
+
+            // Artifact tokens are opaque, while the credential store uses a
+            // username/password record. The empty username has no authentication
+            // meaning, and set_credentials replaces a token with the same name.
+            api.credential_manager
+                .set_credentials(&key, &Credentials::new("", password))
+                .await
+                .map_err(|error| {
+                    CarbideError::internal(format!(
+                        "error setting firmware artifact access token credential: {error:?}"
+                    ))
+                })?;
+        }
     };
 
     Ok(Response::new(rpc::CredentialCreationResult {}))
@@ -398,6 +429,23 @@ pub(crate) async fn delete_credential(
                 .await
                 .map_err(|e| {
                     CarbideError::internal(format!("error deleting BGP credential: {e:?}"))
+                })?;
+        }
+        rpc::CredentialType::FirmwareArtifactAccessToken => {
+            let name = req
+                .credential_name
+                .filter(|name| !name.is_empty())
+                .ok_or_else(|| {
+                    CarbideError::InvalidArgument(MISSING_FIRMWARE_ARTIFACT_CREDENTIAL_NAME.into())
+                })?;
+
+            api.credential_manager
+                .delete_credentials(&CredentialKey::FirmwareArtifactAccessToken { name })
+                .await
+                .map_err(|error| {
+                    CarbideError::internal(format!(
+                        "error deleting firmware artifact access token credential: {error:?}"
+                    ))
                 })?;
         }
     };

--- a/crates/api-core/tests/integration/credential_management.rs
+++ b/crates/api-core/tests/integration/credential_management.rs
@@ -83,6 +83,7 @@ fn ufm_create_request() -> CredentialCreationRequest {
         password: "test-ufm-token".to_string(),
         vendor: None,
         mac_address: None,
+        credential_name: None,
     }
 }
 
@@ -91,7 +92,92 @@ fn ufm_delete_request() -> CredentialDeletionRequest {
         credential_type: RpcCredentialType::Ufm.into(),
         username: Some("https://ufm.example.com".to_string()),
         mac_address: None,
+        credential_name: None,
     }
+}
+
+fn firmware_artifact_token_create_request(name: &str, token: &str) -> CredentialCreationRequest {
+    CredentialCreationRequest {
+        credential_type: RpcCredentialType::FirmwareArtifactAccessToken.into(),
+        username: None,
+        password: token.to_string(),
+        vendor: None,
+        mac_address: None,
+        credential_name: Some(name.to_string()),
+    }
+}
+
+#[sqlx_test]
+async fn firmware_artifact_access_token_can_be_replaced_and_deleted(pool: PgPool) {
+    let (env, credential_manager) = init(pool).await;
+    let name = "repository-a".to_string();
+    let key = CredentialKey::FirmwareArtifactAccessToken { name: name.clone() };
+
+    for token in ["first-token", " rotated-token \r\n"] {
+        env.api()
+            .create_credential(tonic::Request::new(firmware_artifact_token_create_request(
+                &name, token,
+            )))
+            .await
+            .expect("set firmware artifact access token");
+    }
+
+    assert_eq!(
+        credential_manager
+            .get_credentials_from_writer(&key)
+            .await
+            .expect("read stored token"),
+        Some(Credentials::new("", " rotated-token \r\n"))
+    );
+
+    env.api()
+        .delete_credential(tonic::Request::new(CredentialDeletionRequest {
+            credential_type: RpcCredentialType::FirmwareArtifactAccessToken.into(),
+            username: None,
+            mac_address: None,
+            credential_name: Some(name.to_string()),
+        }))
+        .await
+        .expect("delete firmware artifact access token");
+
+    assert_eq!(
+        credential_manager
+            .get_credentials_from_writer(&key)
+            .await
+            .expect("read deleted token"),
+        None
+    );
+}
+
+#[sqlx_test]
+async fn firmware_artifact_access_token_rejects_missing_name_or_token(pool: PgPool) {
+    let (env, _) = init(pool).await;
+
+    for request in [
+        firmware_artifact_token_create_request("", "token"),
+        firmware_artifact_token_create_request("repository-a", ""),
+    ] {
+        let error = env
+            .api()
+            .create_credential(tonic::Request::new(request))
+            .await
+            .expect_err("invalid firmware artifact credential input must fail");
+
+        assert_eq!(error.code(), Code::InvalidArgument);
+    }
+
+    let error = env
+        .api()
+        .delete_credential(tonic::Request::new(CredentialDeletionRequest {
+            credential_type: RpcCredentialType::FirmwareArtifactAccessToken.into(),
+            username: None,
+            mac_address: None,
+            credential_name: None,
+        }))
+        .await
+        .expect_err("missing firmware artifact credential name must fail");
+
+    assert_eq!(error.code(), Code::InvalidArgument);
 }
 
 #[sqlx_test]
@@ -202,6 +288,7 @@ async fn test_create_host_uefi_credential_when_missing(pool: PgPool) {
             password: "test-host-uefi-password".to_string(),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     assert!(response.is_ok());
@@ -229,6 +316,7 @@ async fn test_create_host_uefi_credential_when_missing(pool: PgPool) {
             password: "another-password".to_string(),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     assert!(second.is_err());
@@ -247,6 +335,7 @@ async fn test_create_dpu_uefi_credential_when_missing(pool: PgPool) {
             password: "test-dpu-uefi-password".to_string(),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     assert!(response.is_ok());
@@ -274,6 +363,7 @@ async fn test_create_dpu_uefi_credential_when_missing(pool: PgPool) {
             password: "another-password".to_string(),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     assert!(second.is_err());
@@ -293,6 +383,7 @@ async fn test_create_and_delete_bgp_credential(pool: PgPool) {
             password: "test-dpu-bgp-password".to_string(),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     assert!(response.is_ok());
@@ -319,6 +410,7 @@ async fn test_create_and_delete_bgp_credential(pool: PgPool) {
             credential_type: RpcCredentialType::BgpSiteWideLeafPassword.into(),
             username: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     assert!(delete_response.is_ok());
@@ -368,6 +460,7 @@ async fn test_create_bgp_credential_validates_max_password_length(pool: PgPool) 
             password: max_password.clone(),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     assert!(ok_response.is_ok());
@@ -396,6 +489,7 @@ async fn test_create_bgp_credential_validates_max_password_length(pool: PgPool) 
             password: "a".repeat(MAX_BGP_PASSWORD_LENGTH + 1),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await;
     let err = response.expect_err("passwords longer than the max should be rejected");

--- a/crates/api-core/tests/integration/credential_management.rs
+++ b/crates/api-core/tests/integration/credential_management.rs
@@ -153,7 +153,11 @@ async fn firmware_artifact_access_token_can_be_replaced_and_deleted(pool: PgPool
 async fn firmware_artifact_access_token_rejects_missing_name_or_token(pool: PgPool) {
     let (env, _) = init(pool).await;
 
+    let mut missing_name = firmware_artifact_token_create_request("repository-a", "token");
+    missing_name.credential_name = None;
+
     for request in [
+        missing_name,
         firmware_artifact_token_create_request("", "token"),
         firmware_artifact_token_create_request("repository-a", ""),
     ] {
@@ -166,18 +170,20 @@ async fn firmware_artifact_access_token_rejects_missing_name_or_token(pool: PgPo
         assert_eq!(error.code(), Code::InvalidArgument);
     }
 
-    let error = env
-        .api()
-        .delete_credential(tonic::Request::new(CredentialDeletionRequest {
-            credential_type: RpcCredentialType::FirmwareArtifactAccessToken.into(),
-            username: None,
-            mac_address: None,
-            credential_name: None,
-        }))
-        .await
-        .expect_err("missing firmware artifact credential name must fail");
+    for credential_name in [None, Some(String::new())] {
+        let error = env
+            .api()
+            .delete_credential(tonic::Request::new(CredentialDeletionRequest {
+                credential_type: RpcCredentialType::FirmwareArtifactAccessToken.into(),
+                username: None,
+                mac_address: None,
+                credential_name,
+            }))
+            .await
+            .expect_err("invalid firmware artifact credential name must fail");
 
-    assert_eq!(error.code(), Code::InvalidArgument);
+        assert_eq!(error.code(), Code::InvalidArgument);
+    }
 }
 
 #[sqlx_test]

--- a/crates/api-web/src/explored_endpoint.rs
+++ b/crates/api-web/src/explored_endpoint.rs
@@ -972,6 +972,7 @@ pub(super) async fn clear_bmc_credentials(
             credential_type: rpc::CredentialType::RootBmcByMacAddress.into(),
             username: None,
             mac_address: Some(mac_address),
+            credential_name: None,
         }))
         .await
         .map(|response| response.into_inner())

--- a/crates/api-web/src/tests/explored_endpoint.rs
+++ b/crates/api-web/src/tests/explored_endpoint.rs
@@ -82,6 +82,7 @@ async fn configure_default(env: &TestEnv, credential_type: RpcCredentialType) {
             password: "configured-password".to_string(),
             vendor: None,
             mac_address: None,
+            credential_name: None,
         }))
         .await
         .unwrap();

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1441,6 +1441,8 @@ enum CredentialType {
   NmxM = 10;
   BgpSiteWideLeafPassword = 11;
   SiteWideNicLockdownIkm = 12;
+  // Named credential used to authorize firmware artifact downloads.
+  FirmwareArtifactAccessToken = 13;
 }
 
 message CredentialCreationRequest {
@@ -1452,16 +1454,27 @@ message CredentialCreationRequest {
   optional string username = 2;
   // The password of credential for HostBMC, DPUBMC, DpuUefi.
   // For UFM, the password is the token of UFM.
+  // For FirmwareArtifactAccessToken, the password is the non-empty artifact
+  // access token. Its contents are stored verbatim, including whitespace and
+  // line endings.
   string password = 3;
   // For the BMC factory default credential: "dell", "lenovo", "hpe", "supermicro", etc
   optional string vendor = 4;
   optional string mac_address = 5;
+  // Required and non-empty for FirmwareArtifactAccessToken. This is an opaque,
+  // non-secret lookup name. Setting the same name replaces the stored token;
+  // username, vendor, and mac_address are ignored for this credential type.
+  optional string credential_name = 6;
 }
 
 message CredentialDeletionRequest {
   CredentialType credential_type = 1;
   optional string username = 2;
   optional string mac_address = 3;
+  // Required and non-empty for FirmwareArtifactAccessToken. This opaque,
+  // non-secret lookup name selects the token to delete; username and
+  // mac_address are ignored for this credential type.
+  optional string credential_name = 4;
 }
 
 message CredentialCreationResult {

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1461,7 +1461,8 @@ message CredentialCreationRequest {
   // For the BMC factory default credential: "dell", "lenovo", "hpe", "supermicro", etc
   optional string vendor = 4;
   optional string mac_address = 5;
-  // Required and non-empty for FirmwareArtifactAccessToken. This is an opaque,
+  // Required and non-empty for FirmwareArtifactAccessToken. The server returns
+  // InvalidArgument when this field is omitted or empty. This is an opaque,
   // non-secret lookup name. Setting the same name replaces the stored token;
   // username, vendor, and mac_address are ignored for this credential type.
   optional string credential_name = 6;
@@ -1471,7 +1472,8 @@ message CredentialDeletionRequest {
   CredentialType credential_type = 1;
   optional string username = 2;
   optional string mac_address = 3;
-  // Required and non-empty for FirmwareArtifactAccessToken. This opaque,
+  // Required and non-empty for FirmwareArtifactAccessToken. The server returns
+  // InvalidArgument when this field is omitted or empty. This opaque,
   // non-secret lookup name selects the token to delete; username and
   // mac_address are ignored for this credential type.
   optional string credential_name = 4;

--- a/crates/secrets/src/credentials.rs
+++ b/crates/secrets/src/credentials.rs
@@ -19,6 +19,7 @@ use std::borrow::Cow;
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use base64::Engine;
 use carbide_uuid::machine::MachineId;
 use carbide_uuid::rack::RackId;
 use mac_address::MacAddress;
@@ -544,6 +545,16 @@ pub enum CredentialKey {
     RackMaintenanceAccessToken {
         rack_id: RackId,
     },
+
+    /// Firmware artifact access token addressed by a non-secret, operator-defined name.
+    ///
+    /// [`CredentialKey::to_key_str`] encodes the name as one path segment, preserving
+    /// its UTF-8 bytes without giving separators or traversal segments path semantics.
+    FirmwareArtifactAccessToken {
+        /// Opaque lookup name supplied through the credential API.
+        name: String,
+    },
+
     ContainerRegistry {
         registry: String,
     },
@@ -589,6 +600,10 @@ pub enum CredentialPrefix {
     MqttAuth,
     MachineIdentityEncryptionKey,
     RackMaintenanceAccessToken,
+
+    /// Prefix used to list all named firmware artifact access tokens.
+    FirmwareArtifactAccessToken,
+
     ContainerRegistry,
 }
 
@@ -613,6 +628,7 @@ impl CredentialPrefix {
             Self::MqttAuth => "mqtt/",
             Self::MachineIdentityEncryptionKey => "machine_identity/",
             Self::RackMaintenanceAccessToken => "racks/",
+            Self::FirmwareArtifactAccessToken => "firmware_artifacts/",
             Self::ContainerRegistry => "container_registries/",
         }
     }
@@ -636,6 +652,7 @@ impl CredentialPrefix {
             Self::MqttAuth,
             Self::MachineIdentityEncryptionKey,
             Self::RackMaintenanceAccessToken,
+            Self::FirmwareArtifactAccessToken,
             Self::ContainerRegistry,
         ]
     }
@@ -714,6 +731,9 @@ impl CredentialKey {
                 CredentialPrefix::MachineIdentityEncryptionKey
             }
             Self::RackMaintenanceAccessToken { .. } => CredentialPrefix::RackMaintenanceAccessToken,
+            Self::FirmwareArtifactAccessToken { .. } => {
+                CredentialPrefix::FirmwareArtifactAccessToken
+            }
             Self::ContainerRegistry { .. } => CredentialPrefix::ContainerRegistry,
         }
     }
@@ -835,6 +855,12 @@ impl CredentialKey {
             CredentialKey::RackMaintenanceAccessToken { rack_id } => {
                 Cow::from(format!("racks/{rack_id}/maintenance/access-token"))
             }
+            CredentialKey::FirmwareArtifactAccessToken { name } => {
+                let encoded_name =
+                    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(name.as_bytes());
+
+                Cow::from(format!("firmware_artifacts/{encoded_name}/access-token"))
+            }
             CredentialKey::ContainerRegistry { registry } => {
                 Cow::from(format!("container_registries/{registry}/auth"))
             }
@@ -874,6 +900,17 @@ mod tests {
         assert!(password.chars().any(|c| c.is_lowercase()));
         assert!(password.chars().any(|c| c.is_ascii_digit()));
         assert!(password.chars().all(|c| c.is_ascii_alphanumeric()));
+    }
+
+    #[test]
+    fn firmware_artifact_credential_name_is_encoded_in_store_path() {
+        assert_eq!(
+            CredentialKey::FirmwareArtifactAccessToken {
+                name: "../repo/name".to_string(),
+            }
+            .to_key_str(),
+            "firmware_artifacts/Li4vcmVwby9uYW1l/access-token"
+        );
     }
 
     #[test]
@@ -1439,6 +1476,16 @@ mod tests {
                     expect: PathChecks::all_hold(),
                 },
                 Check {
+                    scenario: "firmware artifact access token",
+                    input: Row {
+                        key: CredentialKey::FirmwareArtifactAccessToken {
+                            name: "repository-a".to_string(),
+                        },
+                        expected_prefix: "firmware_artifacts/",
+                    },
+                    expect: PathChecks::all_hold(),
+                },
+                Check {
                     scenario: "rack maintenance access token",
                     input: Row {
                         key: CredentialKey::RackMaintenanceAccessToken { rack_id },
@@ -1531,6 +1578,9 @@ mod tests {
                 key_id: "k".to_string(),
             },
             CredentialKey::RackMaintenanceAccessToken { rack_id },
+            CredentialKey::FirmwareArtifactAccessToken {
+                name: "repository-a".to_string(),
+            },
             CredentialKey::ContainerRegistry {
                 registry: "nvcr.io".to_string(),
             },
@@ -1553,6 +1603,7 @@ mod tests {
     #[test]
     fn prefix_all_is_complete() {
         let all = CredentialPrefix::all();
-        assert_eq!(all.len(), 17);
+
+        assert_eq!(all.len(), 18);
     }
 }

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token-delete.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token-delete.md
@@ -1,0 +1,53 @@
+# `nico-admin-cli credential firmware-access-token delete`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › [firmware-access-token](./credential-firmware-access-token.md) › **delete**_
+
+## NAME
+
+nico-admin-cli-credential-firmware-access-token-delete - Delete a
+firmware artifact access token
+
+## SYNOPSIS
+
+**nico-admin-cli credential firmware-access-token delete**
+\<**--name**\> \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Delete a firmware artifact access token
+
+## OPTIONS
+
+**--name** *\<NAME\>*  
+Non-secret credential name
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+nico-admin-cli credential firmware-access-token delete --name repository-a
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token-set.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token-set.md
@@ -1,0 +1,56 @@
+# `nico-admin-cli credential firmware-access-token set`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › [firmware-access-token](./credential-firmware-access-token.md) › **set**_
+
+## NAME
+
+nico-admin-cli-credential-firmware-access-token-set - Set or rotate a
+firmware artifact access token
+
+## SYNOPSIS
+
+**nico-admin-cli credential firmware-access-token set** \<**--name**\>
+\<**--token-file**\> \[**--extended**\] \[**--sort-by**\]
+\[**-h**\|**--help**\]
+
+## DESCRIPTION
+
+Set or rotate a firmware artifact access token
+
+## OPTIONS
+
+**--name** *\<NAME\>*  
+Non-secret credential name
+
+**--token-file** *\<TOKEN_FILE\>*  
+File containing the token, or - to read standard input
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Examples
+
+```sh
+printf '%s' "$TOKEN" | nico-admin-cli credential firmware-access-token set --name repository-a --token-file -
+```
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token-set.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token-set.md
@@ -48,7 +48,8 @@ Print help (see a summary with -h)
 ## Examples
 
 ```sh
-printf '%s' "$TOKEN" | nico-admin-cli credential firmware-access-token set --name repository-a --token-file -
+nico-admin-cli credential firmware-access-token set --name repository-a --token-file ./firmware-token.txt
+cat ./firmware-token.txt | nico-admin-cli credential firmware-access-token set --name repository-a --token-file -
 ```
 
 ---

--- a/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential-firmware-access-token.md
@@ -1,0 +1,50 @@
+# `nico-admin-cli credential firmware-access-token`
+
+_[Hardware commands](../../hardware.md) › [credential](./credential.md) › **firmware-access-token**_
+
+## NAME
+
+nico-admin-cli-credential-firmware-access-token - Manage firmware
+artifact access tokens
+
+## SYNOPSIS
+
+**nico-admin-cli credential firmware-access-token** \[**--extended**\]
+\[**--sort-by**\] \[**-h**\|**--help**\] \<*subcommands*\>
+
+## DESCRIPTION
+
+Manage firmware artifact access tokens
+
+## OPTIONS
+
+**--extended**  
+Extended result output.
+
+This used by measured boot, where basic output contains just what you
+probably care about, and "extended" output also dumps out all the
+internal UUIDs that are used to associate instances.
+
+**--sort-by** *\<SORT_BY\>* \[default: primary-id\]  
+Sort output by specified field\
+
+\
+*Possible values:*
+
+- primary-id: Sort by the primary ID
+
+- state: Sort by state
+
+**-h**, **--help**  
+Print help (see a summary with -h)
+
+## Subcommands
+
+| Subcommand | Description |
+|---|---|
+| [`set`](./credential-firmware-access-token-set.md) | Set or rotate a firmware artifact access token |
+| [`delete`](./credential-firmware-access-token-delete.md) | Delete a firmware artifact access token |
+
+---
+
+**See also:** [Hardware commands](../../hardware.md) · [CLI reference index](../../README.md)

--- a/docs/manuals/nico-admin-cli/commands/credential/credential.md
+++ b/docs/manuals/nico-admin-cli/commands/credential/credential.md
@@ -54,6 +54,7 @@ Print help (see a summary with -h)
 | [`delete-nmx-m`](./credential-delete-nmx-m.md) | Deprecated compatibility command; NMX-M is no longer supported |
 | [`bgp`](./credential-bgp.md) | Manage leaf BGP passwords |
 | [`registry`](./credential-registry.md) | Manage container registry credentials |
+| [`firmware-access-token`](./credential-firmware-access-token.md) | Manage firmware artifact access tokens |
 | [`rotate`](./credential-rotate.md) | Stage a site-wide credential rotation (auto-generate or explicit password) |
 | [`rotation-status`](./credential-rotation-status.md) | Show convergence status of a site-wide credential rotation |
 | [`force-bmc`](./credential-force-bmc.md) | Force-converge a single BMC's credentials now (operator escape hatch) |

--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -262,6 +262,12 @@ spec:
               path "{{ .Values.vault.kvMount }}/data/bgp/*" {
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
+              path "{{ .Values.vault.kvMount }}/data/firmware_artifacts/+/access-token" {
+                capabilities = ["create", "read", "update"]
+              }
+              path "{{ .Values.vault.kvMount }}/metadata/firmware_artifacts/+/access-token" {
+                capabilities = ["delete"]
+              }
               path "{{ .Values.vault.kvMount }}/data/switch_nvos/*" {
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -252,6 +252,8 @@ const (
 	CredentialType_NmxM                      CredentialType = 10
 	CredentialType_BgpSiteWideLeafPassword   CredentialType = 11
 	CredentialType_SiteWideNicLockdownIkm    CredentialType = 12
+	// Named credential used to authorize firmware artifact downloads.
+	CredentialType_FirmwareArtifactAccessToken CredentialType = 13
 )
 
 // Enum value maps for CredentialType.
@@ -270,21 +272,23 @@ var (
 		10: "NmxM",
 		11: "BgpSiteWideLeafPassword",
 		12: "SiteWideNicLockdownIkm",
+		13: "FirmwareArtifactAccessToken",
 	}
 	CredentialType_value = map[string]int32{
-		"HostBMC":                   0,
-		"DPUBMC":                    1,
-		"UFM":                       2,
-		"DpuUefi":                   3,
-		"HostUefi":                  4,
-		"HostBMCFactoryDefault":     5,
-		"DpuBMCFactoryDefault":      6,
-		"SiteWideBmcRoot":           7,
-		"RootBmcByMacAddress":       8,
-		"BmcForgeAdminByMacAddress": 9,
-		"NmxM":                      10,
-		"BgpSiteWideLeafPassword":   11,
-		"SiteWideNicLockdownIkm":    12,
+		"HostBMC":                     0,
+		"DPUBMC":                      1,
+		"UFM":                         2,
+		"DpuUefi":                     3,
+		"HostUefi":                    4,
+		"HostBMCFactoryDefault":       5,
+		"DpuBMCFactoryDefault":        6,
+		"SiteWideBmcRoot":             7,
+		"RootBmcByMacAddress":         8,
+		"BmcForgeAdminByMacAddress":   9,
+		"NmxM":                        10,
+		"BgpSiteWideLeafPassword":     11,
+		"SiteWideNicLockdownIkm":      12,
+		"FirmwareArtifactAccessToken": 13,
 	}
 )
 
@@ -8415,12 +8419,19 @@ type CredentialCreationRequest struct {
 	Username *string `protobuf:"bytes,2,opt,name=username,proto3,oneof" json:"username,omitempty"`
 	// The password of credential for HostBMC, DPUBMC, DpuUefi.
 	// For UFM, the password is the token of UFM.
+	// For FirmwareArtifactAccessToken, the password is the non-empty artifact
+	// access token. Its contents are stored verbatim, including whitespace and
+	// line endings.
 	Password string `protobuf:"bytes,3,opt,name=password,proto3" json:"password,omitempty"`
 	// For the BMC factory default credential: "dell", "lenovo", "hpe", "supermicro", etc
-	Vendor        *string `protobuf:"bytes,4,opt,name=vendor,proto3,oneof" json:"vendor,omitempty"`
-	MacAddress    *string `protobuf:"bytes,5,opt,name=mac_address,json=macAddress,proto3,oneof" json:"mac_address,omitempty"`
-	unknownFields protoimpl.UnknownFields
-	sizeCache     protoimpl.SizeCache
+	Vendor     *string `protobuf:"bytes,4,opt,name=vendor,proto3,oneof" json:"vendor,omitempty"`
+	MacAddress *string `protobuf:"bytes,5,opt,name=mac_address,json=macAddress,proto3,oneof" json:"mac_address,omitempty"`
+	// Required and non-empty for FirmwareArtifactAccessToken. This is an opaque,
+	// non-secret lookup name. Setting the same name replaces the stored token;
+	// username, vendor, and mac_address are ignored for this credential type.
+	CredentialName *string `protobuf:"bytes,6,opt,name=credential_name,json=credentialName,proto3,oneof" json:"credential_name,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
 }
 
 func (x *CredentialCreationRequest) Reset() {
@@ -8488,11 +8499,22 @@ func (x *CredentialCreationRequest) GetMacAddress() string {
 	return ""
 }
 
+func (x *CredentialCreationRequest) GetCredentialName() string {
+	if x != nil && x.CredentialName != nil {
+		return *x.CredentialName
+	}
+	return ""
+}
+
 type CredentialDeletionRequest struct {
 	state          protoimpl.MessageState `protogen:"open.v1"`
 	CredentialType CredentialType         `protobuf:"varint,1,opt,name=credential_type,json=credentialType,proto3,enum=forge.CredentialType" json:"credential_type,omitempty"`
 	Username       *string                `protobuf:"bytes,2,opt,name=username,proto3,oneof" json:"username,omitempty"`
 	MacAddress     *string                `protobuf:"bytes,3,opt,name=mac_address,json=macAddress,proto3,oneof" json:"mac_address,omitempty"`
+	// Required and non-empty for FirmwareArtifactAccessToken. This opaque,
+	// non-secret lookup name selects the token to delete; username and
+	// mac_address are ignored for this credential type.
+	CredentialName *string `protobuf:"bytes,4,opt,name=credential_name,json=credentialName,proto3,oneof" json:"credential_name,omitempty"`
 	unknownFields  protoimpl.UnknownFields
 	sizeCache      protoimpl.SizeCache
 }
@@ -8544,6 +8566,13 @@ func (x *CredentialDeletionRequest) GetUsername() string {
 func (x *CredentialDeletionRequest) GetMacAddress() string {
 	if x != nil && x.MacAddress != nil {
 		return *x.MacAddress
+	}
+	return ""
+}
+
+func (x *CredentialDeletionRequest) GetCredentialName() string {
+	if x != nil && x.CredentialName != nil {
+		return *x.CredentialName
 	}
 	return ""
 }
@@ -65978,24 +66007,28 @@ const file_nico_nico_proto_rawDesc = "" +
 	"_event_log\"{\n" +
 	"\x13AttestQuoteResponse\x12\x18\n" +
 	"\asuccess\x18\x01 \x01(\bR\asuccess\x12J\n" +
-	"\x13machine_certificate\x18\x02 \x01(\v2\x19.forge.MachineCertificateR\x12machineCertificate\"\x83\x02\n" +
+	"\x13machine_certificate\x18\x02 \x01(\v2\x19.forge.MachineCertificateR\x12machineCertificate\"\xc5\x02\n" +
 	"\x19CredentialCreationRequest\x12>\n" +
 	"\x0fcredential_type\x18\x01 \x01(\x0e2\x15.forge.CredentialTypeR\x0ecredentialType\x12\x1f\n" +
 	"\busername\x18\x02 \x01(\tH\x00R\busername\x88\x01\x01\x12\x1a\n" +
 	"\bpassword\x18\x03 \x01(\tR\bpassword\x12\x1b\n" +
 	"\x06vendor\x18\x04 \x01(\tH\x01R\x06vendor\x88\x01\x01\x12$\n" +
 	"\vmac_address\x18\x05 \x01(\tH\x02R\n" +
-	"macAddress\x88\x01\x01B\v\n" +
+	"macAddress\x88\x01\x01\x12,\n" +
+	"\x0fcredential_name\x18\x06 \x01(\tH\x03R\x0ecredentialName\x88\x01\x01B\v\n" +
 	"\t_usernameB\t\n" +
 	"\a_vendorB\x0e\n" +
-	"\f_mac_address\"\xbf\x01\n" +
+	"\f_mac_addressB\x12\n" +
+	"\x10_credential_name\"\x81\x02\n" +
 	"\x19CredentialDeletionRequest\x12>\n" +
 	"\x0fcredential_type\x18\x01 \x01(\x0e2\x15.forge.CredentialTypeR\x0ecredentialType\x12\x1f\n" +
 	"\busername\x18\x02 \x01(\tH\x00R\busername\x88\x01\x01\x12$\n" +
 	"\vmac_address\x18\x03 \x01(\tH\x01R\n" +
-	"macAddress\x88\x01\x01B\v\n" +
+	"macAddress\x88\x01\x01\x12,\n" +
+	"\x0fcredential_name\x18\x04 \x01(\tH\x02R\x0ecredentialName\x88\x01\x01B\v\n" +
 	"\t_usernameB\x0e\n" +
-	"\f_mac_address\"\x1a\n" +
+	"\f_mac_addressB\x12\n" +
+	"\x10_credential_name\"\x1a\n" +
 	"\x18CredentialCreationResult\"\x1a\n" +
 	"\x18CredentialDeletionResult\"\xb7\x01\n" +
 	"\x17RotateCredentialRequest\x12F\n" +
@@ -71156,7 +71189,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\rNotDiscovered\x10\x00\x12\x17\n" +
 	"\x13WaitingForIngestion\x10\x01\x12\x1e\n" +
 	"\x1aIngestionMachineNotCreated\x10\x02\x12\x1b\n" +
-	"\x17IngestionMachineCreated\x10\x03*\x92\x02\n" +
+	"\x17IngestionMachineCreated\x10\x03*\xb3\x02\n" +
 	"\x0eCredentialType\x12\v\n" +
 	"\aHostBMC\x10\x00\x12\n" +
 	"\n" +
@@ -71172,7 +71205,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x04NmxM\x10\n" +
 	"\x12\x1b\n" +
 	"\x17BgpSiteWideLeafPassword\x10\v\x12\x1a\n" +
-	"\x16SiteWideNicLockdownIkm\x10\f*\xcf\x01\n" +
+	"\x16SiteWideNicLockdownIkm\x10\f\x12\x1f\n" +
+	"\x1bFirmwareArtifactAccessToken\x10\r*\xcf\x01\n" +
 	"\x16RotationCredentialType\x12(\n" +
 	"$ROTATION_CREDENTIAL_TYPE_UNSPECIFIED\x10\x00\x12\x10\n" +
 	"\fROTATION_BMC\x10\x01\x12\x16\n" +

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -8426,7 +8426,8 @@ type CredentialCreationRequest struct {
 	// For the BMC factory default credential: "dell", "lenovo", "hpe", "supermicro", etc
 	Vendor     *string `protobuf:"bytes,4,opt,name=vendor,proto3,oneof" json:"vendor,omitempty"`
 	MacAddress *string `protobuf:"bytes,5,opt,name=mac_address,json=macAddress,proto3,oneof" json:"mac_address,omitempty"`
-	// Required and non-empty for FirmwareArtifactAccessToken. This is an opaque,
+	// Required and non-empty for FirmwareArtifactAccessToken. The server returns
+	// InvalidArgument when this field is omitted or empty. This is an opaque,
 	// non-secret lookup name. Setting the same name replaces the stored token;
 	// username, vendor, and mac_address are ignored for this credential type.
 	CredentialName *string `protobuf:"bytes,6,opt,name=credential_name,json=credentialName,proto3,oneof" json:"credential_name,omitempty"`
@@ -8511,7 +8512,8 @@ type CredentialDeletionRequest struct {
 	CredentialType CredentialType         `protobuf:"varint,1,opt,name=credential_type,json=credentialType,proto3,enum=forge.CredentialType" json:"credential_type,omitempty"`
 	Username       *string                `protobuf:"bytes,2,opt,name=username,proto3,oneof" json:"username,omitempty"`
 	MacAddress     *string                `protobuf:"bytes,3,opt,name=mac_address,json=macAddress,proto3,oneof" json:"mac_address,omitempty"`
-	// Required and non-empty for FirmwareArtifactAccessToken. This opaque,
+	// Required and non-empty for FirmwareArtifactAccessToken. The server returns
+	// InvalidArgument when this field is omitted or empty. This opaque,
 	// non-secret lookup name selects the token to delete; username and
 	// mac_address are ignored for this credential type.
 	CredentialName *string `protobuf:"bytes,4,opt,name=credential_name,json=credentialName,proto3,oneof" json:"credential_name,omitempty"`

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -1414,6 +1414,8 @@ enum CredentialType {
   NmxM = 10;
   BgpSiteWideLeafPassword = 11;
   SiteWideNicLockdownIkm = 12;
+  // Named credential used to authorize firmware artifact downloads.
+  FirmwareArtifactAccessToken = 13;
 }
 
 message CredentialCreationRequest {
@@ -1425,16 +1427,27 @@ message CredentialCreationRequest {
   optional string username = 2;
   // The password of credential for HostBMC, DPUBMC, DpuUefi.
   // For UFM, the password is the token of UFM.
+  // For FirmwareArtifactAccessToken, the password is the non-empty artifact
+  // access token. Its contents are stored verbatim, including whitespace and
+  // line endings.
   string password = 3;
   // For the BMC factory default credential: "dell", "lenovo", "hpe", "supermicro", etc
   optional string vendor = 4;
   optional string mac_address = 5;
+  // Required and non-empty for FirmwareArtifactAccessToken. This is an opaque,
+  // non-secret lookup name. Setting the same name replaces the stored token;
+  // username, vendor, and mac_address are ignored for this credential type.
+  optional string credential_name = 6;
 }
 
 message CredentialDeletionRequest {
   CredentialType credential_type = 1;
   optional string username = 2;
   optional string mac_address = 3;
+  // Required and non-empty for FirmwareArtifactAccessToken. This opaque,
+  // non-secret lookup name selects the token to delete; username and
+  // mac_address are ignored for this credential type.
+  optional string credential_name = 4;
 }
 
 message CredentialCreationResult {

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -1434,7 +1434,8 @@ message CredentialCreationRequest {
   // For the BMC factory default credential: "dell", "lenovo", "hpe", "supermicro", etc
   optional string vendor = 4;
   optional string mac_address = 5;
-  // Required and non-empty for FirmwareArtifactAccessToken. This is an opaque,
+  // Required and non-empty for FirmwareArtifactAccessToken. The server returns
+  // InvalidArgument when this field is omitted or empty. This is an opaque,
   // non-secret lookup name. Setting the same name replaces the stored token;
   // username, vendor, and mac_address are ignored for this credential type.
   optional string credential_name = 6;
@@ -1444,7 +1445,8 @@ message CredentialDeletionRequest {
   CredentialType credential_type = 1;
   optional string username = 2;
   optional string mac_address = 3;
-  // Required and non-empty for FirmwareArtifactAccessToken. This opaque,
+  // Required and non-empty for FirmwareArtifactAccessToken. The server returns
+  // InvalidArgument when this field is omitted or empty. This opaque,
   // non-secret lookup name selects the token to delete; username and
   // mac_address are ignored for this credential type.
   optional string credential_name = 4;


### PR DESCRIPTION
Add named firmware artifact access-token credentials to the existing credential API and admin CLI. This supplies the credential storage required by the rack pre-ingestion firmware update work tracked in #5628.

`CreateCredential` validates a non-empty credential name and token, then stores or replaces the token under that name. `DeleteCredential` removes the named token. Credential names are encoded as single Vault path segments, while token text is preserved exactly, including whitespace and line endings.

Operators provide tokens through a file or standard input, preventing token values from appearing in command-line arguments.

## Related issues

Supports #5628

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)