### PR TITLE
feat(build): add first-class native ARM image builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,8 @@ bootstrap: ## Set up an Ubuntu/Debian build host: apt deps, rustup, submodules, 
 # registry access is required.
 #
 #   make images        Build the deployable service stack: NICo Core + REST images
+#   make images-arm    Build the deployable service stack for ARM64 only
+#   make images-all-arm Build every ARM64 image and boot artifact natively on ARM64
 #   make images-all    Build everything: the stack plus machine-validation and
 #                       boot-artifact images (needs the full mkosi build host)
 #   make images-core   NICo Core image (nico) only
@@ -116,9 +118,9 @@ CORE_BUILD_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-buildcontainer:$(IMAGE_TAG)
 CORE_RUNTIME_CONTAINER_AMD64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-amd64
 CORE_RUNTIME_CONTAINER_ARM64 ?= $(IMAGE_REGISTRY)/nico-runtime-container:$(IMAGE_TAG)-arm64
 
-.PHONY: images images-all images-validate images-all-validate images-registry \
-        images-base images-core images-rest images-machine-validation \
-        images-boot-artifacts images-bfb
+.PHONY: images images-arm images-all images-all-arm images-validate images-all-validate images-registry \
+		images-base images-core images-rest images-machine-validation images-machine-validation-arm \
+		images-boot-artifacts images-bfb images-bfb-arm
 
 images-validate:
 	$(call check-arches,$(NICO_ARCHES),NICO_ARCHES)
@@ -133,14 +135,28 @@ images: ## Build the deployable service stack (NICo Core + REST images)
 	$(MAKE) images-validate
 	$(MAKE) images-core images-rest
 	@echo ""
-	@echo "Deployable multi-arch images pushed under $(IMAGE_REGISTRY) (tag: $(IMAGE_TAG)):"
+	@echo "Deployable images pushed under $(IMAGE_REGISTRY) (tag: $(IMAGE_TAG)):"
 	@echo "  $(IMAGE_REGISTRY)/nico:$(IMAGE_TAG)   (NICo Core)"
 	@echo "  $(IMAGE_REGISTRY)/nico-rest-*:$(IMAGE_TAG)       (REST services)"
+
+images-arm: ## Build the deployable ARM64 service stack natively on an ARM64 Docker host
+	@arch="$$(docker info --format '{{.Architecture}}')"; \
+		case "$$arch" in arm64|aarch64) ;; *) echo "images-arm requires an ARM64 Docker host; got $$arch" >&2; exit 1 ;; esac
+	$(MAKE) images NICO_ARCHES=arm64
 
 images-all: ## Build every image (stack + machine validation + boot artifacts; needs an mkosi build host)
 	# Ensure validation runs before building even with parallel builds.
 	$(MAKE) images-all-validate
 	$(MAKE) images images-machine-validation images-boot-artifacts images-bfb
+
+images-all-arm: ## Build every ARM64 image and boot artifact natively on an ARM64 host
+	@arch="$$(docker info --format '{{.Architecture}}')"; \
+		case "$$arch" in \
+			arm64|aarch64) ;; \
+			*) echo "images-all-arm requires an ARM64 Docker host; got $$arch. Run 'make images-all' for the multi-architecture compatibility build." >&2; exit 1 ;; \
+		esac
+	$(MAKE) images images-machine-validation-arm images-bfb-arm \
+		NICO_ARCHES=arm64 DPU_ARCHES=arm64
 
 # Safe to call concurrently from multiple sibling targets (images-base,
 # images-rest, images-boot-artifacts, images-bfb each invoke this themselves).
@@ -224,6 +240,22 @@ images-machine-validation: ## Build the machine-validation runner + config image
 	done; \
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG) $$tags
 
