### PR TITLE
fix(api): reap dead HTTP/2 connections

### DIFF
--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -383,6 +383,8 @@ pub(crate) async fn start(
     let mut http = http2::Builder::new(TokioExecutor::new());
     // Ping idle connections so peers that vanish without a clean close get reaped instead of leaking fds.
     // The timer is required: keep-alive drives its interval through it, and hyper panics without one.
+    // The timeout starts after each ping, so it may be shorter than the interval:
+    // https://docs.rs/hyper/latest/hyper/server/conn/http2/struct.Builder.html#method.keep_alive_timeout
     http.timer(TokioTimer::new())
         .keep_alive_interval(Some(Duration::from_secs(30)))
         .keep_alive_timeout(Duration::from_secs(20));

--- a/crates/api-core/src/listener.rs
+++ b/crates/api-core/src/listener.rs
@@ -23,7 +23,7 @@ use ::rpc::forge as rpc;
 use carbide_authn::SpiffeContext;
 use carbide_authn::middleware::{CertDescriptionMiddleware, ConnectionAttributes};
 use hyper::server::conn::{http1, http2};
-use hyper_util::rt::{TokioExecutor, TokioIo};
+use hyper_util::rt::{TokioExecutor, TokioIo, TokioTimer};
 use hyper_util::service::TowerToHyperService;
 use model::ConfigValidationError;
 use opentelemetry::metrics::Meter;
@@ -380,7 +380,12 @@ pub(crate) async fn start(
     let listener = TcpListener::bind(listen_port).await?;
     let listen_address = listener.local_addr()?;
     tracing::info!(effective_listen_address = %listen_address, "API listener started");
-    let http = http2::Builder::new(TokioExecutor::new());
+    let mut http = http2::Builder::new(TokioExecutor::new());
+    // Ping idle connections so peers that vanish without a clean close get reaped instead of leaking fds.
+    // The timer is required: keep-alive drives its interval through it, and hyper panics without one.
+    http.timer(TokioTimer::new())
+        .keep_alive_interval(Some(Duration::from_secs(30)))
+        .keep_alive_timeout(Duration::from_secs(20));
 
     let extra_cli_certs = if let Some(auth_config) = auth_config {
         auth_config.cli_certs.clone()

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -250,16 +250,6 @@ command:
   - /bin/sh
   - -c
   - |
-    # Default nofile (1024) is too low for fleet-scale DPU connections; bounded
-    # bump, not maxed to the hard limit. Use -Sn: a bare `ulimit -n` also lowers
-    # the hard limit, which an unprivileged process can never raise back.
-    FD_LIMIT=8192
-    FD_HARD="$(ulimit -Hn)"
-    if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
-      echo "fd limit ${FD_LIMIT} exceeds hard limit ${FD_HARD}; clamping" >&2
-      FD_LIMIT="$FD_HARD"
-    fi
-    ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
     if [ -x /opt/nico/nico-api ]; then
       exec /opt/nico/nico-api run \
         --config-path /etc/nico/nico-api/nico-api-config.toml \

--- a/helm/charts/nico-api/values.yaml
+++ b/helm/charts/nico-api/values.yaml
@@ -250,6 +250,16 @@ command:
   - /bin/sh
   - -c
   - |
+    # Default nofile (1024) is too low for fleet-scale DPU connections; bounded
+    # bump, not maxed to the hard limit. Use -Sn: a bare `ulimit -n` also lowers
+    # the hard limit, which an unprivileged process can never raise back.
+    FD_LIMIT=8192
+    FD_HARD="$(ulimit -Hn)"
+    if [ "$FD_HARD" != "unlimited" ] && [ "$FD_LIMIT" -gt "$FD_HARD" ]; then
+      echo "fd limit ${FD_LIMIT} exceeds hard limit ${FD_HARD}; clamping" >&2
+      FD_LIMIT="$FD_HARD"
+    fi
+    ulimit -Sn "$FD_LIMIT" || { echo "ulimit -Sn ${FD_LIMIT} failed (hard limit ${FD_HARD})" >&2; exit 1; }
     if [ -x /opt/nico/nico-api ]; then
       exec /opt/nico/nico-api run \
         --config-path /etc/nico/nico-api/nico-api-config.toml \


### PR DESCRIPTION
Today, HTTP/2 persistent connections do not use keepalives. If a client establishes a connection and disappears without sending FIN or RST, the stale connection may remain open indefinitely.

This PR fixes that issue. The fix was originally proposed in #5725, but that PR was closed because stale HTTP/2 connections were not the root cause of the issue being investigated.

## Related issues

Fixes: #5805
Initial PR: #5725

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
