### PR TITLE
Include DPU machines in Flow's Core machine inventory snapshot

### DIFF
--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -225,7 +225,9 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 // (FindMachineIds + FindMachinesByIds).
 func (c *grpcClient) GetMachines(ctx context.Context) ([]MachineDetail, error) {
 	idsCtx, idsCancel := context.WithTimeout(ctx, c.grpcTimeout)
-	machineIDs, err := c.gclient.FindMachineIds(idsCtx, &corev1.MachineSearchConfig{})
+	machineIDs, err := c.gclient.FindMachineIds(idsCtx, &corev1.MachineSearchConfig{
+		IncludeDpus: true,
+	})
 	idsCancel()
 	if err != nil {
 		return nil, err

--- a/rest-api/flow/internal/nicoapi/grpc_batch_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_batch_test.go
@@ -34,6 +34,7 @@ type recordingForgeClient struct {
 	shelfIDDelay      time.Duration
 	shelfDelay        time.Duration
 	versionRequests   []*corev1.VersionRequest
+	includeDPUs       []bool
 	machineIDs        []string
 	switchIDs         []string
 	shelfIDs          []string
@@ -76,9 +77,12 @@ func (c *recordingForgeClient) Version(
 
 func (c *recordingForgeClient) FindMachineIds(
 	ctx context.Context,
-	_ *corev1.MachineSearchConfig,
+	request *corev1.MachineSearchConfig,
 	_ ...grpc.CallOption,
 ) (*corev1.MachineIdList, error) {
+	c.mu.Lock()
+	c.includeDPUs = append(c.includeDPUs, request.GetIncludeDpus())
+	c.mu.Unlock()
 	if c.machineIDDelay > 0 {
 		select {
 		case <-time.After(c.machineIDDelay):
@@ -251,6 +255,19 @@ func stringsToPowerShelfIds(ids []string) []*corev1.PowerShelfId {
 		result = append(result, &corev1.PowerShelfId{Id: id})
 	}
 	return result
+}
+
+func TestGrpcClient_GetMachines(t *testing.T) {
+	t.Run("includes DPUs in the Core snapshot", func(t *testing.T) {
+		fake := &recordingForgeClient{}
+
+		machines, err := newRecordingGRPCClient(fake).GetMachines(context.Background())
+
+		require.NoError(t, err)
+		assert.Empty(t, machines)
+		require.Len(t, fake.includeDPUs, 1)
+		assert.True(t, fake.includeDPUs[0])
+	})
 }
 
 func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {


### PR DESCRIPTION

## Description
Flow's inventory client previously called `FindMachineIds` with an empty `MachineSearchConfig`, which defaults `include_dpus` to false. Host records still contain their associated DPU machine IDs, so DPU BMC reconciliation rejected the incomplete snapshot when those IDs could not be resolved.

This change:
- Sets `IncludeDpus: true` when Flow fetches machine inventory.
- Adds a regression test verifying the search configuration sent to Core.

Host-specific inventory processing remains unchanged because Flow already filters the complete snapshot to host records where required.

## Related issues
This addresses internal bug ID 6740220.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)