+images-machine-validation-arm: ## Build the native ARM64 machine-validation runner + config image
+	@arch="$$(docker info --format '{{.Architecture}}')"; \
+		case "$$arch" in arm64|aarch64) ;; *) echo "images-machine-validation-arm requires an ARM64 Docker host; got $$arch" >&2; exit 1 ;; esac
+	$(MAKE) images-base NICO_ARCHES=arm64
+	docker buildx build --platform linux/arm64 --load --build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64) \
+		-t machine-validation-runner:$(IMAGE_TAG) \
+		--file dev/docker/Dockerfile.machine-validation-runner-aarch64 .
+	mkdir -p crates/machine-validation/images
+	docker save --output crates/machine-validation/images/machine-validation-runner.tar machine-validation-runner:$(IMAGE_TAG)
+	docker buildx build --platform linux/arm64 --push \
+		--build-arg CONTAINER_RUNTIME_AARCH64=$(CORE_RUNTIME_CONTAINER_ARM64) \
+		-t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-arm64 \
+		--file dev/docker/Dockerfile.machine-validation-config-aarch64 .
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG) \
+		$(IMAGE_REGISTRY)/machine-validation:$(IMAGE_TAG)-arm64
+
 images-boot-artifacts: ## Build the x86 boot-artifact image (BOOT_ARTIFACTS_ARCHES="amd64 arm64"; requires mkosi + rust toolchain on the host)
 	$(call check-arches,$(BOOT_ARTIFACTS_ARCHES),BOOT_ARTIFACTS_ARCHES)
 	$(MAKE) images-registry
@@ -251,6 +283,34 @@ images-bfb: ## Build the aarch64 DPU BFB boot-artifact image (DPU_ARCHES="amd64 
 		tags="$$tags $$tag"; \
 	done; \
 	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) $$tags
+
+images-bfb-arm: ## Build the aarch64 DPU BFB boot-artifact image in a native ARM64 build container
+	@arch="$$(docker info --format '{{.Architecture}}')"; \
+		case "$$arch" in arm64|aarch64) ;; *) echo "images-bfb-arm requires an ARM64 Docker host; got $$arch" >&2; exit 1 ;; esac
+	$(MAKE) images-registry
+	docker buildx build --platform linux/arm64 --builder default --load -t carbide-pxe-builder -f dev/docker/Dockerfile.pxe-build-container dev/docker
+	docker buildx build --platform linux/arm64 --builder default --load -t carbide-pxe-builder-aarch64 -f dev/docker/Dockerfile.pxe-build-container-aarch64 dev/docker
+	@set -e; \
+		cargo_home="$${CARGO_HOME:-$$HOME/.cargo}"; \
+		sccache_home="$${SCCACHE_DIR:-$$HOME/.sccache}"; \
+		mkdir -p "$$cargo_home" "$$sccache_home"; \
+		docker run --platform linux/arm64 --rm --privileged \
+			-v /var/run/docker.sock:/var/run/docker.sock \
+			-v "$(CURDIR)":"$(CURDIR)" \
+			-v /dev/null:"$(CURDIR)/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.extra/etc/apt/sources.list.d/forge.list":ro \
+			-v "$$cargo_home":"$$cargo_home" \
+			-v "$$sccache_home":"$$sccache_home" \
+			-w "$(CURDIR)" \
+			-e CARGO_HOME="$$cargo_home" \
+			-e SCCACHE_DIR="$$sccache_home" \
+			-e VERSION="$(VERSION)" \
+			carbide-pxe-builder-aarch64 \
+			sh -c 'git config --global --add safe.directory "$(CURDIR)" && git config --global --add safe.directory "$(CURDIR)/pxe/ipxe/upstream" && cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa'
+	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
+		-t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-arm64 \
+		--file dev/docker/Dockerfile.release-artifacts-aarch64 .
+	docker buildx imagetools create -t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG) \
+		$(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-arm64
 
 # =============================================================================
 # Rest (delegate to rest-api/Makefile)

--- a/Makefile
+++ b/Makefile
@@ -79,7 +79,7 @@ bootstrap: ## Set up an Ubuntu/Debian build host: apt deps, rustup, submodules, 
 #
 #   make images        Build the deployable service stack: NICo Core + REST images
 #   make images-arm    Build the deployable service stack for ARM64 only
-#   make images-all-arm Build every ARM64 image and boot artifact natively on ARM64
+#   make images-all-arm Build 13 native ARM64 outputs (omits boot-artifacts-x86_64)
 #   make images-all    Build everything: the stack plus machine-validation and
 #                       boot-artifact images (needs the full mkosi build host)
 #   make images-core   NICo Core image (nico) only
@@ -149,7 +149,7 @@ images-all: ## Build every image (stack + machine validation + boot artifacts; n
 	$(MAKE) images-all-validate
 	$(MAKE) images images-machine-validation images-boot-artifacts images-bfb
 
-images-all-arm: ## Build every ARM64 image and boot artifact natively on an ARM64 host
+images-all-arm: ## Build 13 native ARM64 outputs; omits the x86 boot-artifact image
 	@arch="$$(docker info --format '{{.Architecture}}')"; \
 		case "$$arch" in \
 			arm64|aarch64) ;; \
