### PR TITLE
fix(helm): nico-api open file limit

### DIFF
--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -104,7 +104,26 @@ spec:
               add:
                 - SYS_PTRACE
           command:
-            {{- toYaml .Values.command | nindent 12 }}
+            - /bin/sh
+            - -c
+            - |
+              {{- /* Native Kubernetes ulimits support: https://github.com/kubernetes/kubernetes/pull/137023 */ -}}
+              {{- $fdLimit := 65536 }}
+              {{- if not (kindIs "invalid" .Values.fileDescriptorLimit) }}
+              {{- $fdLimit = .Values.fileDescriptorLimit | int }}
+              {{- end }}
+              {{- if le $fdLimit 0 }}
+              {{- fail "fileDescriptorLimit must be a positive integer" }}
+              {{- end }}
+              FD_LIMIT={{ $fdLimit }}
+              FD_REQUESTED="$FD_LIMIT"
+              FD_HARD="$(ulimit -Hn)"
+              if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
+                echo "fileDescriptorLimit ${FD_LIMIT} exceeds the hard limit ${FD_HARD}; clamping" >&2
+                FD_LIMIT="$FD_HARD"
+              fi
+              ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (requested ${FD_REQUESTED}, hard limit ${FD_HARD})" >&2; exit 1; }
+              {{ .Values.command | nindent 14 }}
           env:
             - name: VAULT_ROLE_ID
               valueFrom:

--- a/helm/charts/nico-api/tests/file_descriptor_limit_test.yaml
+++ b/helm/charts/nico-api/tests/file_descriptor_limit_test.yaml
@@ -1,0 +1,47 @@
+suite: nico-api file descriptor limit
+templates:
+  - templates/deployment.yaml
+tests:
+  - it: uses the default soft limit with a hard-limit clamp
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=65536'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_HARD="\$\(ulimit -Hn\)"'
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'ulimit -Sn "\$FD_LIMIT"'
+  - it: allows an override
+    set:
+      fileDescriptorLimit: 32768
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=32768'
+  - it: falls back to the default when the value is nulled out
+    set:
+      fileDescriptorLimit: null
+    asserts:
+      - matchRegex:
+          path: spec.template.spec.containers[0].command[2]
+          pattern: 'FD_LIMIT=65536'
+  - it: rejects a non-numeric value at render time
+    set:
+      fileDescriptorLimit: unlimited
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects a negative value at render time
+    set:
+      fileDescriptorLimit: -1
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'
+  - it: rejects zero at render time instead of falling back to the default
+    set:
+      fileDescriptorLimit: 0
+    asserts:
+      - failedTemplate:
+          errorPattern: 'fileDescriptorLimit must be a positive integer'

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -117,6 +117,9 @@ resources:
     cpu: 1500m
     memory: 8Gi
 
+## Soft open-file limit applied before startup. Clamped to the runtime hard
+## limit when it exceeds it. null falls back to 65536; non-null values must be
+## a positive integer (validated at render).
 fileDescriptorLimit: 65536
 
 ## Optional init containers (general-purpose pass-through)
@@ -244,7 +247,8 @@ migrationJob:
 ## with additional time for queue finalization.
 terminationGracePeriodSeconds: 240
 
-## Script body executed after setting the file descriptor limit.
+## Script body executed after setting the file descriptor limit. The template
+## prepends /bin/sh -c and the ulimit wrapper; this value is the script body.
 ## Picks /opt/nico/nico-api if present (renamed image), else /opt/carbide/carbide-api
 ## (current image). Configmaps are mounted at both /etc/nico and /etc/forge paths
 ## so the binary finds its expected config regardless of which it picks.
@@ -436,8 +440,8 @@ auth:
 
 ## Config files -- can be overridden with custom content
 configFiles:
-  nicoApiConfig: "" # If empty, uses the default from files/
-  casbinPolicy: "" # If empty, uses the default from files/
+  nicoApiConfig: ""  # If empty, uses the default from files/
+  casbinPolicy: ""      # If empty, uses the default from files/
 
 ## Site-specific config (nico-api-site-config-files ConfigMap)
 ## nicoApiSiteConfig is REQUIRED: nico-api exits at startup if the four
@@ -446,7 +450,7 @@ configFiles:
 ## deploy/files/nico-api/nico-api-site-config.toml for a full example.
 siteConfig:
   enabled: true
