### PR TITLE
feat(dpf): delegate DPU secure boot handling

### DIFF
--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1957,6 +1957,7 @@ async fn initialize_and_start_controllers<'a>(
         carbide_config.rack_profiles.clone(),
         rms_client.clone(),
         credential_manager.clone(),
+        dpf_sdk.is_some(),
     )
     .start(join_set, cancel_token.clone())?;
 

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -1957,7 +1957,7 @@ async fn initialize_and_start_controllers<'a>(
         carbide_config.rack_profiles.clone(),
         rms_client.clone(),
         credential_manager.clone(),
-        dpf_sdk.is_some(),
+        carbide_config.dpf.enabled && dpf_sdk.is_some(),
     )
     .start(join_set, cancel_token.clone())?;
 

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1719,6 +1719,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         site_explorer_rack_profiles,
         rms_sim.as_rms_client(),
         credential_manager.clone(),
+        api.dpf_sdk.is_some(),
     );
 
     // Create some instance types

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1719,7 +1719,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
         site_explorer_rack_profiles,
         rms_sim.as_rms_client(),
         credential_manager.clone(),
-        api.dpf_sdk.is_some(),
+        api.runtime_config.dpf.enabled && api.dpf_sdk.is_some(),
     );
 
     // Create some instance types

--- a/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/site_explorer.rs
@@ -516,10 +516,6 @@ impl<'a> MockExploredHost<'a> {
                 .await
                 .unwrap()[&dpu_machine_id];
 
-        for machine_id in self.dpu_machine_ids.values() {
-            create_machine_inventory(self.test_env, *machine_id).await;
-        }
-
         self.test_env
             .run_machine_state_controller_iteration_until_state_matches(
                 &host_machine_id,
@@ -543,6 +539,10 @@ impl<'a> MockExploredHost<'a> {
                 },
             )
             .await;
+
+        for machine_id in self.dpu_machine_ids.values() {
+            create_machine_inventory(self.test_env, *machine_id).await;
+        }
 
         //run scout discovery for dpu(s)
         for dpu in self.managed_host.dpus.clone() {

--- a/crates/api-core/src/tests/dpf/dpu_service_sync.rs
+++ b/crates/api-core/src/tests/dpf/dpu_service_sync.rs
@@ -35,7 +35,7 @@ use model::machine::{DpfState, DpuInitState, DpuInitStates, ManagedHostState};
 use model::machine_pending_action::MachinePendingActionKind::DpuServiceSync;
 use tokio::time::timeout;
 
-use super::dpf_config;
+use super::{dpf_config, expect_dpf_service_inventory};
 use crate::tests::common::api_fixtures::test_managed_host::TestManagedHost;
 use crate::tests::common::api_fixtures::{
     TestEnv, TestEnvOverrides, create_managed_host_with_dpf, create_test_env_with_overrides,
@@ -68,6 +68,7 @@ pub(super) fn mock(
     mock.expect_deployment_type_for_dpu()
         .returning(|_, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+    expect_dpf_service_inventory(&mut mock);
 
     let outdated_calls = calls.clone();
     mock.expect_is_dpu_outdated().returning(move |_| {

--- a/crates/api-core/src/tests/dpf/happy_path.rs
+++ b/crates/api-core/src/tests/dpf/happy_path.rs
@@ -32,7 +32,7 @@ use tonic::Request;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(30);
 
-use super::dpf_config;
+use super::{dpf_config, expect_dpf_service_inventory};
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host_with_dpf, create_managed_host_with_dpf_bf4,
     create_test_env_with_overrides, get_config,
@@ -54,7 +54,9 @@ fn default_mock(deployment_type: DpuDeploymentType) -> MockDpfOperations {
 
 #[crate::sqlx_test]
 async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
-    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(default_mock(DpuDeploymentType::Bf3));
+    let mut mock = default_mock(DpuDeploymentType::Bf3);
+    expect_dpf_service_inventory(&mut mock);
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock);
 
     let mut config = get_config();
     config.dpf = dpf_config();
@@ -86,7 +88,9 @@ async fn test_dpu_and_host_till_ready(pool: sqlx::PgPool) {
 /// Provision a BF4 through DPF and verify that NICo performs only the
 /// credential portion of post-ready platform handling.
 async fn assert_bf4_skips_platform_configuration(pool: sqlx::PgPool, enable_secure_boot: bool) {
-    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(default_mock(DpuDeploymentType::Bf4Generic));
+    let mut mock = default_mock(DpuDeploymentType::Bf4Generic);
+    expect_dpf_service_inventory(&mut mock);
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock);
 
     let mut config = get_config();
     config.dpf = dpf_config();

--- a/crates/api-core/src/tests/dpf/mod.rs
+++ b/crates/api-core/src/tests/dpf/mod.rs
@@ -22,6 +22,8 @@ mod reprovisioning;
 mod stale_labels;
 mod waiting_for_ready;
 
+use carbide_dpf::DpuServiceVersion;
+use carbide_machine_controller::dpf::MockDpfOperations;
 use model::machine::ManagedHostState;
 
 use crate::tests::common::api_fixtures::TestEnv;
@@ -41,6 +43,17 @@ fn dpf_config() -> crate::cfg::file::DpfConfig {
         },
         ..Default::default()
     }
+}
+
+/// Models the successful DPF service lookup after the fixture registers a DPU CR.
+fn expect_dpf_service_inventory(mock: &mut MockDpfOperations) {
+    mock.expect_get_service_versions_for_dpu().returning(|_| {
+        Ok(vec![DpuServiceVersion {
+            name: "test-service".to_string(),
+            version: "test-version".to_string(),
+            url: "https://example.com/test-service".to_string(),
+        }])
+    });
 }
 
 // Reads the host's committed state straight from the database rather than through the RPC

--- a/crates/api-core/src/tests/dpf/reprovisioning.rs
+++ b/crates/api-core/src/tests/dpf/reprovisioning.rs
@@ -38,7 +38,7 @@ use rpc::forge::dpu_reprovisioning_request::Mode;
 use rpc::forge::forge_server::Forge;
 use tokio::time::timeout;
 
-use super::{dpf_config, get_host_state};
+use super::{dpf_config, expect_dpf_service_inventory, get_host_state};
 use crate::test_support::builder::TestApiBuilder;
 use crate::tests::common::api_fixtures::site_explorer::TestRackDbBuilder;
 use crate::tests::common::api_fixtures::{
@@ -90,6 +90,7 @@ fn provisioning_mock_with_dpu_count(
     mock.expect_deployment_type_for_dpu()
         .returning(|_, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+    expect_dpf_service_inventory(&mut mock);
     mock.expect_snapshot_host()
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
     mock.expect_get_dpu_phase().returning(move |_, _| {
@@ -130,6 +131,7 @@ fn source_deployment_mock_with_verification_observer(
         .returning(move |_| Ok(snapshot_with_crs_present(dpu_count)));
     mock.expect_get_dpu_phase()
         .returning(|_, _| Ok(DpuPhase::Ready));
+    expect_dpf_service_inventory(&mut mock);
     mock
 }
 
@@ -734,6 +736,7 @@ fn capturing_mock(
     dpu_count: usize,
 ) -> MockDpfOperations {
     let mut mock = MockDpfOperations::new();
+    expect_dpf_service_inventory(&mut mock);
 
     mock.expect_register_dpu_device().returning(move |info, _| {
         registered_devices.lock().unwrap().push(info.device_id);
@@ -840,6 +843,7 @@ async fn test_gb200_b3240_pair_uses_specialized_deployment_from_report_or_rack(p
     let registered_deployments = Arc::new(Mutex::new(Vec::new()));
 
     let mut mock = MockDpfOperations::new();
+    expect_dpf_service_inventory(&mut mock);
     mock.expect_register_dpu_device().returning(|_, _| Ok(()));
     let registered_deployments_for_mock = registered_deployments.clone();
     mock.expect_register_dpu_node().returning(move |info| {
@@ -1036,6 +1040,7 @@ async fn test_gb200_deployment_migration_requires_every_dpu(pool: sqlx::PgPool) 
     let deleted_source_devices = Arc::new(Mutex::new(Vec::new()));
 
     let mut mock = MockDpfOperations::new();
+    expect_dpf_service_inventory(&mut mock);
     mock.expect_register_dpu_device().returning(|_, _| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));
     let released_holds_for_mock = released_holds.clone();
@@ -1531,6 +1536,7 @@ async fn test_mixed_dpu_deployment_types_fail_without_registration(pool: sqlx::P
     let registered_nodes = Arc::new(AtomicUsize::new(0));
 
     let mut mock = MockDpfOperations::new();
+    expect_dpf_service_inventory(&mut mock);
     let registered_devices_for_mock = registered_devices.clone();
     mock.expect_register_dpu_device().returning(move |_, _| {
         registered_devices_for_mock.fetch_add(1, Ordering::SeqCst);

--- a/crates/api-core/src/tests/dpf/stale_labels.rs
+++ b/crates/api-core/src/tests/dpf/stale_labels.rs
@@ -33,7 +33,7 @@ use carbide_uuid::machine::{DpuMachineId, HostMachineId};
 use model::machine::{DpfState, DpuInitState, FailureCause, FailureDetails, ManagedHostState};
 use tokio::time::timeout;
 
-use super::{dpf_config, get_host_state};
+use super::{dpf_config, expect_dpf_service_inventory, get_host_state};
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host_with_dpf, create_test_env_with_overrides, get_config,
 };
@@ -52,6 +52,7 @@ fn provisioning_mock_with_labels_valid(labels_valid: Arc<AtomicBool>) -> MockDpf
         .returning(|_, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels()
         .returning(move |_, _| Ok(labels_valid.load(Ordering::SeqCst)));
+    expect_dpf_service_inventory(&mut mock);
     mock
 }
 

--- a/crates/api-core/src/tests/dpf/waiting_for_ready.rs
+++ b/crates/api-core/src/tests/dpf/waiting_for_ready.rs
@@ -32,7 +32,7 @@ use libredfish::SystemPowerControl;
 use model::machine::{DpfState, DpuInitState, ManagedHostState, PerformPowerOperation};
 use tokio::time::timeout;
 
-use super::{dpf_config, get_host_state};
+use super::{dpf_config, expect_dpf_service_inventory, get_host_state};
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host, create_managed_host_with_dpf,
     create_test_env_with_overrides, get_config, reboot_completed,
@@ -61,6 +61,7 @@ fn expect_provisioning(mock: &mut MockDpfOperations) {
     mock.expect_deployment_type_for_dpu()
         .returning(move |__, _| Ok(DpuDeploymentType::Bf3));
     mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+    expect_dpf_service_inventory(mock);
 }
 
 /// Persists one DPU's DPF substate directly so tests can isolate a handler

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -340,8 +340,7 @@ async fn test_allocate_and_release_instance_impl(
     txn.commit().await.unwrap();
 }
 
-#[crate::sqlx_test]
-async fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_failed_to_ready(
+async fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_failed_to_ready_body(
     _: PgPoolOptions,
     options: PgConnectOptions,
 ) {
@@ -824,6 +823,25 @@ async fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_faile
         0
     );
     txn.commit().await.unwrap();
+}
+
+#[test]
+fn test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_failed_to_ready() {
+    let mut args = ::sqlx::testing::TestArgs::new(concat!(
+        module_path!(),
+        "::test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_failed_to_ready"
+    ));
+    args.fixtures(Box::leak(Box::new(vec![])));
+
+    let test_fn: fn(PgPoolOptions, PgConnectOptions) -> _ =
+        test_measurement_assigned_ready_to_waiting_for_measurements_to_ca_failed_to_ready_body;
+
+    std::thread::Builder::new()
+        .stack_size(16 * 1024 * 1024)
+        .spawn(move || sqlx_testing::TestFn::run_test(test_fn, args))
+        .expect("failed to spawn measurement test thread")
+        .join()
+        .expect("measurement test thread panicked");
 }
 
 #[crate::sqlx_test]

--- a/crates/api-core/src/tests/machine_admin_force_delete.rs
+++ b/crates/api-core/src/tests/machine_admin_force_delete.rs
@@ -1534,6 +1534,13 @@ async fn test_admin_force_delete_with_dpf_uses_bmc_mac(pool: sqlx::PgPool) {
         Arc::new(std::sync::Mutex::new(Vec::new()));
 
     let mut mock = MockDpfOperations::new();
+    mock.expect_get_service_versions_for_dpu().returning(|_| {
+        Ok(vec![carbide_dpf::DpuServiceVersion {
+            name: "test-service".to_string(),
+            version: "test-version".to_string(),
+            url: "https://example.com/test-service".to_string(),
+        }])
+    });
 
     mock.expect_register_dpu_device().returning(|_, _| Ok(()));
     mock.expect_register_dpu_node().returning(|_| Ok(()));

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -455,6 +455,7 @@ async fn test_machine_creator_created_host_advances_through_dpu_discovery(
         Arc::new(env.config.rack_profiles.clone()),
         None,
         env.test_credential_manager.clone(),
+        false,
     );
 
     // Use a known DPU serial so we can assert on the generated MachineId.

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1867,22 +1867,13 @@ impl NextStateBFBSupport<DpuDiscoveringState> for DpuDiscoveringState {
     fn next_substate_based_on_bfb_support(
         enable_secure_boot: bool,
         state: &ManagedHostStateSnapshot,
-        dpf_enabled_at_site: bool,
+        _dpf_enabled_at_site: bool,
     ) -> DpuDiscoveringState {
-        // DPF should be given priority over secure boot.
-        // DPF does not support Secure boot.
-        let is_dpf_based_provisioning_possible =
-            dpf_based_dpu_provisioning_possible(state, dpf_enabled_at_site, false);
-
-        // Secure boot will be handled by DPF itself.
-        if is_dpf_based_provisioning_possible {
+        if state.host_snapshot.config.dpf.used_for_ingestion {
             return DpuDiscoveringState::RebootAllDPUS;
         }
 
-        if !is_dpf_based_provisioning_possible
-            && enable_secure_boot
-            && bfb_install_support(&state.dpu_snapshots)
-        {
+        if enable_secure_boot && bfb_install_support(&state.dpu_snapshots) {
             // Move with a redfish install path
             DpuDiscoveringState::EnableSecureBoot {
                 count: 0,
@@ -4212,7 +4203,6 @@ mod tests {
     #[derive(Clone, Copy)]
     struct DpuProvisioningRouteInput {
         dpf: DpfProvisioningInput,
-        dpf_available: bool,
         enable_secure_boot: bool,
     }
 
@@ -4227,7 +4217,6 @@ mod tests {
                             used_for_ingestion: true,
                             ..dpf_input(&[BF3_SUPPORTED])
                         },
-                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4238,10 +4227,9 @@ mod tests {
                     ),
                 },
                 Check {
-                    scenario: "unavailable DPF uses secure boot fallback",
+                    scenario: "DPF-enabled site uses secure boot fallback when the host was not selected",
                     input: DpuProvisioningRouteInput {
                         dpf: dpf_input(&[BF3_SUPPORTED]),
-                        dpf_available: false,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4261,7 +4249,6 @@ mod tests {
                             dpf_enabled_at_site: false,
                             ..dpf_input(&[BF3_SUPPORTED])
                         },
-                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4281,7 +4268,6 @@ mod tests {
                             dpf_enabled_at_site: false,
                             ..dpf_input(&[BF3_SUPPORTED])
                         },
-                        dpf_available: true,
                         enable_secure_boot: false,
                     },
                     expect: (
@@ -4302,7 +4288,6 @@ mod tests {
                             dpus: &[BF3_SUPPORTED, BF3_UNSUPPORTED_BFB],
                             ..dpf_input(&[])
                         },
-                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4316,17 +4301,19 @@ mod tests {
                     ),
                 },
                 Check {
-                    scenario: "legacy subset only blocks the reprovision DPF route",
+                    scenario: "unselected host only uses the legacy initial-ingestion route",
                     input: DpuProvisioningRouteInput {
                         dpf: DpfProvisioningInput {
                             dpus: &[BF3_REQUESTED, BF3_SUPPORTED],
                             ..dpf_input(&[])
                         },
-                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
-                        DpuDiscoveringState::RebootAllDPUS,
+                        DpuDiscoveringState::EnableSecureBoot {
+                            count: 0,
+                            enable_secure_boot_state: SetSecureBootState::CheckSecureBootStatus,
+                        },
                         ReprovisionState::InstallDpuOs {
                             substate: InstallDpuOsState::InstallingBFB,
                         },
@@ -4336,7 +4323,6 @@ mod tests {
                     scenario: "BF2 falls back to Redfish BFB installation",
                     input: DpuProvisioningRouteInput {
                         dpf: dpf_input(&[BF2_SUPPORTED]),
-                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4353,7 +4339,6 @@ mod tests {
                     scenario: "an empty DPU set cannot select aggregate routes",
                     input: DpuProvisioningRouteInput {
                         dpf: dpf_input(&[]),
-                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4373,7 +4358,7 @@ mod tests {
                     DpuDiscoveringState::next_substate_based_on_bfb_support(
                         input.enable_secure_boot,
                         &state,
-                        input.dpf.dpf_enabled_at_site && input.dpf_available,
+                        input.dpf.dpf_enabled_at_site,
                     ),
                     ReprovisionState::next_substate_based_on_bfb_support(
                         input.enable_secure_boot,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -4212,6 +4212,7 @@ mod tests {
     #[derive(Clone, Copy)]
     struct DpuProvisioningRouteInput {
         dpf: DpfProvisioningInput,
+        dpf_available: bool,
         enable_secure_boot: bool,
     }
 
@@ -4226,6 +4227,7 @@ mod tests {
                             used_for_ingestion: true,
                             ..dpf_input(&[BF3_SUPPORTED])
                         },
+                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4236,12 +4238,30 @@ mod tests {
                     ),
                 },
                 Check {
+                    scenario: "unavailable DPF uses secure boot fallback",
+                    input: DpuProvisioningRouteInput {
+                        dpf: dpf_input(&[BF3_SUPPORTED]),
+                        dpf_available: false,
+                        enable_secure_boot: true,
+                    },
+                    expect: (
+                        DpuDiscoveringState::EnableSecureBoot {
+                            count: 0,
+                            enable_secure_boot_state: SetSecureBootState::CheckSecureBootStatus,
+                        },
+                        ReprovisionState::InstallDpuOs {
+                            substate: InstallDpuOsState::InstallingBFB,
+                        },
+                    ),
+                },
+                Check {
                     scenario: "Redfish BFB is selected when site DPF is disabled",
                     input: DpuProvisioningRouteInput {
                         dpf: DpfProvisioningInput {
                             dpf_enabled_at_site: false,
                             ..dpf_input(&[BF3_SUPPORTED])
                         },
+                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4261,6 +4281,7 @@ mod tests {
                             dpf_enabled_at_site: false,
                             ..dpf_input(&[BF3_SUPPORTED])
                         },
+                        dpf_available: true,
                         enable_secure_boot: false,
                     },
                     expect: (
@@ -4281,6 +4302,7 @@ mod tests {
                             dpus: &[BF3_SUPPORTED, BF3_UNSUPPORTED_BFB],
                             ..dpf_input(&[])
                         },
+                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4300,6 +4322,7 @@ mod tests {
                             dpus: &[BF3_REQUESTED, BF3_SUPPORTED],
                             ..dpf_input(&[])
                         },
+                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4313,6 +4336,7 @@ mod tests {
                     scenario: "BF2 falls back to Redfish BFB installation",
                     input: DpuProvisioningRouteInput {
                         dpf: dpf_input(&[BF2_SUPPORTED]),
+                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4329,6 +4353,7 @@ mod tests {
                     scenario: "an empty DPU set cannot select aggregate routes",
                     input: DpuProvisioningRouteInput {
                         dpf: dpf_input(&[]),
+                        dpf_available: true,
                         enable_secure_boot: true,
                     },
                     expect: (
@@ -4348,7 +4373,7 @@ mod tests {
                     DpuDiscoveringState::next_substate_based_on_bfb_support(
                         input.enable_secure_boot,
                         &state,
-                        input.dpf.dpf_enabled_at_site,
+                        input.dpf.dpf_enabled_at_site && input.dpf_available,
                     ),
                     ReprovisionState::next_substate_based_on_bfb_support(
                         input.enable_secure_boot,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -1874,6 +1874,11 @@ impl NextStateBFBSupport<DpuDiscoveringState> for DpuDiscoveringState {
         let is_dpf_based_provisioning_possible =
             dpf_based_dpu_provisioning_possible(state, dpf_enabled_at_site, false);
 
+        // Secure boot will be handled by DPF itself.
+        if is_dpf_based_provisioning_possible {
+            return DpuDiscoveringState::RebootAllDPUS;
+        }
+
         if !is_dpf_based_provisioning_possible
             && enable_secure_boot
             && bfb_install_support(&state.dpu_snapshots)
@@ -4224,12 +4229,7 @@ mod tests {
                         enable_secure_boot: true,
                     },
                     expect: (
-                        DpuDiscoveringState::DisableSecureBoot {
-                            count: 0,
-                            disable_secure_boot_state: Some(
-                                SetSecureBootState::CheckSecureBootStatus,
-                            ),
-                        },
+                        DpuDiscoveringState::RebootAllDPUS,
                         ReprovisionState::DpfStates {
                             substate: DpfState::Reprovisioning,
                         },
@@ -4303,12 +4303,7 @@ mod tests {
                         enable_secure_boot: true,
                     },
                     expect: (
-                        DpuDiscoveringState::DisableSecureBoot {
-                            count: 0,
-                            disable_secure_boot_state: Some(
-                                SetSecureBootState::CheckSecureBootStatus,
-                            ),
-                        },
+                        DpuDiscoveringState::RebootAllDPUS,
                         ReprovisionState::InstallDpuOs {
                             substate: InstallDpuOsState::InstallingBFB,
                         },

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -1168,7 +1168,7 @@ pub fn build_deployment(
                     rolling_update: None,
                     r#type: DpuDeploymentDpusDpuSetStrategyType::OnDelete,
                 },
-                secure_boot: None,
+                secure_boot: Some(false),
                 astra_enabled: matches!(deployment_type, DpuDeploymentType::Bf4Astra)
                     .then_some(true),
                 blue_field_software: match source {
@@ -4651,6 +4651,22 @@ mod tests {
                 DpuDeploymentType::Bf4Astra => ("bf4astra", Some(true)),
             }
         );
+    }
+
+    #[test]
+    fn deployment_disables_secure_boot() {
+        let deployment = build_deployment(
+            &[],
+            "deployment",
+            &DpuProvisioningSource::Bfb("bfb".to_string()),
+            "flavor",
+            TEST_NAMESPACE,
+            &[],
+            BTreeMap::new(),
+            DpuDeploymentType::Bf3,
+        );
+
+        assert_eq!(deployment.spec.dpus.secure_boot, Some(false));
     }
 
     #[derive(Clone, Default)]

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -4667,6 +4667,10 @@ mod tests {
         );
 
         assert_eq!(deployment.spec.dpus.secure_boot, Some(false));
+        assert_eq!(
+            serde_json::to_value(deployment).unwrap()["spec"]["dpus"]["secureBoot"],
+            false,
+        );
     }
 
     #[derive(Clone, Default)]

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -4745,7 +4745,7 @@ impl DpuMachineStateHandler {
                     DpuDiscoveringState::next_substate_based_on_bfb_support(
                         self.enable_secure_boot,
                         state,
-                        ctx.services.site_config.dpf_enabled,
+                        ctx.services.site_config.dpf_enabled && self.dpf_sdk.is_some(),
                     );
 
                 tracing::info!(

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -87,7 +87,7 @@ use model::machine::{
     PowerState, ReadyBootConfigPostLockAction, ReadyBootConfigState, ReprovisionState, RetryInfo,
     SecureEraseBossContext, SecureEraseBossState, SetBootOrderInfo, SetBootOrderState,
     SetSecureBootState, SpdmMeasuringState, StateMachineArea, UefiSetupInfo, UefiSetupState,
-    UnlockHostState, ValidationState, dpf_based_dpu_provisioning_possible, get_display_ids,
+    UnlockHostState, ValidationState, get_display_ids,
 };
 use model::machine_boot_interface::MachineBootInterfaceTarget;
 use model::power_manager::PowerHandlingOutcome;
@@ -4820,20 +4820,13 @@ impl DpuMachineStateHandler {
                     ));
                 }
 
-                if dpf_based_dpu_provisioning_possible(state, self.dpf_sdk.is_some(), false) {
-                    let mut txn = ctx.services.db_pool.begin().await?;
-                    db::machine::mark_machine_ingestion_done_with_dpf(
-                        &mut txn,
-                        &state.host_snapshot.id,
-                    )
-                    .await?;
-
+                if state.host_snapshot.config.dpf.used_for_ingestion {
                     let next_state = DpuInitState::DpfStates {
                         state: model::machine::DpfState::Provisioning,
                     }
                     .next_state_with_all_dpus_updated(&state.managed_state)?;
 
-                    return Ok(StateHandlerOutcome::transition(next_state).with_txn(txn));
+                    return Ok(StateHandlerOutcome::transition(next_state));
                 }
 
                 for dpu_snapshot in &state.dpu_snapshots {

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -523,6 +523,7 @@ impl SiteExplorer {
         rack_profiles: RackProfileConfig,
         rms_client: Option<Arc<dyn RmsApi>>,
         credential_manager: Arc<dyn CredentialManager>,
+        dpf_enabled_at_site: bool,
     ) -> Self {
         // We want to hold metrics for longer than the iteration interval, so there is continuity
         // in emitting metrics. However we want to avoid reporting outdated metrics in case
@@ -547,6 +548,7 @@ impl SiteExplorer {
                 rack_profiles,
                 rms_client.clone(),
                 credential_manager,
+                dpf_enabled_at_site,
             ),
             switch_creator: SwitchCreator::new(
                 database_connection.clone(),

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -512,6 +512,10 @@ impl SiteExplorer {
     const SITE_EXPLORER_HEALTH_REPORT_WRITE_BATCH_SIZE: usize = 500;
 
     #[allow(clippy::too_many_arguments)]
+    /// Creates a site explorer.
+    ///
+    /// When `dpf_enabled_at_site` is true, eligible hosts are marked for DPF-managed ingestion.
+    /// Otherwise, hosts use the non-DPF ingestion path.
     pub fn new(
         database_connection: sqlx::PgPool,
         explorer_config: SiteExplorerConfig,

--- a/crates/site-explorer/src/machine_creator.rs
+++ b/crates/site-explorer/src/machine_creator.rs
@@ -34,8 +34,9 @@ use model::hardware_info::HardwareInfo;
 use model::machine::machine_id::host_id_from_dpu_hardware_info;
 use model::machine::machine_search_config::MachineSearchConfig;
 use model::machine::{
-    AnyMachine, CURRENT_STATE_MODEL_VERSION, ConfigureAstraState, MachineInterfaceSnapshot,
-    ManagedHostState, pick_boot_interface, pick_boot_prediction,
+    AnyMachine, CURRENT_STATE_MODEL_VERSION, ConfigureAstraState, LoadSnapshotOptions,
+    MachineInterfaceSnapshot, ManagedHostState, dpf_based_dpu_provisioning_possible,
+    pick_boot_interface, pick_boot_prediction,
 };
 use model::machine_boot_interface::{
     BootInterfaceSelectionSource, MachineBootInterface, MachineBootInterfaceTarget,
@@ -68,6 +69,7 @@ pub struct MachineCreator {
     rack_profiles: Arc<RackProfileConfig>,
     rms_client: Option<Arc<dyn RmsApi>>,
     credential_manager: Arc<dyn CredentialManager>,
+    dpf_enabled_at_site: bool,
 }
 
 impl MachineCreator {
@@ -79,6 +81,7 @@ impl MachineCreator {
         rack_profiles: Arc<RackProfileConfig>,
         rms_client: Option<Arc<dyn RmsApi>>,
         credential_manager: Arc<dyn CredentialManager>,
+        dpf_enabled_at_site: bool,
     ) -> Self {
         Self {
             database_connection,
@@ -87,6 +90,7 @@ impl MachineCreator {
             rack_profiles,
             rms_client,
             credential_manager,
+            dpf_enabled_at_site,
         }
     }
 
@@ -398,6 +402,13 @@ impl MachineCreator {
         )
         .await?;
 
+        if self
+            .dpf_based_dpu_provisioning_possible(&mut txn, &host_machine_id)
+            .await?
+        {
+            db::machine::mark_machine_ingestion_done_with_dpf(&mut txn, &host_machine_id).await?;
+        }
+
         let mut rack_profile_id = None;
         if let Some(rack_id) = machine_data.and_then(|d| d.rack_id.as_ref()) {
             tracing::info!(%rack_id, %host_machine_id, "Ensuring rack exists for host machine");
@@ -518,6 +529,27 @@ impl MachineCreator {
         }
 
         Ok(true)
+    }
+
+    async fn dpf_based_dpu_provisioning_possible(
+        &self,
+        txn: &mut PgConnection,
+        host_machine_id: &HostMachineId,
+    ) -> SiteExplorerResult<bool> {
+        let managed_host =
+            db::managed_host::load_snapshot(txn, host_machine_id, LoadSnapshotOptions::default())
+                .await?
+                .ok_or_else(|| {
+                    SiteExplorerError::internal(format!(
+                        "managed host {host_machine_id} disappeared while being created"
+                    ))
+                })?;
+
+        Ok(dpf_based_dpu_provisioning_possible(
+            &managed_host,
+            self.dpf_enabled_at_site,
+            false,
+        ))
     }
 
     // Returns MachineId if machine was created.

--- a/crates/site-explorer/tests/integration/env.rs
+++ b/crates/site-explorer/tests/integration/env.rs
@@ -79,6 +79,7 @@ pub(super) fn test_site_explorer(
         api.runtime_config.rack_profiles.clone(),
         None,
         api.credential_manager().clone(),
+        false,
     );
     TestSiteExplorer::new(site_explorer, endpoint_explorer)
 }

--- a/crates/site-explorer/tests/integration/health_report.rs
+++ b/crates/site-explorer/tests/integration/health_report.rs
@@ -77,6 +77,7 @@ fn test_site_explorer(
         api.runtime_config.rack_profiles.clone(),
         None,
         api.credential_manager().clone(),
+        false,
     );
     TestSiteExplorer::new(site_explorer, endpoint_explorer)
 }

--- a/crates/site-explorer/tests/integration/machine_creator.rs
+++ b/crates/site-explorer/tests/integration/machine_creator.rs
@@ -101,6 +101,14 @@ fn machine_creator_config() -> SiteExplorerConfig {
 }
 
 fn machine_creator(env: &Env, config: SiteExplorerConfig) -> MachineCreator {
+    machine_creator_with_dpf(env, config, false)
+}
+
+fn machine_creator_with_dpf(
+    env: &Env,
+    config: SiteExplorerConfig,
+    dpf_enabled_at_site: bool,
+) -> MachineCreator {
     MachineCreator::new(
         env.pool.clone(),
         config,
@@ -108,6 +116,7 @@ fn machine_creator(env: &Env, config: SiteExplorerConfig) -> MachineCreator {
         Arc::new(env.api().runtime_config.rack_profiles.clone()),
         None,
         env.api().credential_manager().clone(),
+        dpf_enabled_at_site,
     )
 }
 
@@ -159,6 +168,7 @@ fn machine_creator_with_rms(env: &Env, rms_sim: &RmsSim) -> MachineCreator {
         Arc::new(rack_profiles),
         rms_sim.as_rms_client(),
         env.api().credential_manager().clone(),
+        false,
     )
 }
 
@@ -767,7 +777,7 @@ async fn test_machine_creator_creates_managed_host_with_dpf_enabled(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let env = Env::new(pool).await;
-    let creator = machine_creator(&env, machine_creator_config());
+    let creator = machine_creator_with_dpf(&env, machine_creator_config(), true);
 
     let mock_dpu = DpuConfig::with_serial("MT2328XZ185R".to_string());
     let mock_host = ManagedHostConfig {
@@ -803,6 +813,9 @@ async fn test_machine_creator_creates_managed_host_with_dpf_enabled(
     assert_eq!(machines.len(), 2);
     for machine in machines {
         assert!(machine.config.dpf.enabled);
+        if !machine.is_dpu() {
+            assert!(machine.config.dpf.used_for_ingestion);
+        }
     }
 
     Ok(())

--- a/crates/site-explorer/tests/integration/zero_dpu.rs
+++ b/crates/site-explorer/tests/integration/zero_dpu.rs
@@ -84,6 +84,7 @@ async fn init(pool: PgPool) -> ZeroDpuEnv {
             api.runtime_config.rack_profiles.clone(),
             None,
             api.credential_manager().clone(),
+            false,
         ),
         endpoint_explorer,
     );

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -143,6 +143,7 @@ impl TestHarness {
             api.runtime_config.rack_profiles.clone(),
             None,
             api.credential_manager().clone(),
+            false,
         );
         TestSiteExplorer::new(site_explorer, endpoint_explorer)
     }

--- a/docs/architecture/state_machines/managedhost.md
+++ b/docs/architecture/state_machines/managedhost.md
@@ -806,7 +806,6 @@ stateDiagram-v2
 
 ## Failed State
 
-
 ```mermaid
 stateDiagram-v2
     direction LR

--- a/docs/architecture/state_machines/managedhost.md
+++ b/docs/architecture/state_machines/managedhost.md
@@ -122,8 +122,8 @@ stateDiagram-v2
     if_state_dpu_nodpu --> HostInit_HI_WaitingForPlatformConfiguration : No DPU
 
     DD_Configuring --> DD_EnableRshim
-    DD_EnableRshim --> DD_RebootAllDPUS : DPF provisioning eligible and available
-    DD_EnableRshim --> if_bfb_supported : DPF provisioning ineligible or unavailable
+    DD_EnableRshim --> DD_RebootAllDPUS : DPF selected during site exploration
+    DD_EnableRshim --> if_bfb_supported : DPF not selected during site exploration
 
     if_bfb_supported --> DD_SSB_E_CheckSecureBootStatus : BFB install supported
     if_bfb_supported --> DD_SSB_D_CheckSecureBootStatus : BFB install not supported
@@ -187,8 +187,8 @@ stateDiagram-v2
     state "HostInit/EnableIpmiOverLan" as HostInit_HI_EnableIpmiOverLan
 
     DpuDiscoveringState_DD_SSB_E_CheckSecureBootStatus --> DI_IDO_InstallingBFB : Security boot is enabled
-    DpuDiscoveringState_DD_RebootAllDPUS --> DI_DpfStates_Provisioning : DPF provisioning eligible and available
-    DpuDiscoveringState_DD_RebootAllDPUS --> DI_Init : DPF provisioning ineligible or unavailable
+    DpuDiscoveringState_DD_RebootAllDPUS --> DI_DpfStates_Provisioning : DPF selected during site exploration
+    DpuDiscoveringState_DD_RebootAllDPUS --> DI_Init : DPF not selected during site exploration
 
     DI_IDO_InstallingBFB --> DI_IDO_WaitForInstallComplete
     DI_IDO_WaitForInstallComplete --> DI_IDO_WaitForInstallComplete : Task Running/New/Starting (wait more)

--- a/docs/architecture/state_machines/managedhost.md
+++ b/docs/architecture/state_machines/managedhost.md
@@ -122,7 +122,8 @@ stateDiagram-v2
     if_state_dpu_nodpu --> HostInit_HI_WaitingForPlatformConfiguration : No DPU
 
     DD_Configuring --> DD_EnableRshim
-    DD_EnableRshim --> if_bfb_supported
+    DD_EnableRshim --> DD_RebootAllDPUS : DPF provisioning eligible
+    DD_EnableRshim --> if_bfb_supported : DPF provisioning not eligible
 
     if_bfb_supported --> DD_SSB_E_CheckSecureBootStatus : BFB install supported
     if_bfb_supported --> DD_SSB_D_CheckSecureBootStatus : BFB install not supported
@@ -182,10 +183,12 @@ stateDiagram-v2
 
     state "WaitingForPlatformConfiguration" as DI_WaitingForPlatformConfiguration
     state "WaitingForNetworkConfig" as DI_WaitingForNetworkConfig
+    state "DpfStates/Provisioning" as DI_DpfStates_Provisioning
     state "HostInit/EnableIpmiOverLan" as HostInit_HI_EnableIpmiOverLan
 
     DpuDiscoveringState_DD_SSB_E_CheckSecureBootStatus --> DI_IDO_InstallingBFB : Security boot is enabled
-    DpuDiscoveringState_DD_RebootAllDPUS --> DI_Init
+    DpuDiscoveringState_DD_RebootAllDPUS --> DI_DpfStates_Provisioning : DPF provisioning eligible
+    DpuDiscoveringState_DD_RebootAllDPUS --> DI_Init : DPF provisioning not eligible
 
     DI_IDO_InstallingBFB --> DI_IDO_WaitForInstallComplete
     DI_IDO_WaitForInstallComplete --> DI_IDO_WaitForInstallComplete : Task Running/New/Starting (wait more)

--- a/docs/architecture/state_machines/managedhost.md
+++ b/docs/architecture/state_machines/managedhost.md
@@ -122,8 +122,8 @@ stateDiagram-v2
     if_state_dpu_nodpu --> HostInit_HI_WaitingForPlatformConfiguration : No DPU
 
     DD_Configuring --> DD_EnableRshim
-    DD_EnableRshim --> DD_RebootAllDPUS : DPF provisioning eligible
-    DD_EnableRshim --> if_bfb_supported : DPF provisioning not eligible
+    DD_EnableRshim --> DD_RebootAllDPUS : DPF provisioning eligible and available
+    DD_EnableRshim --> if_bfb_supported : DPF provisioning ineligible or unavailable
 
     if_bfb_supported --> DD_SSB_E_CheckSecureBootStatus : BFB install supported
     if_bfb_supported --> DD_SSB_D_CheckSecureBootStatus : BFB install not supported
@@ -187,8 +187,8 @@ stateDiagram-v2
     state "HostInit/EnableIpmiOverLan" as HostInit_HI_EnableIpmiOverLan
 
     DpuDiscoveringState_DD_SSB_E_CheckSecureBootStatus --> DI_IDO_InstallingBFB : Security boot is enabled
-    DpuDiscoveringState_DD_RebootAllDPUS --> DI_DpfStates_Provisioning : DPF provisioning eligible
-    DpuDiscoveringState_DD_RebootAllDPUS --> DI_Init : DPF provisioning not eligible
+    DpuDiscoveringState_DD_RebootAllDPUS --> DI_DpfStates_Provisioning : DPF provisioning eligible and available
+    DpuDiscoveringState_DD_RebootAllDPUS --> DI_Init : DPF provisioning ineligible or unavailable
 
     DI_IDO_InstallingBFB --> DI_IDO_WaitForInstallComplete
     DI_IDO_WaitForInstallComplete --> DI_IDO_WaitForInstallComplete : Task Running/New/Starting (wait more)


### PR DESCRIPTION
DPF-managed DPUs should rely on DPF to manage UEFI Secure Boot during ingestion, avoiding duplicate management by NICo.

The logic to detect if a DPU can be ingested using DPF is moved to site-explorer now (for initial ingestion).

## Related issues

Closes #5842

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

None.