@@ -290,22 +290,29 @@ images-bfb-arm: ## Build the aarch64 DPU BFB boot-artifact image in a native ARM
 	$(MAKE) images-registry
 	docker buildx build --platform linux/arm64 --builder default --load -t carbide-pxe-builder -f dev/docker/Dockerfile.pxe-build-container dev/docker
 	docker buildx build --platform linux/arm64 --builder default --load -t carbide-pxe-builder-aarch64 -f dev/docker/Dockerfile.pxe-build-container-aarch64 dev/docker
+	# carbide-pxe.forge is deployment-local, so the portable native build masks it with an empty regular file.
 	@set -e; \
 		cargo_home="$${CARGO_HOME:-$$HOME/.cargo}"; \
 		sccache_home="$${SCCACHE_DIR:-$$HOME/.sccache}"; \
+		host_uid="$$(id -u)"; \
+		host_gid="$$(id -g)"; \
+		empty_forge_list="$$(mktemp)"; \
+		trap 'rm -f "$$empty_forge_list"' EXIT; \
 		mkdir -p "$$cargo_home" "$$sccache_home"; \
 		docker run --platform linux/arm64 --rm --privileged \
 			-v /var/run/docker.sock:/var/run/docker.sock \
-			-v "$(CURDIR)":"$(CURDIR)" \
-			-v /dev/null:"$(CURDIR)/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.extra/etc/apt/sources.list.d/forge.list":ro \
-			-v "$$cargo_home":"$$cargo_home" \
-			-v "$$sccache_home":"$$sccache_home" \
-			-w "$(CURDIR)" \
-			-e CARGO_HOME="$$cargo_home" \
-			-e SCCACHE_DIR="$$sccache_home" \
+			-v "$(CURDIR)":/code \
+			-v "$$empty_forge_list":/code/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.extra/etc/apt/sources.list.d/forge.list:ro \
+			-v "$$cargo_home":/cargo \
+			-v "$$sccache_home":/sccache \
+			-w /code \
+			-e CARGO_HOME=/cargo \
+			-e SCCACHE_DIR=/sccache \
 			-e VERSION="$(VERSION)" \
+			-e HOST_UID="$$host_uid" \
+			-e HOST_GID="$$host_gid" \
 			carbide-pxe-builder-aarch64 \
-			sh -c 'git config --global --add safe.directory "$(CURDIR)" && git config --global --add safe.directory "$(CURDIR)/pxe/ipxe/upstream" && cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa'
+			sh -c 'git config --global --add safe.directory /code && git config --global --add safe.directory /code/pxe/ipxe/upstream && r=0; cargo make --cwd pxe --env SA_ENABLEMENT=1 build-boot-artifacts-bfb-sa || r=$$?; chown -R $${HOST_UID}:$${HOST_GID} /code 2>/dev/null || true; exit $$r'
 	docker buildx build --platform linux/arm64 --push --build-arg CONTAINER_RUNTIME_AARCH64=$(BOOT_ARTIFACTS_RUNTIME_IMAGE) \
 		-t $(IMAGE_REGISTRY)/boot-artifacts-aarch64:$(IMAGE_TAG)-arm64 \
 		--file dev/docker/Dockerfile.release-artifacts-aarch64 .

--- a/dev/docker/Dockerfile.machine-validation-runner-aarch64
+++ b/dev/docker/Dockerfile.machine-validation-runner-aarch64
@@ -1,0 +1,11 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+ARG CONTAINER_RUNTIME_AARCH64
+
+FROM $CONTAINER_RUNTIME_AARCH64
+
+# Machine-validation supports privileged and full-host plugins. The runtime
+# grants those modes per plugin, so this image intentionally retains root.
+WORKDIR /
+COPY crates/machine-validation/scripts /machine-validation/scripts

