### PR TITLE
test(ssh-console): fix log rotation test boundary

### DIFF
--- a/crates/ssh-console/tests/main.rs
+++ b/crates/ssh-console/tests/main.rs
@@ -501,7 +501,7 @@ async fn test_ssh_console_log_rotation() -> eyre::Result<()> {
             assert!(path.exists(), "did not see any logs at {}", path.display());
             let size = path.metadata()?.len();
             assert!(
-                size < 1024 * 10,
+                size <= 1024 * 10,
                 "logs at {} exceeded configured size: {} > 10 KiB",
                 path.display(),
                 size


### PR DESCRIPTION
The SSH console logger rotates after its tracked byte count exceeds the configured maximum. The rotation test instead required every file to be strictly smaller than that maximum, so it could fail when a write produced a file exactly 10 KiB long.

Accept the configured maximum as a valid file size. This aligns the assertion with the logger boundary and removes the timing-dependent failure without changing production behavior.

## Type of Change

- [x] **Fix** - Bug fixes

## Testing

- [x] Integration tests added/updated
- [x] Manual testing performed

## Additional Notes

The production logger already treats exactly the configured maximum as valid and rotates on a subsequent write once the tracked count is greater than the maximum.