### PR TITLE
patch(v2.1): fix repo check strings 

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report_form.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report_form.yml
@@ -67,9 +67,9 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/infra-controller/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/infra-controller/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow NVIDIA Infra Controller's Code of Conduct
           required: true
-        - label: I have searched the [open bugs](https://github.com/NVIDIA/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Bug) and have found no duplicates for this bug report
+        - label: I have searched the [open bugs](https://github.com/dsx-ai-factory/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Bug) and have found no duplicates for this bug report
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -22,5 +22,5 @@ blank_issues_enabled: true
 # link that below to have it show up in the 'Submit Issue' page
 contact_links:
   - name: Ask a Question
-    url: https://github.com/NVIDIA/infra-controller/discussions
+    url: https://github.com/dsx-ai-factory/infra-controller/discussions
     about: Please ask any questions here.

--- a/.github/ISSUE_TEMPLATE/documentation_request_correction.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request_correction.yml
@@ -42,7 +42,7 @@ body:
     id: correction_location
     attributes:
       label: Please provide a link or source to the relevant docs
-      placeholder: "ex: https://github.com/NVIDIA/infra-controller/blob/main/README.md"
+      placeholder: "ex: https://github.com/dsx-ai-factory/infra-controller/blob/main/README.md"
     validations:
       required: true
 
@@ -64,9 +64,9 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/infra-controller/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/infra-controller/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow NVIDIA Infra Controller's Code of Conduct
           required: true
-        - label: I have searched the [open documentation issues](https://github.com/NVIDIA/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Documentation) and have found no duplicates for this documentation issue
+        - label: I have searched the [open documentation issues](https://github.com/dsx-ai-factory/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Documentation) and have found no duplicates for this documentation issue
           required: true

--- a/.github/ISSUE_TEMPLATE/documentation_request_new.yml
+++ b/.github/ISSUE_TEMPLATE/documentation_request_new.yml
@@ -49,9 +49,9 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/infra-controller/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/infra-controller/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow NVIDIA Infra Controller's Code of Conduct
           required: true
-        - label: I have searched the [open documentation issues](https://github.com/NVIDIA/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Documentation) and have found no duplicates for this documentation issue
+        - label: I have searched the [open documentation issues](https://github.com/dsx-ai-factory/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Documentation) and have found no duplicates for this documentation issue
           required: true

--- a/.github/ISSUE_TEMPLATE/feature_request_form.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request_form.yml
@@ -101,9 +101,9 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/NVIDIA/infra-controller/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/dsx-ai-factory/infra-controller/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow NVIDIA Infra Controller's Code of Conduct
           required: true
-        - label: I have searched the [open feature requests](https://github.com/NVIDIA/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Enhancement,Epic) and have found no duplicates for this feature request
+        - label: I have searched the [open feature requests](https://github.com/dsx-ai-factory/infra-controller/issues?q=is%3Aopen+is%3Aissue+type:Enhancement,Epic) and have found no duplicates for this feature request
           required: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -251,14 +251,14 @@ jobs:
               exit 1
             fi
           done
-          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
+          if [[ "${GITHUB_REPOSITORY}" == "dsx-ai-factory/infra-controller" ]]; then
             # canonical endpoints are constants: repository variables must not
             # be able to redirect canonical credentials without a workflow diff
             TARGET="${CANONICAL_DEV}"
             PROD="${CANONICAL_PROD}"
           else
             if [[ -z "${TARGET_OVERRIDE}" ]]; then
-              echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside NVIDIA/infra-controller"
+              echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside dsx-ai-factory/infra-controller"
               exit 1
             fi
             TARGET="${TARGET_OVERRIDE}"
@@ -280,7 +280,7 @@ jobs:
           fi
           TARGET="${TARGET%/}"
           PROD="${PROD%/}"
-          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
+          if [[ "${GITHUB_REPOSITORY}" == "dsx-ai-factory/infra-controller" ]]; then
             SOURCE="${CANONICAL_DEV}"
             EXTRAS="${SOURCE}/nvmetal-carbide-extras:latest"
           else
@@ -292,7 +292,7 @@ jobs:
             echo "::error::NICO_EXTRAS_IMAGE must live on the source registry host (${SOURCE%%/*}); refusing to send source credentials to ${EXTRAS%%/*}"
             exit 1
           fi
-          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" ]]; then
+          if [[ "${GITHUB_REPOSITORY}" == "dsx-ai-factory/infra-controller" ]]; then
             NGC_PATH="${TARGET#*/}"
           else
             NGC_PATH="${NGC_PATH_OVERRIDE:-}"
@@ -435,7 +435,7 @@ jobs:
           # checks on `v2.1-latest`; mirrors continue using the `latest` tag from
           # their configured source registry.
           build_container_fallback_version=latest
-          if [[ "${GITHUB_REPOSITORY}" == "NVIDIA/infra-controller" && "${MAJOR_MINOR}" == "v2.1" ]]; then
+          if [[ "${GITHUB_REPOSITORY}" == "dsx-ai-factory/infra-controller" && "${MAJOR_MINOR}" == "v2.1" ]]; then
             build_container_fallback_version="${MAJOR_MINOR}-latest"
           fi
 
@@ -528,7 +528,7 @@ jobs:
           echo "publish_built_container=${PUBLISH}" >> "$GITHUB_OUTPUT"
           # job containers log in before any step runs, so the lint job must
           # never point at a target ref that was not published (mirror PRs)
-          if [[ "${BUILD_X86_RUN}" == "true" && "${GITHUB_REPOSITORY}" != "NVIDIA/infra-controller" && "${PUBLISH}" != "true" ]]; then
+          if [[ "${BUILD_X86_RUN}" == "true" && "${GITHUB_REPOSITORY}" != "dsx-ai-factory/infra-controller" && "${PUBLISH}" != "true" ]]; then
             echo "lint_container_ref=${SOURCE_REGISTRY}/build-container-x86_64:latest" >> "$GITHUB_OUTPUT"
           else
             echo "lint_container_ref=${BUILD_X86_REF}" >> "$GITHUB_OUTPUT"
@@ -592,7 +592,7 @@ jobs:
       additional_tags: ${{ needs.prepare.outputs.build_container_x86_64_version_latest }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      push: ${{ github.repository == 'dsx-ai-factory/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: true
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -610,7 +610,7 @@ jobs:
       additional_tags: ${{ needs.prepare.outputs.build_container_aarch64_version_latest }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      push: ${{ github.repository == 'dsx-ai-factory/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -628,7 +628,7 @@ jobs:
       additional_tags: ${{ needs.prepare.outputs.runtime_container_x86_64_version_latest }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      push: ${{ github.repository == 'dsx-ai-factory/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: true
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -646,7 +646,7 @@ jobs:
       additional_tags: ${{ needs.prepare.outputs.runtime_container_aarch64_version_latest }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      push: ${{ github.repository == 'dsx-ai-factory/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -664,7 +664,7 @@ jobs:
       additional_tags: ${{needs.prepare.outputs.build_artifacts_container_x86_64_version_latest }}
       platforms: linux/amd64
       runner: linux-amd64-cpu4
-      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      push: ${{ github.repository == 'dsx-ai-factory/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: true
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -682,7 +682,7 @@ jobs:
       additional_tags: ${{ needs.prepare.outputs.build_artifacts_container_aarch64_version_latest }}
       platforms: linux/arm64
       runner: linux-arm64-cpu4
-      push: ${{ github.repository == 'NVIDIA/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
+      push: ${{ github.repository == 'dsx-ai-factory/infra-controller' || needs.prepare.outputs.publish_images == 'true' }}
       load: false
       tag_latest: ${{ github.ref == 'refs/heads/main' }}
     secrets: inherit
@@ -1493,6 +1493,10 @@ jobs:
         username: ${{ secrets.NICO_SOURCE_REGISTRY_USERNAME || secrets.NVCR_USERNAME }}
         password: ${{ secrets.NICO_SOURCE_REGISTRY_TOKEN || secrets.NVCR_TOKEN }}
     steps:
+      # The PR mirror's `github.sha` is the submitted head commit. Keep lint on
+      # the same revision as the other PR checks and builds. Validation of the
+      # exact queued revision is tracked at:
+      # https://github.com/dsx-ai-factory/infra-controller/issues/4587
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -2016,7 +2020,7 @@ jobs:
 
   promote-to-be-scanned-image:
     # Skip for pull-request/* branches (main, release/*, and tags are allowed by workflow trigger)
-    if: ${{ !cancelled() && github.repository == 'NVIDIA/infra-controller' && needs.build-release-container-x86_64.result == 'success' && github.event_name != 'schedule' && needs.prepare.outputs.publish_images == 'true' }}
+    if: ${{ !cancelled() && github.repository == 'dsx-ai-factory/infra-controller' && needs.build-release-container-x86_64.result == 'success' && github.event_name != 'schedule' && needs.prepare.outputs.publish_images == 'true' }}
     needs:
       - prepare
       - build-release-container-x86_64

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -167,7 +167,7 @@ jobs:
       # needed when this run rebuilt base containers (their refs point at the
       # target) and for multi-platform builds that push from the build step
       - name: Login to target registry (pre-build)
-        if: ${{ (inputs.target_prebuild_login && inputs.source_registry_host != '') || (inputs.push && (contains(inputs.platforms, ',') || github.repository == 'NVIDIA/infra-controller')) }}
+        if: ${{ (inputs.target_prebuild_login && inputs.source_registry_host != '') || (inputs.push && (contains(inputs.platforms, ',') || github.repository == 'dsx-ai-factory/infra-controller')) }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-host.outputs.host }}
@@ -227,11 +227,11 @@ jobs:
           # build so no credential is present during base pulls. Multi-platform
           # images cannot be loaded into the classic store, so they always push
           # directly.
-          push: ${{ inputs.push && (contains(inputs.platforms, ',') || github.repository == 'NVIDIA/infra-controller') }}
-          load: ${{ (inputs.load && !inputs.push) || (inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller') }}
+          push: ${{ inputs.push && (contains(inputs.platforms, ',') || github.repository == 'dsx-ai-factory/infra-controller') }}
+          load: ${{ (inputs.load && !inputs.push) || (inputs.push && !contains(inputs.platforms, ',') && github.repository != 'dsx-ai-factory/infra-controller') }}
           # mirrors: the docker exporter cannot attach attestations, and
           # provenance would embed private downstream repo refs into artifacts
-          provenance: ${{ github.repository == 'NVIDIA/infra-controller' && 'mode=min' || 'false' }}
+          provenance: ${{ github.repository == 'dsx-ai-factory/infra-controller' && 'mode=min' || 'false' }}
           tags: ${{ steps.tag_list.outputs.tags }}
           build-args: ${{ steps.parse-args.outputs.build_args }}
           cache-from: ${{ inputs.cache && 'type=gha' || '' }}
@@ -247,7 +247,7 @@ jobs:
           cache-to: ''
 
       - name: Login to target registry
-        if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller' }}
+        if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'dsx-ai-factory/infra-controller' }}
         uses: ./.github/actions/docker-auth
         with:
           registry: ${{ steps.registry-host.outputs.host }}
@@ -256,7 +256,7 @@ jobs:
 
       - name: Push image tags
         id: push
-        if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'NVIDIA/infra-controller' }}
+        if: ${{ inputs.push && !contains(inputs.platforms, ',') && github.repository != 'dsx-ai-factory/infra-controller' }}
         env:
           TAGS: ${{ steps.tag_list.outputs.tags }}
           PRIMARY: ${{ steps.tag_list.outputs.primary }}

--- a/.github/workflows/promotion.yaml
+++ b/.github/workflows/promotion.yaml
@@ -30,7 +30,7 @@ jobs:
   # ============================================================================
   prepare:
     # Production promotion never runs outside the canonical repo.
-    if: github.repository == 'NVIDIA/infra-controller'
+    if: github.repository == 'dsx-ai-factory/infra-controller'
     runs-on: linux-amd64-cpu4
     outputs:
       version: ${{ inputs.version }}

--- a/.github/workflows/rest-prepare-build-info.yml
+++ b/.github/workflows/rest-prepare-build-info.yml
@@ -89,11 +89,11 @@ jobs:
             exit 1
           fi
           # canonical endpoints are constants: variables must not redirect them
-          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
+          if [ "${GITHUB_REPOSITORY}" = "dsx-ai-factory/infra-controller" ]; then
             target_registry="nvcr.io/0837451325059433/carbide-dev"
           else
             if [ -z "${REGISTRY_OVERRIDE}" ]; then
-              echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside NVIDIA/infra-controller"
+              echo "::error::NICO_TARGET_IMAGE_REGISTRY repository variable is required outside dsx-ai-factory/infra-controller"
               exit 1
             fi
             _norm="${REGISTRY_OVERRIDE%/}"
@@ -135,7 +135,7 @@ jobs:
           echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
           echo "full_sha=$FULL_SHA" >> $GITHUB_OUTPUT
           echo "target_registry=$target_registry" >> $GITHUB_OUTPUT
-          if [ "${GITHUB_REPOSITORY}" = "NVIDIA/infra-controller" ]; then
+          if [ "${GITHUB_REPOSITORY}" = "dsx-ai-factory/infra-controller" ]; then
             echo "target_ngc_path=${target_registry#*/}" >> $GITHUB_OUTPUT
           else
             case "${NGC_PATH_OVERRIDE%/}" in


### PR DESCRIPTION
Backports (#5810)

Updates CI references to old `NVIDIA/infra-controller` which does string comparison against `github.repository`. Since the repo was moved, the repo value changes potentially causing this comparison to fail. This does not affect the other references to the old repo location due to how APIs intelligently redirect to the new location.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [] No testing required (docs, internal refactor, etc.)

## Additional Notes