--- a/dev/docker/Dockerfile.pxe-build-container-aarch64
+++ b/dev/docker/Dockerfile.pxe-build-container-aarch64
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+FROM carbide-pxe-builder
+
+# Existing ARM boot-artifact tasks build helper images and export the HBN image.
+# Reuse the host daemon so the native build container only needs the Docker CLI.
+RUN apt-get update && \
+	DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends docker.io file pigz && \
+	rm -rf /var/lib/apt/lists/*

--- a/docs/manuals/building_nico_containers.md
+++ b/docs/manuals/building_nico_containers.md
@@ -48,8 +48,17 @@ top of the repo with a single `make` command:
 
 ```sh
 make images          # deployable stack: NICo Core (nico) + the REST service images
+make images-arm      # the deployable stack for ARM64, built natively on ARM64
 make images-all      # the above plus machine-validation and both boot-artifact images
+make images-all-arm  # 13 native ARM64 outputs; omits boot-artifacts-x86_64
 ```
+
+The `-arm` targets require an ARM64 Docker host and stop before building on any
+other architecture, so they do not use QEMU or binfmt emulation. `images-all-arm`
+publishes the 11 service images, the ARM64 machine-validation image, and the DPU
+BFB boot-artifact image. It does not build the x86 boot-artifact image. The DPU
+artifact build also omits the deployment-local `carbide-pxe.forge` package source
+so the native build does not depend on that service being reachable.
 
 Images are pushed as `linux/amd64` and `linux/arm64` manifests at
 `localhost:5000/<name>:latest` by default. The Makefile starts a local registry named
@@ -68,6 +77,10 @@ own override variable if you only need one architecture:
 - `BOOT_ARTIFACTS_ARCHES` — the x86 boot-artifact image (`images-boot-artifacts`)
 - `DPU_ARCHES` — the DPU BFB boot-artifact image (`images-bfb`)
 
+`images-arm` sets `NICO_ARCHES=arm64`. `images-all-arm` sets both
+`NICO_ARCHES=arm64` and `DPU_ARCHES=arm64`; it does not use
+`BOOT_ARTIFACTS_ARCHES` because it does not run `images-boot-artifacts`.
+
 ```sh
 make images-all NICO_ARCHES=amd64 DPU_ARCHES=arm64
 ```
@@ -75,30 +88,30 @@ make images-all NICO_ARCHES=amd64 DPU_ARCHES=arm64
 A single-architecture build still produces a valid tag at `$(IMAGE_TAG)` (the multi-arch
 manifest just has one entry). Values other than `amd64`/`arm64` fail fast with an error.
 
-`images-machine-validation` additionally requires `NICO_ARCHES` to include `amd64`:
-the `machine-validation-runner` intermediate image it embeds is always built for
-`amd64` regardless of which architectures you're publishing, and it depends on the
-amd64 Core runtime base container that `images-base` only pushes when `amd64` is
-requested. `NICO_ARCHES=arm64` alone fails fast with an error; use
-`NICO_ARCHES="amd64 arm64"` (the default) or `NICO_ARCHES=amd64`.
+The compatibility target `images-machine-validation` requires `NICO_ARCHES` to
+include `amd64`: its `machine-validation-runner` intermediate image is built for
+`amd64` and depends on the amd64 Core runtime base container. `NICO_ARCHES=arm64`
+alone therefore fails fast for that target. The native
+`images-machine-validation-arm` target builds the runner and published image for
+ARM64 instead.
 
 Each architecture is built separately before the bare tag is assembled. This matches CI
 and is required for the REST Dockerfiles: a single combined Buildx invocation would reuse
 one builder stage and could copy an amd64 binary into the arm64 image. Building the
 non-native architecture uses the platforms configured on the active Docker Buildx builder.
 
-Run `make help` from the repo root to list the individual image targets (`images-core`,
-`images-rest`, `images-machine-validation`, `images-boot-artifacts`, `images-bfb`). The
-sections below document the per-image build commands that these targets wrap, for when you
-need to build or debug a single image.
+Run `make help` from the repo root to list the individual image targets
+(`images-core`, `images-rest`, `images-machine-validation`,
+`images-machine-validation-arm`, `images-boot-artifacts`, `images-bfb`, and
+`images-bfb-arm`). The sections below document the per-image build commands that
+these targets wrap, for when you need to build or debug a single image.
 
 ### Verifying the build
 
-After `make images-all` completes, verify that each of the 14 deployable image tags
-contains the platforms you actually built. Set `NICO_ARCHES`, `BOOT_ARTIFACTS_ARCHES`,
-and `DPU_ARCHES` below to whatever you passed to `make` (they default to `amd64 arm64`,
-matching the Makefile); the script derives each image's expected platform list from its
-group automatically, so a narrowed selection doesn't produce false failures.
+After `make images-all` or `make images-all-arm` completes, verify that each
+published image tag contains the platforms you built. Set `ARM_ONLY=1` after an
+`images-all-arm` build; leave it unset after `images-all`. Initialize the registry
+and tag to the values passed to `make` before running the loop.
 
 ```bash
 images=(
@@ -108,10 +121,22 @@ images=(
   boot-artifacts-x86_64 boot-artifacts-aarch64
 )
 
-# Mirrors the Makefile defaults; set these to whatever you passed to `make`.
+# Mirrors the Makefile defaults; override these to match the build command.
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-localhost:5000}"
+IMAGE_TAG="${IMAGE_TAG:-latest}"
 NICO_ARCHES="${NICO_ARCHES:-amd64 arm64}"
 BOOT_ARTIFACTS_ARCHES="${BOOT_ARTIFACTS_ARCHES:-amd64 arm64}"
 DPU_ARCHES="${DPU_ARCHES:-amd64 arm64}"
+
+if [ "${ARM_ONLY:-0}" = "1" ]; then
+  images=(
+    nico nico-rest-api nico-rest-workflow nico-rest-site-manager
+    nico-rest-site-agent nico-rest-db nico-rest-cert-manager nico-flow
+    nico-psm nico-nsm nico-mcp machine-validation boot-artifacts-aarch64
+  )
+  NICO_ARCHES=arm64
+  DPU_ARCHES=arm64
+fi
 
 expected_platforms_for() {
   local arches
@@ -136,7 +161,8 @@ for image in "${images[@]}"; do
 done
 ```
 
-The loop should print exactly 14 successful checks:
+The loop prints 14 successful checks for `images-all` or 13 for
+`images-all-arm`:
 
 | Image | Target |
 |---|---|
@@ -151,9 +177,9 @@ The loop should print exactly 14 successful checks:
 | `nico-psm` | `images-rest` |
 | `nico-nsm` | `images-rest` |
 | `nico-mcp` | `images-rest` |
-| `machine-validation` | `images-machine-validation` |
+| `machine-validation` | `images-machine-validation` or `images-machine-validation-arm` |
 | `boot-artifacts-x86_64` | `images-boot-artifacts` |
-| `boot-artifacts-aarch64` | `images-bfb` |
+| `boot-artifacts-aarch64` | `images-bfb` or `images-bfb-arm` |
 
 If the loop exits early, the `FAIL` line identifies which image has an incomplete
 manifest. The three boot/validation images (`machine-validation`,


### PR DESCRIPTION
ARM64 systems should be able to build the deployable NICo images and required DPU boot artifacts natively while retaining the existing multi-architecture compatibility workflow. This adds `make images-arm` and `make images-all-arm` plus native ARM64 machine-validation and DPU BFB build containers.

## Related issues
Related to #5827

## Type of Change
- [x] **Add** - New feature or capability

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

- `git diff --check` passed on current head `0d6497340b7ff2c40eb59ca56b42258380cf6379`.
- An earlier branch state completed `make images-all-arm` on an ARM64 DGX Spark without QEMU or binfmt execution. The 13 outputs still in scope were published as single-platform `linux/arm64` manifests.

## Additional Notes
Machine-a-tron changes remain excluded. The canonical container build manual now documents the ARM targets and their 13-output verification path.