### PR TITLE
refactor(api-core): Separate config validation from runtime setup

### DIFF
--- a/crates/api-core/src/bootstrap.rs
+++ b/crates/api-core/src/bootstrap.rs
@@ -59,6 +59,9 @@ pub struct RuntimePrelude {
 /// Starts the core runtime work that follows logging initialization and precedes
 /// external resource initialization.
 ///
+/// Process-wide settings derived from the validated configuration are installed
+/// here, immediately before runtime consumers can observe them.
+///
 /// Rack-profile attribute override collisions are logged once here so the
 /// configured tracing subscriber receives the diagnostics.
 #[doc(hidden)]
@@ -68,6 +71,13 @@ pub fn start_runtime_prelude(
     join_set: &mut JoinSet<()>,
     cancel_token: &CancellationToken,
 ) -> RuntimePrelude {
+    // Install process-wide settings only after the caller has finished loading
+    // and validating the configuration.
+    crate::init_tools(carbide_config.web_ui_sidebar_tools.clone());
+    crate::init_site_name(carbide_config.sitename.clone());
+    crate::init_logs_link_template(carbide_config.web_ui_logs_link_template.clone());
+    db::host_naming::configure(carbide_config.host_naming_strategy);
+
     // These diagnostics require the tracing subscriber installed by the caller.
     warn_rms_node_descriptor_attribute_overrides(&carbide_config.rack_profiles);
 

--- a/crates/api-core/src/cfg/load.rs
+++ b/crates/api-core/src/cfg/load.rs
@@ -313,23 +313,6 @@ pub fn parse_carbide_config(
         config.periodic_state_republish.validate()?;
     }
 
-    // Publish the configured tool list so the admin-UI sidebar and per-machine
-    // "Logs" deep link can read it back via `crate::configured_tools`. The list
-    // is owned here (not in `carbide-api-web`) because it is derived from the
-    // parsed config, before the web layer exists.
-    crate::init_tools(config.web_ui_sidebar_tools.clone());
-
-    // Publish the site name the same way, for the admin-UI sidebar header.
-    crate::init_site_name(config.sitename.clone());
-
-    // Publish the logs link URL template for the "Logs" link on machine and
-    // endpoint detail pages.
-    crate::init_logs_link_template(config.web_ui_logs_link_template.clone());
-
-    // Publish the deployment-wide host naming policy so the DB layer can read it
-    // wherever an interface is [re]named (same way we do it w/ `init_tools` above).
-    db::host_naming::configure(config.host_naming_strategy);
-
     // Validate that the firmware profile config keys match their inner
     // part_number and psid values. Mismatches are logged as warnings.
     config.validate_supernic_firmware_profiles();
@@ -368,6 +351,80 @@ pub fn parse_carbide_config(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn valid_base_and_site_configs_are_merged_and_validated() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "base.toml",
+                r#"
+                database_url = "postgres://base"
+                listen = "[::]:1081"
+                asn = 65000
+                sitename = "base-site"
+                web_ui_logs_link_template = "https://logs.example.com/{search}"
+                host_naming_strategy = "fun"
+
+                [[web_ui_sidebar_tools]]
+                name = "grafana"
+                display_name = "Grafana"
+                url = "https://grafana.example.com"
+                "#,
+            )?;
+            jail.create_file(
+                "site.toml",
+                r#"
+                listen = "[::]:1082"
+                sitename = "site-override"
+                "#,
+            )?;
+
+            let config = parse_carbide_config(Path::new("base.toml"), Some(Path::new("site.toml")))
+                .expect("valid merged config should parse");
+
+            assert_eq!(config.database_url, "postgres://base");
+            assert_eq!(config.listen, "[::]:1082".parse().unwrap());
+            assert_eq!(config.asn, 65000);
+            assert_eq!(config.sitename.as_deref(), Some("site-override"));
+            assert!(crate::configured_tools().is_empty());
+            assert_eq!(crate::configured_site_name(), None);
+            assert_eq!(crate::configured_logs_link_template(), "");
+            assert_eq!(db::host_naming::configured(), Default::default());
+            Ok(())
+        })
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn semantic_error_in_site_config_is_rejected() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "base.toml",
+                r#"
+                database_url = "postgres://test"
+                listen = "[::]:1081"
+                asn = 1
+                "#,
+            )?;
+            jail.create_file(
+                "site.toml",
+                r#"
+                [api_admission_control]
+                max_work_in_flight = 0
+                "#,
+            )?;
+
+            let error = parse_carbide_config(Path::new("base.toml"), Some(Path::new("site.toml")))
+                .expect_err("invalid merged config should be rejected");
+
+            assert_eq!(
+                error.to_string(),
+                "api_admission_control.max_work_in_flight must be greater than zero"
+            );
+            Ok(())
+        })
+    }
 
     #[test]
     #[allow(clippy::result_large_err)]

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -2694,6 +2694,14 @@ attributes = { attribute1 = "site", additional_attribute3 = "site" }
                 database_url = "postgres://test"
                 listen = "[::]:1081"
                 asn = 1
