### PR TITLE
cherry-pick(v2.1): bump libredfish to v0.47.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6844,7 +6844,7 @@ dependencies = [
 [[package]]
 name = "libredfish"
 version = "0.0.0"
-source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.47.3#8f0eb0ed25955d9ba486b8c495f0adf9a85a8e7a"
+source = "git+https://github.com/NVIDIA/libredfish.git?tag=v0.47.5#569bc602d2aa03b3f2ea4c9e006d593a05c7b1dc"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ repository = "https://github.com/NVIDIA/infra-controller"
 
 [workspace.dependencies]
 clap = { version = "4", features = ["derive", "env"] }
-libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.47.3" }
+libredfish = { git = "https://github.com/NVIDIA/libredfish.git", tag = "v0.47.5" }
 librms = { git = "https://github.com/NVIDIA/nv-rms-client.git", tag = "v0.10.0" }
 ansi-to-html = "0.2.2"
 


### PR DESCRIPTION
This PR bumps libredfish to `v0.47.5` which brings in the following changes:

- fix: smc gb300 detection by @krish-nvidia in https://github.com/dsx-ai-factory/libredfish/pull/140
- fix: implement liteon pmc factory reset by @spydaNVIDIA in https://github.com/dsx-ai-factory/libredfish/pull/136

## Related issues
https://github.com/dsx-ai-factory/infra-controller/issues/5848

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
