### PR TITLE
fix: predicted host BIOS recovery

### DIFF
--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -5849,9 +5849,13 @@ async fn test_polling_bios_setup_exhausted_enters_failed_and_recovers_when_bios_
     pool: sqlx::PgPool,
 ) {
     let env = create_test_env(pool).await;
-
-    let mh = common::api_fixtures::create_managed_host(&env).await;
+    let host_config = env.managed_host_config();
+    common::api_fixtures::site_explorer::seed_bmc_root_credentials(&env, &host_config)
+        .await
+        .unwrap();
+    let mh = create_dpu_machine_in_waiting_for_network_install(&env, &host_config).await;
     let host_id = mh.host().id;
+    assert!(host_id.machine_type().is_predicted_host());
 
     env.redfish_sim.set_is_bios_setup(false);
 

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -1970,7 +1970,7 @@ impl MachineStateHandler {
                             None => Ok(StateHandlerOutcome::do_nothing()),
                         }
                     }
-                    FailureCause::BiosSetupFailed { .. } if machine_id.machine_type().is_host() => {
+                    FailureCause::BiosSetupFailed { .. } if machine_id == host_machine_id => {
                         let recovered = ManagedHostState::HostInit {
                             machine_state: MachineState::SetBootOrder {
                                 set_boot_order_info: Some(initial_set_boot_order_info()),


### PR DESCRIPTION
Predicted hosts stuck in `Failed/BiosSetupFailed` ignored successful manual BIOS remediation because recovery only accepted discovered host IDs.

This PR allows recovery when the failed machine ID matches the managed host ID. This supports predicted and discovered hosts while excluding DPUs.

## Related issues
https://github.com/NVIDIA/infra-controller/issues/5754

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
