### PR TITLE
refactor(rack): route firmware updates through component-manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2901,7 +2901,6 @@ dependencies = [
  "config-version",
  "duration-str",
  "eyre",
- "librms",
  "mac_address",
  "opentelemetry 0.32.0",
  "reqwest 0.13.4",

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1243,6 +1243,12 @@ async fn initialize_and_start_controllers<'a>(
             as Arc<dyn component_manager::NvosUpdateManager>
     });
 
+    let rack_firmware_update_manager = rms_client.clone().map(|client| {
+        Arc::new(component_manager::rms::rms_rack_firmware_update_manager(
+            client,
+        )) as Arc<dyn component_manager::RackFirmwareUpdateManager>
+    });
+
     // As soon as we get the database up, observe this version of forge so that we know when it was
     // first deployed
     {
@@ -1864,7 +1870,6 @@ async fn initialize_and_start_controllers<'a>(
         .services(
             RackStateHandlerServices {
                 db_pool: db_pool.clone(),
-                rms_client: rms_client.clone(),
                 site_config: RackConfig {
                     rms: carbide_config.rms.clone(),
                     rack_validation_config: carbide_config.rack_validation_config.clone(),
@@ -1872,6 +1877,7 @@ async fn initialize_and_start_controllers<'a>(
                 }
                 .into(),
                 nvos_update_manager: nvos_update_manager.clone(),
+                rack_firmware_update_manager: rack_firmware_update_manager.clone(),
                 credential_manager: credential_manager.clone(),
                 component_manager: component_manager.clone().map(Arc::new),
                 nmx_cluster_switch_mtls_services: carbide_config

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -158,6 +158,16 @@ fn test_nvos_update_manager(
     })
 }
 
+fn test_rack_firmware_update_manager(
+    rms_sim: &RmsSim,
+) -> Option<Arc<dyn component_manager::RackFirmwareUpdateManager>> {
+    rms_sim.as_rms_client().map(|client| {
+        Arc::new(component_manager::rms::rms_rack_firmware_update_manager(
+            client,
+        )) as Arc<dyn component_manager::RackFirmwareUpdateManager>
+    })
+}
+
 pub(in crate::tests) mod dpu;
 pub(in crate::tests) mod host;
 pub(in crate::tests) mod ib_partition;
@@ -377,7 +387,6 @@ impl TestEnv {
     pub(in crate::tests) fn rack_state_handler_services(&self) -> RackStateHandlerServices {
         RackStateHandlerServices {
             db_pool: self.pool.clone(),
-            rms_client: self.rms_sim.as_rms_client(),
             site_config: RackConfig {
                 rms: self.config.rms.clone(),
                 rack_validation_config: self.config.rack_validation_config.clone(),
@@ -385,6 +394,7 @@ impl TestEnv {
             }
             .into(),
             nvos_update_manager: test_nvos_update_manager(&self.rms_sim),
+            rack_firmware_update_manager: test_rack_firmware_update_manager(&self.rms_sim),
             credential_manager: self.test_credential_manager.clone(),
             component_manager: self.test_component_manager.clone(),
             nmx_cluster_switch_mtls_services:
@@ -1657,7 +1667,6 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         .services(
             RackStateHandlerServices {
                 db_pool: db_pool.clone(),
-                rms_client: rms_sim.as_rms_client(),
                 site_config: RackConfig {
                     rms: config.rms.clone(),
                     rack_validation_config: config.rack_validation_config.clone(),
@@ -1665,6 +1674,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
                 }
                 .into(),
                 nvos_update_manager: test_nvos_update_manager(&rms_sim),
+                rack_firmware_update_manager: test_rack_firmware_update_manager(&rms_sim),
                 credential_manager: credential_manager.clone(),
                 component_manager: test_component_manager.clone(),
                 nmx_cluster_switch_mtls_services:

--- a/crates/api-core/src/tests/rack_state_controller/handler.rs
+++ b/crates/api-core/src/tests/rack_state_controller/handler.rs
@@ -3513,7 +3513,6 @@ async fn run_configure_nmx_cluster_v2_workflow(
     let handler_instance = RackStateHandler::default();
 
     let mut services = env.rack_state_handler_services();
-    services.rms_client = None;
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
 
@@ -3867,7 +3866,6 @@ async fn test_configure_nmx_cluster_v2_completed_job_with_unknown_profile_stops_
     let handler_instance = RackStateHandler::default();
 
     let mut services = env.rack_state_handler_services();
-    services.rms_client = None;
     let mut metrics = RackMetrics::default();
     let mut db_writes = DbWriteBatch::default();
 

--- a/crates/component-manager/src/lib.rs
+++ b/crates/component-manager/src/lib.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 mod nvos_update_manager;
+mod rack_firmware_update_manager;
 #[cfg(test)]
 mod test_support;
 
@@ -21,6 +22,7 @@ pub mod tls;
 pub mod types;
 
 pub use nvos_update_manager::{NvosUpdateManager, NvosUpdateRequest};
+pub use rack_firmware_update_manager::{RackFirmwareUpdateManager, RackFirmwareUpdateRequest};
 
 pub mod proto {
     #[allow(clippy::enum_variant_names)]

--- a/crates/component-manager/src/rack_firmware_update_manager.rs
+++ b/crates/component-manager/src/rack_firmware_update_manager.rs
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Backend-neutral contracts for durable rack-level firmware-object updates.
+
+use carbide_uuid::rack::RackId;
+use model::rack::{FirmwareUpgradeDeviceInfo, FirmwareUpgradeJob};
+use model::rack_type::RackProfile;
+
+use crate::error::ComponentManagerError;
+
+pub(crate) mod sealed {
+    pub trait Sealed {}
+}
+
+/// Input for one rack-level firmware-object update.
+pub struct RackFirmwareUpdateRequest<'a> {
+    /// Rack that owns every target device.
+    pub rack_id: &'a RackId,
+
+    /// Rack profile used by the backend to identify target hardware.
+    pub profile: &'a RackProfile,
+
+    /// Source-of-truth firmware-object JSON.
+    pub config_json: &'a str,
+
+    /// Optional authorization token supplied with the maintenance request.
+    pub access_token: Option<&'a str>,
+
+    /// Whether the backend should apply matching firmware again.
+    pub force_update: bool,
+
+    /// Firmware-object component filters.
+    pub components: &'a [String],
+
+    /// Compute targets and their credentials.
+    pub machines: Vec<FirmwareUpgradeDeviceInfo>,
+
+    /// NV-Switch targets and their credentials.
+    pub switches: Vec<FirmwareUpgradeDeviceInfo>,
+}
+
+/// Backend contract for durable rack-level firmware-object updates.
+#[async_trait::async_trait]
+pub trait RackFirmwareUpdateManager: sealed::Sealed + Send + Sync {
+    /// Submits a firmware-object update and returns the durable job handles for
+    /// every requested device.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the request cannot be translated or submitted to
+    /// the configured backend.
+    async fn start_firmware_update(
+        &self,
+        request: RackFirmwareUpdateRequest<'_>,
+    ) -> Result<FirmwareUpgradeJob, ComponentManagerError>;
+
+    /// Polls a submitted firmware-object update using its durable job handles.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the configured backend cannot process the status
+    /// request.
+    async fn get_firmware_update_status(
+        &self,
+        job: &FirmwareUpgradeJob,
+    ) -> Result<FirmwareUpgradeJob, ComponentManagerError>;
+}

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -39,7 +39,10 @@ use model::component_manager::{
     ComputeTrayComponent, ConfigureSwitchCertificateState, FirmwareState, NvSwitchComponent,
     PowerAction, PowerShelfComponent,
 };
-use model::rack::{NvosUpdateJob, NvosUpdateSwitchStatus};
+use model::rack::{
+    FirmwareProgressState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeDeviceStatus,
+    FirmwareUpgradeJob, NvosUpdateJob, NvosUpdateSwitchStatus,
+};
 use model::rack_type::{RackHardwareTopology, RackProfile, RackProfileConfig};
 use model::switch::{FabricManagerState, FabricManagerStatus};
 use serde::Deserialize;
@@ -65,7 +68,9 @@ use crate::power_shelf_manager::{
     PowerShelfPowerStateResult,
 };
 use crate::types::FirmwareUpdateOptions;
-use crate::{NvosUpdateManager, NvosUpdateRequest};
+use crate::{
+    NvosUpdateManager, NvosUpdateRequest, RackFirmwareUpdateManager, RackFirmwareUpdateRequest,
+};
 
 /// Common RMS identity needed to address a device in RMS.
 #[derive(Clone)]
@@ -228,6 +233,432 @@ impl RmsSwitchSystemImageStatusApi for librms::RackManagerApi {
         cmd: rms::GetSwitchSystemImageJobStatusRequest,
     ) -> Result<rms::GetSwitchSystemImageJobStatusResponse, RackManagerError> {
         Ok(self.client.get_switch_system_image_job_status(cmd).await?)
+    }
+}
+
+/// RMS implementation of durable rack-level firmware-object operations.
+struct RmsRackFirmwareUpdateManager {
+    client: Arc<dyn RmsApi>,
+}
+
+impl crate::rack_firmware_update_manager::sealed::Sealed for RmsRackFirmwareUpdateManager {}
+
+#[async_trait::async_trait]
+impl RackFirmwareUpdateManager for RmsRackFirmwareUpdateManager {
+    async fn start_firmware_update(
+        &self,
+        request: RackFirmwareUpdateRequest<'_>,
+    ) -> Result<FirmwareUpgradeJob, ComponentManagerError> {
+        let started_at = chrono::Utc::now();
+        let rack_id = request.rack_id.to_string();
+        let machine_count = request.machines.len();
+        let switch_count = request.switches.len();
+        let firmware_type = firmware_type_for_profile(request.profile);
+        let hardware_type = profile_hardware_type_wire_value(request.profile);
+
+        let hardware_type = if hardware_type.trim().is_empty() {
+            ANY_RACK_HARDWARE_TYPE.to_string()
+        } else {
+            hardware_type
+        };
+
+        tracing::info!(
+            rack_id = %rack_id,
+            firmware_type,
+            hardware_type = %hardware_type,
+            force_update = request.force_update,
+            machine_count,
+            switch_count,
+            "Rack firmware object JSON apply starting",
+        );
+
+        let apply_request = rack_firmware_apply_request(&request, firmware_type, hardware_type)?;
+
+        let response = self
+            .client
+            .apply_firmware_object(apply_request)
+            .await
+            .map_err(|error| match error {
+                RackManagerError::ApiInvocationError(status)
+                    if status.code() == tonic::Code::InvalidArgument =>
+                {
+                    ComponentManagerError::InvalidArgument(format!(
+                        "failed to submit firmware object JSON apply to RMS: {status}"
+                    ))
+                }
+                RackManagerError::ApiInvocationError(status) => ComponentManagerError::Internal(
+                    format!("failed to submit firmware object JSON apply to RMS: {status}"),
+                ),
+                error => ComponentManagerError::Internal(format!(
+                    "failed to submit firmware object JSON apply to RMS: {error}"
+                )),
+            })?;
+
+        let job = rack_firmware_job_from_response(request, started_at, response)?;
+
+        tracing::info!(
+            rack_id = %rack_id,
+            parent_job_id = ?job.job_id,
+            object_id = ?job.firmware_id,
+            machine_count,
+            switch_count,
+            "RMS firmware object JSON apply submitted",
+        );
+
+        Ok(finish_rack_firmware_job(job))
+    }
+
+    async fn get_firmware_update_status(
+        &self,
+        job: &FirmwareUpgradeJob,
+    ) -> Result<FirmwareUpgradeJob, ComponentManagerError> {
+        let mut updated = job.clone();
+
+        for device in updated.all_devices_mut() {
+            if device.status.is_terminal() {
+                continue;
+            }
+
+            let Some(job_id) = device.job_id.clone() else {
+                device.status = FirmwareProgressState::Failed;
+
+                if device.error_message.is_none() {
+                    device.error_message = Some("Device has no firmware job ID to poll".into());
+                }
+
+                continue;
+            };
+
+            let response = self
+                .client
+                .get_firmware_job_status(rms::GetFirmwareJobStatusRequest {
+                    job_id: job_id.clone(),
+                })
+                .await;
+
+            apply_rack_firmware_job_status_response(device, &job_id, response);
+        }
+
+        Ok(finish_rack_firmware_job(updated))
+    }
+}
+
+fn rack_firmware_apply_request(
+    request: &RackFirmwareUpdateRequest<'_>,
+    firmware_type: &str,
+    hardware_type: String,
+) -> Result<rms::ApplyFirmwareObjectRequest, ComponentManagerError> {
+    let mut nodes = Vec::with_capacity(request.machines.len() + request.switches.len());
+
+    // Resolve every identity before dispatch so a mixed-device request
+    // cannot submit a partial rack update.
+    let compute_node_identity = if request.machines.is_empty() {
+        None
+    } else {
+        Some(
+            compute_node_identity_for_profile(request.profile).map_err(|error| {
+                ComponentManagerError::InvalidArgument(format!(
+                    "failed to resolve RMS compute descriptor: {error}"
+                ))
+            })?,
+        )
+    };
+
+    let switch_node_identity = if request.switches.is_empty() {
+        None
+    } else {
+        Some(
+            switch_node_identity_for_profile(request.profile).map_err(|error| {
+                ComponentManagerError::InvalidArgument(format!(
+                    "failed to resolve RMS switch descriptor: {error}"
+                ))
+            })?,
+        )
+    };
+
+    if let Some(node_identity) = &compute_node_identity {
+        nodes.extend(
+            request
+                .machines
+                .iter()
+                .map(|device| build_new_node_info(request.rack_id, device, node_identity)),
+        );
+    }
+
+    if let Some(node_identity) = &switch_node_identity {
+        nodes.extend(
+            request
+                .switches
+                .iter()
+                .map(|device| build_new_node_info(request.rack_id, device, node_identity)),
+        );
+    }
+
+    let (component_filters, node_descriptor_component_filters) =
+        firmware_object_component_filters_for_node_identities(
+            request.components,
+            compute_node_identity
+                .iter()
+                .chain(switch_node_identity.iter()),
+        );
+
+    Ok(rms::ApplyFirmwareObjectRequest {
+        rack_id: request.rack_id.to_string(),
+        config_json: request.config_json.to_string(),
+        access_token: Some(rms_access_token_or_noauth(request.access_token)),
+        firmware_type: firmware_type.to_string(),
+        hardware_type,
+        nodes: Some(rms::NodeSet { nodes }),
+        force_update: request.force_update,
+        component_filters,
+        node_descriptor_component_filters,
+    })
+}
+
+fn rack_firmware_job_from_response(
+    request: RackFirmwareUpdateRequest<'_>,
+    started_at: chrono::DateTime<chrono::Utc>,
+    response: rms::ApplyFirmwareObjectResponse,
+) -> Result<FirmwareUpgradeJob, ComponentManagerError> {
+    let batch_response = response.response.as_ref();
+
+    let batch_status = batch_response
+        .map(|batch_response| batch_response.status)
+        .unwrap_or(rms::ReturnCode::Failure as i32);
+
+    let batch_job_id = batch_response
+        .map(|batch_response| batch_response.job_id.as_str())
+        .unwrap_or_default();
+
+    if batch_status != rms::ReturnCode::Success as i32
+        && batch_job_id.is_empty()
+        && response.jobs.is_empty()
+    {
+        let message = batch_response
+            .map(|batch_response| batch_response.message.as_str())
+            .unwrap_or_default();
+
+        let message = if message.is_empty() {
+            "RMS returned failure for ApplyFirmwareObject".to_string()
+        } else {
+            message.to_string()
+        };
+
+        return Err(ComponentManagerError::RejectedBeforeDispatch(message));
+    }
+
+    let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
+
+    let child_jobs = response
+        .jobs
+        .iter()
+        .map(|child| (child.node_id.clone(), child.job_id.clone()))
+        .collect::<HashMap<_, _>>();
+
+    let node_errors = batch_response
+        .map(|batch_response| {
+            batch_response
+                .node_results
+                .iter()
+                .filter(|result| {
+                    result.status != rms::ReturnCode::Success as i32
+                        || !result.error_message.is_empty()
+                })
+                .map(|result| (result.node_id.clone(), result.error_message.clone()))
+                .collect::<HashMap<_, _>>()
+        })
+        .unwrap_or_default();
+
+    let batch_error = batch_response.and_then(|batch_response| {
+        if batch_response.status == rms::ReturnCode::Success as i32
+            || batch_response.message.is_empty()
+        {
+            None
+        } else {
+            Some(batch_response.message.clone())
+        }
+    });
+
+    Ok(FirmwareUpgradeJob {
+        job_id: parent_job_id.clone(),
+        firmware_id: Some(response.object_id),
+        started_at: Some(started_at),
+        batch_job_ids: parent_job_id.iter().cloned().collect(),
+        machines: request
+            .machines
+            .into_iter()
+            .map(|device| {
+                rack_firmware_device_status(
+                    device,
+                    parent_job_id.clone(),
+                    &child_jobs,
+                    &node_errors,
+                    batch_error.as_deref(),
+                )
+            })
+            .collect(),
+        switches: request
+            .switches
+            .into_iter()
+            .map(|device| {
+                rack_firmware_device_status(
+                    device,
+                    parent_job_id.clone(),
+                    &child_jobs,
+                    &node_errors,
+                    batch_error.as_deref(),
+                )
+            })
+            .collect(),
+        ..Default::default()
+    })
+}
+
+fn rack_firmware_device_status(
+    device: FirmwareUpgradeDeviceInfo,
+    parent_job_id: Option<String>,
+    child_jobs: &HashMap<String, String>,
+    node_errors: &HashMap<String, String>,
+    batch_error: Option<&str>,
+) -> FirmwareUpgradeDeviceStatus {
+    let mut status = FirmwareUpgradeDeviceStatus {
+        node_id: device.node_id.clone(),
+        mac: device.mac,
+        bmc_ip: device.bmc_ip,
+        status: FirmwareProgressState::InProgress,
+        job_id: None,
+        parent_job_id,
+        error_message: None,
+    };
+
+    if let Some(error_message) = node_errors.get(&device.node_id) {
+        status.status = FirmwareProgressState::Failed;
+        status.error_message = Some(error_message.clone());
+    } else if let Some(job_id) = child_jobs.get(&device.node_id) {
+        status.job_id = Some(job_id.clone());
+    } else {
+        status.status = FirmwareProgressState::Failed;
+
+        status.error_message = Some(
+            batch_error
+                .unwrap_or("RMS did not return a child firmware job for this device")
+                .to_string(),
+        );
+    }
+
+    status
+}
+
+fn finish_rack_firmware_job(mut job: FirmwareUpgradeJob) -> FirmwareUpgradeJob {
+    let total = job.all_devices().count();
+
+    let completed = job
+        .all_devices()
+        .filter(|device| device.status == FirmwareProgressState::Completed)
+        .count();
+
+    let failed = job
+        .all_devices()
+        .filter(|device| device.status == FirmwareProgressState::Failed)
+        .count();
+
+    let terminal = completed + failed;
+
+    job.status = Some(if total > 0 && terminal < total {
+        FirmwareProgressState::InProgress
+    } else if failed > 0 {
+        FirmwareProgressState::Failed
+    } else {
+        FirmwareProgressState::Completed
+    });
+
+    if total > 0 && terminal == total {
+        job.completed_at.get_or_insert_with(chrono::Utc::now);
+    } else {
+        job.completed_at = None;
+    }
+
+    job
+}
+
+fn apply_rack_firmware_job_status_response(
+    device: &mut FirmwareUpgradeDeviceStatus,
+    job_id: &str,
+    response: Result<rms::GetFirmwareJobStatusResponse, RackManagerError>,
+) {
+    match response {
+        Ok(response) if response.status == rms::ReturnCode::Success as i32 => {
+            if !response.node_id.is_empty() {
+                device.node_id = response.node_id.clone();
+            }
+
+            match rms::FirmwareJobState::try_from(response.job_state) {
+                Ok(rms::FirmwareJobState::Queued) => {
+                    device.status = FirmwareProgressState::Pending;
+                    device.error_message = None;
+                }
+                Ok(rms::FirmwareJobState::Running) => {
+                    device.status = FirmwareProgressState::InProgress;
+                    device.error_message = None;
+                }
+                Ok(rms::FirmwareJobState::Completed) => {
+                    device.status = FirmwareProgressState::Completed;
+                    device.error_message = None;
+                }
+                Ok(rms::FirmwareJobState::Failed) => {
+                    device.status = FirmwareProgressState::Failed;
+
+                    device.error_message = Some(if response.error_message.is_empty() {
+                        response.state_description
+                    } else {
+                        response.error_message
+                    });
+                }
+                Ok(rms::FirmwareJobState::Unspecified) | Err(_) => {
+                    tracing::warn!(
+                        job_id = %job_id,
+                        job_state = response.job_state,
+                        "RMS returned unknown firmware job state; keeping previous device status",
+                    );
+
+                    device.error_message = Some(format!(
+                        "Unknown RMS firmware job state {}",
+                        response.job_state
+                    ));
+                }
+            }
+        }
+        Ok(response) => {
+            let message = if response.error_message.is_empty() {
+                if response.state_description.is_empty() {
+                    format!("RMS could not report status for firmware job {job_id}")
+                } else {
+                    response.state_description
+                }
+            } else {
+                response.error_message
+            };
+
+            tracing::warn!(
+                job_id = %job_id,
+                job_status = response.status,
+                error = %message,
+                "RMS returned a non-success firmware job status lookup; retrying later",
+            );
+
+            device.error_message = Some(message);
+        }
+        Err(error) => {
+            let error = carbide_rack::rack_manager_error("get_firmware_job_status", error);
+
+            tracing::warn!(
+                job_id = %job_id,
+                error = %error,
+                "Transient RMS firmware job polling error; retrying later",
+            );
+
+            device.error_message = Some(error.to_string());
+        }
     }
 }
 
@@ -543,6 +974,11 @@ fn apply_nvos_job_status_response(
 /// Creates the RMS implementation of durable rack-level NVOS operations.
 pub fn rms_nvos_update_manager(client: Arc<dyn RmsApi>) -> impl NvosUpdateManager {
     RmsNvosUpdateManager { client }
+}
+
+/// Creates the RMS implementation of durable rack-level firmware-object operations.
+pub fn rms_rack_firmware_update_manager(client: Arc<dyn RmsApi>) -> impl RackFirmwareUpdateManager {
+    RmsRackFirmwareUpdateManager { client }
 }
 
 impl std::fmt::Debug for RmsBackend {
@@ -3842,6 +4278,103 @@ mod tests {
     };
 
     // ---- Mapping unit tests ----
+
+    #[test]
+    fn rack_firmware_device_status_uses_batch_error_when_child_job_missing() {
+        let status = rack_firmware_device_status(
+            FirmwareUpgradeDeviceInfo {
+                node_id: "node-1".into(),
+                mac: "00:11:22:33:44:55".into(),
+                bmc_ip: "192.0.2.10".into(),
+                bmc_username: "admin".into(),
+                bmc_password: "password".into(),
+                os_mac: None,
+                os_ip: None,
+                os_username: None,
+                os_password: None,
+                os_hostname: None,
+            },
+            Some("parent-job".into()),
+            &HashMap::new(),
+            &HashMap::new(),
+            Some("invalid SOT JSON"),
+        );
+
+        assert_eq!(status.status, FirmwareProgressState::Failed);
+        assert_eq!(status.error_message.as_deref(), Some("invalid SOT JSON"));
+    }
+
+    #[tokio::test]
+    async fn rack_firmware_submission_classifies_invalid_and_rejected_requests() {
+        let mock = Arc::new(MockRmsApi::new());
+
+        let manager = RmsRackFirmwareUpdateManager {
+            client: mock.clone(),
+        };
+
+        let rack_id = RackId::new("rack-1");
+        let profile = test_rms_profile();
+
+        let request = || RackFirmwareUpdateRequest {
+            rack_id: &rack_id,
+            profile: &profile,
+            config_json: r#"{"Id":"fw-default"}"#,
+            access_token: Some("token"),
+            force_update: false,
+            components: &[],
+            machines: Vec::new(),
+            switches: Vec::new(),
+        };
+
+        mock.enqueue_apply_firmware_object(Err(RackManagerError::ApiInvocationError(
+            tonic::Status::invalid_argument("unsupported node descriptor"),
+        )))
+        .await;
+
+        let result = manager.start_firmware_update(request()).await;
+
+        assert!(matches!(
+            result,
+            Err(ComponentManagerError::InvalidArgument(cause))
+                if cause.contains("unsupported node descriptor")
+        ));
+
+        mock.enqueue_apply_firmware_object(Ok(MockRmsApi::firmware_object_apply_fail(
+            "node-1",
+            "unsupported firmware object",
+        )))
+        .await;
+
+        let result = manager.start_firmware_update(request()).await;
+
+        assert!(matches!(
+            result,
+            Err(ComponentManagerError::RejectedBeforeDispatch(_))
+        ));
+    }
+
+    #[test]
+    fn rack_firmware_repoll_preserves_completion_timestamp() {
+        let completed_at = chrono::Utc::now();
+
+        let job = FirmwareUpgradeJob {
+            completed_at: Some(completed_at),
+            machines: vec![FirmwareUpgradeDeviceStatus {
+                node_id: "node-1".into(),
+                mac: "00:11:22:33:44:55".into(),
+                bmc_ip: "192.0.2.10".into(),
+                status: FirmwareProgressState::Completed,
+                job_id: Some("child-job".into()),
+                parent_job_id: Some("parent-job".into()),
+                error_message: None,
+            }],
+            ..Default::default()
+        };
+
+        let repolled = finish_rack_firmware_job(job);
+
+        assert_eq!(repolled.completed_at, Some(completed_at));
+    }
 
     #[test]
     fn power_action_maps_to_rms_operation() {

--- a/crates/rack-controller/Cargo.toml
+++ b/crates/rack-controller/Cargo.toml
@@ -40,7 +40,6 @@ async-trait = { workspace = true }
 chrono = { workspace = true }
 duration-str = { workspace = true }
 eyre = { workspace = true }
-librms = { workspace = true }
 mac_address = { workspace = true }
 opentelemetry = { workspace = true }
 reqwest = { workspace = true, default-features = false, features = ["rustls"] }

--- a/crates/rack-controller/src/context.rs
+++ b/crates/rack-controller/src/context.rs
@@ -21,9 +21,8 @@ use carbide_health_metrics::PerObjectMetricsRegistry;
 use carbide_rack_controller::config::RackConfig;
 use carbide_rack_controller::metrics::RackMetrics;
 use carbide_secrets::credentials::CredentialManager;
-use component_manager::NvosUpdateManager;
 use component_manager::component_manager::ComponentManager;
-use librms::RmsApi;
+use component_manager::{NvosUpdateManager, RackFirmwareUpdateManager};
 use sqlx::PgPool;
 use state_controller::state_handler::StateHandlerContextObjects;
 
@@ -36,8 +35,7 @@ pub struct RackStateHandlerContextObjects {}
 #[derive(Clone)]
 pub struct RackStateHandlerServices {
     pub db_pool: PgPool,
-    /// Rack Manager Service client
-    pub rms_client: Option<Arc<dyn RmsApi>>,
+
     // TODO: probably this is not the best place for config. But this
     // field is introduced during refactoring. In original code it was
     // full CarbideConfig.
@@ -45,6 +43,10 @@ pub struct RackStateHandlerServices {
 
     /// Backend-neutral rack NVOS update operations.
     pub nvos_update_manager: Option<Arc<dyn NvosUpdateManager>>,
+
+    /// Backend-neutral rack firmware-object update operations.
+    pub rack_firmware_update_manager: Option<Arc<dyn RackFirmwareUpdateManager>>,
+
     pub credential_manager: Arc<dyn CredentialManager>,
     /// Component manager used for switch operations during rack maintenance.
     pub component_manager: Option<Arc<ComponentManager>>,

--- a/crates/rack-controller/src/maintenance.rs
+++ b/crates/rack-controller/src/maintenance.rs
@@ -20,17 +20,12 @@
 use carbide_instrument::{Event, emit};
 use carbide_rack::firmware_object::{
     ANY_RACK_HARDWARE_TYPE, profile_hardware_type_wire_value, rack_maintenance_access_token_key,
-    rms_access_token_or_noauth,
 };
 use carbide_rack::firmware_update::{
-    RackFirmwareInventory, RackSwitchFirmwareInventory, build_new_node_info,
-    firmware_type_for_profile, load_rack_firmware_inventory, load_rack_switch_firmware_inventory,
+    RackFirmwareInventory, RackSwitchFirmwareInventory, firmware_type_for_profile,
+    load_rack_firmware_inventory, load_rack_switch_firmware_inventory,
 };
-use carbide_rack::rack_manager_error;
-use carbide_rack::rms_node_type::{
-    compute_node_identity_for_profile, firmware_object_component_filters_for_node_identities,
-    switch_node_identity_for_profile,
-};
+use carbide_rack::rms_node_type::switch_node_identity_for_profile;
 use carbide_rack_controller::context::RackStateHandlerContextObjects;
 use carbide_rack_controller::fabric_manager::{
     observed_primary_switch, persist_fabric_manager_statuses, persist_primary_switch,
@@ -40,23 +35,22 @@ use carbide_rack_controller::validating::strip_rv_labels;
 use carbide_secrets::credentials::{CredentialManager, Credentials};
 use carbide_uuid::machine::HostMachineId;
 use carbide_uuid::rack::{RackId, RackProfileId};
-use component_manager::NvosUpdateRequest;
 use component_manager::component_manager::ComponentManager;
 use component_manager::error::ComponentManagerError;
 use component_manager::nv_switch_manager::ScaleUpFabricManagerJobStatus;
+use component_manager::{NvosUpdateRequest, RackFirmwareUpdateRequest};
 use db::{
     host_machine_update as db_host_machine_update, machine as db_machine,
     machine_topology as db_machine_topology, power_options as db_power_options,
     power_shelf as db_power_shelf, rack as db_rack, switch as db_switch,
 };
-use librms::protos::rack_manager as rms;
 use model::machine::HostMachine;
 use model::rack::{
-    ConfigureNmxClusterState, FirmwareProgressState, FirmwareUpgradeDeviceInfo,
-    FirmwareUpgradeDeviceStatus, FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope,
-    NvosUpdateState, NvosUpdateSwitchStatus, Rack, RackFirmwareUpgradeState,
-    RackFirmwareUpgradeStatus, RackMaintenanceState, RackPowerState, RackState,
-    RackValidationState, SwitchNvosUpdateState, SwitchNvosUpdateStatus,
+    ConfigureNmxClusterState, FirmwareProgressState, FirmwareUpgradeDeviceStatus,
+    FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateState,
+    NvosUpdateSwitchStatus, Rack, RackFirmwareUpgradeState, RackFirmwareUpgradeStatus,
+    RackMaintenanceState, RackPowerState, RackState, RackValidationState, SwitchNvosUpdateState,
+    SwitchNvosUpdateStatus,
 };
 use model::rack_type::RackProfile;
 use state_controller::state_handler::{
@@ -1086,381 +1080,6 @@ fn skip_configure_nmx_cluster_outcome(
     })
 }
 
-fn firmware_device_status(
-    device: FirmwareUpgradeDeviceInfo,
-    parent_job_id: Option<String>,
-    child_jobs: &std::collections::HashMap<String, String>,
-    node_errors: &std::collections::HashMap<String, String>,
-    batch_error: Option<&str>,
-) -> FirmwareUpgradeDeviceStatus {
-    let mut status = FirmwareUpgradeDeviceStatus {
-        node_id: device.node_id.clone(),
-        mac: device.mac,
-        bmc_ip: device.bmc_ip,
-        status: FirmwareProgressState::InProgress,
-        job_id: None,
-        parent_job_id,
-        error_message: None,
-    };
-
-    if let Some(error_message) = node_errors.get(&device.node_id) {
-        status.status = FirmwareProgressState::Failed;
-        status.error_message = Some(error_message.clone());
-    } else if let Some(job_id) = child_jobs.get(&device.node_id) {
-        status.job_id = Some(job_id.clone());
-    } else {
-        status.status = FirmwareProgressState::Failed;
-        status.error_message = Some(
-            batch_error
-                .unwrap_or("RMS did not return a child firmware job for this device")
-                .to_string(),
-        );
-    }
-
-    status
-}
-
-struct RmsFirmwareObjectJsonApply<'a> {
-    rack_id: &'a RackId,
-    profile: &'a RackProfile,
-    config_json: &'a str,
-    access_token: &'a str,
-    firmware_type: &'a str,
-    hardware_type: &'a str,
-    force_update: bool,
-    components: &'a [String],
-    machines: Vec<FirmwareUpgradeDeviceInfo>,
-    switches: Vec<FirmwareUpgradeDeviceInfo>,
-}
-
-async fn rms_start_firmware_upgrade_from_json(
-    rms_client: &dyn librms::RmsApi,
-    request: RmsFirmwareObjectJsonApply<'_>,
-) -> Result<model::rack::FirmwareUpgradeJob, StateHandlerError> {
-    let started_at = chrono::Utc::now();
-    let machine_count = request.machines.len();
-    let switch_count = request.switches.len();
-    let mut nodes = Vec::with_capacity(machine_count + switch_count);
-
-    // Resolve all required RMS identities before constructing the RMS request
-    // so a mixed-device update fails before any partial firmware submission.
-    let compute_node_identity = if machine_count > 0 {
-        Some(
-            compute_node_identity_for_profile(request.profile).map_err(|error| {
-                StateHandlerError::GenericError(eyre::eyre!(
-                    "failed to resolve RMS compute descriptor: {}",
-                    error
-                ))
-            })?,
-        )
-    } else {
-        None
-    };
-
-    let switch_node_identity = if switch_count > 0 {
-        Some(
-            switch_node_identity_for_profile(request.profile).map_err(|error| {
-                StateHandlerError::GenericError(eyre::eyre!(
-                    "failed to resolve RMS switch descriptor: {}",
-                    error
-                ))
-            })?,
-        )
-    } else {
-        None
-    };
-
-    if let Some(node_identity) = &compute_node_identity {
-        nodes.extend(
-            request
-                .machines
-                .iter()
-                .map(|device| build_new_node_info(request.rack_id, device, node_identity)),
-        );
-    }
-
-    if let Some(node_identity) = &switch_node_identity {
-        nodes.extend(
-            request
-                .switches
-                .iter()
-                .map(|device| build_new_node_info(request.rack_id, device, node_identity)),
-        );
-    }
-
-    let (component_filters, node_descriptor_component_filters) =
-        firmware_object_component_filters_for_node_identities(
-            request.components,
-            compute_node_identity
-                .iter()
-                .chain(switch_node_identity.iter()),
-        );
-
-    let response = rms_client
-        .apply_firmware_object(rms::ApplyFirmwareObjectRequest {
-            rack_id: request.rack_id.to_string(),
-            config_json: request.config_json.to_string(),
-            access_token: Some(rms_access_token_or_noauth(Some(request.access_token))),
-            firmware_type: request.firmware_type.to_string(),
-            hardware_type: request.hardware_type.to_string(),
-            nodes: Some(rms::NodeSet { nodes }),
-            force_update: request.force_update,
-            component_filters,
-            node_descriptor_component_filters,
-        })
-        .await
-        .map_err(|error| {
-            StateHandlerError::GenericError(eyre::eyre!(
-                "failed to submit firmware object JSON apply to RMS: {}",
-                error
-            ))
-        })?;
-
-    let batch_response = response.response.as_ref();
-    let batch_status = batch_response
-        .map(|batch_response| batch_response.status)
-        .unwrap_or(rms::ReturnCode::Failure as i32);
-    let batch_job_id = batch_response
-        .map(|batch_response| batch_response.job_id.as_str())
-        .unwrap_or_default();
-    if batch_status != rms::ReturnCode::Success as i32
-        && batch_job_id.is_empty()
-        && response.jobs.is_empty()
-    {
-        let message = batch_response
-            .map(|batch_response| batch_response.message.as_str())
-            .unwrap_or_default();
-        let message = if message.is_empty() {
-            "RMS returned failure for ApplyFirmwareObject".to_string()
-        } else {
-            message.to_string()
-        };
-        return Err(StateHandlerError::GenericError(eyre::eyre!(message)));
-    }
-
-    let parent_job_id = (!batch_job_id.is_empty()).then(|| batch_job_id.to_string());
-    let child_jobs = response
-        .jobs
-        .iter()
-        .map(|child| (child.node_id.clone(), child.job_id.clone()))
-        .collect::<std::collections::HashMap<_, _>>();
-    let node_errors = batch_response
-        .map(|batch_response| {
-            batch_response
-                .node_results
-                .iter()
-                .filter(|result| {
-                    result.status != rms::ReturnCode::Success as i32
-                        || !result.error_message.is_empty()
-                })
-                .map(|result| (result.node_id.clone(), result.error_message.clone()))
-                .collect::<std::collections::HashMap<_, _>>()
-        })
-        .unwrap_or_default();
-    let batch_error = batch_response.and_then(|batch_response| {
-        if batch_response.status == rms::ReturnCode::Success as i32
-            || batch_response.message.is_empty()
-        {
-            None
-        } else {
-            Some(batch_response.message.clone())
-        }
-    });
-
-    let mut job = model::rack::FirmwareUpgradeJob {
-        job_id: parent_job_id.clone(),
-        firmware_id: Some(response.object_id),
-        started_at: Some(started_at),
-        batch_job_ids: parent_job_id.iter().cloned().collect(),
-        machines: request
-            .machines
-            .into_iter()
-            .map(|device| {
-                firmware_device_status(
-                    device,
-                    parent_job_id.clone(),
-                    &child_jobs,
-                    &node_errors,
-                    batch_error.as_deref(),
-                )
-            })
-            .collect(),
-        switches: request
-            .switches
-            .into_iter()
-            .map(|device| {
-                firmware_device_status(
-                    device,
-                    parent_job_id.clone(),
-                    &child_jobs,
-                    &node_errors,
-                    batch_error.as_deref(),
-                )
-            })
-            .collect(),
-        ..Default::default()
-    };
-
-    tracing::info!(
-        rack_id = %request.rack_id,
-        parent_job_id = ?job.job_id,
-        object_id = ?job.firmware_id,
-        machine_count,
-        switch_count,
-        "RMS firmware object JSON apply submitted",
-    );
-
-    let all_devices: Vec<_> = job.all_devices().collect();
-    let failed = all_devices
-        .iter()
-        .filter(|device| device.status == FirmwareProgressState::Failed)
-        .count();
-    let completed = all_devices
-        .iter()
-        .filter(|device| device.status == FirmwareProgressState::Completed)
-        .count();
-    let total = all_devices.len();
-    let terminal = completed + failed;
-
-    job.status = Some(if total > 0 && terminal < total {
-        FirmwareProgressState::InProgress
-    } else if failed > 0 {
-        FirmwareProgressState::Failed
-    } else {
-        FirmwareProgressState::Completed
-    });
-    if total > 0 && terminal == total {
-        job.completed_at = Some(chrono::Utc::now());
-    }
-
-    Ok(job)
-}
-
-/// Poll RMS GetFirmwareJobStatus for each tracked child job and update the
-/// in-memory rack firmware job with the latest per-device result.
-async fn rms_get_firmware_upgrade_status(
-    rms_client: &dyn librms::RmsApi,
-    job: &model::rack::FirmwareUpgradeJob,
-) -> Result<model::rack::FirmwareUpgradeJob, StateHandlerError> {
-    let mut updated = job.clone();
-    for device in updated.all_devices_mut() {
-        if device.status.is_terminal() {
-            continue;
-        }
-
-        let Some(job_id) = device.job_id.clone() else {
-            device.status = FirmwareProgressState::Failed;
-            if device.error_message.is_none() {
-                device.error_message = Some("Device has no firmware job ID to poll".into());
-            }
-            continue;
-        };
-
-        let response = rms_client
-            .get_firmware_job_status(librms::protos::rack_manager::GetFirmwareJobStatusRequest {
-                job_id: job_id.clone(),
-            })
-            .await;
-
-        match response {
-            Ok(response)
-                if response.status == librms::protos::rack_manager::ReturnCode::Success as i32 =>
-            {
-                if !response.node_id.is_empty() {
-                    device.node_id = response.node_id.clone();
-                }
-                match rms::FirmwareJobState::try_from(response.job_state) {
-                    Ok(rms::FirmwareJobState::Queued) => {
-                        device.status = FirmwareProgressState::Pending;
-                        device.error_message = None;
-                    }
-                    Ok(rms::FirmwareJobState::Running) => {
-                        device.status = FirmwareProgressState::InProgress;
-                        device.error_message = None;
-                    }
-                    Ok(rms::FirmwareJobState::Completed) => {
-                        device.status = FirmwareProgressState::Completed;
-                        device.error_message = None;
-                    }
-                    Ok(rms::FirmwareJobState::Failed) => {
-                        device.status = FirmwareProgressState::Failed;
-                        device.error_message = Some(if response.error_message.is_empty() {
-                            response.state_description
-                        } else {
-                            response.error_message
-                        });
-                    }
-                    Ok(rms::FirmwareJobState::Unspecified) | Err(_) => {
-                        tracing::warn!(
-                            job_id = %job_id,
-                            job_state = response.job_state,
-                            "RMS returned unknown firmware job state; keeping previous device status"
-                        );
-                        device.error_message = Some(format!(
-                            "Unknown RMS firmware job state {}",
-                            response.job_state
-                        ));
-                    }
-                }
-            }
-            Ok(response) => {
-                let message = if response.error_message.is_empty() {
-                    if response.state_description.is_empty() {
-                        format!("RMS could not report status for firmware job {}", job_id)
-                    } else {
-                        response.state_description
-                    }
-                } else {
-                    response.error_message
-                };
-                tracing::warn!(
-                    job_id = %job_id,
-                    job_status = response.status,
-                    error = %message,
-                    "RMS returned a non-success firmware job status lookup; retrying later"
-                );
-                device.error_message = Some(message);
-            }
-            Err(error) => {
-                let error = rack_manager_error("get_firmware_job_status", error);
-                tracing::warn!(
-                    job_id = %job_id,
-                    error = %error,
-                    "Transient RMS firmware job polling error; retrying later"
-                );
-                device.error_message = Some(error.to_string());
-            }
-        }
-    }
-
-    let all_devices: Vec<_> = updated.all_devices().collect();
-    let failed = all_devices
-        .iter()
-        .filter(|device| device.status == FirmwareProgressState::Failed)
-        .count();
-    let completed = all_devices
-        .iter()
-        .filter(|device| device.status == FirmwareProgressState::Completed)
-        .count();
-    let total = all_devices.len();
-    let terminal = completed + failed;
-
-    updated.status = Some(if total > 0 && terminal < total {
-        FirmwareProgressState::InProgress
-    } else if failed > 0 {
-        FirmwareProgressState::Failed
-    } else {
-        FirmwareProgressState::Completed
-    });
-    updated.completed_at = if total > 0 && terminal == total {
-        Some(chrono::Utc::now())
-    } else {
-        None
-    };
-
-    Ok(updated)
-}
-
 fn validate_complete_nmx_fabric_inventory(
     switch_inventory: &RackSwitchFirmwareInventory,
 ) -> Result<(), String> {
@@ -2033,7 +1652,9 @@ pub async fn handle_maintenance(
                     .await;
                 }
 
-                let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+                let Some(rack_firmware_update_manager) =
+                    ctx.services.rack_firmware_update_manager.as_deref()
+                else {
                     if uses_stored_token {
                         delete_rack_maintenance_access_token(
                             ctx.services.credential_manager.as_ref(),
@@ -2042,12 +1663,12 @@ pub async fn handle_maintenance(
                         .await;
                     }
 
-                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
-                        .await;
+                    let cause = "rack firmware update manager not configured";
+                    return transition_to_rack_error(id, state, cause, ctx).await;
                 };
 
-                // Profile-driven ingestion has no caller token, so it uses the RMS
-                // NOAUTH sentinel.
+                // Profile-driven ingestion has no caller token. The backend
+                // supplies its unauthenticated representation.
                 let access_token = if uses_stored_token {
                     match load_rack_maintenance_access_token(
                         ctx.services.credential_manager.as_ref(),
@@ -2055,21 +1676,18 @@ pub async fn handle_maintenance(
                     )
                     .await
                     {
-                        Ok(access_token) => access_token,
+                        Ok(access_token) => Some(access_token),
                         Err(error) => {
                             let message = error.to_string();
                             return transition_to_rack_error(id, state, &message, ctx).await;
                         }
                     }
                 } else {
-                    rms_access_token_or_noauth(None)
+                    None
                 };
+
                 let profile = super::resolve_profile(id, rack_profile_id, ctx);
-                let rack_hardware_type = profile_hardware_type_or_any(profile);
-                let firmware_type = profile
-                    .map(firmware_type_for_profile)
-                    .unwrap_or("prod")
-                    .to_string();
+
                 let inventory = load_rack_firmware_inventory(
                     &ctx.services.db_pool,
                     ctx.services.credential_manager.as_ref(),
@@ -2120,32 +1738,18 @@ pub async fn handle_maintenance(
                     .await;
                 };
 
-                tracing::info!(
-                    rack_id = %id,
-                    firmware_type = %firmware_type,
-                    hardware_type = %rack_hardware_type,
-                    force_update,
-                    machine_count = inventory.machines.len(),
-                    switch_count = inventory.switches.len(),
-                    "Rack firmware object JSON apply starting",
-                );
-
-                let submit_result = rms_start_firmware_upgrade_from_json(
-                    rms_client.as_ref(),
-                    RmsFirmwareObjectJsonApply {
+                let submit_result = rack_firmware_update_manager
+                    .start_firmware_update(RackFirmwareUpdateRequest {
                         rack_id: id,
                         profile,
                         config_json: &config_json,
-                        access_token: &access_token,
-                        firmware_type: &firmware_type,
-                        hardware_type: &rack_hardware_type,
+                        access_token: access_token.as_deref(),
                         force_update,
                         components: &components,
                         machines: inventory.machines.clone(),
                         switches: inventory.switches.clone(),
-                    },
-                )
-                .await;
+                    })
+                    .await;
 
                 if uses_stored_token && (submit_result.is_err() || !nvos_json_pending) {
                     delete_rack_maintenance_access_token(
@@ -2157,6 +1761,18 @@ pub async fn handle_maintenance(
 
                 let mut job = match submit_result {
                     Ok(job) => job,
+                    Err(ComponentManagerError::Internal(cause)) => {
+                        let cause = StateHandlerError::GenericError(eyre::eyre!(cause)).to_string();
+
+                        return transition_to_rack_error_with_firmware_job(
+                            id,
+                            state,
+                            "firmware-object-json",
+                            cause,
+                            ctx,
+                        )
+                        .await;
+                    }
                     Err(error) => {
                         return transition_to_rack_error_with_firmware_job(
                             id,
@@ -2262,7 +1878,9 @@ pub async fn handle_maintenance(
                         .with_txn(recovery_txn));
                 }
 
-                let Some(rms_client) = ctx.services.rms_client.as_ref() else {
+                let Some(rack_firmware_update_manager) =
+                    ctx.services.rack_firmware_update_manager.as_deref()
+                else {
                     if requested_nvos_config_json(scope).is_some() {
                         delete_rack_maintenance_access_token(
                             ctx.services.credential_manager.as_ref(),
@@ -2270,12 +1888,17 @@ pub async fn handle_maintenance(
                         )
                         .await;
                     }
-                    return transition_to_rack_error(id, state, "RMS client not configured", ctx)
-                        .await;
+
+                    let cause = "rack firmware update manager not configured";
+                    return transition_to_rack_error(id, state, cause, ctx).await;
                 };
+
                 let current_job = state.firmware_upgrade_job.as_ref().unwrap();
-                let mut job =
-                    rms_get_firmware_upgrade_status(rms_client.as_ref(), current_job).await?;
+
+                let mut job = rack_firmware_update_manager
+                    .get_firmware_update_status(current_job)
+                    .await
+                    .map_err(|error| StateHandlerError::GenericError(eyre::eyre!(error)))?;
 
                 let mut txn = ctx.services.db_pool.begin().await?;
 
@@ -2892,18 +2515,18 @@ mod tests {
     use carbide_uuid::rack::RackId;
     use carbide_uuid::switch::{SwitchId, SwitchIdSource, SwitchType};
     use model::rack::{
-        ConfigureNmxClusterState, FirmwareProgressState, FirmwareUpgradeDeviceInfo,
-        FirmwareUpgradeState, MaintenanceActivity, MaintenanceScope, NvosUpdateState,
-        RackMaintenanceState, RackPowerState,
+        ConfigureNmxClusterState, FirmwareUpgradeDeviceInfo, FirmwareUpgradeState,
+        MaintenanceActivity, MaintenanceScope, NvosUpdateState, RackMaintenanceState,
+        RackPowerState,
     };
     use model::rack_type::{RackHardwareType, RackProfile};
 
     use super::{
         DeviceFirmwareOutcome, DeviceFirmwareProgress, delete_rack_maintenance_access_token,
-        filter_inventory_by_scope, firmware_device_status, first_maintenance_state,
-        next_state_after_configure, next_state_after_firmware, next_state_after_nvos,
-        next_state_if_activity_not_requested, profile_hardware_type_or_any,
-        summarize_firmware_outcomes, validate_complete_nmx_fabric_inventory,
+        filter_inventory_by_scope, first_maintenance_state, next_state_after_configure,
+        next_state_after_firmware, next_state_after_nvos, next_state_if_activity_not_requested,
+        profile_hardware_type_or_any, summarize_firmware_outcomes,
+        validate_complete_nmx_fabric_inventory,
     };
 
     fn test_machine_id(seed: u8) -> HostMachineId {
@@ -3190,20 +2813,6 @@ mod tests {
         assert_eq!(filtered.switch_ids, vec![switch_id]);
         assert_eq!(filtered.switches.len(), 1);
         assert_eq!(filtered.switches[0].node_id, switch_id.to_string());
-    }
-
-    #[test]
-    fn firmware_device_status_uses_batch_error_when_child_job_missing() {
-        let status = firmware_device_status(
-            test_device_info("node-1"),
-            Some("parent-job".to_string()),
-            &std::collections::HashMap::new(),
-            &std::collections::HashMap::new(),
-            Some("invalid SOT JSON"),
-        );
-
-        assert_eq!(status.status, FirmwareProgressState::Failed);
-        assert_eq!(status.error_message.as_deref(), Some("invalid SOT JSON"));
     }
 
     #[test]


### PR DESCRIPTION
Route rack firmware-object submission and polling through the backend-neutral `RackFirmwareUpdateManager`. The RMS implementation owns `ApplyFirmwareObject` request construction, durable parent and child job mapping, and status polling. This is part of the cleanup tracked in #4240 (work spans across multiple PRs).

## Related issues

Supports #4240

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)