### PR TITLE
fix(admin-cli): show effective NMX-C state

### DIFF
--- a/crates/admin-cli/src/switch/show/cmd.rs
+++ b/crates/admin-cli/src/switch/show/cmd.rs
@@ -275,7 +275,12 @@ fn switch_details_text(switch: &Switch) -> CarbideCliResult<String> {
     writeln!(&mut lines, "\nConfig:")?;
     if let Some(config) = &switch.config {
         writeln!(&mut lines, "\tName       : {}", config.name)?;
-        writeln!(&mut lines, "\tEnable NMX-C : {}", config.enable_nmxc)?;
+        writeln!(&mut lines, "\tNMX-C Configured : {}", config.enable_nmxc)?;
+        writeln!(
+            &mut lines,
+            "\tNMX-C Effective  : {}",
+            config.enable_nmxc || switch.is_primary
+        )?;
         if let Some(fm_config) = &config.fabric_manager_config
             && !fm_config.config_map.is_empty()
         {
@@ -490,7 +495,7 @@ mod tests {
                 slot_number: Some(13),
                 tray_index: Some(8),
             }),
-            is_primary: false,
+            is_primary: true,
             controller_state:
                 r#"{"state":"reprovisioning","reprovisioning_state":"WaitingForNVOSUpgrade"}"#
                     .to_string(),
@@ -513,7 +518,10 @@ mod tests {
 
         for expected in [
             "ID            : sw100nsner0op5osl6n85t7772j010jmhafm934n7oej4mlome3okrn9b60",
+            "Primary       : Yes",
             "\tName       : MT2519600UD6",
+            "\tNMX-C Configured : false",
+            "\tNMX-C Effective  : true",
             "\tPower State      : on",
             "\tFirmware Version     : 1.3.5-GA",
             "\tNAME: sw100nsner0op5osl6n85t7772j010jmhafm934n7oej4mlome3okrn9b60",


### PR DESCRIPTION
`switch show` currently prints only the persisted legacy NMX-C flag. When RMS selects a primary switch, that can report `false` even though hardware health treats NMX-C as enabled.

This change labels the persisted value as configured and displays the effective value using the same `config.enable_nmxc || switch.is_primary` expression as hardware health.

## Related issues

Fixes #5799

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`PROTOC=/data/NICo/.tools/protoc-28.3/bin/protoc cargo test -p nico-admin-cli` (255 passed)

## Additional Notes

The implementation and regression assertion are contained in the existing switch-show source file; no API or database change is required.
