### PR TITLE
fix(admin-cli,core): Add guards against empty tenant profiles with FNN

### DIFF
--- a/crates/admin-cli/src/tenant/update/cmd.rs
+++ b/crates/admin-cli/src/tenant/update/cmd.rs
@@ -42,6 +42,10 @@ pub(super) async fn update(
         .tenant
         .ok_or(CarbideCliError::TenantNotFound(id.clone()))?;
 
+    // Core treats the profile as a replacement, so an omitted CLI flag must preserve it.
+    // Match the fetched version to avoid restoring stale tenant state after a concurrent update.
+    let if_version_match = args.version.or(Some(tenant.version));
+    let routing_profile_type = args.routing_profile_type.or(tenant.routing_profile_type);
     let mut metadata = tenant.metadata.unwrap_or_default();
 
     if let Some(n) = args.name {
@@ -53,8 +57,8 @@ pub(super) async fn update(
         .update_tenant(UpdateTenantRequest {
             organization_id: id.clone(),
             metadata: Some(metadata),
-            if_version_match: args.version,
-            routing_profile_type: args.routing_profile_type,
+            if_version_match,
+            routing_profile_type,
         })
         .await?
         .tenant

--- a/crates/api-core/src/handlers/tenant.rs
+++ b/crates/api-core/src/handlers/tenant.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 use ::rpc::forge as rpc;
+use carbide_network::virtualization::VpcVirtualizationType;
 use model::ConfigValidationError;
 use model::metadata::Metadata;
 use tonic::{Request, Response, Status};
@@ -210,6 +211,14 @@ pub(crate) async fn update(
         .into());
     };
 
+    // FNN tenant policy must always have a named profile from which VPC policy can inherit.
+    if api.runtime_config.fnn.is_some() && routing_profile_type.is_none() {
+        return Err(CarbideError::InvalidArgument(
+            "`routing_profile_type` is required when FNN is enabled".to_string(),
+        )
+        .into());
+    }
+
     // We won't use it if FNN isn't enabled, but we can still map so a caller integrating
     // with us before FNN is enabled on a site will be told if they're sending invalid values.
     if let Some(profile) = routing_profile_type.as_ref() {
@@ -230,18 +239,14 @@ pub(crate) async fn update(
         }
     };
 
-    // If a tenant routing profile is being updated,
-    // it can only be allowed if there are no existing VPCs
-    // for the tenant.  Technically, at the moment, it's probably
-    // ok to allow it as long it's not switching between profiles
-    // that have a differing `internal` value (e.g., switching from
-    // internal==true to false), but total restriction is safer
-    // and easy to loosen later if we find we need it.
+    // Tenant routing profiles affect only FNN VPC policy, so non-FNN VPCs do not block
+    // an update needed to prepare a historical profileless tenant for FNN.
     if current_tenant.routing_profile_type != routing_profile_type
         && !db::vpc::find_ids(
             &mut txn,
             model::vpc::VpcSearchFilter {
                 tenant_org_id: Some(organization_id.clone()),
+                network_virtualization_type: Some(VpcVirtualizationType::Fnn),
                 ..Default::default()
             },
         )
@@ -249,7 +254,7 @@ pub(crate) async fn update(
         .is_empty()
     {
         return Err(CarbideError::FailedPrecondition(
-            "cannot update tenant routing profile type for tenant with active VPCs".to_string(),
+            "cannot update tenant routing profile type for tenant with active FNN VPCs".to_string(),
         )
         .into());
     }

--- a/crates/api-core/src/handlers/vpc.rs
+++ b/crates/api-core/src/handlers/vpc.rs
@@ -46,24 +46,10 @@ pub(crate) async fn create(
     let mut txn = api.txn_begin().await?;
 
     // Grab the tenant details and a row-lock if found so we can coordinate around the tenant record.
-    // If we're still allowing VPC creation for tenant org IDs that don't actually exist
-    // in the DB, we're limited with the coordinating we can do, but it also doesn't matter
-    // because those VPCs are going to default to external and force us to deal with the missing,
-    // tenant records.
+    // Missing tenants remain supported for non-FNN VPCs; FNN creation rejects them below after
+    // resolving the requested virtualization type.
     let tenant =
         db::tenant::find(&vpc_creation_request.tenant_organization_id, true, &mut txn).await?;
-
-    // A lot of tests seem to still allow tenant IDs for tenants that don't
-    // exist.  We should audit and see if there are still sites with missing tenants
-    // if we expect NICo-core to have knowledge of tenants.  Otherwise, this would just go away
-    // when we _remove_ any expectation of tenant knowledge from NICo-core, and the details we
-    // need from tenant would just come in from the VPC creation request.
-    if tenant.is_none() {
-        tracing::warn!(
-            tenant_organization_id = vpc_creation_request.tenant_organization_id.clone(),
-            "Database record for tenant ID in VPC creation request not found"
-        );
-    };
 
     if let Some(ref nsg_id) = vpc_creation_request.network_security_group_id {
         let id = nsg_id.parse::<NetworkSecurityGroupId>().map_err(|e| {
@@ -107,6 +93,23 @@ pub(crate) async fn create(
         None => DEFAULT_NETWORK_VIRTUALIZATION_TYPE,
         Some(v) => vpc_virtualization_type_try_from_rpc(v).map_err(CarbideError::from)?,
     };
+
+    // FNN routing policy requires tenant context for inheritance and authorization.
+    if requested_virtualization_type == VpcVirtualizationType::Fnn && tenant.is_none() {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "tenant `{}` must exist before creating an FNN VPC",
+            vpc_creation_request.tenant_organization_id
+        ))
+        .into());
+    }
+
+    // Non-FNN VPC creation retains the legacy missing-tenant behavior.
+    if tenant.is_none() {
+        tracing::warn!(
+            tenant_organization_id = vpc_creation_request.tenant_organization_id.clone(),
+            "Database record for tenant ID in VPC creation request not found"
+        );
+    }
 
     if vpc_creation_request.routing_profile_type.is_some()
         || vpc_creation_request.routing_profile_overrides.is_some()
@@ -650,19 +653,10 @@ fn resolve_vpc_routing(
     let tenant_profile_type = tenant.and_then(|t| t.routing_profile_type.as_deref());
 
     match (requested_profile_type, tenant_profile_type) {
-        // No VPC routing profile requested and no tenant profile.
-        // Falling back to a default. With FNN disabled, assume
-        // internal (legacy/pre-FNN behavior); with FNN enabled,
-        // external must be assumed.
-        (None, None) if vpc_profile_overrides.is_none() => Ok(ResolvedVpcRouting {
-            profile_type: None,
-            internal: fnn_config.is_none(),
-        }),
-
-        // A requested profile type or inline profile needs tenant context
-        // to establish and authorize its named base profile.
+        // Every FNN VPC needs a tenant profile to establish its named routing policy and
+        // authorize any explicitly requested profile or inline overrides.
         (_, None) => Err(CarbideError::FailedPrecondition(format!(
-            "VPC routing profile type or overrides requested but no tenant or routing profile type found for organization id `{organization_id}`"
+            "tenant `{organization_id}` must have a routing profile before creating an FNN VPC"
         ))),
 
         // Tenant has a routing profile; resolve the request against it.
@@ -817,24 +811,24 @@ mod tests {
                 } => Yields((None, true)),
             }
 
-            "missing tenant context" {
-                // Without FNN or explicit routing properties, preserve the legacy internal
-                // allocation default even when no tenant record is available.
+            "missing tenant routing profile" {
+                // An FNN VPC cannot use the legacy internal default without a named tenant
+                // profile because downstream policy resolution requires that name.
                 RoutingResolutionInput {
                     network_virtualization_type: Fnn,
                     requested_profile_type: None,
                     routing_profile_overrides: None,
                     tenant: None,
                     fnn_config: None,
-                } => Yields((None, true)),
-                // Enabling FNN changes the no-profile allocation default to external.
+                } => FailsWith(FailedPrecondition),
+                // Enabling FNN cannot make missing tenant routing context resolvable.
                 RoutingResolutionInput {
                     network_virtualization_type: Fnn,
                     requested_profile_type: None,
                     routing_profile_overrides: None,
                     tenant: None,
                     fnn_config: Some(fnn_with_profiles(&[])),
-                } => Yields((None, false)),
+                } => FailsWith(FailedPrecondition),
                 // A named profile request needs tenant context to authorize its access tier.
                 RoutingResolutionInput {
                     network_virtualization_type: Fnn,

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -5316,8 +5316,15 @@ async fn test_allocate_instance_with_multiple_fnn_vpc_prefixes(
     options: PgConnectOptions,
 ) {
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
-    let env = create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
     let mh = create_managed_host_multi_dpu(&env, 2).await;
+
+    // Register the tenant required by both FNN VPCs used in this allocation scenario.
+    create_fixture_tenant(&env, FIXTURE_TENANT_ORG_ID)
+        .await
+        .unwrap();
 
     // Create two FNN VPCs and prefixes to exercise cross-VPC allocation.
     let first_vpc = env
@@ -5615,8 +5622,15 @@ async fn test_allocate_instance_rejects_dual_stack_prefixes_from_different_vpcs(
     options: PgConnectOptions,
 ) {
     let pool = PgPoolOptions::new().connect_with(options).await.unwrap();
-    let env = create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
     let mh = create_managed_host(&env).await;
+
+    // Register the tenant required by both FNN VPCs used in this validation scenario.
+    create_fixture_tenant(&env, FIXTURE_TENANT_ORG_ID)
+        .await
+        .unwrap();
 
     // Create two FNN VPCs so the global multi-FNN check passes.
     let first_vpc = env

--- a/crates/api-core/src/tests/network_segment.rs
+++ b/crates/api-core/src/tests/network_segment.rs
@@ -54,6 +54,7 @@ use crate::db_init;
 use crate::test_support::network_segment::FIXTURE_TENANT_ORG_ID;
 use crate::tests::common;
 use crate::tests::common::api_fixtures::network_segment::FIXTURE_TENANT_NETWORK_SEGMENT_GATEWAYS;
+use crate::tests::common::api_fixtures::tenant::create_fixture_tenant;
 use crate::tests::common::api_fixtures::{
     TEST_SITE_PREFIXES, TestEnvOverrides, create_test_env, create_test_env_with_overrides,
     get_vpc_fixture_id,
@@ -1698,9 +1699,13 @@ async fn test_create_dual_stack_tenant_segment(pool: sqlx::PgPool) -> Result<(),
             create_network_segments: Some(false),
             site_prefixes: Some(site_prefixes),
             ..Default::default()
-        },
+        }
+        .with_fnn_config(None),
     )
     .await;
+
+    // Register the tenant required by the FNN VPC before exercising dual-stack segments.
+    create_fixture_tenant(&env, FIXTURE_TENANT_ORG_ID).await?;
 
     let vpc = env
         .api
@@ -1788,9 +1793,13 @@ async fn test_ipv6_tenant_prefix_rejected_when_not_in_site_fabric(
             create_network_segments: Some(false),
             site_prefixes: Some(site_prefixes),
             ..Default::default()
-        },
+        }
+        .with_fnn_config(None),
     )
     .await;
+
+    // Register the tenant required by the FNN VPC before exercising prefix containment.
+    create_fixture_tenant(&env, FIXTURE_TENANT_ORG_ID).await?;
 
     let vpc = env
         .api

--- a/crates/api-core/src/tests/tenants.rs
+++ b/crates/api-core/src/tests/tenants.rs
@@ -223,8 +223,7 @@ async fn test_tenant(pool: sqlx::PgPool) {
             .contains("RoutingProfile not found: ADMIN")
     );
 
-    // Create a VPC for the tenant
-    // No network_virtualization_type, should default.
+    // Create an active FNN VPC whose inherited routing policy makes profile changes unsafe.
     let new_vpc = env
         .api
         .create_vpc(
@@ -234,6 +233,7 @@ async fn test_tenant(pool: sqlx::PgPool) {
                     description: "".to_string(),
                     labels: Vec::new(),
                 })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
                 .tonic_request(),
         )
         .await
@@ -256,7 +256,7 @@ async fn test_tenant(pool: sqlx::PgPool) {
             .await
             .unwrap_err()
             .message()
-            .contains("cannot update tenant routing profile type")
+            .contains("cannot update tenant routing profile type for tenant with active FNN VPCs")
     );
 
     //
@@ -404,6 +404,74 @@ async fn test_tenant(pool: sqlx::PgPool) {
     );
 }
 
+/// Verifies an FNN tenant update without a routing profile rejects the whole write so metadata,
+/// version, and inherited policy cannot diverge.
+#[crate::sqlx_test]
+async fn update_tenant_requires_routing_profile_with_fnn(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+
+    // Create through the public API so the tenant receives the site's default FNN profile.
+    let tenant = env
+        .api
+        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
+            organization_id: "fnn-update-profile".to_string(),
+            routing_profile_type: None,
+            metadata: Some(rpc::forge::Metadata {
+                name: "FNN update profile".to_string(),
+                ..Default::default()
+            }),
+        }))
+        .await?
+        .into_inner()
+        .tenant
+        .expect("created tenant");
+
+    // Capture the original state so the rejected write can be checked for partial persistence.
+    let original_metadata = tenant.metadata.clone();
+    let original_version = tenant.version.clone();
+
+    // Omitting the replacement profile must fail even before the tenant owns any VPCs.
+    let error = env
+        .api
+        .update_tenant(tonic::Request::new(rpc::forge::UpdateTenantRequest {
+            organization_id: tenant.organization_id.clone(),
+            routing_profile_type: None,
+            metadata: Some(rpc::forge::Metadata {
+                name: "Rejected FNN metadata update".to_string(),
+                ..Default::default()
+            }),
+            if_version_match: Some(original_version.clone()),
+        }))
+        .await
+        .expect_err("an FNN tenant update without a routing profile must fail");
+    assert_eq!(error.code(), Code::InvalidArgument);
+    assert!(
+        error
+            .message()
+            .contains("`routing_profile_type` is required")
+    );
+
+    // Reload through the public API to prove no part of the rejected write was persisted.
+    let persisted = env
+        .api
+        .find_tenant(tonic::Request::new(rpc::forge::FindTenantRequest {
+            tenant_organization_id: tenant.organization_id,
+        }))
+        .await?
+        .into_inner()
+        .tenant
+        .expect("persisted tenant");
+    assert_eq!(persisted.metadata, original_metadata);
+    assert_eq!(persisted.version, original_version);
+    assert_eq!(persisted.routing_profile_type.as_deref(), Some("EXTERNAL"));
+
+    Ok(())
+}
+
 #[crate::sqlx_test]
 async fn test_find_tenant_ids(pool: sqlx::PgPool) {
     let env = create_test_env(pool).await;
@@ -518,6 +586,34 @@ async fn test_tenant_create_without_fnn(pool: sqlx::PgPool) {
     assert_eq!(tenant.organization_id, "PreFnnOrg");
     assert_eq!(tenant.routing_profile_type, None);
 
+    // Omitting the replacement profile remains valid without FNN and leaves it unset.
+    let tenant_update = env
+        .api
+        .update_tenant(tonic::Request::new(rpc::forge::UpdateTenantRequest {
+            organization_id: tenant.organization_id.clone(),
+            routing_profile_type: None,
+            metadata: tenant.metadata.clone(),
+            if_version_match: Some(tenant.version),
+        }))
+        .await
+        .unwrap()
+        .into_inner();
+    let updated_tenant = tenant_update.tenant.expect("updated tenant");
+    assert_eq!(updated_tenant.routing_profile_type, None);
+
+    // Reload through the public API to prove the successful update persisted no profile.
+    let persisted_tenant = env
+        .api
+        .find_tenant(tonic::Request::new(rpc::forge::FindTenantRequest {
+            tenant_organization_id: updated_tenant.organization_id,
+        }))
+        .await
+        .unwrap()
+        .into_inner()
+        .tenant
+        .expect("persisted tenant");
+    assert_eq!(persisted_tenant.routing_profile_type, None);
+
     // Updating a tenant with a routing profile while FNN is disabled should fail.
     let update_tenant = env
         .api
@@ -529,7 +625,7 @@ async fn test_tenant_create_without_fnn(pool: sqlx::PgPool) {
                 description: "".to_string(),
                 labels: vec![],
             }),
-            if_version_match: Some(tenant.version.clone()),
+            if_version_match: Some(persisted_tenant.version),
         }))
         .await
         .unwrap_err();