-  nicoApiSiteConfig: "" # Must include [pools.lo-ip], [pools.vlan-id], [pools.vni], [pools.vpc-vni]
+  nicoApiSiteConfig: ""  # Must include [pools.lo-ip], [pools.vlan-id], [pools.vni], [pools.vpc-vni]
   ## Public CA trust bundle used to verify admin client certificates. Use a dedicated
   ## admin-client intermediate whose entire issuance population may cross this trust boundary.
   ## Accepts only bare PEM CERTIFICATE blocks separated by whitespace; strip subject=/issuer=

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -117,6 +117,8 @@ resources:
     cpu: 1500m
     memory: 8Gi
 
+fileDescriptorLimit: 65536
+
 ## Optional init containers (general-purpose pass-through)
 initContainers: []
 
@@ -242,23 +244,20 @@ migrationJob:
 ## with additional time for queue finalization.
 terminationGracePeriodSeconds: 240
 
-## Container command (override to customise startup).
+## Script body executed after setting the file descriptor limit.
 ## Picks /opt/nico/nico-api if present (renamed image), else /opt/carbide/carbide-api
 ## (current image). Configmaps are mounted at both /etc/nico and /etc/forge paths
 ## so the binary finds its expected config regardless of which it picks.
-command:
-  - /bin/sh
-  - -c
-  - |
-    if [ -x /opt/nico/nico-api ]; then
-      exec /opt/nico/nico-api run \
-        --config-path /etc/nico/nico-api/nico-api-config.toml \
-        --site-config-path /etc/nico/nico-api/site/nico-api-site-config.toml
-    else
-      exec /opt/carbide/carbide-api run \
-        --config-path /etc/forge/carbide-api/carbide-api-config.toml \
-        --site-config-path /etc/forge/carbide-api/site/carbide-api-site-config.toml
-    fi
+command: |
+  if [ -x /opt/nico/nico-api ]; then
+    exec /opt/nico/nico-api run \
+      --config-path /etc/nico/nico-api/nico-api-config.toml \
+      --site-config-path /etc/nico/nico-api/site/nico-api-site-config.toml
+  else
+    exec /opt/carbide/carbide-api run \
+      --config-path /etc/forge/carbide-api/carbide-api-config.toml \
+      --site-config-path /etc/forge/carbide-api/site/carbide-api-site-config.toml
+  fi
 
 ## Environment variables for nico-api
 env:
@@ -437,8 +436,8 @@ auth:
 
 ## Config files -- can be overridden with custom content
 configFiles:
-  nicoApiConfig: ""  # If empty, uses the default from files/
-  casbinPolicy: ""      # If empty, uses the default from files/
+  nicoApiConfig: "" # If empty, uses the default from files/
+  casbinPolicy: "" # If empty, uses the default from files/
 
 ## Site-specific config (nico-api-site-config-files ConfigMap)
 ## nicoApiSiteConfig is REQUIRED: nico-api exits at startup if the four
@@ -447,7 +446,7 @@ configFiles:
 ## deploy/files/nico-api/nico-api-site-config.toml for a full example.
 siteConfig:
   enabled: true
-  nicoApiSiteConfig: ""  # Must include [pools.lo-ip], [pools.vlan-id], [pools.vni], [pools.vpc-vni]
+  nicoApiSiteConfig: "" # Must include [pools.lo-ip], [pools.vlan-id], [pools.vni], [pools.vpc-vni]
   ## Public CA trust bundle used to verify admin client certificates. Use a dedicated
   ## admin-client intermediate whose entire issuance population may cross this trust boundary.
   ## Accepts only bare PEM CERTIFICATE blocks separated by whitespace; strip subject=/issuer=


### PR DESCRIPTION
The `nico-api` Helm chart doesn't configure the process FD limit. Under load `nico-api` can exhaust FD leading to connection failures and service degradation

The implementation follows the pattern already used by `nico-hardware-health` abd `nico-pxe`

## Related issues
- Fixes #5713

## Type of Change
- [x] **Change** - Changes in existing functionality

## Testing
- [x] Unit tests added/updated

## Additional Notes
Native k8s `ulimits` support is in progress: https://github.com/kubernetes/kubernetes/pull/137023
Once that lands and stabilizes, we can simplify this to use `securityContext.ulimits` instead of the shell wrapper

A follow-up issue could consolidate the FD_LIMIT logic into a shared library chart for reuse across all NICo subcharts


