### PR TITLE
feat(component-manager): enable RMS NVOS password rotation by default

### DIFF
--- a/crates/component-manager/src/component_manager.rs
+++ b/crates/component-manager/src/component_manager.rs
@@ -781,6 +781,7 @@ pub async fn build_component_manager(
 
 #[cfg(test)]
 mod tests {
+    use api_test_helper::mock_rms::MockRmsApi;
     use async_trait::async_trait;
     use carbide_secrets::SecretsError;
     use carbide_secrets::credentials::{CredentialKey, CredentialReader, CredentialWriter};
@@ -1402,6 +1403,34 @@ mod tests {
         assert_eq!(cm.nv_switch.name(), "mock-nsm");
         assert_eq!(cm.power_shelf.name(), "mock-psm");
         assert_eq!(cm.compute_tray.name(), "mock-ctm");
+    }
+
+    #[tokio::test]
+    async fn rms_password_rotation_support_ignores_legacy_config() {
+        let config = ComponentManagerConfig {
+            nv_switch_backend: NvSwitchBackend::Rms,
+            power_shelf_backend: PowerShelfBackend::Mock,
+            compute_tray_backend: ComputeBackend::Mock,
+            nvos_password_rotation_enabled: false,
+            ..Default::default()
+        };
+
+        let db = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgresql://postgres:postgres@localhost/test")
+            .expect("test database URL should be valid");
+
+        let cm = build_component_manager(
+            &config,
+            rms_rack_profiles(rms_rack_profile()),
+            Some(Arc::new(MockRmsApi::new())),
+            None,
+            Some(db),
+            None,
+        )
+        .await
+        .expect("RMS switch backend should build");
+
+        assert!(cm.nv_switch.supports_password_rotation());
     }
 
     #[test]

--- a/crates/component-manager/src/config.rs
+++ b/crates/component-manager/src/config.rs
@@ -50,10 +50,10 @@ pub struct ComponentManagerConfig {
     #[serde(default)]
     pub compute_tray_use_state_controller: bool,
 
-    /// Enables the NVOS password-rotation backend capability.
+    /// Legacy rollout gate retained so existing site configurations deserialize.
     ///
-    /// Keep this rollout gate until every reachable RMS supports repeat-safe
-    /// current-to-target password convergence.
+    /// The value is accepted and serialized but does not change RMS
+    /// password-rotation support.
     #[serde(default)]
     pub nvos_password_rotation_enabled: bool,
 }
@@ -203,12 +203,29 @@ mod tests {
     }
 
     #[test]
-    fn nvos_password_rotation_deserializes() {
-        for (toml, expected) in [("", false), ("nvos_password_rotation_enabled = true", true)] {
+    fn nvos_password_rotation_config_is_preserved_for_compatibility() {
+        for (toml, expected) in [
+            ("", false),
+            ("nvos_password_rotation_enabled = false", false),
+            ("nvos_password_rotation_enabled = true", true),
+        ] {
             let cfg: ComponentManagerConfig =
                 toml::from_str(toml).expect("component-manager configuration should deserialize");
 
             assert_eq!(cfg.nvos_password_rotation_enabled, expected);
+
+            let serialized =
+                toml::to_string(&cfg).expect("component-manager configuration should serialize");
+
+            let serialized_value: toml::Value = toml::from_str(&serialized)
+                .expect("serialized component-manager configuration should be valid TOML");
+
+            assert_eq!(
+                serialized_value
+                    .get("nvos_password_rotation_enabled")
+                    .and_then(toml::Value::as_bool),
+                Some(expected),
+            );
         }
     }
 

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -175,9 +175,9 @@ pub struct RmsBackend {
     switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
     db: PgPool,
     rack_profiles: Arc<RackProfileConfig>,
+
     /// Tracks firmware update job IDs keyed by device MAC address.
     firmware_jobs: Mutex<HashMap<MacAddress, Vec<RmsTrackedFirmwareJob>>>,
-    nvos_password_rotation_enabled: bool,
 }
 
 #[async_trait::async_trait]
@@ -526,7 +526,7 @@ impl RmsBackend {
         switch_system_image_client: Option<Arc<dyn RmsSwitchSystemImageStatusApi>>,
         db: PgPool,
         rack_profiles: Arc<RackProfileConfig>,
-        nvos_password_rotation_enabled: bool,
+        _nvos_password_rotation_enabled: bool,
     ) -> Self {
         Self {
             client,
@@ -534,7 +534,6 @@ impl RmsBackend {
             db,
             rack_profiles,
             firmware_jobs: Mutex::new(HashMap::new()),
-            nvos_password_rotation_enabled,
         }
     }
 
@@ -1967,7 +1966,7 @@ impl NvSwitchManager for RmsBackend {
     }
 
     fn supports_password_rotation(&self) -> bool {
-        self.nvos_password_rotation_enabled
+        true
     }
 
     fn supports_firmware_object_json(&self) -> bool {
@@ -2606,13 +2605,6 @@ impl NvSwitchManager for RmsBackend {
         endpoint: &SwitchEndpoint,
         next_password: &str,
     ) -> Result<String, ComponentManagerError> {
-        if !self.supports_password_rotation() {
-            return Err(ComponentManagerError::Unsupported(
-                "RMS switch password rotation is disabled; enable it only after every RMS server has been upgraded"
-                    .to_string(),
-            ));
-        }
-
         let identities =
             resolve_switch_identities(&self.db, std::slice::from_ref(&endpoint.bmc_mac)).await?;
 

--- a/docs/operations/nvos-password-rotation.md
+++ b/docs/operations/nvos-password-rotation.md
@@ -24,15 +24,12 @@ NVOS password rotation is a site-wide, asynchronous operation. NICo publishes on
 - Ensure each managed switch has an NVOS credential that authenticates to the switch. The credential must be available from the expected-switch record or the NICo credential store.
 - Set expected-switch NVOS username and password fields together. Both values must be non-empty, or both fields must be unset.
 
-Enable the RMS switch backend and password-rotation gate in the `nico-api` site configuration. The gate defaults to `false`.
+Enable the RMS switch backend in the `nico-api` site configuration.
 
 ```toml
 [component_manager]
 nv_switch_backend = "rms"
-nvos_password_rotation_enabled = true
 ```
-
-The gate is a deployment assertion, not a runtime capability negotiation. Enable it only through a coordinated NICo and RMS rollout that qualifies every reachable RMS instance, including every replica behind a load balancer.
 
 RPC availability alone does not establish compatibility. Each RMS instance must meet these requirements:
 
@@ -41,7 +38,7 @@ RPC availability alone does not establish compatibility. Each RMS instance must 
 - Safely repeat the same active-to-target transition.
 - Recognize that a switch already using the target password is converged.
 
-When the gate is `false`, an NVOS rotation request returns `FailedPrecondition`.
+`nvos_password_rotation_enabled` remains in the configuration schema for compatibility with existing site configurations. The optional boolean accepts `true` or `false` and defaults to `false` when omitted. NICo serializes the setting, but the configured value does not control RMS password-rotation support.
 
 ## Configure Switch Credentials
 
@@ -117,7 +114,7 @@ Device status also includes the confirmed version, staged version, attempt count
 
 | Symptom | Action |
 | ------- | ------ |
-| Rotation request returns `FailedPrecondition` | Follow the error details: enable the gate, use a supported backend, or supply valid credentials for the listed switches. |
+| Rotation request returns `FailedPrecondition` | Follow the error details: use a supported backend or supply valid credentials for the listed switches. |
 | Site status shows pending switches | Query each switch with `--mac-address` and inspect its staged version, attempt count, and redacted error. |
 | Component-manager reports a non-retryable rejection | Correct the backend, endpoint, or credential issue, then issue another rotation request. |
 | Reconciliation remains unresolved | Verify RMS reachability and job handling. Inspect NICo and RMS logs without removing versioned credentials. |


### PR DESCRIPTION
Enable NVOS password rotation whenever the RMS switch backend is selected. Password rotation support no longer depends on `nvos_password_rotation_enabled`.

The optional `nvos_password_rotation_enabled` field remains accepted and serialized for configuration compatibility.

## Related Issues

Resolves #5839

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)