--- a/crates/api-core/src/tests/vpc.rs
+++ b/crates/api-core/src/tests/vpc.rs
@@ -46,69 +46,230 @@ fn forge_vpc_config(vpc: &rpc::forge::Vpc) -> &rpc::forge::VpcConfig {
         .expect("structured config must be populated")
 }
 
+/// Verifies an active non-FNN VPC does not prevent repairing a historical profileless tenant, so
+/// existing non-FNN workloads do not block later FNN adoption.
 #[crate::sqlx_test]
 async fn create_vpc_for_tenant_without_profile(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+    let tenant_organization_id = "historical-profileless-tenant";
 
-    // Create a tenant.
+    // Persist the historical state produced by creating a tenant before enabling FNN.
+    let mut txn = env.pool.begin().await?;
+    db::tenant::create_and_persist(
+        tenant_organization_id.to_string(),
+        Metadata {
+            name: "Historical profileless tenant".to_string(),
+            ..Default::default()
+        },
+        None,
+        txn.as_mut(),
+    )
+    .await?;
+    txn.commit().await?;
+
+    // Omitting the VPC profile must not persist an FNN VPC without named routing policy.
+    let error = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder(tenant_organization_id)
+                .metadata(rpc::forge::Metadata {
+                    name: "Profileless FNN VPC".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await
+        .expect_err("an FNN VPC requires a tenant routing profile");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(error.message().contains("must have a routing profile"));
+
+    // Read through the public API to prove the rejected request persisted no VPC.
+    let persisted_ids = env
+        .api
+        .find_vpc_ids(tonic::Request::new(rpc::forge::VpcSearchFilter {
+            name: None,
+            tenant_org_id: Some(tenant_organization_id.to_string()),
+            label: None,
+        }))
+        .await?
+        .into_inner()
+        .vpc_ids;
+    assert!(persisted_ids.is_empty());
+
+    // Create an ETV VPC to prove non-FNN workloads do not prevent profile remediation.
+    env.api
+        .create_vpc(
+            VpcCreationRequest::builder(tenant_organization_id)
+                .metadata(rpc::forge::Metadata {
+                    name: "Historical tenant ETV VPC".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(
+                    rpc::forge::VpcVirtualizationType::EthernetVirtualizer as i32,
+                )
+                .tonic_request(),
+        )
+        .await?;
+
+    // Load the tenant through the public API so the update uses its persisted version and metadata.
     let tenant = env
         .api
-        .create_tenant(tonic::Request::new(rpc::forge::CreateTenantRequest {
-            organization_id: "sizzle".to_string(),
-            routing_profile_type: None,
-            metadata: Some(rpc::forge::Metadata {
-                name: "sizzle".to_string(),
-                description: "".to_string(),
-                labels: vec![],
-            }),
+        .find_tenant(tonic::Request::new(rpc::forge::FindTenantRequest {
+            tenant_organization_id: tenant_organization_id.to_string(),
         }))
-        .await
-        .unwrap()
+        .await?
         .into_inner()
         .tenant
-        .unwrap();
+        .expect("historical tenant");
 
-    // Try to request a VPC without sending a valid tenant org. Routing-
-    // profile validation lives behind the FNN-only path, so the request
-    // has to be an FNN VPC to exercise the "no tenant" branch.
-    assert!(
-        env.api
-            .create_vpc(
-                VpcCreationRequest::builder("")
-                    .metadata(rpc::forge::Metadata {
-                        name: "Forge".to_string(),
-                        ..Default::default()
-                    })
-                    .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
-                    .routing_profile_type("PRIVILEGED_INTERNAL".to_string())
-                    .tonic_request(),
-            )
-            .await
-            .unwrap_err()
-            .message()
-            .contains("no tenant or routing profile type found")
+    // Assign a valid profile while only the non-FNN VPC is active.
+    let updated_tenant = env
+        .api
+        .update_tenant(tonic::Request::new(rpc::forge::UpdateTenantRequest {
+            organization_id: tenant_organization_id.to_string(),
+            routing_profile_type: Some("INTERNAL".to_string()),
+            metadata: tenant.metadata,
+            if_version_match: Some(tenant.version),
+        }))
+        .await?
+        .into_inner()
+        .tenant
+        .expect("updated tenant");
+    assert_eq!(
+        updated_tenant.routing_profile_type.as_deref(),
+        Some("INTERNAL")
     );
 
-    // Try to request a VPC with a routing profile when the tenant has no routing profile type
-    assert!(
-        env.api
-            .create_vpc(
-                VpcCreationRequest::builder(tenant.organization_id)
-                    .metadata(rpc::forge::Metadata {
-                        name: "Forge".to_string(),
-                        ..Default::default()
-                    })
-                    .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
-                    .routing_profile_type("PRIVILEGED_INTERNAL".to_string())
-                    .tonic_request(),
-            )
-            .await
-            .unwrap_err()
-            .message()
-            .contains("no tenant or routing profile type found")
+    // Reload through the public API to prove the profile and new version were persisted.
+    let persisted_tenant = env
+        .api
+        .find_tenant(tonic::Request::new(rpc::forge::FindTenantRequest {
+            tenant_organization_id: tenant_organization_id.to_string(),
+        }))
+        .await?
+        .into_inner()
+        .tenant
+        .expect("persisted tenant");
+    assert_eq!(
+        persisted_tenant.routing_profile_type.as_deref(),
+        Some("INTERNAL")
     );
+    assert_eq!(persisted_tenant.version, updated_tenant.version);
+
+    // A later FNN VPC can now inherit the tenant's repaired named profile.
+    let fnn_vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder(tenant_organization_id)
+                .metadata(rpc::forge::Metadata {
+                    name: "Repaired tenant FNN VPC".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let created_config = forge_vpc_config(&fnn_vpc);
+    assert_eq!(
+        created_config.network_virtualization_type,
+        Some(rpc::forge::VpcVirtualizationType::Fnn as i32)
+    );
+    assert_eq!(
+        created_config.routing_profile_type.as_deref(),
+        Some("INTERNAL")
+    );
+
+    // Reload the FNN VPC to prove the inherited profile was persisted.
+    let persisted_vpc = env
+        .api
+        .find_vpcs_by_ids(tonic::Request::new(rpc::forge::VpcsByIdsRequest {
+            vpc_ids: vec![fnn_vpc.id.expect("created FNN VPC ID")],
+        }))
+        .await?
+        .into_inner()
+        .vpcs
+        .pop()
+        .expect("persisted FNN VPC");
+    let persisted_config = forge_vpc_config(&persisted_vpc);
+    assert_eq!(
+        persisted_config.network_virtualization_type,
+        Some(rpc::forge::VpcVirtualizationType::Fnn as i32)
+    );
+    assert_eq!(
+        persisted_config.routing_profile_type.as_deref(),
+        Some("INTERNAL")
+    );
+
+    Ok(())
+}
+
+/// Verifies only FNN VPC creation requires a persisted tenant because its routing policy depends
+/// on tenant context, while non-FNN creation retains the legacy missing-tenant behavior.
+#[crate::sqlx_test]
+async fn create_fnn_vpc_requires_existing_tenant(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+    let missing_tenant = "missing-vpc-tenant";
+
+    // An FNN VPC cannot resolve inherited routing policy without a tenant record.
+    let error = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder(missing_tenant)
+                .metadata(Metadata {
+                    name: "FNN without tenant".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
+                .tonic_request(),
+        )
+        .await
+        .expect_err("an FNN VPC without a tenant must fail");
+    assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        error
+            .message()
+            .contains("must exist before creating an FNN VPC")
+    );
+
+    // A non-FNN VPC does not consume tenant routing policy, so preserve its existing behavior.
+    let etv_vpc = env
+        .api
+        .create_vpc(
+            VpcCreationRequest::builder(missing_tenant)
+                .metadata(Metadata {
+                    name: "ETV without tenant".to_string(),
+                    ..Default::default()
+                })
+                .network_virtualization_type(
+                    rpc::forge::VpcVirtualizationType::EthernetVirtualizer as i32,
+                )
+                .tonic_request(),
+        )
+        .await?
+        .into_inner();
+
+    // Reload through the public API to prove the rejected FNN request created no additional VPC.
+    let persisted_ids = env
+        .api
+        .find_vpc_ids(tonic::Request::new(rpc::forge::VpcSearchFilter {
+            name: None,
+            tenant_org_id: Some(missing_tenant.to_string()),
+            label: None,
+        }))
+        .await?
+        .into_inner()
+        .vpc_ids;
+    assert_eq!(persisted_ids, vec![etv_vpc.id.expect("created ETV VPC ID")]);
 
     Ok(())
 }
@@ -892,28 +1053,31 @@ async fn update_vpc_rejects_unresolvable_routing_profile_base(
         create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
             .await;
 
-    // Create through the supported missing-tenant fallback, which leaves an
-    // FNN VPC without a named routing profile.
-    let profileless = env
-        .api
-        .create_vpc(
-            VpcCreationRequest::builder("profileless-vpc")
-                .metadata(rpc::forge::Metadata {
-                    name: "profileless VPC".to_string(),
-                    ..Default::default()
-                })
-                .network_virtualization_type(rpc::forge::VpcVirtualizationType::Fnn as i32)
-                .tonic_request(),
-        )
-        .await?
-        .into_inner();
-    let profileless_id = profileless.id.expect("profileless VPC ID");
-
-    // Model configuration drift directly because runtime configuration is
-    // immutable after the test API starts and the database intentionally has
-    // no constraint tying profile names to that configuration.
+    // Model historical invalid rows and configuration drift directly because the public FNN
+    // creation path now requires a tenant and runtime configuration is immutable after startup.
+    let profileless_id = VpcId::new();
     let stale_profile_id = VpcId::new();
     let mut txn = env.pool.begin().await?;
+    db::vpc::persist(
+        NewVpc {
+            id: profileless_id,
+            tenant_organization_id: "profileless-vpc".to_string(),
+            network_virtualization_type: VpcVirtualizationType::Fnn,
+            metadata: Metadata {
+                name: "profileless VPC".to_string(),
+                ..Default::default()
+            },
+            network_security_group_id: None,
+            routing_profile_type: None,
+            routing_profile_overrides: None,
+            power_resource_group: None,
+            vni: None,
+            slaac_enabled: false,
+        },
+        VpcStatus { vni: None },
+        &mut txn,
+    )
+    .await?;
     let stale_vpc = db::vpc::persist(
         NewVpc {
             id: stale_profile_id,

--- a/crates/api-core/src/tests/vpc_peering.rs
+++ b/crates/api-core/src/tests/vpc_peering.rs
@@ -525,20 +525,27 @@ async fn test_vpc_peering_network_config(
     Ok(())
 }
 
+/// Verifies FNN and ETV VPCs reach and fail the virtualization compatibility boundary.
 #[crate::sqlx_test]
 async fn test_vpc_peering_network_config_mixed(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = api_fixtures::create_test_env(pool).await;
+    // Enable FNN so the helper creates the required tenants and valid FNN routing state.
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
 
-    let response = create_vpc_peering(
+    let error = create_vpc_peering(
         &env,
         VpcVirtualizationType::Fnn,
         VpcVirtualizationType::EthernetVirtualizer,
     )
-    .await;
-
-    assert!(response.is_err());
+    .await
+    .expect_err("mixed virtualization types cannot be peered");
+    assert!(
+        error.to_string().contains("cannot be peered"),
+        "unexpected error: {error}"
+    );
 
     Ok(())
 }
@@ -786,7 +793,12 @@ async fn flat_vpc_can_peer_with_fnn_under_exclusive_policy(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Same short-circuit as the ETV case, but on the FNN side: Flat VPCs are
     // peer-policy-neutral.
-    let env = api_fixtures::create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+
+    // Register the tenant required by the FNN side of the peering.
+    create_fixture_tenant(&env, FIXTURE_TENANT_ORG_ID).await?;
 
     let fnn_vpc = env
         .api

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -1660,7 +1660,9 @@ async fn test_vpc_prefix_search(pool: PgPool) -> Result<(), Box<dyn std::error::
 async fn exact_site_prefix_attachment_enforces_lineage_and_round_trips(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
     let tenant = "site-prefix-tenant-a";
     let other_tenant = "site-prefix-tenant-b";
     create_fixture_tenant(&env, tenant).await?;
@@ -1893,7 +1895,8 @@ async fn omitted_site_prefix_id_checks_only_the_vpc_tenant(
             site_prefixes: Some(Vec::new()),
             create_network_segments: Some(false),
             ..Default::default()
-        },
+        }
+        .with_fnn_config(None),
     )
     .await;
     let tenant = "legacy-prefix-tenant-a";
@@ -1968,7 +1971,8 @@ async fn omitted_site_prefix_id_serializes_with_tenant_root_creation(
             site_prefixes: Some(Vec::new()),
             create_network_segments: Some(false),
             ..Default::default()
-        },
+        }
+        .with_fnn_config(None),
     )
     .await;
     let tenant = "legacy-prefix-creation-race";
@@ -2018,7 +2022,8 @@ async fn omitted_site_prefix_id_serializes_with_first_operator_root_reconciliati
             site_prefixes: Some(Vec::new()),
             create_network_segments: Some(false),
             ..Default::default()
-        },
+        }
+        .with_fnn_config(None),
     )
     .await;
     let tenant = "legacy-operator-creation-race";
@@ -2055,7 +2060,9 @@ async fn omitted_site_prefix_id_serializes_with_first_operator_root_reconciliati
 async fn vpc_prefix_create_rechecks_parent_after_concurrent_retirement(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
     let tenant = "site-prefix-retirement-race";
     create_fixture_tenant(&env, tenant).await?;
     let vpc_id = create_fnn_vpc_for_tenant(&env, tenant, "retirement race VPC", None).await;
@@ -2109,7 +2116,9 @@ async fn vpc_prefix_create_rechecks_parent_after_concurrent_retirement(
 async fn tenant_managed_lineage_blocks_virtualization_transition_and_race(
     pool: PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let env = create_test_env(pool).await;
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
     let tenant = "site-prefix-virtualization-guard";
     create_fixture_tenant(&env, tenant).await?;
 

--- a/crates/api-db/src/vpc.rs
+++ b/crates/api-db/src/vpc.rs
@@ -112,6 +112,14 @@ pub async fn find_ids(
         builder.push_bind(tenant_org_id);
         has_filter = true;
     }
+    if let Some(network_virtualization_type) = filter.network_virtualization_type {
+        if has_filter {
+            builder.push(" AND ");
+        }
+        builder.push("network_virtualization_type = ");
+        builder.push_bind(network_virtualization_type);
+        has_filter = true;
+    }
     if let Some(label) = filter.label {
         if has_filter {
             builder.push(" AND ");

--- a/crates/api-model/src/vpc/mod.rs
+++ b/crates/api-model/src/vpc/mod.rs
@@ -117,6 +117,7 @@ pub struct VpcDefinition {
 pub struct VpcSearchFilter {
     pub name: Option<String>,
     pub tenant_org_id: Option<String>,
+    pub network_virtualization_type: Option<VpcVirtualizationType>,
     pub label: Option<LabelFilter>,
 }
 

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1932,6 +1932,7 @@ message Vpc {
 
 message VpcCreationRequest {
   reserved 2;  // was: string name, replaced with metadata.name
+  // Must identify an existing tenant with a routing profile when creating an FNN VPC.
   string tenantOrganizationId = 3; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
   // this keyset will enable any key contained within it to access any instance associated with this VPC.
   optional string tenantKeysetId = 4; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
@@ -6157,7 +6158,9 @@ message UpdateTenantRequest {
 
   reserved 4;
   
-  // Updating will only be allowed if the tenant has no active VPCs
+  // Core treats omission as a replacement with no profile, not patch-preserve behavior.
+  // When FNN is enabled, omission is rejected. When FNN is disabled, omission clears any existing
+  // profile, subject to the restriction against profile changes while active FNN VPCs exist.
   optional string routing_profile_type = 5;
 }
 message UpdateTenantResponse {

--- a/crates/rpc/src/model/vpc.rs
+++ b/crates/rpc/src/model/vpc.rs
@@ -34,6 +34,7 @@ impl From<rpc::forge::VpcSearchFilter> for VpcSearchFilter {
         VpcSearchFilter {
             name: filter.name,
             tenant_org_id: filter.tenant_org_id,
+            network_virtualization_type: None,
             label: filter.label.map(LabelFilter::from),
         }
     }

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -10827,9 +10827,10 @@ func (x *Vpc) GetConfig() *VpcConfig {
 }
 
 type VpcCreationRequest struct {
-	state                protoimpl.MessageState `protogen:"open.v1"`
-	Name                 string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"`                                 // Removed in v0.9.x and above, retained here for backwards compatibility
-	TenantOrganizationId string                 `protobuf:"bytes,3,opt,name=tenantOrganizationId,proto3" json:"tenantOrganizationId,omitempty"` // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
+	state protoimpl.MessageState `protogen:"open.v1"`
+	Name  string                 `protobuf:"bytes,2,opt,name=name,proto3" json:"name,omitempty"` // Removed in v0.9.x and above, retained here for backwards compatibility
+	// Must identify an existing tenant with a routing profile when creating an FNN VPC.
+	TenantOrganizationId string `protobuf:"bytes,3,opt,name=tenantOrganizationId,proto3" json:"tenantOrganizationId,omitempty"` // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
 	// this keyset will enable any key contained within it to access any instance associated with this VPC.
 	TenantKeysetId            *string                `protobuf:"bytes,4,opt,name=tenantKeysetId,proto3,oneof" json:"tenantKeysetId,omitempty"` // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
 	NetworkVirtualizationType *VpcVirtualizationType `protobuf:"varint,5,opt,name=network_virtualization_type,json=networkVirtualizationType,proto3,enum=forge.VpcVirtualizationType,oneof" json:"network_virtualization_type,omitempty"`
@@ -32838,7 +32839,9 @@ type UpdateTenantRequest struct {
 	// if this field is set and non-empty, the request will only update the tenant if the version matches the server's view,
 	// otherwise it will return a concurrency related error.
 	IfVersionMatch *string `protobuf:"bytes,3,opt,name=if_version_match,json=ifVersionMatch,proto3,oneof" json:"if_version_match,omitempty"`
-	// Updating will only be allowed if the tenant has no active VPCs
+	// Core treats omission as a replacement with no profile, not patch-preserve behavior.
+	// When FNN is enabled, omission is rejected. When FNN is disabled, omission clears any existing
+	// profile, subject to the restriction against profile changes while active FNN VPCs exist.
 	RoutingProfileType *string `protobuf:"bytes,5,opt,name=routing_profile_type,json=routingProfileType,proto3,oneof" json:"routing_profile_type,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -1854,6 +1854,7 @@ message Vpc {
 
 message VpcCreationRequest {
   string name = 2; // Removed in v0.9.x and above, retained here for backwards compatibility
+  // Must identify an existing tenant with a routing profile when creating an FNN VPC.
   string tenantOrganizationId = 3; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
   // this keyset will enable any key contained within it to access any instance associated with this VPC.
   optional string tenantKeysetId = 4; // protolint:disable:this FIELD_NAMES_LOWER_SNAKE_CASE
@@ -5939,7 +5940,9 @@ message UpdateTenantRequest {
 
   reserved 4;
 
-  // Updating will only be allowed if the tenant has no active VPCs
+  // Core treats omission as a replacement with no profile, not patch-preserve behavior.
+  // When FNN is enabled, omission is rejected. When FNN is disabled, omission clears any existing
+  // profile, subject to the restriction against profile changes while active FNN VPCs exist.
   optional string routing_profile_type = 5;
 }
 message UpdateTenantResponse {


### PR DESCRIPTION

This branch closes two reachable write paths that could produce invalid FNN routing state:

1. Clearing a tenant's routing profile through `UpdateTenant` while FNN is enabled.
2. Creating an FNN VPC for a tenant that does not exist.

## Related issues
https://github.com/dsx-ai-factory/infra-controller/issues/5733

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Closes https://github.com/dsx-ai-factory/infra-controller/issues/5733

<details><summary>Deeper Dive</summary>

# FNN Tenant and VPC Validation: Behavioral Overview

## Tenant update behavior

When runtime FNN configuration is enabled, every `UpdateTenant` request must provide `routing_profile_type`.

This applies to all tenant updates, including metadata-only changes. The field has replacement semantics rather than patch semantics: omitting it does not mean "leave unchanged."

The resulting contract is:

- Omitting `routing_profile_type` while FNN is enabled returns `INVALID_ARGUMENT`.
- Supplying an unknown or empty profile name continues to fail profile validation.
- Supplying a valid profile retains the existing rule that the profile cannot be changed while the tenant has active VPCs.
- When FNN is disabled, an omitted profile remains permitted.
- A rejected update does not modify the tenant.

Tenant creation behavior is unchanged. Creating a tenant while FNN is enabled already assigns the configured default tenant routing profile when none is explicitly requested.

## FNN VPC creation behavior

Creating an FNN VPC now requires the referenced tenant to exist in Core and have a named routing profile.

The tenant and routing-profile requirements apply whenever the requested or defaulted VPC virtualization type resolves to FNN. They do not depend on whether runtime FNN configuration is enabled, and the tenant must have a profile even if the VPC request supplies an explicit routing profile or routing-profile overrides.

Ethernet Virtualizer and Flat VPC creation continue to permit a missing tenant. Core retains the existing warning and persistence behavior for those VPC types.

This intentionally narrows the tenant-existence requirement to FNN VPCs rather than changing the compatibility contract for every VPC type.

## Admin CLI compatibility and concurrency

The admin CLI previously sent the optional `--routing-profile-type` value directly to `UpdateTenant`. Consequently, a metadata-only command omitted the profile and would now be rejected on an FNN-enabled site.

The CLI now treats an omitted flag as "preserve the current profile":

## Go REST API compatibility

The supported Go REST reconciliation path already preserves the routing profile correctly.

## Operational consequences

Operators and direct gRPC clients must treat `UpdateTenant` as a complete replacement for the tenant's routing-profile field when FNN is enabled. Metadata-only clients must first read and resend the current profile, preferably with optimistic version matching.

Callers creating FNN VPCs must ensure tenant provisioning has completed in Core before attempting VPC creation. Workflows that previously depended on creating an FNN VPC before its tenant must change their operation ordering.

A tenant in historical invalid state (no routing profile while FNN is enabled) cannot receive a metadata-only update or create a new FNN VPC until the caller supplies a valid profile. This includes REST reconciliation, which faithfully preserves the missing value rather than inventing a profile. An operator can repair such a tenant by explicitly updating it with a valid configured profile, provided the existing active-VPC restriction permits that change.

## Compatibility promises

The branch preserves the following behavior:

- Tenant creation continues to inherit the configured default tenant profile when FNN is enabled.
- VPC-level profile omission continues to inherit from an existing tenant when that tenant has a profile.
- Explicit VPC profiles continue to be checked against the tenant's access boundary.
- Tenant profiles still cannot be changed while active VPCs exist.
- Non-FNN VPCs may still be created for missing tenants.
- Existing protobuf field numbers, optionality, and wire encoding are unchanged.
- No database schema or migration is introduced.
- No existing tenant or VPC data is automatically rewritten.

## Explicit limits and deferred paths

This branch does not establish a database-wide invariant that every FNN tenant or VPC has a routing profile.

In particular:

- Existing tenants with no routing profile are not backfilled when FNN is enabled.
- Existing profileless tenants cannot create new FNN VPCs, but the new API guards do not repair their historical state.
- Existing profileless FNN VPCs remain unchanged.
- `UpdateVpcVirtualization` is not changed and may still convert suitable legacy VPC state into FNN without establishing a routing profile.
- Startup-seeded VPC creation is not changed and retains its existing optional-profile behavior.
- Direct database writes remain capable of creating states that the public mutation APIs reject.
- No startup validation or operator alert is added for historical invalid state.

These paths were deliberately left outside this branch's scope.

</details>