+                sitename = "rejected-site"
+                web_ui_logs_link_template = "https://logs.example.com/{search}"
+                host_naming_strategy = "fun"
+
+                [[web_ui_sidebar_tools]]
+                name = "grafana"
+                display_name = "Grafana"
+                url = "https://grafana.example.com"
 
                 [component_manager]
                 nv_switch_backend = "rms"
@@ -2717,6 +2725,11 @@ attributes = { attribute1 = "site", additional_attribute3 = "site" }
             "#,
         )?;
 
+        assert!(crate::configured_tools().is_empty());
+        assert_eq!(crate::configured_site_name(), None);
+        assert_eq!(crate::configured_logs_link_template(), "");
+        assert_eq!(db::host_naming::configured(), Default::default());
+
         let result = parse_carbide_config(config.path(), None);
         let Err(error) = result else {
             panic!("missing RMS vendor should be rejected");
@@ -2729,6 +2742,10 @@ attributes = { attribute1 = "site", additional_attribute3 = "site" }
                 && error.contains("rack profile does not identify an RMS switch vendor"),
             "error message should identify the rack profile and missing role vendor: {error}"
         );
+        assert!(crate::configured_tools().is_empty());
+        assert_eq!(crate::configured_site_name(), None);
+        assert_eq!(crate::configured_logs_link_template(), "");
+        assert_eq!(db::host_naming::configured(), Default::default());
 
         Ok(())
     }

--- a/crates/api-web/src/lib.rs
+++ b/crates/api-web/src/lib.rs
@@ -57,12 +57,12 @@ use tower_http::normalize_path::NormalizePath;
 /// `Self::tools()`.
 ///
 /// The tool list itself is owned by `carbide-api-core` (it is derived from the
-/// parsed `CarbideConfig` during API Core configuration loading).
+/// validated `CarbideConfig` during API Core runtime startup).
 /// This trait just surfaces it to templates.
 trait Base {
     /// Configured external tool links rendered in the admin UI's
     /// "Tools" sidebar. Empty when no tools are configured or
-    /// before API Core configuration loading has initialized them (e.g. unit tests).
+    /// before API Core runtime startup has initialized them (e.g. unit tests).
     fn tools() -> &'static [ToolLink] {
         carbide_api_core::configured_tools()
     }


### PR DESCRIPTION
Core config parsing currently installs write-once UI and host-naming settings before all semantic checks finish. That prevents the parser from safely validating a candidate config because even a rejected candidate can change process state. This change keeps the existing parsing, normalization, and semantic checks together while moving runtime-global initialization to the production runtime prelude.

## Related issues

Supports #2654

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

- `cargo test --locked -p carbide-api-core --no-default-features --lib 'cfg::load::tests'`
- `cargo test --locked -p carbide-api-core --no-default-features --lib setup::tests::parse_rejects_rms_component_manager_missing_vendor -- --exact`
- `cargo test --locked -p carbide-api-core --no-default-features --lib 'cfg::'`
- `cargo clippy --locked -p carbide-api-core --lib --no-default-features -- -D warnings`
- `cargo +nightly-2026-06-16 fmt --all -- --check`

## Additional Notes

This first slice is limited to the semantic checks already owned by `parse_carbide_config`. The separate startup network-prefix check is unchanged, and this does not add the unresolved RPC, REST, nicocli, result-schema, config-kind, or versioning contracts.
