### PR TITLE
feat: extend the NICo component management API to allow operators to specify switches by BMC MAC and target uningested switches

### DIFF
--- a/crates/admin-cli/src/component_manager/common.rs
+++ b/crates/admin-cli/src/component_manager/common.rs
@@ -76,8 +76,10 @@ impl From<ComputeTrayComponentArg> for rpc::forge::ComputeTrayComponent {
     }
 }
 
+/// Switch-id-only target for operations that have no pre-ingestion MAC path
+/// (e.g. `configure-switch-certificate`).
 #[derive(ClapArgs, Debug)]
-pub(super) struct SwitchTargetArgs {
+pub(super) struct SwitchIdArgs {
     #[clap(
         long = "switch-id",
         required = true,
@@ -88,10 +90,51 @@ pub(super) struct SwitchTargetArgs {
     switch_ids: Vec<SwitchId>,
 }
 
-impl From<SwitchTargetArgs> for rpc::forge::SwitchIdList {
-    fn from(args: SwitchTargetArgs) -> Self {
+impl From<SwitchIdArgs> for rpc::forge::SwitchIdList {
+    fn from(args: SwitchIdArgs) -> Self {
         Self {
             ids: args.switch_ids,
+        }
+    }
+}
+
+/// Switch target: either switch ids or BMC MAC addresses, exactly one of which
+/// must be supplied. MACs let operators target switches before ingestion has
+/// assigned a switch id.
+#[derive(ClapArgs, Debug)]
+#[clap(group(
+    clap::ArgGroup::new("switch_target")
+        .required(true)
+        .args(["switch_ids", "mac_addresses"])
+))]
+pub(super) struct SwitchTargetArgs {
+    #[clap(
+        long = "switch-id",
+        num_args = 1..,
+        value_delimiter = ',',
+        help = "Switch IDs to target"
+    )]
+    switch_ids: Vec<SwitchId>,
+
+    #[clap(flatten)]
+    macs: MacTargetArgs,
+}
+
+/// The resolved switch selection, mapped by each command into the proto oneof
+/// variant for its request type.
+pub(super) enum SwitchSelection {
+    SwitchIds(rpc::forge::SwitchIdList),
+    Macs(rpc::forge::MacAddressList),
+}
+
+impl SwitchTargetArgs {
+    pub(super) fn into_selection(self) -> SwitchSelection {
+        if !self.macs.is_present() {
+            SwitchSelection::SwitchIds(rpc::forge::SwitchIdList {
+                ids: self.switch_ids,
+            })
+        } else {
+            SwitchSelection::Macs(self.macs.into())
         }
     }
 }

--- a/crates/admin-cli/src/component_manager/configure_switch_certificate/args.rs
+++ b/crates/admin-cli/src/component_manager/configure_switch_certificate/args.rs
@@ -17,7 +17,7 @@
 
 use clap::Parser;
 
-use crate::component_manager::common::SwitchTargetArgs;
+use crate::component_manager::common::SwitchIdArgs;
 
 #[derive(Parser, Debug)]
 #[command(after_long_help = "\
@@ -38,7 +38,7 @@ Dispatch directly to the component backend, bypassing the switch state controlle
 ")]
 pub(crate) struct Args {
     #[clap(flatten)]
-    ids: SwitchTargetArgs,
+    ids: SwitchIdArgs,
 
     #[clap(
         long = "domain-name",

--- a/crates/admin-cli/src/component_manager/power_control/args.rs
+++ b/crates/admin-cli/src/component_manager/power_control/args.rs
@@ -18,7 +18,7 @@
 use clap::Parser;
 
 use crate::component_manager::common::{
-    ComputeTraySelection, PowerActionArg, PowerControlTargetArgs,
+    ComputeTraySelection, PowerActionArg, PowerControlTargetArgs, SwitchSelection,
 };
 
 #[derive(Parser, Debug)]
@@ -28,6 +28,10 @@ EXAMPLES:
 Power on a switch:
     $ nico-admin-cli component-manager component-power-control switch \
     --switch-id 12345678-1234-5678-90ab-cdef01234567 --action on
+
+Power on a switch by BMC MAC (targets the switch before ingestion):
+    $ nico-admin-cli component-manager component-power-control switch \
+    --mac-address 00:11:22:33:44:55 --action on
 
 Force off a compute tray:
     $ nico-admin-cli component-manager component-power-control compute-tray \
@@ -65,13 +69,21 @@ impl From<Args> for rpc::forge::ComponentPowerControlRequest {
         let action = ::rpc::common::SystemPowerControl::from(args.action) as i32;
         let bypass_state_controller = args.bypass_state_controller;
         match args.target {
-            PowerControlTargetArgs::Switch(target) => Self {
-                target: Some(
-                    rpc::forge::component_power_control_request::Target::SwitchIds(target.into()),
-                ),
-                action,
-                bypass_state_controller,
-            },
+            PowerControlTargetArgs::Switch(target) => {
+                let target = match target.into_selection() {
+                    SwitchSelection::SwitchIds(list) => {
+                        rpc::forge::component_power_control_request::Target::SwitchIds(list)
+                    }
+                    SwitchSelection::Macs(macs) => {
+                        rpc::forge::component_power_control_request::Target::SwitchBmcMacs(macs)
+                    }
+                };
+                Self {
+                    target: Some(target),
+                    action,
+                    bypass_state_controller,
+                }
+            }
             PowerControlTargetArgs::PowerShelf(target) => Self {
                 target: Some(
                     rpc::forge::component_power_control_request::Target::PowerShelfIds(

--- a/crates/admin-cli/src/component_manager/status/args.rs
+++ b/crates/admin-cli/src/component_manager/status/args.rs
@@ -17,7 +17,7 @@
 
 use clap::Parser;
 
-use crate::component_manager::common::{ComputeTraySelection, DeviceTargetArgs};
+use crate::component_manager::common::{ComputeTraySelection, DeviceTargetArgs, SwitchSelection};
 
 #[derive(Parser, Debug)]
 #[command(after_long_help = "\
@@ -26,6 +26,10 @@ EXAMPLES:
 Get firmware update status for switches:
     $ nico-admin-cli component-manager get-firmware-update-status switch \
     --switch-id 12345678-1234-5678-90ab-cdef01234567
+
+Get status for a switch by BMC MAC (targets the switch before ingestion):
+    $ nico-admin-cli component-manager get-firmware-update-status switch \
+    --mac-address 00:11:22:33:44:55
 
 Get status for several compute trays at once:
     $ nico-admin-cli component-manager get-firmware-update-status compute-tray \
@@ -49,11 +53,16 @@ impl From<Args> for rpc::forge::GetComponentFirmwareStatusRequest {
     fn from(args: Args) -> Self {
         match args.target {
             DeviceTargetArgs::Switch(target) => Self {
-                target: Some(
-                    rpc::forge::get_component_firmware_status_request::Target::SwitchIds(
-                        target.into(),
-                    ),
-                ),
+                target: Some(match target.into_selection() {
+                    SwitchSelection::SwitchIds(list) => {
+                        rpc::forge::get_component_firmware_status_request::Target::SwitchIds(list)
+                    }
+                    SwitchSelection::Macs(macs) => {
+                        rpc::forge::get_component_firmware_status_request::Target::SwitchBmcMacs(
+                            macs,
+                        )
+                    }
+                }),
             },
             DeviceTargetArgs::PowerShelf(target) => Self {
                 target: Some(

--- a/crates/admin-cli/src/component_manager/update_firmware/args.rs
+++ b/crates/admin-cli/src/component_manager/update_firmware/args.rs
@@ -21,7 +21,8 @@ use clap::{Args as ClapArgs, Parser, Subcommand};
 
 use crate::component_manager::common::{
     ComputeTrayComponentArg, ComputeTraySelection, ComputeTrayTargetArgs, NvSwitchComponentArg,
-    PowerShelfComponentArg, PowerShelfTargetArgs, RackTargetArgs, SwitchTargetArgs,
+    PowerShelfComponentArg, PowerShelfTargetArgs, RackTargetArgs, SwitchSelection,
+    SwitchTargetArgs,
 };
 use crate::errors::{CarbideCliError, CarbideCliResult};
 
@@ -37,6 +38,10 @@ Update only specific switch components, forcing the update:
     $ nico-admin-cli component-manager update-firmware switch \
     --switch-id 12345678-1234-5678-90ab-cdef01234567 --component bmc,bios --force-update \
     --target-version fw-1.2.3
+
+Queue firmware on a switch by BMC MAC (targets the switch before ingestion):
+    $ nico-admin-cli component-manager update-firmware switch \
+    --mac-address 00:11:22:33:44:55 --target-version fw-1.2.3
 
 Queue firmware on compute trays from an RMS SOT JSON file:
     $ nico-admin-cli component-manager update-firmware compute-tray \
@@ -242,9 +247,14 @@ impl TryFrom<Args> for rpc::forge::UpdateComponentFirmwareRequest {
                     force_update: target.force_update,
                     bypass_state_controller: target.bypass_state_controller,
                     target: Some(
-                        rpc::forge::update_component_firmware_request::Target::Switches(
+                        rpc::forge::update_component_firmware_request::Target::Switches({
+                            let (switch_ids, bmc_macs) = match target.ids.into_selection() {
+                                SwitchSelection::SwitchIds(list) => (Some(list), None),
+                                SwitchSelection::Macs(macs) => (None, Some(macs)),
+                            };
                             rpc::forge::UpdateSwitchFirmwareTarget {
-                                switch_ids: Some(target.ids.into()),
+                                switch_ids,
+                                bmc_macs,
                                 components: target
                                     .components
                                     .into_iter()
@@ -252,8 +262,8 @@ impl TryFrom<Args> for rpc::forge::UpdateComponentFirmwareRequest {
                                         rpc::forge::NvSwitchComponent::from(component) as i32
                                     })
                                     .collect(),
-                            },
-                        ),
+                            }
+                        }),
                     ),
                 })
             }
@@ -499,6 +509,10 @@ mod tests {
 
         assert_eq!(switch_ids.ids.len(), 1);
         assert_eq!(switch_ids.ids[0].to_string(), SWITCH_ID);
+        assert!(
+            target.bmc_macs.is_none(),
+            "switch-id target must not also set bmc_macs",
+        );
 
         assert_eq!(
             target.components,
@@ -507,6 +521,34 @@ mod tests {
                 rpc::forge::NvSwitchComponent::Nvos as i32,
             ]
         );
+
+        let switch_mac_request = rpc::forge::UpdateComponentFirmwareRequest::try_from(
+            Args::try_parse_from([
+                "update-firmware",
+                "switch",
+                "--mac-address",
+                MAC_ADDRESS,
+                "--target-version",
+                "fw-1.2.3",
+            ])
+            .expect("switch MAC command should parse"),
+        )
+        .expect("switch MAC command should build a request");
+
+        let Some(rpc::forge::update_component_firmware_request::Target::Switches(target)) =
+            switch_mac_request.target
+        else {
+            panic!("switch MAC command should build a switch target");
+        };
+
+        let Some(bmc_macs) = target.bmc_macs else {
+            panic!("switch MAC command should build a bmc-macs target");
+        };
+        assert!(
+            target.switch_ids.is_none(),
+            "MAC target must not also set switch_ids",
+        );
+        assert_eq!(bmc_macs.mac_addresses, [MAC_ADDRESS]);
 
         let compute_request = rpc::forge::UpdateComponentFirmwareRequest::try_from(
             Args::try_parse_from([

--- a/crates/admin-cli/src/component_manager/versions/args.rs
+++ b/crates/admin-cli/src/component_manager/versions/args.rs
@@ -17,7 +17,7 @@
 
 use clap::Parser;
 
-use crate::component_manager::common::{ComputeTraySelection, DeviceTargetArgs};
+use crate::component_manager::common::{ComputeTraySelection, DeviceTargetArgs, SwitchSelection};
 
 #[derive(Parser, Debug)]
 #[command(after_long_help = "\
@@ -26,6 +26,10 @@ EXAMPLES:
 List available firmware versions for switches:
     $ nico-admin-cli component-manager get-firmware-versions switch \
     --switch-id 12345678-1234-5678-90ab-cdef01234567
+
+List versions for a switch by BMC MAC (targets the switch before ingestion):
+    $ nico-admin-cli component-manager get-firmware-versions switch \
+    --mac-address 00:11:22:33:44:55
 
 List versions for a compute tray by BMC MAC (targets the tray before ingestion):
     $ nico-admin-cli component-manager get-firmware-versions compute-tray \
@@ -49,11 +53,18 @@ impl From<Args> for rpc::forge::ListComponentFirmwareVersionsRequest {
     fn from(args: Args) -> Self {
         match args.target {
             DeviceTargetArgs::Switch(target) => Self {
-                target: Some(
-                    rpc::forge::list_component_firmware_versions_request::Target::SwitchIds(
-                        target.into(),
-                    ),
-                ),
+                target: Some(match target.into_selection() {
+                    SwitchSelection::SwitchIds(list) => {
+                        rpc::forge::list_component_firmware_versions_request::Target::SwitchIds(
+                            list,
+                        )
+                    }
+                    SwitchSelection::Macs(macs) => {
+                        rpc::forge::list_component_firmware_versions_request::Target::SwitchBmcMacs(
+                            macs,
+                        )
+                    }
+                }),
             },
             DeviceTargetArgs::PowerShelf(target) => Self {
                 target: Some(

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -35,7 +35,7 @@ use component_manager::compute_tray_manager::{
 };
 use component_manager::core_compute_manager::CoreComputeTrayManager;
 use component_manager::error::ComponentManagerError;
-use component_manager::nv_switch_manager::SwitchEndpoint;
+use component_manager::nv_switch_manager::{NvSwitchManager, SwitchEndpoint};
 use component_manager::power_shelf_manager::{PowerShelfEndpoint, PowerShelfVendor};
 use component_manager::types::FirmwareUpdateOptions;
 use db::{self, WithTransaction};
@@ -1419,38 +1419,40 @@ fn pre_ingestion_unsupported_result(mac: &MacAddress, operation: &str) -> rpc::C
     )
 }
 
-/// Outcome of resolving caller-supplied compute BMC MAC addresses.
+/// Outcome of resolving a batch of caller-supplied BMC MAC addresses for one
+/// component type, keyed by that type's id (`Id`).
 ///
-/// `ingested` MACs resolve to an existing machine row and are dispatched by
-/// reusing that machine's id-based path, so state-controller routing and all
-/// power/firmware bookkeeping match an id target exactly. `uningested` MACs have no
-/// machine row yet (only reachable before ingestion completes). `errors` holds
-/// MACs that could not be parsed, already rendered as per-MAC results.
-struct ComputeMacResolution {
-    ingested: HashMap<HostMachineId, MacAddress>,
+/// `ingested` MACs resolve to an existing component row and are dispatched by
+/// reusing that component's id-based path, so state-controller routing and all
+/// power/firmware bookkeeping match an id target exactly. `uningested` MACs have
+/// no row yet (only reachable before ingestion completes). `errors` holds MACs
+/// that could not be parsed, already rendered as per-MAC results.
+struct MacResolution<Id> {
+    ingested: HashMap<Id, MacAddress>,
     uningested: Vec<MacAddress>,
     errors: Vec<rpc::ComponentResult>,
 }
 
-impl ComputeMacResolution {
-    /// Machine ids of the ingested MACs, for building an id-target sub-request.
-    fn ingested_machine_ids(&self) -> Vec<HostMachineId> {
+impl<Id> MacResolution<Id>
+where
+    Id: Copy + Eq + std::hash::Hash + std::str::FromStr,
+{
+    /// Component ids of the ingested MACs, for building an id-target sub-request.
+    fn ingested_ids(&self) -> Vec<Id> {
         self.ingested.keys().copied().collect()
     }
 
-    /// Look up the MAC an ingested result's `component_id` (a machine-id string)
-    /// resolved from, by parsing the id back into a [`MachineId`]. Returns
-    /// `None` for a missing or unparseable id, or one not in this resolution.
-    /// `MachineId`'s `FromStr` decodes into a stack buffer, so this allocates
-    /// nothing.
+    /// Look up the MAC an ingested result's `component_id` (an id string)
+    /// resolved from, by parsing the id back into an `Id`. Returns `None` for a
+    /// missing or unparseable id, or one not in this resolution. Both id types
+    /// decode into a stack buffer, so this allocates nothing.
     fn mac_for_component_id(&self, component_id: Option<&str>) -> Option<MacAddress> {
-        let id = component_id?.parse::<HostMachineId>().ok()?;
+        let id = component_id?.parse::<Id>().ok()?;
         self.ingested.get(&id).copied()
     }
 
     /// Set `mac_address` on results from the reused id path, keyed by the
-    /// `component_id` (machine id string) each result carries.
-    fn echo_mac_by_component_id(
+    /// `component_id` (id string) each result carries.
         &self,
         mut results: Vec<rpc::ComponentResult>,
     ) -> Vec<rpc::ComponentResult> {
@@ -1462,6 +1464,10 @@ impl ComputeMacResolution {
         results
     }
 }
+
+/// Compute (machine) MAC resolution. Ingested MACs reuse the machine id path;
+/// `uningested` MACs are reachable only before ingestion completes.
+type ComputeMacResolution = MacResolution<MachineId>;
 
 /// Resolve each caller-supplied compute BMC MAC to an ingested machine id or
 /// classify it as having no row yet. Parse failures are collected as per-MAC
@@ -1615,6 +1621,179 @@ fn switch_mac_to_id_str(mac: &MacAddress, mac_to_id: &HashMap<MacAddress, Switch
         .get(mac)
         .map(|id| id.to_string())
         .unwrap_or_else(|| mac.to_string())
+}
+
+/// Switch MAC resolution. Ingested MACs reuse the switch id path; `uningested`
+/// MACs are reachable before ingestion via the expected inventory.
+type SwitchMacResolution = MacResolution<SwitchId>;
+
+/// Resolve each caller-supplied switch BMC MAC to an ingested `switch_id` or
+/// classify it as having no row yet. Parse failures are collected as per-MAC
+/// error results rather than failing the whole request.
+async fn resolve_switch_macs(
+    api: &Api,
+    mac_addresses: &[String],
+) -> Result<SwitchMacResolution, Status> {
+    let mut ingested = HashMap::new();
+    let mut uningested = Vec::new();
+    let mut errors = Vec::new();
+
+    let mut parsed = Vec::new();
+    for raw_mac in mac_addresses {
+        match raw_mac.parse::<MacAddress>() {
+            Ok(mac) => parsed.push(mac),
+            Err(_) => errors.push(invalid_mac_result(raw_mac)),
+        }
+    }
+
+    if !parsed.is_empty() {
+        let rows = db::switch::find_ids_by_bmc_macs(&mut api.db_reader(), &parsed)
+            .await
+            .map_err(|e| Status::internal(format!("db error: {e}")))?;
+        let mac_to_id: HashMap<MacAddress, SwitchId> = rows
+            .into_iter()
+            .map(|r| (r.bmc_mac_address, r.id))
+            .collect();
+        for mac in parsed {
+            match mac_to_id.get(&mac) {
+                Some(id) => {
+                    ingested.insert(*id, mac);
+                }
+                None => uningested.push(mac),
+            }
+        }
+    }
+
+    Ok(SwitchMacResolution {
+        ingested,
+        uningested,
+        errors,
+    })
+}
+
+/// Build direct switch endpoints for pre-ingestion switches from the expected
+/// inventory (BMC + NVOS IP/MAC) and stored credentials, keyed by BMC MAC.
+///
+/// Returns the resolvable endpoints plus per-MAC error results for MACs missing
+/// from the expected inventory, missing NVOS info, or missing credentials.
+/// Switch vendor is always NVIDIA, so no vendor lookup is needed (unlike the
+/// compute pre-ingestion path).
+async fn build_pre_ingestion_switch_endpoints(
+    api: &Api,
+    macs: &[MacAddress],
+) -> Result<(Vec<SwitchEndpoint>, Vec<rpc::ComponentResult>), Status> {
+    let rows = db::switch::find_switch_endpoints_by_bmc_macs(&mut api.db_reader(), macs)
+        .await
+        .map_err(|e| Status::internal(format!("db error resolving switch endpoints: {e}")))?;
+
+    let mut by_mac: HashMap<MacAddress, _> = rows.into_iter().map(|r| (r.bmc_mac, r)).collect();
+
+    let mut endpoints = Vec::new();
+    let mut errors = Vec::new();
+
+    for &mac in macs {
+        let Some(row) = by_mac.remove(&mac) else {
+            errors.push(mac_result(
+                &mac,
+                rpc::ComponentManagerStatusCode::NotFound,
+                Some("switch BMC MAC not found in expected inventory".to_owned()),
+            ));
+            continue;
+        };
+
+        let (Some(nvos_mac), Some(nvos_ip)) = (row.nvos_mac, row.nvos_ip) else {
+            errors.push(mac_result(
+                &mac,
+                rpc::ComponentManagerStatusCode::NotFound,
+                Some("NVOS MAC or IP not available".to_owned()),
+            ));
+            continue;
+        };
+
+        let bmc_credentials =
+            match fetch_switch_bmc_credentials(api.credential_manager.as_ref(), mac).await {
+                Ok(c) => c,
+                Err(e) => {
+                    errors.push(mac_result(
+                        &mac,
+                        rpc::ComponentManagerStatusCode::NotFound,
+                        Some(format!("BMC credentials unavailable: {e}")),
+                    ));
+                    continue;
+                }
+            };
+
+        let nvos_credentials =
+            match fetch_switch_nvos_credentials(api.credential_manager.as_ref(), mac).await {
+                Ok(c) => c,
+                Err(e) => {
+                    errors.push(mac_result(
+                        &mac,
+                        rpc::ComponentManagerStatusCode::NotFound,
+                        Some(format!("NVOS credentials unavailable: {e}")),
+                    ));
+                    continue;
+                }
+            };
+
+        endpoints.push(SwitchEndpoint {
+            bmc_ip: row.bmc_ip,
+            bmc_mac: mac,
+            nvos_ip,
+            nvos_mac,
+            bmc_credentials,
+            nvos_credentials,
+            nvos_host_name: row.nvos_hostname.none_if_empty(),
+        });
+    }
+
+    Ok((endpoints, errors))
+}
+
+/// Dispatch power control to the BMCs of pre-ingestion switches through the
+/// configured `backend`, returning per-MAC results and the BMC IPs dispatched
+/// to (for site re-exploration). The backend echoes each endpoint's BMC MAC, so
+/// results correlate on it directly.
+async fn dispatch_pre_ingestion_switch_power_control(
+    api: &Api,
+    backend: &dyn NvSwitchManager,
+    macs: &[MacAddress],
+    action: PowerAction,
+) -> Result<(Vec<rpc::ComponentResult>, Vec<IpAddr>), Status> {
+    let (endpoints, mut results) = build_pre_ingestion_switch_endpoints(api, macs).await?;
+
+    if endpoints.is_empty() {
+        return Ok((results, Vec::new()));
+    }
+
+    let ips: Vec<IpAddr> = endpoints.iter().map(|ep| ep.bmc_ip).collect();
+    match backend.power_control(&endpoints, action).await {
+        Ok(backend_results) => {
+            results.extend(backend_results.into_iter().map(|r| {
+                mac_result(
+                    &r.bmc_mac,
+                    if r.success {
+                        rpc::ComponentManagerStatusCode::Success
+                    } else {
+                        rpc::ComponentManagerStatusCode::InternalError
+                    },
+                    r.error,
+                )
+            }));
+        }
+        Err(e) => {
+            let status = component_manager_error_to_status(e);
+            for ep in &endpoints {
+                results.push(mac_result(
+                    &ep.bmc_mac,
+                    rpc::ComponentManagerStatusCode::Unavailable,
+                    Some(status.message().to_owned()),
+                ));
+            }
+        }
+    }
+
+    Ok((results, ips))
 }
 
 fn ps_mac_to_id_str(mac: &MacAddress, mac_to_id: &HashMap<MacAddress, PowerShelfId>) -> String {
@@ -2101,6 +2280,62 @@ async fn power_control_ingested_machine_ids(
     Ok((results, ips))
 }
 
+/// Power-control ingested switches by id: through the state controller when
+/// enabled and not bypassed, otherwise directly via the configured backend.
+/// Returns per-switch results and the BMC IPs dispatched to (for
+/// re-exploration). Shared by the `switch_ids` target and the ingested branch
+/// of the `switch_bmc_macs` target.
+async fn power_control_switch_ids(
+    api: &Api,
+    cm: &ComponentManager,
+    switch_ids: &[SwitchId],
+    action: PowerAction,
+    bypass_state_controller: bool,
+) -> Result<(Vec<rpc::ComponentResult>, Vec<IpAddr>), Status> {
+    if cm.nv_switch_use_state_controller && !bypass_state_controller {
+        let results =
+            queue_switch_power_control_via_state_controller(api, cm, switch_ids, action).await?;
+        Ok((results, Vec::new()))
+    } else {
+        let endpoints = resolve_switch_endpoints(api, switch_ids).await?;
+
+        let mut results: Vec<_> = endpoints
+            .unresolved
+            .iter()
+            .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
+            .collect();
+
+        tracing::info!(
+            backend = cm.nv_switch.name(),
+            switch_count = endpoints.resolved.endpoints.len(),
+            ?action,
+            "power control for switches"
+        );
+        let backend_results = cm
+            .nv_switch
+            .power_control(&endpoints.resolved.endpoints, action)
+            .await
+            .map_err(component_manager_error_to_status)?;
+        results.extend(backend_results.into_iter().map(|r| {
+            let id = switch_mac_to_id_str(&r.bmc_mac, &endpoints.resolved.mac_to_id);
+            if r.success {
+                success_result(&id)
+            } else {
+                error_result(&id, r.error.unwrap_or_default())
+            }
+        }));
+
+        let ips: Vec<IpAddr> = endpoints
+            .resolved
+            .endpoints
+            .iter()
+            .map(|ep| ep.bmc_ip)
+            .collect();
+
+        Ok((results, ips))
+    }
+}
+
 pub(crate) async fn component_power_control(
     api: &Api,
     request: Request<rpc::ComponentPowerControlRequest>,
@@ -2118,49 +2353,46 @@ pub(crate) async fn component_power_control(
 
     let (results, exploration_ips) = match target {
         rpc::component_power_control_request::Target::SwitchIds(list) => {
-            if cm.nv_switch_use_state_controller && !bypass_state_controller {
-                let results =
-                    queue_switch_power_control_via_state_controller(api, cm, &list.ids, action)
-                        .await?;
-                (results, Vec::new())
-            } else {
-                let endpoints = resolve_switch_endpoints(api, &list.ids).await?;
+            power_control_switch_ids(api, cm, &list.ids, action, bypass_state_controller).await?
+        }
+        rpc::component_power_control_request::Target::SwitchBmcMacs(list) => {
+            let resolution = resolve_switch_macs(api, &list.mac_addresses).await?;
+            let mut results = resolution.errors.clone();
+            let mut ips: Vec<IpAddr> = Vec::new();
 
-                let mut results: Vec<_> = endpoints
-                    .unresolved
-                    .iter()
-                    .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
-                    .collect();
-
-                tracing::info!(
-                    backend = cm.nv_switch.name(),
-                    switch_count = endpoints.resolved.endpoints.len(),
-                    ?action,
-                    "power control for switches"
-                );
-                let backend_results = cm
-                    .nv_switch
-                    .power_control(&endpoints.resolved.endpoints, action)
-                    .await
-                    .map_err(component_manager_error_to_status)?;
-                results.extend(backend_results.into_iter().map(|r| {
-                    let id = switch_mac_to_id_str(&r.bmc_mac, &endpoints.resolved.mac_to_id);
-                    if r.success {
-                        success_result(&id)
-                    } else {
-                        error_result(&id, r.error.unwrap_or_default())
-                    }
-                }));
-
-                let ips: Vec<IpAddr> = endpoints
-                    .resolved
-                    .endpoints
-                    .iter()
-                    .map(|ep| ep.bmc_ip)
-                    .collect();
-
-                (results, ips)
+            // Uningested switch MACs (no switches row) always dispatch directly
+            // through the configured backend: a row-less device has no persisted
+            // state for the state controller to reconcile, so
+            // --bypass-state-controller only governs ingested targets.
+            if !resolution.uningested.is_empty() {
+                let (pre_results, pre_ips) = dispatch_pre_ingestion_switch_power_control(
+                    api,
+                    cm.nv_switch.as_ref(),
+                    &resolution.uningested,
+                    action,
+                )
+                .await?;
+                results.extend(pre_results);
+                ips.extend(pre_ips);
             }
+
+            // Ingested MACs: reuse the switch-id path verbatim (state-controller
+            // routing matches an id target), then echo the caller's MAC onto
+            // each result.
+            if !resolution.ingested.is_empty() {
+                let (ingested_results, ingested_ips) = power_control_switch_ids(
+                    api,
+                    cm,
+                    &resolution.ingested_ids(),
+                    action,
+                    bypass_state_controller,
+                )
+                .await?;
+                results.extend(resolution.echo_mac_by_component_id(ingested_results));
+                ips.extend(ingested_ips);
+            }
+
+            (results, ips)
         }
         rpc::component_power_control_request::Target::PowerShelfIds(list) => {
             if cm.power_shelf_use_state_controller && !bypass_state_controller {
@@ -2279,7 +2511,7 @@ pub(crate) async fn component_power_control(
                     power_control_ingested_machine_ids(
                         api,
                         cm,
-                        &resolution.ingested_machine_ids(),
+                        &resolution.ingested_ids(),
                         action,
                         bypass_state_controller,
                     )
@@ -2531,6 +2763,73 @@ async fn request_re_exploration(api: &Api, ips: &[IpAddr]) {
 
 // ---- Inventory ----
 
+/// Serve inventory for a set of BMC MAC targets.
+///
+/// Inventory is read-only, so a MAC target resolves to the same exploration
+/// report an id target serves — no state-controller routing and no
+/// ingested/pre-ingestion split needed. Resolve each BMC MAC to its BMC IP
+/// through the interface tables (populated by DHCP for both ingested and
+/// pre-ingestion devices), then serve the report via the same indexed `address`
+/// lookup the id paths use. Vendor-agnostic, so shared by compute and switch.
+async fn inventory_by_bmc_macs(
+    api: &Api,
+    mac_addresses: &[String],
+) -> Result<Vec<rpc::ComponentInventoryEntry>, Status> {
+    let mut entries: Vec<rpc::ComponentInventoryEntry> = Vec::new();
+    let mut mac_ips: Vec<(MacAddress, Vec<IpAddr>)> = Vec::new();
+    let mut all_ips: Vec<IpAddr> = Vec::new();
+
+    for raw_mac in mac_addresses {
+        let Ok(mac) = raw_mac.parse::<MacAddress>() else {
+            entries.push(rpc::ComponentInventoryEntry {
+                result: Some(invalid_mac_result(raw_mac)),
+                report: None,
+            });
+            continue;
+        };
+        let ips = db::machine_interface::lookup_bmc_ip_by_mac_address(&mut api.db_reader(), mac)
+            .await
+            .map_err(|e| Status::internal(format!("db error: {e}")))?;
+        all_ips.extend(ips.iter().copied());
+        mac_ips.push((mac, ips));
+    }
+
+    let report_by_ip: HashMap<IpAddr, _> = if all_ips.is_empty() {
+        HashMap::new()
+    } else {
+        db::explored_endpoints::find_by_ips(&mut api.db_reader(), all_ips)
+            .await
+            .map_err(|e| Status::internal(format!("db error: {e}")))?
+            .into_iter()
+            .map(|ep| (ep.address, ep.report))
+            .collect()
+    };
+
+    for (mac, ips) in mac_ips {
+        let report = ips.iter().find_map(|ip| report_by_ip.get(ip).cloned());
+        entries.push(match report {
+            Some(report) => rpc::ComponentInventoryEntry {
+                result: Some(mac_result(
+                    &mac,
+                    rpc::ComponentManagerStatusCode::Success,
+                    None,
+                )),
+                report: Some(report.into()),
+            },
+            None => rpc::ComponentInventoryEntry {
+                result: Some(mac_result(
+                    &mac,
+                    rpc::ComponentManagerStatusCode::NotFound,
+                    Some("no explored endpoint found for MAC".to_owned()),
+                )),
+                report: None,
+            },
+        });
+    }
+
+    Ok(entries)
+}
+
 pub(crate) async fn get_component_inventory(
     api: &Api,
     request: Request<rpc::GetComponentInventoryRequest>,
@@ -2641,67 +2940,10 @@ pub(crate) async fn get_component_inventory(
             build_inventory_entries(&id_strings, &report_by_id)
         }
         rpc::get_component_inventory_request::Target::ComputeBmcMacs(list) => {
-            // Inventory is read-only, so a MAC target resolves to the same
-            // exploration report an id target serves — no state-controller
-            // routing and no ingested/pre-ingestion split needed. Resolve each
-            // BMC MAC to its BMC IP through the interface tables (populated by
-            // DHCP for both ingested and pre-ingestion devices), then serve the
-            // report via the same indexed `address` lookup the machine-id path
-            // uses.
-            let mut entries: Vec<rpc::ComponentInventoryEntry> = Vec::new();
-            let mut mac_ips: Vec<(MacAddress, Vec<IpAddr>)> = Vec::new();
-            let mut all_ips: Vec<IpAddr> = Vec::new();
-
-            for raw_mac in &list.mac_addresses {
-                let Ok(mac) = raw_mac.parse::<MacAddress>() else {
-                    entries.push(rpc::ComponentInventoryEntry {
-                        result: Some(invalid_mac_result(raw_mac)),
-                        report: None,
-                    });
-                    continue;
-                };
-                let ips =
-                    db::machine_interface::lookup_bmc_ip_by_mac_address(&mut api.db_reader(), mac)
-                        .await
-                        .map_err(|e| Status::internal(format!("db error: {e}")))?;
-                all_ips.extend(ips.iter().copied());
-                mac_ips.push((mac, ips));
-            }
-
-            let report_by_ip: HashMap<IpAddr, _> = if all_ips.is_empty() {
-                HashMap::new()
-            } else {
-                db::explored_endpoints::find_by_ips(&mut api.db_reader(), all_ips)
-                    .await
-                    .map_err(|e| Status::internal(format!("db error: {e}")))?
-                    .into_iter()
-                    .map(|ep| (ep.address, ep.report))
-                    .collect()
-            };
-
-            for (mac, ips) in mac_ips {
-                let report = ips.iter().find_map(|ip| report_by_ip.get(ip).cloned());
-                entries.push(match report {
-                    Some(report) => rpc::ComponentInventoryEntry {
-                        result: Some(mac_result(
-                            &mac,
-                            rpc::ComponentManagerStatusCode::Success,
-                            None,
-                        )),
-                        report: Some(report.into()),
-                    },
-                    None => rpc::ComponentInventoryEntry {
-                        result: Some(mac_result(
-                            &mac,
-                            rpc::ComponentManagerStatusCode::NotFound,
-                            Some("no explored endpoint found for MAC".to_owned()),
-                        )),
-                        report: None,
-                    },
-                });
-            }
-
-            entries
+            inventory_by_bmc_macs(api, &list.mac_addresses).await?
+        }
+        rpc::get_component_inventory_request::Target::SwitchBmcMacs(list) => {
+            inventory_by_bmc_macs(api, &list.mac_addresses).await?
         }
     };
 
@@ -2711,6 +2953,191 @@ pub(crate) async fn get_component_inventory(
 }
 
 // ---- Firmware Update ----
+
+/// Update firmware for a set of ingested switches by id.
+///
+/// Routes through rack maintenance when the state controller is enabled and not
+/// bypassed (submitting the maintenance request inline and returning its
+/// results), otherwise dispatches directly to the configured backend. Returns
+/// per-switch results. Shared by the `switch_ids` target and the ingested
+/// branch of the `bmc_macs` target.
+async fn update_switch_firmware_by_ids(
+    api: &Api,
+    switch_ids: &[SwitchId],
+    components: &[i32],
+    target_version: &str,
+    access_token: &Option<String>,
+    force_update: bool,
+    bypass_state_controller: bool,
+) -> Result<Vec<rpc::ComponentResult>, Status> {
+    let cm = require_component_manager(api)?;
+    let route_through_state_controller =
+        cm.nv_switch_use_state_controller && !bypass_state_controller;
+    let use_direct_rms_json =
+        !route_through_state_controller && cm.nv_switch.supports_firmware_object_json();
+
+    if route_through_state_controller {
+        let token = require_firmware_object_json_for_rack_maintenance(
+            "switch",
+            access_token,
+            target_version,
+        )?;
+        let components = map_nv_switch_components(components)?;
+        let maintenance_activities = switch_firmware_maintenance_activities(
+            target_version,
+            &token,
+            &components,
+            force_update,
+        );
+        let rack_maintenance_targets = group_switch_ids_by_rack(api, switch_ids).await?;
+        submit_rack_firmware_maintenance_requests(
+            api,
+            rack_maintenance_targets,
+            maintenance_activities,
+        )
+        .await
+    } else {
+        let options = if use_direct_rms_json {
+            require_firmware_object_json_for_direct_rms(
+                "switch",
+                access_token,
+                target_version,
+                force_update,
+            )?
+        } else {
+            reject_firmware_object_json_for_direct_dispatch("switch", access_token)?;
+            FirmwareUpdateOptions::default()
+        };
+        let components = map_nv_switch_components(components)?;
+        let endpoints = resolve_switch_endpoints(api, switch_ids).await?;
+
+        let mut results: Vec<_> = endpoints
+            .unresolved
+            .iter()
+            .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
+            .collect();
+
+        let backend_results = cm
+            .nv_switch
+            .queue_firmware_updates(
+                &endpoints.resolved.endpoints,
+                target_version,
+                &components,
+                &options,
+            )
+            .await
+            .map_err(component_manager_error_to_status)?;
+        results.extend(backend_results.into_iter().map(|r| {
+            let id = switch_mac_to_id_str(&r.bmc_mac, &endpoints.resolved.mac_to_id);
+            if r.success {
+                success_result(&id)
+            } else {
+                error_result(&id, r.error.unwrap_or_default())
+            }
+        }));
+
+        Ok(results)
+    }
+}
+
+/// Direct-dispatch a firmware update to pre-ingestion switches through the
+/// configured backend, correlated by BMC MAC. A row-less switch has no
+/// persisted state for the state controller to reconcile, so it is always
+/// dispatched directly regardless of `--bypass-state-controller`.
+async fn dispatch_pre_ingestion_switch_firmware(
+    api: &Api,
+    macs: &[MacAddress],
+    components: &[i32],
+    target_version: &str,
+    access_token: &Option<String>,
+    force_update: bool,
+) -> Result<Vec<rpc::ComponentResult>, Status> {
+    let cm = require_component_manager(api)?;
+    let options = if cm.nv_switch.supports_firmware_object_json() {
+        require_firmware_object_json_for_direct_rms(
+            "switch",
+            access_token,
+            target_version,
+            force_update,
+        )?
+    } else {
+        reject_firmware_object_json_for_direct_dispatch("switch", access_token)?;
+        FirmwareUpdateOptions::default()
+    };
+    let components = map_nv_switch_components(components)?;
+
+    let (endpoints, mut results) = build_pre_ingestion_switch_endpoints(api, macs).await?;
+    if endpoints.is_empty() {
+        return Ok(results);
+    }
+
+    let backend_results = cm
+        .nv_switch
+        .queue_firmware_updates(&endpoints, target_version, &components, &options)
+        .await
+        .map_err(component_manager_error_to_status)?;
+    results.extend(backend_results.into_iter().map(|r| {
+        mac_result(
+            &r.bmc_mac,
+            if r.success {
+                rpc::ComponentManagerStatusCode::Success
+            } else {
+                rpc::ComponentManagerStatusCode::InternalError
+            },
+            r.error,
+        )
+    }));
+
+    Ok(results)
+}
+
+/// Update firmware for a set of switch BMC MAC targets.
+///
+/// Ingested MACs reuse the switch-id path verbatim (state-controller routing
+/// matches an id target), then echo the caller's MAC onto each result.
+/// Uningested MACs always direct-dispatch through the configured backend.
+async fn update_switch_firmware_by_mac(
+    api: &Api,
+    mac_addresses: &[String],
+    components: &[i32],
+    target_version: &str,
+    access_token: &Option<String>,
+    force_update: bool,
+    bypass_state_controller: bool,
+) -> Result<Vec<rpc::ComponentResult>, Status> {
+    let resolution = resolve_switch_macs(api, mac_addresses).await?;
+    let mut results = resolution.errors.clone();
+
+    if !resolution.uningested.is_empty() {
+        results.extend(
+            dispatch_pre_ingestion_switch_firmware(
+                api,
+                &resolution.uningested,
+                components,
+                target_version,
+                access_token,
+                force_update,
+            )
+            .await?,
+        );
+    }
+
+    if !resolution.ingested.is_empty() {
+        let ingested = update_switch_firmware_by_ids(
+            api,
+            &resolution.ingested_ids(),
+            components,
+            target_version,
+            access_token,
+            force_update,
+            bypass_state_controller,
+        )
+        .await?;
+        results.extend(resolution.echo_mac_by_component_id(ingested));
+    }
+
+    Ok(results)
+}
 
 pub(crate) async fn update_component_firmware(
     api: &Api,
@@ -2733,76 +3160,57 @@ pub(crate) async fn update_component_firmware(
 
     match target {
         rpc::update_component_firmware_request::Target::Switches(t) => {
-            let list = t
-                .switch_ids
-                .ok_or_else(|| Status::invalid_argument("switch_ids is required"))?;
-            if list.ids.is_empty() {
-                return Err(Status::invalid_argument("switch_ids must not be empty"));
-            }
-
-            let cm = require_component_manager(api)?;
-            let route_through_state_controller =
-                cm.nv_switch_use_state_controller && !bypass_state_controller;
-            let use_direct_rms_json =
-                !route_through_state_controller && cm.nv_switch.supports_firmware_object_json();
-
-            if route_through_state_controller {
-                let token = require_firmware_object_json_for_rack_maintenance(
-                    "switch",
-                    &access_token,
-                    &req.target_version,
-                )?;
-                let components = map_nv_switch_components(&t.components)?;
-                maintenance_activities = switch_firmware_maintenance_activities(
-                    &req.target_version,
-                    &token,
-                    &components,
-                    force_update,
-                );
-                rack_maintenance_targets = group_switch_ids_by_rack(api, &list.ids).await?;
-            } else {
-                let options = if use_direct_rms_json {
-                    require_firmware_object_json_for_direct_rms(
-                        "switch",
-                        &access_token,
-                        &req.target_version,
-                        force_update,
-                    )?
-                } else {
-                    reject_firmware_object_json_for_direct_dispatch("switch", &access_token)?;
-                    FirmwareUpdateOptions::default()
-                };
-                let components = map_nv_switch_components(&t.components)?;
-                let endpoints = resolve_switch_endpoints(api, &list.ids).await?;
-
-                let mut results: Vec<_> = endpoints
-                    .unresolved
-                    .iter()
-                    .map(|u| error_result(&u.id.to_string(), u.reason.clone()))
-                    .collect();
-
-                let backend_results = cm
-                    .nv_switch
-                    .queue_firmware_updates(
-                        &endpoints.resolved.endpoints,
-                        &req.target_version,
-                        &components,
-                        &options,
-                    )
-                    .await
-                    .map_err(component_manager_error_to_status)?;
-                results.extend(backend_results.into_iter().map(|r| {
-                    let id = switch_mac_to_id_str(&r.bmc_mac, &endpoints.resolved.mac_to_id);
-                    if r.success {
-                        success_result(&id)
-                    } else {
-                        error_result(&id, r.error.unwrap_or_default())
+            require_component_manager(api)?;
+            let components = t.components;
+            // switch_ids and bmc_macs are plain fields (not a proto oneof, to
+            // keep field 1 wire-compatible), so the server enforces exactly one.
+            match (t.switch_ids, t.bmc_macs) {
+                (Some(_), Some(_)) => {
+                    return Err(Status::invalid_argument(
+                        "switch target must set exactly one of switch_ids or bmc_macs, not both",
+                    ));
+                }
+                (None, None) => {
+                    return Err(Status::invalid_argument(
+                        "switch target (switch_ids or bmc_macs) is required",
+                    ));
+                }
+                (Some(list), None) => {
+                    if list.ids.is_empty() {
+                        return Err(Status::invalid_argument("switch_ids must not be empty"));
                     }
-                }));
-
-                return Ok(Response::new(rpc::UpdateComponentFirmwareResponse {
-                    results,
-                }));
+                    let results = update_switch_firmware_by_ids(
+                        api,
+                        &list.ids,
+                        &components,
+                        &req.target_version,
+                        &access_token,
+                        force_update,
+                        bypass_state_controller,
+                    )
+                    .await?;
+                    return Ok(Response::new(rpc::UpdateComponentFirmwareResponse {
+                        results,
+                    }));
+                }
+                (None, Some(macs)) => {
+                    if macs.mac_addresses.is_empty() {
+                        return Err(Status::invalid_argument("bmc_macs must not be empty"));
+                    }
+                    let results = update_switch_firmware_by_mac(
+                        api,
+                        &macs.mac_addresses,
+                        &components,
+                        &req.target_version,
+                        &access_token,
+                        force_update,
+                        bypass_state_controller,
+                    )
+                    .await?;
+                    return Ok(Response::new(rpc::UpdateComponentFirmwareResponse {
+                        results,
+                    }));
+                }
             }
         }
         rpc::update_component_firmware_request::Target::ComputeTrays(t) => {
@@ -3266,7 +3674,7 @@ async fn update_compute_tray_firmware_by_mac(
     if !resolution.ingested.is_empty() {
         let ingested_firmware_results = update_compute_tray_firmware_by_machine_ids(
             api,
-            &resolution.ingested_machine_ids(),
+            &resolution.ingested_ids(),
             components,
             target_version,
             access_token,
@@ -3354,6 +3762,101 @@ fn select_firmware_status_routing(
     }
 }
 
+/// Firmware status for a set of ingested switches by id, via the configured
+/// backend. Shared by the `switch_ids` target and the ingested branch of the
+/// `switch_bmc_macs` target.
+async fn firmware_status_switch_ids(
+    api: &Api,
+    cm: &ComponentManager,
+    switch_ids: &[SwitchId],
+) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
+    let endpoints = resolve_switch_endpoints(api, switch_ids).await?;
+
+    let mut statuses: Vec<_> = endpoints
+        .unresolved
+        .iter()
+        .map(|u| rpc::FirmwareUpdateStatus {
+            result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+            state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+            target_version: String::new(),
+            updated_at: None,
+        })
+        .collect();
+
+    let backend_statuses = cm
+        .nv_switch
+        .get_firmware_status(&endpoints.resolved.endpoints)
+        .await
+        .map_err(component_manager_error_to_status)?;
+    statuses.extend(backend_statuses.into_iter().map(|s| {
+        let id = switch_mac_to_id_str(&s.bmc_mac, &endpoints.resolved.mac_to_id);
+        rpc::FirmwareUpdateStatus {
+            result: Some(if s.error.is_none() {
+                success_result(&id)
+            } else {
+                error_result(&id, s.error.unwrap_or_default())
+            }),
+            state: map_fw_state(s.state),
+            target_version: s.target_version,
+            updated_at: None,
+        }
+    }));
+
+    Ok(statuses)
+}
+
+/// Firmware status for pre-ingestion switches, dispatched to the configured
+/// backend via direct endpoints and correlated by BMC MAC. Endpoints that
+/// cannot be resolved (missing NVOS info, credentials, or expected inventory)
+/// are reported per-MAC.
+async fn pre_ingestion_switch_firmware_statuses(
+    api: &Api,
+    cm: &ComponentManager,
+    macs: &[MacAddress],
+) -> Result<Vec<rpc::FirmwareUpdateStatus>, Status> {
+    let (endpoints, errors) = build_pre_ingestion_switch_endpoints(api, macs).await?;
+
+    let mut statuses: Vec<rpc::FirmwareUpdateStatus> = errors
+        .into_iter()
+        .map(|result| rpc::FirmwareUpdateStatus {
+            result: Some(result),
+            state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
+            target_version: String::new(),
+            updated_at: None,
+        })
+        .collect();
+
+    if endpoints.is_empty() {
+        return Ok(statuses);
+    }
+
+    let backend_statuses = cm
+        .nv_switch
+        .get_firmware_status(&endpoints)
+        .await
+        .map_err(component_manager_error_to_status)?;
+    statuses.extend(
+        backend_statuses
+            .into_iter()
+            .map(|s| rpc::FirmwareUpdateStatus {
+                result: Some(if s.error.is_none() {
+                    mac_result(&s.bmc_mac, rpc::ComponentManagerStatusCode::Success, None)
+                } else {
+                    mac_result(
+                        &s.bmc_mac,
+                        rpc::ComponentManagerStatusCode::InternalError,
+                        s.error,
+                    )
+                }),
+                state: map_fw_state(s.state),
+                target_version: s.target_version,
+                updated_at: None,
+            }),
+    );
+
+    Ok(statuses)
+}
+
 pub(crate) async fn get_component_firmware_status(
     api: &Api,
     request: Request<rpc::GetComponentFirmwareStatusRequest>,
@@ -3368,37 +3871,45 @@ pub(crate) async fn get_component_firmware_status(
     let statuses = match target {
         rpc::get_component_firmware_status_request::Target::SwitchIds(list) => {
             let cm = require_component_manager(api)?;
-            let endpoints = resolve_switch_endpoints(api, &list.ids).await?;
-
-            let mut statuses: Vec<_> = endpoints
-                .unresolved
+            firmware_status_switch_ids(api, cm, &list.ids).await?
+        }
+        rpc::get_component_firmware_status_request::Target::SwitchBmcMacs(list) => {
+            let cm = require_component_manager(api)?;
+            let resolution = resolve_switch_macs(api, &list.mac_addresses).await?;
+            let mut statuses: Vec<rpc::FirmwareUpdateStatus> = resolution
+                .errors
                 .iter()
-                .map(|u| rpc::FirmwareUpdateStatus {
-                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+                .map(|result| rpc::FirmwareUpdateStatus {
+                    result: Some(result.clone()),
                     state: rpc::FirmwareUpdateState::FwStateUnknown as i32,
                     target_version: String::new(),
                     updated_at: None,
                 })
                 .collect();
 
-            let backend_statuses = cm
-                .nv_switch
-                .get_firmware_status(&endpoints.resolved.endpoints)
-                .await
-                .map_err(component_manager_error_to_status)?;
-            statuses.extend(backend_statuses.into_iter().map(|s| {
-                let id = switch_mac_to_id_str(&s.bmc_mac, &endpoints.resolved.mac_to_id);
-                rpc::FirmwareUpdateStatus {
-                    result: Some(if s.error.is_none() {
-                        success_result(&id)
-                    } else {
-                        error_result(&id, s.error.unwrap_or_default())
-                    }),
-                    state: map_fw_state(s.state),
-                    target_version: s.target_version,
-                    updated_at: None,
-                }
-            }));
+            // Uningested switches: query the backend directly via pre-ingestion
+            // endpoints, correlated by MAC.
+            if !resolution.uningested.is_empty() {
+                statuses.extend(
+                    pre_ingestion_switch_firmware_statuses(api, cm, &resolution.uningested).await?,
+                );
+            }
+
+            // Ingested MACs: reuse the switch-id path, then echo the MAC.
+            if !resolution.ingested.is_empty() {
+                let ingested =
+                    firmware_status_switch_ids(api, cm, &resolution.ingested_ids()).await?;
+                statuses.extend(ingested.into_iter().map(|mut status| {
+                    if let Some(result) = status.result.as_mut()
+                        && let Some(mac) =
+                            resolution.mac_for_component_id(result.component_id.as_deref())
+                    {
+                        result.mac_address = Some(mac.to_string());
+                    }
+                    status
+                }));
+            }
+
             statuses
         }
         rpc::get_component_firmware_status_request::Target::PowerShelfIds(list) => {
@@ -3584,8 +4095,8 @@ pub(crate) async fn get_component_firmware_status(
                 let sub = rpc::GetComponentFirmwareStatusRequest {
                     target: Some(
                         rpc::get_component_firmware_status_request::Target::MachineIds(
-                            ::rpc::common::HostMachineIdList {
-                                machine_ids: resolution.ingested_machine_ids(),
+                            ::rpc::common::MachineIdList {
+                                machine_ids: resolution.ingested_ids(),
                             },
                         ),
                     ),
@@ -3678,6 +4189,51 @@ async fn compute_tray_firmware_versions_by_machine_ids(
     Ok(devices)
 }
 
+/// List available switch firmware versions for a set of ingested switch ids.
+///
+/// The version list is a backend-global catalog, so it is fetched once and
+/// cloned onto every resolved id. Ids that cannot be resolved to an endpoint
+/// produce an inline error entry. Shared by the `switch_ids` target and the
+/// ingested-MAC branch. Callers apply the `cm`/state-controller guards.
+async fn firmware_versions_switch_ids(
+    api: &Api,
+    cm: &ComponentManager,
+    switch_ids: &[SwitchId],
+) -> Result<Vec<rpc::DeviceFirmwareVersions>, Status> {
+    let endpoints = resolve_switch_endpoints(api, switch_ids).await?;
+
+    let mut devices: Vec<rpc::DeviceFirmwareVersions> = endpoints
+        .unresolved
+        .iter()
+        .map(|u| rpc::DeviceFirmwareVersions {
+            result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+            ..Default::default()
+        })
+        .collect();
+
+    let versions = cm
+        .nv_switch
+        .list_firmware_bundles()
+        .await
+        .map_err(component_manager_error_to_status)?;
+
+    for ep in &endpoints.resolved.endpoints {
+        let id = endpoints
+            .resolved
+            .mac_to_id
+            .get(&ep.bmc_mac)
+            .map(|id| id.to_string())
+            .unwrap_or_default();
+        devices.push(rpc::DeviceFirmwareVersions {
+            result: Some(success_result(&id)),
+            versions: versions.clone(),
+            ..Default::default()
+        });
+    }
+
+    Ok(devices)
+}
+
 pub(crate) async fn list_component_firmware_versions(
     api: &Api,
     request: Request<rpc::ListComponentFirmwareVersionsRequest>,
@@ -3697,35 +4253,65 @@ pub(crate) async fn list_component_firmware_versions(
             if cm.nv_switch_use_state_controller {
                 return Err(unsupported_from_json_firmware_versions("switch"));
             }
-            let endpoints = resolve_switch_endpoints(api, &list.ids).await?;
+            let devices = firmware_versions_switch_ids(api, cm, &list.ids).await?;
 
-            let mut devices: Vec<rpc::DeviceFirmwareVersions> = endpoints
-                .unresolved
+            Ok(Response::new(rpc::ListComponentFirmwareVersionsResponse {
+                devices,
+            }))
+        }
+        rpc::list_component_firmware_versions_request::Target::SwitchBmcMacs(list) => {
+            let Some(cm) = api.component_manager.as_ref() else {
+                return Err(unsupported_from_json_firmware_versions("switch"));
+            };
+            if cm.nv_switch_use_state_controller {
+                return Err(unsupported_from_json_firmware_versions("switch"));
+            }
+
+            let resolution = resolve_switch_macs(api, &list.mac_addresses).await?;
+            let mut devices: Vec<rpc::DeviceFirmwareVersions> = resolution
+                .errors
                 .iter()
-                .map(|u| rpc::DeviceFirmwareVersions {
-                    result: Some(error_result(&u.id.to_string(), u.reason.clone())),
+                .map(|result| rpc::DeviceFirmwareVersions {
+                    result: Some(result.clone()),
                     ..Default::default()
                 })
                 .collect();
 
-            let versions = cm
-                .nv_switch
-                .list_firmware_bundles()
-                .await
-                .map_err(component_manager_error_to_status)?;
+            // Uningested switches report the backend-global catalog directly by
+            // MAC: the switch vendor is always NVIDIA and the catalog needs no
+            // resolved endpoint, so no rack-scale/standalone split is required.
+            if !resolution.uningested.is_empty() {
+                let versions = cm
+                    .nv_switch
+                    .list_firmware_bundles()
+                    .await
+                    .map_err(component_manager_error_to_status)?;
+                devices.extend(resolution.uningested.iter().map(|mac| {
+                    rpc::DeviceFirmwareVersions {
+                        result: Some(mac_result(
+                            mac,
+                            rpc::ComponentManagerStatusCode::Success,
+                            None,
+                        )),
+                        versions: versions.clone(),
+                        ..Default::default()
+                    }
+                }));
+            }
 
-            for ep in &endpoints.resolved.endpoints {
-                let id = endpoints
-                    .resolved
-                    .mac_to_id
-                    .get(&ep.bmc_mac)
-                    .map(|id| id.to_string())
-                    .unwrap_or_default();
-                devices.push(rpc::DeviceFirmwareVersions {
-                    result: Some(success_result(&id)),
-                    versions: versions.clone(),
-                    ..Default::default()
-                });
+            // Ingested MACs: reuse the switch-id path, then echo the MAC.
+            if !resolution.ingested.is_empty() {
+                let ingested =
+                    firmware_versions_switch_ids(api, cm, &resolution.ingested_ids()).await?;
+                devices.extend(ingested.into_iter().map(|mut device| {
+                    if let Some(result) = device.result.as_mut()
+                        && let Some(mac) =
+                            resolution.mac_for_component_id(result.component_id.as_deref())
+                    {
+                        result.mac_address = Some(mac.to_string());
+                    }
+                    device
+                }));
             }
 
             Ok(Response::new(rpc::ListComponentFirmwareVersionsResponse {
@@ -3845,11 +4431,8 @@ pub(crate) async fn list_component_firmware_versions(
             }
 
             if !resolution.ingested.is_empty() {
-                match compute_tray_firmware_versions_by_machine_ids(
-                    api,
-                    &resolution.ingested_machine_ids(),
-                )
-                .await
+                match compute_tray_firmware_versions_by_machine_ids(api, &resolution.ingested_ids())
+                    .await
                 {
                     Ok(sub_devices) => {
                         devices.extend(sub_devices.into_iter().map(|mut device| {

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -120,8 +120,9 @@ fn error_result(id: &str, error: String) -> rpc::ComponentResult {
     )
 }
 
-fn status_result(id: &str, status: Status) -> rpc::ComponentResult {
-    let component_status = match status.code() {
+/// Map a gRPC `Status` code onto the caller-facing per-component status code.
+fn component_status_code_for(code: Code) -> rpc::ComponentManagerStatusCode {
+    match code {
         Code::InvalidArgument | Code::FailedPrecondition | Code::OutOfRange => {
             rpc::ComponentManagerStatusCode::InvalidArgument
         }
@@ -131,8 +132,15 @@ fn status_result(id: &str, status: Status) -> rpc::ComponentResult {
             rpc::ComponentManagerStatusCode::Unavailable
         }
         _ => rpc::ComponentManagerStatusCode::InternalError,
-    };
-    make_result(id, component_status, Some(status.message().to_string()))
+    }
+}
+
+fn status_result(id: &str, status: Status) -> rpc::ComponentResult {
+    make_result(
+        id,
+        component_status_code_for(status.code()),
+        Some(status.message().to_string()),
+    )
 }
 
 fn not_found_component_result(id: &str, message: impl Into<String>) -> rpc::ComponentResult {
@@ -1394,6 +1402,17 @@ fn mac_result(
     }
 }
 
+/// Per-MAC result carrying a gRPC `Status`, echoing the MAC so the caller can
+/// correlate the failure with its input. Used to report a subset-level failure
+/// against the MACs it pertains to instead of aborting the whole batch.
+fn mac_status_result(mac: &MacAddress, status: &Status) -> rpc::ComponentResult {
+    mac_result(
+        mac,
+        component_status_code_for(status.code()),
+        Some(status.message().to_string()),
+    )
+}
+
 /// Result for a `--mac-address` value that could not be parsed as a MAC. The
 /// raw text is echoed so the caller can correlate it with its input.
 fn invalid_mac_result(raw: &str) -> rpc::ComponentResult {
@@ -2365,32 +2384,58 @@ pub(crate) async fn component_power_control(
             // through the configured backend: a row-less device has no persisted
             // state for the state controller to reconcile, so
             // --bypass-state-controller only governs ingested targets.
+            // Dispatching the uningested subset must not discard parse-error
+            // results already collected above, nor block the independent
+            // ingested subset below. Report a dispatch failure per-MAC against
+            // the uningested targets instead of aborting the whole batch.
             if !resolution.uningested.is_empty() {
-                let (pre_results, pre_ips) = dispatch_pre_ingestion_switch_power_control(
+                match dispatch_pre_ingestion_switch_power_control(
                     api,
                     cm.nv_switch.as_ref(),
                     &resolution.uningested,
                     action,
                 )
-                .await?;
-                results.extend(pre_results);
-                ips.extend(pre_ips);
+                .await
+                {
+                    Ok((pre_results, pre_ips)) => {
+                        results.extend(pre_results);
+                        ips.extend(pre_ips);
+                    }
+                    Err(status) => results.extend(
+                        resolution
+                            .uningested
+                            .iter()
+                            .map(|mac| mac_status_result(mac, &status)),
+                    ),
+                }
             }
 
             // Ingested MACs: reuse the switch-id path verbatim (state-controller
             // routing matches an id target), then echo the caller's MAC onto
-            // each result.
+            // each result. The pre-ingestion dispatch above has already committed
+            // power actions, so a failure resolving the ingested subset must not
+            // discard those results; report it per-MAC instead.
             if !resolution.ingested.is_empty() {
-                let (ingested_results, ingested_ips) = power_control_switch_ids(
+                match power_control_switch_ids(
                     api,
                     cm,
                     &resolution.ingested_ids(),
                     action,
                     bypass_state_controller,
                 )
-                .await?;
-                results.extend(resolution.echo_mac_by_component_id(ingested_results));
-                ips.extend(ingested_ips);
+                .await
+                {
+                    Ok((ingested_results, ingested_ips)) => {
+                        results.extend(resolution.echo_mac_by_component_id(ingested_results));
+                        ips.extend(ingested_ips);
+                    }
+                    Err(status) => results.extend(
+                        resolution
+                            .ingested
+                            .values()
+                            .map(|mac| mac_status_result(mac, &status)),
+                    ),
+                }
             }
 
             (results, ips)
@@ -3110,21 +3155,36 @@ async fn update_switch_firmware_by_mac(
     let mut results = resolution.errors.clone();
 
     if !resolution.uningested.is_empty() {
-        results.extend(
-            dispatch_pre_ingestion_switch_firmware(
-                api,
-                &resolution.uningested,
-                components,
-                target_version,
-                access_token,
-                force_update,
-            )
-            .await?,
-        );
+        // Dispatching the uningested subset must not discard parse-error results
+        // already collected above, nor block the independent ingested subset
+        // below. Report a dispatch failure per-MAC against the uningested
+        // targets instead of aborting the whole batch.
+        match dispatch_pre_ingestion_switch_firmware(
+            api,
+            &resolution.uningested,
+            components,
+            target_version,
+            access_token,
+            force_update,
+        )
+        .await
+        {
+            Ok(dispatched) => results.extend(dispatched),
+            Err(status) => results.extend(
+                resolution
+                    .uningested
+                    .iter()
+                    .map(|mac| mac_status_result(mac, &status)),
+            ),
+        }
     }
 
     if !resolution.ingested.is_empty() {
-        let ingested = update_switch_firmware_by_ids(
+        // The pre-ingestion dispatch above has already queued backend jobs, so
+        // a failure resolving the ingested subset (e.g. an ingested switch with
+        // no rack) must not discard those results. Report it per-MAC against the
+        // ingested targets instead of aborting after submission.
+        match update_switch_firmware_by_ids(
             api,
             &resolution.ingested_ids(),
             components,
@@ -3133,8 +3193,16 @@ async fn update_switch_firmware_by_mac(
             force_update,
             bypass_state_controller,
         )
-        .await?;
-        results.extend(resolution.echo_mac_by_component_id(ingested));
+        .await
+        {
+            Ok(ingested) => results.extend(resolution.echo_mac_by_component_id(ingested)),
+            Err(status) => results.extend(
+                resolution
+                    .ingested
+                    .values()
+                    .map(|mac| mac_status_result(mac, &status)),
+            ),
+        }
     }
 
     Ok(results)
@@ -5893,6 +5961,25 @@ mod tests {
             rpc::ComponentManagerStatusCode::NotFound as i32,
         );
         assert!(unsupported.error.contains("firmware status"));
+    }
+
+    #[test]
+    fn mac_status_result_echoes_mac_and_maps_status_code() {
+        let mac: MacAddress = "AA:BB:CC:DD:EE:12".parse().unwrap();
+
+        // A rack-precondition failure from the ingested subset maps to a
+        // caller-facing invalid-argument result rather than aborting the batch.
+        let result = mac_status_result(
+            &mac,
+            &Status::failed_precondition("switch is not associated with a rack"),
+        );
+        assert_eq!(result.component_id, None);
+        assert_eq!(result.mac_address, Some(mac.to_string()));
+        assert_eq!(
+            result.status,
+            rpc::ComponentManagerStatusCode::InvalidArgument as i32,
+        );
+        assert_eq!(result.error, "switch is not associated with a rack");
     }
 
     #[test]

--- a/crates/api-core/src/handlers/component_manager.rs
+++ b/crates/api-core/src/handlers/component_manager.rs
@@ -1453,6 +1453,7 @@ where
 
     /// Set `mac_address` on results from the reused id path, keyed by the
     /// `component_id` (id string) each result carries.
+    fn echo_mac_by_component_id(
         &self,
         mut results: Vec<rpc::ComponentResult>,
     ) -> Vec<rpc::ComponentResult> {
@@ -1467,7 +1468,7 @@ where
 
 /// Compute (machine) MAC resolution. Ingested MACs reuse the machine id path;
 /// `uningested` MACs are reachable only before ingestion completes.
-type ComputeMacResolution = MacResolution<MachineId>;
+type ComputeMacResolution = MacResolution<HostMachineId>;
 
 /// Resolve each caller-supplied compute BMC MAC to an ingested machine id or
 /// classify it as having no row yet. Parse failures are collected as per-MAC
@@ -4095,7 +4096,7 @@ pub(crate) async fn get_component_firmware_status(
                 let sub = rpc::GetComponentFirmwareStatusRequest {
                     target: Some(
                         rpc::get_component_firmware_status_request::Target::MachineIds(
-                            ::rpc::common::MachineIdList {
+                            ::rpc::common::HostMachineIdList {
                                 machine_ids: resolution.ingested_ids(),
                             },
                         ),

--- a/crates/api-db/migrations/20260908162734_direct_dispatch_firmware_update_jobs_job_kind.sql
+++ b/crates/api-db/migrations/20260908162734_direct_dispatch_firmware_update_jobs_job_kind.sql
@@ -1,0 +1,16 @@
+-- Widen the direct-dispatch firmware-job key from bmc_mac to (bmc_mac,
+-- job_kind). A device can have more than one in-flight job of distinct kinds (a
+-- switch tracks a firmware-object bundle job and an NVOS system-image job
+-- independently), so the kind is part of a row's identity and selects which
+-- backend query recovers a job's status after a restart.
+--
+-- Every row written before this migration was a firmware-object job, so that
+-- value is a true default for existing rows. Keeping the default also lets a
+-- prior-release writer, which inserts without job_kind during a rolling
+-- upgrade, still land a valid firmware-object row.
+ALTER TABLE direct_dispatch_firmware_update_jobs
+    ADD COLUMN job_kind text NOT NULL DEFAULT 'firmware_object';
+
+ALTER TABLE direct_dispatch_firmware_update_jobs
+    DROP CONSTRAINT direct_dispatch_firmware_update_jobs_pkey,
+    ADD PRIMARY KEY (bmc_mac, job_kind);

--- a/crates/api-db/src/direct_dispatch_firmware_job.rs
+++ b/crates/api-db/src/direct_dispatch_firmware_job.rs
@@ -16,7 +16,7 @@
  */
 
 //! Storage for direct-dispatch (`--bypass-state-controller`) firmware-update
-//! job IDs, keyed by device BMC MAC.
+//! job IDs, keyed by device BMC MAC and job kind.
 //!
 //! The BMC MAC is a device's stable identity across ingestion, so a single
 //! table serves both ingested devices (which have a machine/switch/power-shelf
@@ -24,6 +24,12 @@
 //! here lets `get_firmware_status` recover it after a nico-api restart clears
 //! the in-memory job map, without splitting the state across per-device-type
 //! rows.
+//!
+//! A device can have several concurrent jobs of distinct kinds (a switch tracks
+//! a firmware-object job and an NVOS system-image job independently), so rows
+//! are keyed by `(bmc_mac, job_kind)`. `job_kind` is an opaque backend-job-class
+//! label owned by the caller (the component-manager backend); this layer only
+//! stores and returns it.
 
 use std::collections::HashSet;
 
@@ -31,19 +37,67 @@ use mac_address::MacAddress;
 
 use crate::DatabaseError;
 
-/// Persist (or overwrite) the backend firmware-update job ID for `bmc_mac`.
+/// The class of backend firmware-update job stored in a row.
 ///
-/// A re-dispatch to the same device replaces the previous job, so this upserts.
+/// A device can have one in-flight job per kind (a switch tracks a
+/// firmware-object job and an NVOS system-image job independently), so the kind
+/// is part of the row's identity (`PRIMARY KEY (bmc_mac, job_kind)`) and selects
+/// which backend query recovers a job's status after a restart.
+///
+/// Stored as `text` rather than a native Postgres enum: this table is
+/// device-agnostic (reused across compute, switch, and future power-shelf
+/// backends), so the set of kinds is the union across backends and grows with a
+/// one-line change here rather than an `ALTER TYPE` migration. The database does
+/// not branch on the value, so it owns no invariant a schema enum would enforce.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum FirmwareJobKind {
+    /// An RMS firmware-object bundle update (compute trays and switches).
+    FirmwareObject,
+    /// An NVOS system-image update (switches).
+    SwitchSystemImage,
+}
+
+impl FirmwareJobKind {
+    /// The value persisted in the `job_kind` column. Stable: existing rows and
+    /// the backfill migration depend on these exact strings.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            FirmwareJobKind::FirmwareObject => "firmware_object",
+            FirmwareJobKind::SwitchSystemImage => "switch_system_image",
+        }
+    }
+
+    /// Parse a persisted `job_kind` value. Returns `None` for a kind this
+    /// release does not recognize (e.g. one written by a newer release, or by a
+    /// backend whose kinds this reader does not handle).
+    pub fn from_db_value(value: &str) -> Option<Self> {
+        match value {
+            "firmware_object" => Some(FirmwareJobKind::FirmwareObject),
+            "switch_system_image" => Some(FirmwareJobKind::SwitchSystemImage),
+            _ => None,
+        }
+    }
+}
+
+/// Persist (or overwrite) the backend firmware-update job ID for one
+/// `(bmc_mac, job_kind)`.
+///
+/// A re-dispatch of the same job kind to the same device replaces the previous
+/// job, so this upserts. Jobs of other kinds for the device are untouched; use
+/// [`replace`] to set a device's full job set atomically.
 pub async fn save(
     db: &sqlx::PgPool,
     bmc_mac: MacAddress,
+    job_kind: FirmwareJobKind,
     job_id: &str,
 ) -> Result<(), DatabaseError> {
-    let sql = "INSERT INTO direct_dispatch_firmware_update_jobs (bmc_mac, job_id) \
-               VALUES ($1, $2) \
-               ON CONFLICT (bmc_mac) DO UPDATE SET job_id = EXCLUDED.job_id, created = now()";
+    let sql = "INSERT INTO direct_dispatch_firmware_update_jobs (bmc_mac, job_kind, job_id) \
+               VALUES ($1, $2, $3) \
+               ON CONFLICT (bmc_mac, job_kind) \
+               DO UPDATE SET job_id = EXCLUDED.job_id, created = now()";
     sqlx::query(sql)
         .bind(bmc_mac)
+        .bind(job_kind.as_str())
         .bind(job_id)
         .execute(db)
         .await
@@ -51,15 +105,85 @@ pub async fn save(
     Ok(())
 }
 
-/// Fetch the persisted backend firmware-update job ID for `bmc_mac`, if any.
-pub async fn get(db: &sqlx::PgPool, bmc_mac: MacAddress) -> Result<Option<String>, DatabaseError> {
-    let sql = "SELECT job_id FROM direct_dispatch_firmware_update_jobs WHERE bmc_mac = $1";
+/// Fetch the persisted job ID for one `(bmc_mac, job_kind)`, if any.
+pub async fn get(
+    db: &sqlx::PgPool,
+    bmc_mac: MacAddress,
+    job_kind: FirmwareJobKind,
+) -> Result<Option<String>, DatabaseError> {
+    let sql = "SELECT job_id FROM direct_dispatch_firmware_update_jobs \
+               WHERE bmc_mac = $1 AND job_kind = $2";
     let row: Option<(String,)> = sqlx::query_as(sql)
         .bind(bmc_mac)
+        .bind(job_kind.as_str())
         .fetch_optional(db)
         .await
         .map_err(|e| DatabaseError::new(sql, e))?;
     Ok(row.map(|(job_id,)| job_id))
+}
+
+/// Fetch every persisted `(job_kind, job_id)` for `bmc_mac`.
+///
+/// Used by backends whose devices track multiple job kinds (e.g. a switch's
+/// firmware-object and system-image jobs) to rebuild the full set after a
+/// restart. Rows whose `job_kind` this release does not recognize are skipped,
+/// so a reader tolerates kinds written by another backend or a newer release.
+pub async fn get_all(
+    db: &sqlx::PgPool,
+    bmc_mac: MacAddress,
+) -> Result<Vec<(FirmwareJobKind, String)>, DatabaseError> {
+    let sql = "SELECT job_kind, job_id FROM direct_dispatch_firmware_update_jobs \
+               WHERE bmc_mac = $1";
+    let rows: Vec<(String, String)> = sqlx::query_as(sql)
+        .bind(bmc_mac)
+        .fetch_all(db)
+        .await
+        .map_err(|e| DatabaseError::new(sql, e))?;
+    Ok(rows
+        .into_iter()
+        .filter_map(|(kind, job_id)| FirmwareJobKind::from_db_value(&kind).map(|k| (k, job_id)))
+        .collect())
+}
+
+/// Replace a device's entire persisted job set with `jobs` (pairs of
+/// `(job_kind, job_id)`), atomically.
+///
+/// Deletes any rows for `bmc_mac` whose kind is absent from `jobs`, matching the
+/// backend's in-memory "the latest update owns the whole set" semantics. An
+/// empty `jobs` clears all rows for the device.
+pub async fn replace(
+    db: &sqlx::PgPool,
+    bmc_mac: MacAddress,
+    jobs: &[(FirmwareJobKind, String)],
+) -> Result<(), DatabaseError> {
+    let mut txn = db
+        .begin()
+        .await
+        .map_err(|e| DatabaseError::new("direct_dispatch_firmware_job::replace: begin", e))?;
+
+    let delete_sql = "DELETE FROM direct_dispatch_firmware_update_jobs WHERE bmc_mac = $1";
+    sqlx::query(delete_sql)
+        .bind(bmc_mac)
+        .execute(&mut *txn)
+        .await
+        .map_err(|e| DatabaseError::new(delete_sql, e))?;
+
+    let insert_sql = "INSERT INTO direct_dispatch_firmware_update_jobs (bmc_mac, job_kind, job_id) \
+                      VALUES ($1, $2, $3)";
+    for (job_kind, job_id) in jobs {
+        sqlx::query(insert_sql)
+            .bind(bmc_mac)
+            .bind(job_kind.as_str())
+            .bind(job_id)
+            .execute(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::new(insert_sql, e))?;
+    }
+
+    txn.commit()
+        .await
+        .map_err(|e| DatabaseError::new("direct_dispatch_firmware_job::replace: commit", e))?;
+    Ok(())
 }
 
 /// Return the subset of `bmc_macs` that have a persisted firmware-update job.
@@ -89,7 +213,10 @@ mod tests {
 
     use mac_address::MacAddress;
 
-    use super::{find_macs_with_job, get, save};
+    use super::{FirmwareJobKind, find_macs_with_job, get, get_all, replace, save};
+
+    const FW_OBJECT: FirmwareJobKind = FirmwareJobKind::FirmwareObject;
+    const SYS_IMAGE: FirmwareJobKind = FirmwareJobKind::SwitchSystemImage;
 
     fn mac(last: u8) -> MacAddress {
         MacAddress::new([0x02, 0x00, 0x00, 0x00, 0x00, last])
@@ -97,23 +224,60 @@ mod tests {
 
     #[crate::sqlx_test]
     async fn save_then_get_round_trips_and_upserts(pool: sqlx::PgPool) {
-        // Absent MAC has no job.
-        assert_eq!(get(&pool, mac(1)).await.unwrap(), None);
+        // Absent (MAC, kind) has no job.
+        assert_eq!(get(&pool, mac(1), FW_OBJECT).await.unwrap(), None);
 
         // First dispatch persists the job.
-        save(&pool, mac(1), "job-a").await.unwrap();
-        assert_eq!(get(&pool, mac(1)).await.unwrap(), Some("job-a".to_string()));
+        save(&pool, mac(1), FW_OBJECT, "job-a").await.unwrap();
+        assert_eq!(
+            get(&pool, mac(1), FW_OBJECT).await.unwrap(),
+            Some("job-a".to_string())
+        );
 
-        // Re-dispatch to the same MAC replaces the job rather than erroring or
-        // duplicating (ON CONFLICT (bmc_mac) DO UPDATE).
-        save(&pool, mac(1), "job-b").await.unwrap();
-        assert_eq!(get(&pool, mac(1)).await.unwrap(), Some("job-b".to_string()));
+        // Re-dispatch of the same kind replaces the job rather than erroring or
+        // duplicating (ON CONFLICT (bmc_mac, job_kind) DO UPDATE).
+        save(&pool, mac(1), FW_OBJECT, "job-b").await.unwrap();
+        assert_eq!(
+            get(&pool, mac(1), FW_OBJECT).await.unwrap(),
+            Some("job-b".to_string())
+        );
+    }
+
+    #[crate::sqlx_test]
+    async fn distinct_kinds_coexist_and_replace_sets_full_set(pool: sqlx::PgPool) {
+        // Two kinds for one device coexist under the composite key.
+        save(&pool, mac(1), FW_OBJECT, "job-fw").await.unwrap();
+        save(&pool, mac(1), SYS_IMAGE, "job-img").await.unwrap();
+        let mut all = get_all(&pool, mac(1)).await.unwrap();
+        all.sort();
+        assert_eq!(
+            all,
+            vec![
+                (FW_OBJECT, "job-fw".to_string()),
+                (SYS_IMAGE, "job-img".to_string()),
+            ]
+        );
+
+        // replace() installs the whole set: a kind absent from the new set is
+        // dropped, and a present kind is overwritten.
+        replace(&pool, mac(1), &[(SYS_IMAGE, "job-img2".to_string())])
+            .await
+            .unwrap();
+        assert_eq!(
+            get_all(&pool, mac(1)).await.unwrap(),
+            vec![(SYS_IMAGE, "job-img2".to_string())]
+        );
+        assert_eq!(get(&pool, mac(1), FW_OBJECT).await.unwrap(), None);
+
+        // An empty set clears the device.
+        replace(&pool, mac(1), &[]).await.unwrap();
+        assert!(get_all(&pool, mac(1)).await.unwrap().is_empty());
     }
 
     #[crate::sqlx_test]
     async fn find_macs_with_job_returns_only_present_macs(pool: sqlx::PgPool) {
-        save(&pool, mac(1), "job-1").await.unwrap();
-        save(&pool, mac(3), "job-3").await.unwrap();
+        save(&pool, mac(1), FW_OBJECT, "job-1").await.unwrap();
+        save(&pool, mac(3), FW_OBJECT, "job-3").await.unwrap();
 
         // mac(2) was never dispatched, so it is excluded from the result.
         let found = find_macs_with_job(&pool, &[mac(1), mac(2), mac(3)])
@@ -124,21 +288,27 @@ mod tests {
 
     #[crate::sqlx_test]
     async fn find_macs_with_job_short_circuits_on_empty_input(pool: sqlx::PgPool) {
-        save(&pool, mac(1), "job-1").await.unwrap();
+        save(&pool, mac(1), FW_OBJECT, "job-1").await.unwrap();
 
         let found = find_macs_with_job(&pool, &[]).await.unwrap();
         assert!(found.is_empty());
     }
 
-    // The backfill migration has no Rust counterpart, so exercise the real SQL
-    // file (via `include_str!`, so the test cannot drift from what ships)
-    // against a database seeded at the predecessor schema. The `sqlx_test`
-    // harness applies every migration first on an empty database, where the
-    // backfill is a no-op; re-applying it here after seeding proves the
-    // row-migration behavior, and the `ON CONFLICT DO NOTHING` in the file makes
-    // the second application safe.
+    // The table's create, backfill, and job_kind migrations have no Rust
+    // counterpart, so exercise the real SQL files (via `include_str!`, so the
+    // test cannot drift from what ships). The `sqlx_test` harness has already
+    // advanced this table to the final `(bmc_mac, job_kind)` key, so the test
+    // resets it to the create-migration schema and replays the three migrations
+    // in production order: `create` -> `backfill` (which upserts on the
+    // `bmc_mac`-only key that predates job_kind) -> `job_kind` (which widens the
+    // key and defaults every backfilled row to firmware_object).
+    const CREATE_MIGRATION: &str =
+        include_str!("../migrations/20260904214512_direct_dispatch_firmware_update_jobs.sql");
     const BACKFILL_MIGRATION: &str = include_str!(
         "../migrations/20260904214537_backfill_direct_dispatch_firmware_update_jobs.sql"
+    );
+    const JOB_KIND_MIGRATION: &str = include_str!(
+        "../migrations/20260908162734_direct_dispatch_firmware_update_jobs_job_kind.sql"
     );
 
     const SEGMENT_ID: &str = "20000000-0000-0000-0000-000000000001";
@@ -226,9 +396,9 @@ mod tests {
         .unwrap();
     }
 
-    async fn backfilled_jobs(pool: &sqlx::PgPool) -> Vec<(String, String)> {
+    async fn backfilled_jobs(pool: &sqlx::PgPool) -> Vec<(String, String, String)> {
         sqlx::query_as(
-            "SELECT bmc_mac::text, job_id FROM direct_dispatch_firmware_update_jobs \
+            "SELECT bmc_mac::text, job_kind, job_id FROM direct_dispatch_firmware_update_jobs \
              ORDER BY bmc_mac::text",
         )
         .fetch_all(pool)
@@ -239,6 +409,19 @@ mod tests {
     #[crate::sqlx_test]
     async fn backfill_migrates_legacy_job_ids_keyed_by_bmc_mac(pool: sqlx::PgPool) {
         seed_segment(&pool).await;
+
+        // The harness has already migrated this table to the (bmc_mac, job_kind)
+        // key; rebuild it at the create-migration schema so the backfill (which
+        // upserts on the bmc_mac-only key that predates job_kind) runs exactly as
+        // it did in the release that shipped it.
+        sqlx::raw_sql("DROP TABLE direct_dispatch_firmware_update_jobs")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::raw_sql(CREATE_MIGRATION)
+            .execute(&pool)
+            .await
+            .unwrap();
 
         // Ingested tray with a job, resolved via its machine's BMC interface.
         seed_machine(&pool, "m-ingested", Some("job-ingested")).await;
@@ -261,29 +444,48 @@ mod tests {
         seed_machine(&pool, "m-nojob", None).await;
         seed_bmc_interface(&pool, "02:00:00:00:00:40", Some("m-nojob")).await;
 
+        // The backfill upserts against the bmc_mac-keyed predecessor table.
         sqlx::raw_sql(BACKFILL_MIGRATION)
             .execute(&pool)
             .await
             .unwrap();
 
+        // Re-applying the backfill is idempotent (no duplicate-key error, no
+        // change), matching how the harness runs it a second time. This must
+        // happen before the key is widened, since the backfill's ON CONFLICT
+        // targets the bmc_mac-only key.
+        sqlx::raw_sql(BACKFILL_MIGRATION)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Widen the key to (bmc_mac, job_kind); every backfilled row takes the
+        // firmware_object default.
+        sqlx::raw_sql(JOB_KIND_MIGRATION)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        // Every legacy job survives the full sequence as a firmware-object job.
         assert_eq!(
             backfilled_jobs(&pool).await,
             vec![
-                ("02:00:00:00:00:10".to_string(), "job-ingested".to_string()),
-                ("02:00:00:00:00:20".to_string(), "job-preingest".to_string()),
+                (
+                    "02:00:00:00:00:10".to_string(),
+                    "firmware_object".to_string(),
+                    "job-ingested".to_string()
+                ),
+                (
+                    "02:00:00:00:00:20".to_string(),
+                    "firmware_object".to_string(),
+                    "job-preingest".to_string()
+                ),
                 (
                     "02:00:00:00:00:30".to_string(),
+                    "firmware_object".to_string(),
                     "job-both-machine".to_string()
                 ),
             ]
         );
-
-        // Re-applying the backfill is idempotent (no duplicate-key error, no
-        // change), matching how the harness runs it a second time.
-        sqlx::raw_sql(BACKFILL_MIGRATION)
-            .execute(&pool)
-            .await
-            .unwrap();
-        assert_eq!(backfilled_jobs(&pool).await.len(), 3);
     }
 }

--- a/crates/api-db/src/expected_switch.rs
+++ b/crates/api-db/src/expected_switch.rs
@@ -17,7 +17,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use carbide_uuid::rack::RackId;
+use carbide_uuid::rack::{RackId, RackProfileId};
 use itertools::Itertools;
 use mac_address::MacAddress;
 use model::expected_switch::{ExpectedSwitch, ExpectedSwitchRequest, LinkedExpectedSwitch};
@@ -551,6 +551,49 @@ pub async fn create_missing_from(
     }
 
     Ok(())
+}
+
+/// RMS rack identity for a switch that does not yet have a `switches` row,
+/// resolved from the expected inventory. Every switch is rack-scale
+/// (RMS-managed), so this serves the pre-ingestion firmware and power paths for
+/// any switch.
+#[derive(Debug, sqlx::FromRow)]
+pub struct PreIngestionSwitchRmsIdentity {
+    pub bmc_mac_address: MacAddress,
+    pub rack_id: RackId,
+    pub rack_profile_id: Option<RackProfileId>,
+}
+
+/// Resolve RMS rack identities for pre-ingestion switches by BMC MAC.
+///
+/// Every switch is rack-scale (RMS-managed), so its expected record is expected
+/// to declare a `rack_id`; that rack is required to build the RMS node
+/// descriptor. The rack profile is taken from the live `racks` row when it
+/// exists and otherwise from the `expected_racks` declaration, so the descriptor
+/// resolves before the rack row is created. Rows missing a `rack_id` are a
+/// misconfiguration and are omitted (they cannot resolve an RMS identity).
+/// Mirrors `expected_machine::find_rms_identities_by_bmc_macs`.
+pub async fn find_rms_identities_by_bmc_macs(
+    db: impl crate::db_read::DbReader<'_>,
+    bmc_macs: &[MacAddress],
+) -> DatabaseResult<Vec<PreIngestionSwitchRmsIdentity>> {
+    let sql = r#"
+        SELECT
+            es.bmc_mac_address AS bmc_mac_address,
+            es.rack_id AS rack_id,
+            COALESCE(r.rack_profile_id, er.rack_profile_id) AS rack_profile_id
+        FROM expected_switches es
+        LEFT JOIN racks r ON r.id = es.rack_id
+        LEFT JOIN expected_racks er ON er.rack_id = es.rack_id
+        WHERE es.bmc_mac_address = ANY($1)
+          AND es.rack_id IS NOT NULL
+    "#;
+
+    sqlx::query_as(sql)
+        .bind(bmc_macs)
+        .fetch_all(db)
+        .await
+        .map_err(|err| DatabaseError::new("expected_switch::find_rms_identities_by_bmc_macs", err))
 }
 
 #[cfg(test)]

--- a/crates/api-db/src/expected_switch/tests.rs
+++ b/crates/api-db/src/expected_switch/tests.rs
@@ -19,6 +19,7 @@ use std::collections::HashMap;
 
 use model::expected_switch::ExpectedSwitch;
 use model::metadata::Metadata;
+use model::rack::RackConfig;
 
 use super::*;
 use crate as db;
@@ -296,4 +297,103 @@ async fn test_delete(pool: sqlx::PgPool) -> () {
         async |txn, mac| db::expected_switch::find_by_bmc_mac_address(txn, mac).await,
     )
     .await;
+}
+
+/// Every switch is rack-scale, so the pre-ingestion RMS identity resolver
+/// requires a declared `rack_id` and takes its rack profile from the live
+/// `racks` row when present, otherwise the `expected_racks` declaration.
+/// A switch missing a `rack_id` is a misconfiguration and is omitted.
+#[crate::sqlx_test]
+async fn test_find_rms_identities_by_bmc_macs(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut txn = pool.begin().await?;
+
+    let bmc_expected_only = "02:00:00:00:0d:01";
+    let bmc_live_rack = "02:00:00:00:0d:02";
+    let bmc_no_rack = "02:00:00:00:0d:03";
+
+    let rack_expected: RackId = "rack-expected-only".parse().unwrap();
+    let rack_live: RackId = "rack-live".parse().unwrap();
+    let profile_expected = RackProfileId::new("NVL72-EXPECTED");
+    let profile_live = RackProfileId::new("NVL72-LIVE");
+
+    // Both racks are declared in expected_racks; only rack_live also has a
+    // live racks row (with a different profile) to prove COALESCE precedence.
+    sqlx::query("INSERT INTO expected_racks (rack_id, rack_profile_id) VALUES ($1, $2), ($3, $4)")
+        .bind(rack_expected.to_string())
+        .bind(profile_expected.to_string())
+        .bind(rack_live.to_string())
+        .bind("NVL72-EXPECTED-IGNORED")
+        .execute(txn.as_mut())
+        .await?;
+
+    crate::rack::create(
+        txn.as_mut(),
+        &rack_live,
+        Some(&profile_live),
+        &RackConfig::default(),
+        None,
+    )
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO expected_switches
+             (serial_number, bmc_mac_address, bmc_username, bmc_password, rack_id)
+         VALUES ('SW-EXP', $1::macaddr, 'admin', 'pw', $2),
+                ('SW-LIVE', $3::macaddr, 'admin', 'pw', $4),
+                ('SW-NORACK', $5::macaddr, 'admin', 'pw', NULL)",
+    )
+    .bind(bmc_expected_only)
+    .bind(rack_expected.to_string())
+    .bind(bmc_live_rack)
+    .bind(rack_live.to_string())
+    .bind(bmc_no_rack)
+    .execute(txn.as_mut())
+    .await?;
+
+    let identities = find_rms_identities_by_bmc_macs(
+        txn.as_mut(),
+        &[
+            bmc_expected_only.parse()?,
+            bmc_live_rack.parse()?,
+            bmc_no_rack.parse()?,
+        ],
+    )
+    .await?;
+
+    let by_mac: HashMap<_, _> = identities
+        .iter()
+        .map(|id| (id.bmc_mac_address, id))
+        .collect();
+
+    assert_eq!(by_mac.len(), 2, "the no-rack switch must be omitted");
+
+    let expected_only = by_mac
+        .get(&bmc_expected_only.parse()?)
+        .expect("expected-only switch resolves");
+    assert_eq!(expected_only.rack_id, rack_expected);
+    assert_eq!(
+        expected_only.rack_profile_id.as_ref(),
+        Some(&profile_expected),
+        "rack profile falls back to expected_racks when no live rack exists"
+    );
+
+    let live = by_mac
+        .get(&bmc_live_rack.parse()?)
+        .expect("live-rack switch resolves");
+    assert_eq!(live.rack_id, rack_live);
+    assert_eq!(
+        live.rack_profile_id.as_ref(),
+        Some(&profile_live),
+        "a live racks row takes precedence over the expected_racks declaration"
+    );
+
+    assert!(
+        !by_mac.contains_key(&bmc_no_rack.parse()?),
+        "a switch without a rack_id cannot resolve an RMS identity"
+    );
+
+    txn.rollback().await?;
+    Ok(())
 }

--- a/crates/api-db/src/switch.rs
+++ b/crates/api-db/src/switch.rs
@@ -824,6 +824,70 @@ pub async fn find_switch_endpoints_by_ids(
         .map_err(|err| DatabaseError::new("switch::find_switch_endpoints_by_ids", err))
 }
 
+/// Endpoint info for a pre-ingestion switch, resolved by BMC MAC without a
+/// `switches` row.
+///
+/// Same shape as [`SwitchEndpointRow`] minus `switch_id`, which does not exist
+/// before ingestion. NVOS fields stay nullable for the same reasons.
+#[derive(Debug, sqlx::FromRow)]
+pub struct PreIngestionSwitchEndpointRow {
+    pub bmc_mac: MacAddress,
+    pub bmc_ip: IpAddr,
+    pub nvos_mac: Option<MacAddress>,
+    pub nvos_ip: Option<IpAddr>,
+    /// `machine_interfaces.hostname` plus domain for the NVOS interface (TLS SNI).
+    pub nvos_hostname: Option<String>,
+}
+
+/// Resolve BMC MACs to full endpoint info (BMC + NVOS MAC/IP) for switches that
+/// may not be ingested yet.
+///
+/// Identical joins to [`find_switch_endpoints_by_ids`] but anchored on
+/// `expected_switches.bmc_mac_address` instead of a `switches` row, so it works
+/// before ingestion creates the switch. `DISTINCT ON (es.bmc_mac_address)`
+/// collapses duplicate address rows; NVOS LEFT JOINs keep switches without NVOS
+/// info (caller reports those as unresolved).
+pub async fn find_switch_endpoints_by_bmc_macs(
+    db: impl crate::db_read::DbReader<'_>,
+    bmc_macs: &[MacAddress],
+) -> DatabaseResult<Vec<PreIngestionSwitchEndpointRow>> {
+    let sql = r#"
+        SELECT DISTINCT ON (es.bmc_mac_address)
+            es.bmc_mac_address   AS bmc_mac,
+            bmc_mia.address      AS bmc_ip,
+            nvos_mi.mac_address  AS nvos_mac,
+            nvos_mia.address     AS nvos_ip,
+            CASE
+                WHEN nvos_d.name IS NOT NULL AND nvos_d.name <> '' THEN
+                    nvos_mi.hostname || '.' || nvos_d.name
+                ELSE nvos_mi.hostname
+            END                  AS nvos_hostname
+        FROM expected_switches es
+        JOIN machine_interfaces bmc_mi
+            ON bmc_mi.mac_address = es.bmc_mac_address
+        JOIN machine_interface_addresses bmc_mia
+            ON bmc_mia.interface_id = bmc_mi.id
+        JOIN network_segments bmc_ns
+            ON bmc_ns.id = bmc_mi.segment_id
+        LEFT JOIN machine_interfaces nvos_mi
+            ON es.nvos_mac_addresses IS NOT NULL
+           AND nvos_mi.mac_address = ANY(es.nvos_mac_addresses)
+        LEFT JOIN machine_interface_addresses nvos_mia
+            ON nvos_mia.interface_id = nvos_mi.id
+        LEFT JOIN domains nvos_d
+            ON nvos_d.id = nvos_mi.domain_id
+        WHERE es.bmc_mac_address = ANY($1)
+          AND bmc_ns.network_segment_type = 'underlay'
+        ORDER BY es.bmc_mac_address
+    "#;
+
+    sqlx::query_as(sql)
+        .bind(bmc_macs)
+        .fetch_all(db)
+        .await
+        .map_err(|err| DatabaseError::new("switch::find_switch_endpoints_by_bmc_macs", err))
+}
+
 /// Resolve one ready Fabric Manager control-plane switch endpoint per rack.
 ///
 /// When several switches in a rack match, the primary switch is preferred.
@@ -1427,6 +1491,135 @@ mod tests {
             clear_bmc_credential_rotation_requested(txn.as_mut(), ghost).await,
             Err(DatabaseError::NotFoundError { kind: "switch", .. })
         ));
+
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    /// The pre-ingestion endpoint resolver is anchored on
+    /// `expected_switches.bmc_mac_address` (no `switches` row): it resolves the
+    /// BMC IP from an underlay-segment BMC interface, joins the NVOS MAC/IP by
+    /// `nvos_mac_addresses` membership, and builds the NVOS hostname from the
+    /// interface hostname plus its domain. A BMC interface on a non-underlay
+    /// segment must not resolve.
+    #[crate::sqlx_test]
+    async fn test_find_switch_endpoints_by_bmc_macs_resolves_bmc_and_nvos(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut txn = pool.begin().await?;
+
+        let bmc_mac_a = "02:00:00:00:0c:01";
+        let nvos_mac_a = "02:00:00:00:0c:02";
+        let bmc_ip_a: IpAddr = "10.40.50.1".parse()?;
+        let nvos_ip_a: IpAddr = "10.40.50.2".parse()?;
+        // SW-B's BMC lands on a tenant (non-underlay) segment, so it must be
+        // excluded even though its expected record and interface exist.
+        let bmc_mac_b = "02:00:00:00:0c:11";
+
+        sqlx::query(
+            "INSERT INTO expected_switches
+                 (serial_number, bmc_mac_address, bmc_username, bmc_password, nvos_mac_addresses)
+             VALUES ('SW-A', $1::macaddr, 'admin', 'pw', ARRAY[$2]::macaddr[]),
+                    ('SW-B', $3::macaddr, 'admin', 'pw', NULL)",
+        )
+        .bind(bmc_mac_a)
+        .bind(nvos_mac_a)
+        .bind(bmc_mac_b)
+        .execute(txn.as_mut())
+        .await?;
+
+        let underlay_segment: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version, network_segment_type)
+             VALUES ('sw-underlay', 'V1-T0', 'underlay') RETURNING id",
+        )
+        .fetch_one(txn.as_mut())
+        .await?;
+        let tenant_segment: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version, network_segment_type)
+             VALUES ('sw-tenant', 'V1-T0', 'tenant') RETURNING id",
+        )
+        .fetch_one(txn.as_mut())
+        .await?;
+
+        let domain_id: uuid::Uuid =
+            sqlx::query_scalar("INSERT INTO domains (name) VALUES ('example.com') RETURNING id")
+                .fetch_one(txn.as_mut())
+                .await?;
+
+        // SW-A: BMC on underlay, NVOS with a domain for the SNI hostname.
+        let bmc_iface_a: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (segment_id, mac_address, primary_interface, hostname, interface_type)
+             VALUES ($1, $2::macaddr, false, 'bmc-a', 'Bmc') RETURNING id",
+        )
+        .bind(underlay_segment)
+        .bind(bmc_mac_a)
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            bmc_iface_a,
+            bmc_ip_a,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        let nvos_iface_a: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (segment_id, mac_address, primary_interface, hostname, interface_type, domain_id)
+             VALUES ($1, $2::macaddr, false, 'nvos-a', 'Data', $3) RETURNING id",
+        )
+        .bind(underlay_segment)
+        .bind(nvos_mac_a)
+        .bind(domain_id)
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            nvos_iface_a,
+            nvos_ip_a,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        // SW-B: BMC on a tenant segment (must be excluded by the underlay filter).
+        let bmc_iface_b: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces
+                 (segment_id, mac_address, primary_interface, hostname, interface_type)
+             VALUES ($1, $2::macaddr, false, 'bmc-b', 'Bmc') RETURNING id",
+        )
+        .bind(tenant_segment)
+        .bind(bmc_mac_b)
+        .fetch_one(txn.as_mut())
+        .await?;
+        crate::machine_interface_address::insert(
+            txn.as_mut(),
+            bmc_iface_b,
+            "10.40.50.11".parse::<IpAddr>()?,
+            AllocationType::Dhcp,
+        )
+        .await?;
+
+        let endpoints = find_switch_endpoints_by_bmc_macs(
+            txn.as_mut(),
+            &[bmc_mac_a.parse()?, bmc_mac_b.parse()?],
+        )
+        .await?;
+
+        assert_eq!(
+            endpoints.len(),
+            1,
+            "only the underlay-BMC switch should resolve"
+        );
+        let endpoint = &endpoints[0];
+        assert_eq!(endpoint.bmc_mac, bmc_mac_a.parse()?);
+        assert_eq!(endpoint.bmc_ip, bmc_ip_a);
+        assert_eq!(endpoint.nvos_mac, Some(nvos_mac_a.parse()?));
+        assert_eq!(endpoint.nvos_ip, Some(nvos_ip_a));
+        assert_eq!(
+            endpoint.nvos_hostname.as_deref(),
+            Some("nvos-a.example.com")
+        );
 
         txn.rollback().await?;
         Ok(())

--- a/crates/component-manager/src/rms.rs
+++ b/crates/component-manager/src/rms.rs
@@ -31,6 +31,7 @@ use carbide_rack::rms_node_type::{
 };
 use carbide_secrets::credentials::Credentials;
 use carbide_uuid::rack::RackProfileId;
+use db::direct_dispatch_firmware_job::FirmwareJobKind;
 use librms::protos::{rack_manager as rms, rack_manager_v2 as rms_v2};
 use librms::{RackManagerError, RmsApi};
 use mac_address::MacAddress;
@@ -74,6 +75,20 @@ struct RmsIdentity {
     rack_profile_id: Option<RackProfileId>,
 }
 
+/// A pre-ingestion switch has no `switches` row, so its BMC MAC is the opaque
+/// RMS `node_id` (RMS treats `node_id` as a string, and the request also carries
+/// the full node descriptor and endpoints). Every switch is rack-scale, so the
+/// rack identity comes straight from the expected inventory.
+impl From<db::expected_switch::PreIngestionSwitchRmsIdentity> for RmsIdentity {
+    fn from(row: db::expected_switch::PreIngestionSwitchRmsIdentity) -> Self {
+        Self {
+            node_id: row.bmc_mac_address.to_string(),
+            rack_id: row.rack_id.to_string(),
+            rack_profile_id: row.rack_profile_id,
+        }
+    }
+}
+
 struct ResolvedRmsNode<'a> {
     identity: &'a RmsIdentity,
     node_identity: RmsNodeIdentity,
@@ -94,6 +109,34 @@ enum SwitchOrPowerShelfRole {
 enum RmsTrackedFirmwareJob {
     FirmwareObject(String),
     SwitchSystemImage(String),
+}
+
+impl RmsTrackedFirmwareJob {
+    /// The [`FirmwareJobKind`] this job persists under in
+    /// `direct_dispatch_firmware_update_jobs`, so it can be rebuilt (and its
+    /// backend re-queried) after a restart clears the in-memory job map.
+    fn kind(&self) -> FirmwareJobKind {
+        match self {
+            RmsTrackedFirmwareJob::FirmwareObject(_) => FirmwareJobKind::FirmwareObject,
+            RmsTrackedFirmwareJob::SwitchSystemImage(_) => FirmwareJobKind::SwitchSystemImage,
+        }
+    }
+
+    /// Backend job id this job tracks.
+    fn job_id(&self) -> &str {
+        match self {
+            RmsTrackedFirmwareJob::FirmwareObject(job_id)
+            | RmsTrackedFirmwareJob::SwitchSystemImage(job_id) => job_id,
+        }
+    }
+
+    /// Rebuild a tracked job from a persisted `(job_kind, job_id)` row.
+    fn from_persisted(job_kind: FirmwareJobKind, job_id: String) -> Self {
+        match job_kind {
+            FirmwareJobKind::FirmwareObject => RmsTrackedFirmwareJob::FirmwareObject(job_id),
+            FirmwareJobKind::SwitchSystemImage => RmsTrackedFirmwareJob::SwitchSystemImage(job_id),
+        }
+    }
 }
 
 // The direct RMS path matches the rack-maintenance flow and applies production
@@ -658,6 +701,23 @@ struct ComputeTrayRmsIdentity {
     bmc_mac: MacAddress,
 }
 
+/// A row-less compute tray has no machine id; like a pre-ingestion switch its
+/// BMC MAC is the opaque RMS `node_id` (RMS treats it as a string, and the
+/// request also carries the full node descriptor and BMC endpoint). The wrapper
+/// retains the BMC MAC so callers can key results by device.
+impl From<db::expected_machine::PreIngestionComputeRmsIdentity> for ComputeTrayRmsIdentity {
+    fn from(row: db::expected_machine::PreIngestionComputeRmsIdentity) -> Self {
+        Self {
+            identity: RmsIdentity {
+                node_id: row.bmc_mac_address.to_string(),
+                rack_id: row.rack_id.to_string(),
+                rack_profile_id: row.rack_profile_id,
+            },
+            bmc_mac: row.bmc_mac_address,
+        }
+    }
+}
+
 /// Resolve compute tray BMC IP addresses to RMS identities via the api-db layer.
 async fn resolve_compute_tray_identities(
     db: &PgPool,
@@ -719,6 +779,38 @@ async fn resolve_switch_identities(
         );
     }
     Ok(map)
+}
+
+/// Resolve RMS identities for pre-ingestion (row-less) switches from the
+/// expected inventory, keyed by BMC MAC.
+///
+/// Every switch is rack-scale (RMS-managed), so its expected record is expected
+/// to declare a `rack_id`; that rack is required to build the RMS node
+/// descriptor. A record missing a `rack_id` is a misconfiguration and is
+/// omitted here, surfacing as an identity-lookup error at dispatch. The BMC MAC
+/// doubles as the RMS node id because no switch id exists yet — RMS treats
+/// `node_id` as an opaque string and the request also carries the full node
+/// descriptor and endpoints. Mirrors `resolve_pre_ingestion_compute_identities`.
+async fn resolve_pre_ingestion_switch_identities(
+    db: &PgPool,
+    macs: &[MacAddress],
+) -> Result<HashMap<MacAddress, RmsIdentity>, ComponentManagerError> {
+    if macs.is_empty() {
+        return Ok(HashMap::new());
+    }
+
+    let rows = db::expected_switch::find_rms_identities_by_bmc_macs(db, macs)
+        .await
+        .map_err(|e| {
+            ComponentManagerError::Internal(format!(
+                "failed to resolve pre-ingestion switch RMS identities: {e}"
+            ))
+        })?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| (row.bmc_mac_address, row.into()))
+        .collect())
 }
 
 fn to_rms_power_operation(action: PowerAction) -> i32 {
@@ -1971,7 +2063,17 @@ impl NvSwitchManager for RmsBackend {
         action: PowerAction,
     ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
         let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.bmc_mac).collect();
-        let ids = resolve_switch_identities(&self.db, &macs).await?;
+        let mut ids = resolve_switch_identities(&self.db, &macs).await?;
+        // Switches with no `switches` row yet (pre-ingestion) fall back to the
+        // expected inventory keyed by BMC MAC. Every switch is rack-scale, so a
+        // declared rack_id is expected; the BMC MAC doubles as the RMS node id
+        // since no switch id exists.
+        let pre_ingestion_macs: Vec<MacAddress> = macs
+            .iter()
+            .copied()
+            .filter(|m| !ids.contains_key(m))
+            .collect();
+        ids.extend(resolve_pre_ingestion_switch_identities(&self.db, &pre_ingestion_macs).await?);
         let operation = to_rms_power_operation(action);
         let mut results = Vec::with_capacity(endpoints.len());
         let hostnames = resolve_switch_machine_interface_hostnames(&self.db, endpoints).await?;
@@ -2046,7 +2148,16 @@ impl NvSwitchManager for RmsBackend {
         options: &FirmwareUpdateOptions,
     ) -> Result<Vec<SwitchComponentResult>, ComponentManagerError> {
         let macs: Vec<MacAddress> = endpoints.iter().map(|ep| ep.bmc_mac).collect();
-        let ids = resolve_switch_identities(&self.db, &macs).await?;
+        let mut ids = resolve_switch_identities(&self.db, &macs).await?;
+        // Pre-ingestion (row-less) switches fall back to the expected inventory
+        // keyed by BMC MAC. Every switch is rack-scale, so a declared rack_id is
+        // expected; the BMC MAC doubles as the RMS node id.
+        let pre_ingestion_macs: Vec<MacAddress> = macs
+            .iter()
+            .copied()
+            .filter(|m| !ids.contains_key(m))
+            .collect();
+        ids.extend(resolve_pre_ingestion_switch_identities(&self.db, &pre_ingestion_macs).await?);
         let include_firmware_object = switch_update_includes_firmware_object(components);
         let include_system_image = switch_update_includes_system_image(components);
         let component_filters = switch_firmware_object_component_filters(components);
@@ -2191,6 +2302,29 @@ impl NvSwitchManager for RmsBackend {
                 }
             }
 
+            // Persist the tracked jobs keyed by BMC MAC + kind (replacing any
+            // prior set for this switch, including clearing it when empty) so
+            // status queries survive a nico-api restart, for both ingested and
+            // pre-ingestion switches.
+            //
+            // TODO: modify the behavior of the in memory map to only delete the relevant job and not clear all jobs for a given switch on every fw update.
+            // For example, if we want to just update the System Image, we shouldnt clear the firmware object job ID from the in memory table (or in the DB)
+            // Leave it as is for now.
+            let persisted_jobs: Vec<(FirmwareJobKind, String)> = tracked_jobs
+                .iter()
+                .map(|job| (job.kind(), job.job_id().to_owned()))
+                .collect();
+            if let Err(e) =
+                db::direct_dispatch_firmware_job::replace(&self.db, ep.bmc_mac, &persisted_jobs)
+                    .await
+            {
+                tracing::warn!(
+                    bmc_mac_address = %ep.bmc_mac,
+                    error = %e,
+                    "failed to persist switch firmware job IDs to database"
+                );
+            }
+
             if !tracked_jobs.is_empty() {
                 self.firmware_jobs
                     .lock()
@@ -2230,7 +2364,29 @@ impl NvSwitchManager for RmsBackend {
 
         let mut statuses = Vec::with_capacity(endpoints.len());
 
-        for (bmc_mac, jobs) in &endpoint_jobs {
+        for (bmc_mac, in_memory_jobs) in &endpoint_jobs {
+            // When the in-memory map has no jobs (e.g. after a pod restart), fall
+            // back to the DB-persisted set written by queue_firmware_updates,
+            // keyed by BMC MAC for both ingested and pre-ingestion switches.
+            let jobs: Vec<RmsTrackedFirmwareJob> = if !in_memory_jobs.is_empty() {
+                in_memory_jobs.clone()
+            } else {
+                match db::direct_dispatch_firmware_job::get_all(&self.db, *bmc_mac).await {
+                    Ok(rows) => rows
+                        .into_iter()
+                        .map(|(kind, job_id)| RmsTrackedFirmwareJob::from_persisted(kind, job_id))
+                        .collect(),
+                    Err(e) => {
+                        tracing::warn!(
+                            bmc_mac_address = %bmc_mac,
+                            error = %e,
+                            "failed to fetch persisted switch firmware job IDs from database"
+                        );
+                        Vec::new()
+                    }
+                }
+            };
+
             if jobs.is_empty() {
                 statuses.push(SwitchFirmwareUpdateStatus {
                     bmc_mac: *bmc_mac,
@@ -2243,7 +2399,7 @@ impl NvSwitchManager for RmsBackend {
 
             let mut states = Vec::with_capacity(jobs.len());
             let mut errors = Vec::new();
-            for job in jobs {
+            for job in &jobs {
                 let (state, error) = query_tracked_firmware_job_status(
                     self.client.as_ref(),
                     self.switch_system_image_client.as_deref(),
@@ -3236,23 +3392,7 @@ impl RmsBackend {
 
         Ok(rows
             .into_iter()
-            .map(|row| {
-                (
-                    row.bmc_mac_address,
-                    ComputeTrayRmsIdentity {
-                        identity: RmsIdentity {
-                            // A row-less tray has no machine id; the BMC MAC is a
-                            // stable per-device id and RMS treats node_id as an
-                            // opaque string (the request also carries the full
-                            // node descriptor and BMC endpoint).
-                            node_id: row.bmc_mac_address.to_string(),
-                            rack_id: row.rack_id.to_string(),
-                            rack_profile_id: row.rack_profile_id,
-                        },
-                        bmc_mac: row.bmc_mac_address,
-                    },
-                )
-            })
+            .map(|row| (row.bmc_mac_address, row.into()))
             .collect())
     }
 
@@ -3322,9 +3462,13 @@ impl RmsBackend {
                             ep.bmc_mac,
                             vec![RmsTrackedFirmwareJob::FirmwareObject(job_id.clone())],
                         );
-                        if let Err(e) =
-                            db::direct_dispatch_firmware_job::save(&self.db, ep.bmc_mac, job_id)
-                                .await
+                        if let Err(e) = db::direct_dispatch_firmware_job::save(
+                            &self.db,
+                            ep.bmc_mac,
+                            FirmwareJobKind::FirmwareObject,
+                            job_id,
+                        )
+                        .await
                         {
                             tracing::warn!(
                                 node_id = %identity.identity.node_id,
@@ -3580,7 +3724,13 @@ impl ComputeTrayManager for RmsBackend {
             let resolved_job_id: Option<String> = if in_memory_job.is_some() {
                 in_memory_job
             } else {
-                match db::direct_dispatch_firmware_job::get(&self.db, ep.bmc_mac).await {
+                match db::direct_dispatch_firmware_job::get(
+                    &self.db,
+                    ep.bmc_mac,
+                    FirmwareJobKind::FirmwareObject,
+                )
+                .await
+                {
                     Ok(db_job_id) => db_job_id,
                     Err(e) => {
                         tracing::warn!(

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -9943,6 +9943,7 @@ message GetComponentInventoryRequest {
     SwitchIdList switch_ids = 2;
     PowerShelfIdList power_shelf_ids = 3;
     MacAddressList compute_bmc_macs = 4;
+    MacAddressList switch_bmc_macs = 5;
   }
 }
 
@@ -9963,6 +9964,7 @@ message ComponentPowerControlRequest {
     SwitchIdList switch_ids = 2;
     PowerShelfIdList power_shelf_ids = 3;
     MacAddressList compute_bmc_macs = 6;
+    MacAddressList switch_bmc_macs = 7;
   }
   common.SystemPowerControl action = 4;
   // When true, bypass the state controller and dispatch directly to the
@@ -10045,8 +10047,14 @@ message UpdateComputeTrayFirmwareTarget {
 }
 
 message UpdateSwitchFirmwareTarget {
+  // Exactly one of switch_ids or bmc_macs must be set (the server rejects
+  // neither/both). switch_ids targets ingested switches; bmc_macs targets by
+  // BMC MAC, including pre-ingestion. These are plain fields rather than a oneof
+  // so field 1 stays wire-compatible with earlier releases that predate
+  // bmc_macs.
   SwitchIdList switch_ids = 1;
   repeated NvSwitchComponent components = 2;
+  MacAddressList bmc_macs = 3;
 }
 
 message UpdatePowerShelfFirmwareTarget {
@@ -10094,6 +10102,7 @@ message GetComponentFirmwareStatusRequest {
     PowerShelfIdList power_shelf_ids = 3;
     RackIdList rack_ids = 4;
     MacAddressList compute_bmc_macs = 5;
+    MacAddressList switch_bmc_macs = 6;
   }
 }
 
@@ -10108,6 +10117,7 @@ message ListComponentFirmwareVersionsRequest {
     PowerShelfIdList power_shelf_ids = 3;
     RackIdList rack_ids = 4;
     MacAddressList compute_bmc_macs = 5;
+    MacAddressList switch_bmc_macs = 6;
   }
 }
 

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -59310,6 +59310,7 @@ type GetComponentInventoryRequest struct {
 	//	*GetComponentInventoryRequest_SwitchIds
 	//	*GetComponentInventoryRequest_PowerShelfIds
 	//	*GetComponentInventoryRequest_ComputeBmcMacs
+	//	*GetComponentInventoryRequest_SwitchBmcMacs
 	Target        isGetComponentInventoryRequest_Target `protobuf_oneof:"target"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -59388,6 +59389,15 @@ func (x *GetComponentInventoryRequest) GetComputeBmcMacs() *MacAddressList {
 	return nil
 }
 
+func (x *GetComponentInventoryRequest) GetSwitchBmcMacs() *MacAddressList {
+	if x != nil {
+		if x, ok := x.Target.(*GetComponentInventoryRequest_SwitchBmcMacs); ok {
+			return x.SwitchBmcMacs
+		}
+	}
+	return nil
+}
+
 type isGetComponentInventoryRequest_Target interface {
 	isGetComponentInventoryRequest_Target()
 }
@@ -59408,6 +59418,10 @@ type GetComponentInventoryRequest_ComputeBmcMacs struct {
 	ComputeBmcMacs *MacAddressList `protobuf:"bytes,4,opt,name=compute_bmc_macs,json=computeBmcMacs,proto3,oneof"`
 }
 
+type GetComponentInventoryRequest_SwitchBmcMacs struct {
+	SwitchBmcMacs *MacAddressList `protobuf:"bytes,5,opt,name=switch_bmc_macs,json=switchBmcMacs,proto3,oneof"`
+}
+
 func (*GetComponentInventoryRequest_MachineIds) isGetComponentInventoryRequest_Target() {}
 
 func (*GetComponentInventoryRequest_SwitchIds) isGetComponentInventoryRequest_Target() {}
@@ -59415,6 +59429,8 @@ func (*GetComponentInventoryRequest_SwitchIds) isGetComponentInventoryRequest_Ta
 func (*GetComponentInventoryRequest_PowerShelfIds) isGetComponentInventoryRequest_Target() {}
 
 func (*GetComponentInventoryRequest_ComputeBmcMacs) isGetComponentInventoryRequest_Target() {}
+
+func (*GetComponentInventoryRequest_SwitchBmcMacs) isGetComponentInventoryRequest_Target() {}
 
 type ComponentInventoryEntry struct {
 	state         protoimpl.MessageState     `protogen:"open.v1"`
@@ -59520,6 +59536,7 @@ type ComponentPowerControlRequest struct {
 	//	*ComponentPowerControlRequest_SwitchIds
 	//	*ComponentPowerControlRequest_PowerShelfIds
 	//	*ComponentPowerControlRequest_ComputeBmcMacs
+	//	*ComponentPowerControlRequest_SwitchBmcMacs
 	Target isComponentPowerControlRequest_Target `protobuf_oneof:"target"`
 	Action SystemPowerControl                    `protobuf:"varint,4,opt,name=action,proto3,enum=common.SystemPowerControl" json:"action,omitempty"`
 	// When true, bypass the state controller and dispatch directly to the
@@ -59602,6 +59619,15 @@ func (x *ComponentPowerControlRequest) GetComputeBmcMacs() *MacAddressList {
 	return nil
 }
 
+func (x *ComponentPowerControlRequest) GetSwitchBmcMacs() *MacAddressList {
+	if x != nil {
+		if x, ok := x.Target.(*ComponentPowerControlRequest_SwitchBmcMacs); ok {
+			return x.SwitchBmcMacs
+		}
+	}
+	return nil
+}
+
 func (x *ComponentPowerControlRequest) GetAction() SystemPowerControl {
 	if x != nil {
 		return x.Action
@@ -59636,6 +59662,10 @@ type ComponentPowerControlRequest_ComputeBmcMacs struct {
 	ComputeBmcMacs *MacAddressList `protobuf:"bytes,6,opt,name=compute_bmc_macs,json=computeBmcMacs,proto3,oneof"`
 }
 
+type ComponentPowerControlRequest_SwitchBmcMacs struct {
+	SwitchBmcMacs *MacAddressList `protobuf:"bytes,7,opt,name=switch_bmc_macs,json=switchBmcMacs,proto3,oneof"`
+}
+
 func (*ComponentPowerControlRequest_MachineIds) isComponentPowerControlRequest_Target() {}
 
 func (*ComponentPowerControlRequest_SwitchIds) isComponentPowerControlRequest_Target() {}
@@ -59643,6 +59673,8 @@ func (*ComponentPowerControlRequest_SwitchIds) isComponentPowerControlRequest_Ta
 func (*ComponentPowerControlRequest_PowerShelfIds) isComponentPowerControlRequest_Target() {}
 
 func (*ComponentPowerControlRequest_ComputeBmcMacs) isComponentPowerControlRequest_Target() {}
+
+func (*ComponentPowerControlRequest_SwitchBmcMacs) isComponentPowerControlRequest_Target() {}
 
 type ComponentPowerControlResponse struct {
 	state         protoimpl.MessageState `protogen:"open.v1"`
@@ -59928,9 +59960,15 @@ func (x *UpdateComputeTrayFirmwareTarget) GetBmcMacs() *MacAddressList {
 }
 
 type UpdateSwitchFirmwareTarget struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	SwitchIds     *SwitchIdList          `protobuf:"bytes,1,opt,name=switch_ids,json=switchIds,proto3" json:"switch_ids,omitempty"`
-	Components    []NvSwitchComponent    `protobuf:"varint,2,rep,packed,name=components,proto3,enum=forge.NvSwitchComponent" json:"components,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Exactly one of switch_ids or bmc_macs must be set (the server rejects
+	// neither/both). switch_ids targets ingested switches; bmc_macs targets by
+	// BMC MAC, including pre-ingestion. These are plain fields rather than a oneof
+	// so field 1 stays wire-compatible with earlier releases that predate
+	// bmc_macs.
+	SwitchIds     *SwitchIdList       `protobuf:"bytes,1,opt,name=switch_ids,json=switchIds,proto3" json:"switch_ids,omitempty"`
+	Components    []NvSwitchComponent `protobuf:"varint,2,rep,packed,name=components,proto3,enum=forge.NvSwitchComponent" json:"components,omitempty"`
+	BmcMacs       *MacAddressList     `protobuf:"bytes,3,opt,name=bmc_macs,json=bmcMacs,proto3" json:"bmc_macs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -59975,6 +60013,13 @@ func (x *UpdateSwitchFirmwareTarget) GetSwitchIds() *SwitchIdList {
 func (x *UpdateSwitchFirmwareTarget) GetComponents() []NvSwitchComponent {
 	if x != nil {
 		return x.Components
+	}
+	return nil
+}
+
+func (x *UpdateSwitchFirmwareTarget) GetBmcMacs() *MacAddressList {
+	if x != nil {
+		return x.BmcMacs
 	}
 	return nil
 }
@@ -60285,6 +60330,7 @@ type GetComponentFirmwareStatusRequest struct {
 	//	*GetComponentFirmwareStatusRequest_PowerShelfIds
 	//	*GetComponentFirmwareStatusRequest_RackIds
 	//	*GetComponentFirmwareStatusRequest_ComputeBmcMacs
+	//	*GetComponentFirmwareStatusRequest_SwitchBmcMacs
 	Target        isGetComponentFirmwareStatusRequest_Target `protobuf_oneof:"target"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -60372,6 +60418,15 @@ func (x *GetComponentFirmwareStatusRequest) GetComputeBmcMacs() *MacAddressList 
 	return nil
 }
 
+func (x *GetComponentFirmwareStatusRequest) GetSwitchBmcMacs() *MacAddressList {
+	if x != nil {
+		if x, ok := x.Target.(*GetComponentFirmwareStatusRequest_SwitchBmcMacs); ok {
+			return x.SwitchBmcMacs
+		}
+	}
+	return nil
+}
+
 type isGetComponentFirmwareStatusRequest_Target interface {
 	isGetComponentFirmwareStatusRequest_Target()
 }
@@ -60396,6 +60451,10 @@ type GetComponentFirmwareStatusRequest_ComputeBmcMacs struct {
 	ComputeBmcMacs *MacAddressList `protobuf:"bytes,5,opt,name=compute_bmc_macs,json=computeBmcMacs,proto3,oneof"`
 }
 
+type GetComponentFirmwareStatusRequest_SwitchBmcMacs struct {
+	SwitchBmcMacs *MacAddressList `protobuf:"bytes,6,opt,name=switch_bmc_macs,json=switchBmcMacs,proto3,oneof"`
+}
+
 func (*GetComponentFirmwareStatusRequest_MachineIds) isGetComponentFirmwareStatusRequest_Target() {}
 
 func (*GetComponentFirmwareStatusRequest_SwitchIds) isGetComponentFirmwareStatusRequest_Target() {}
@@ -60406,6 +60465,9 @@ func (*GetComponentFirmwareStatusRequest_PowerShelfIds) isGetComponentFirmwareSt
 func (*GetComponentFirmwareStatusRequest_RackIds) isGetComponentFirmwareStatusRequest_Target() {}
 
 func (*GetComponentFirmwareStatusRequest_ComputeBmcMacs) isGetComponentFirmwareStatusRequest_Target() {
+}
+
+func (*GetComponentFirmwareStatusRequest_SwitchBmcMacs) isGetComponentFirmwareStatusRequest_Target() {
 }
 
 type GetComponentFirmwareStatusResponse struct {
@@ -60461,6 +60523,7 @@ type ListComponentFirmwareVersionsRequest struct {
 	//	*ListComponentFirmwareVersionsRequest_PowerShelfIds
 	//	*ListComponentFirmwareVersionsRequest_RackIds
 	//	*ListComponentFirmwareVersionsRequest_ComputeBmcMacs
+	//	*ListComponentFirmwareVersionsRequest_SwitchBmcMacs
 	Target        isListComponentFirmwareVersionsRequest_Target `protobuf_oneof:"target"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -60548,6 +60611,15 @@ func (x *ListComponentFirmwareVersionsRequest) GetComputeBmcMacs() *MacAddressLi
 	return nil
 }
 
+func (x *ListComponentFirmwareVersionsRequest) GetSwitchBmcMacs() *MacAddressList {
+	if x != nil {
+		if x, ok := x.Target.(*ListComponentFirmwareVersionsRequest_SwitchBmcMacs); ok {
+			return x.SwitchBmcMacs
+		}
+	}
+	return nil
+}
+
 type isListComponentFirmwareVersionsRequest_Target interface {
 	isListComponentFirmwareVersionsRequest_Target()
 }
@@ -60572,6 +60644,10 @@ type ListComponentFirmwareVersionsRequest_ComputeBmcMacs struct {
 	ComputeBmcMacs *MacAddressList `protobuf:"bytes,5,opt,name=compute_bmc_macs,json=computeBmcMacs,proto3,oneof"`
 }
 
+type ListComponentFirmwareVersionsRequest_SwitchBmcMacs struct {
+	SwitchBmcMacs *MacAddressList `protobuf:"bytes,6,opt,name=switch_bmc_macs,json=switchBmcMacs,proto3,oneof"`
+}
+
 func (*ListComponentFirmwareVersionsRequest_MachineIds) isListComponentFirmwareVersionsRequest_Target() {
 }
 
@@ -60585,6 +60661,9 @@ func (*ListComponentFirmwareVersionsRequest_RackIds) isListComponentFirmwareVers
 }
 
 func (*ListComponentFirmwareVersionsRequest_ComputeBmcMacs) isListComponentFirmwareVersionsRequest_Target() {
+}
+
+func (*ListComponentFirmwareVersionsRequest_SwitchBmcMacs) isListComponentFirmwareVersionsRequest_Target() {
 }
 
 // Per-component firmware versions for a compute tray. Since compute trays
@@ -70752,28 +70831,30 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x10PowerShelfIdList\x12&\n" +
 	"\x03ids\x18\x01 \x03(\v2\x14.common.PowerShelfIdR\x03ids\"5\n" +
 	"\x0eMacAddressList\x12#\n" +
-	"\rmac_addresses\x18\x01 \x03(\tR\fmacAddresses\"\x9e\x02\n" +
+	"\rmac_addresses\x18\x01 \x03(\tR\fmacAddresses\"\xdf\x02\n" +
 	"\x1cGetComponentInventoryRequest\x128\n" +
 	"\vmachine_ids\x18\x01 \x01(\v2\x15.common.MachineIdListH\x00R\n" +
 	"machineIds\x124\n" +
 	"\n" +
 	"switch_ids\x18\x02 \x01(\v2\x13.forge.SwitchIdListH\x00R\tswitchIds\x12A\n" +
 	"\x0fpower_shelf_ids\x18\x03 \x01(\v2\x17.forge.PowerShelfIdListH\x00R\rpowerShelfIds\x12A\n" +
-	"\x10compute_bmc_macs\x18\x04 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacsB\b\n" +
+	"\x10compute_bmc_macs\x18\x04 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacs\x12?\n" +
+	"\x0fswitch_bmc_macs\x18\x05 \x01(\v2\x15.forge.MacAddressListH\x00R\rswitchBmcMacsB\b\n" +
 	"\x06target\"\x9b\x01\n" +
 	"\x17ComponentInventoryEntry\x12.\n" +
 	"\x06result\x18\x01 \x01(\v2\x16.forge.ComponentResultR\x06result\x12E\n" +
 	"\x06report\x18\x02 \x01(\v2(.site_explorer.EndpointExplorationReportH\x00R\x06report\x88\x01\x01B\t\n" +
 	"\a_report\"Y\n" +
 	"\x1dGetComponentInventoryResponse\x128\n" +
-	"\aentries\x18\x01 \x03(\v2\x1e.forge.ComponentInventoryEntryR\aentries\"\x8a\x03\n" +
+	"\aentries\x18\x01 \x03(\v2\x1e.forge.ComponentInventoryEntryR\aentries\"\xcb\x03\n" +
 	"\x1cComponentPowerControlRequest\x128\n" +
 	"\vmachine_ids\x18\x01 \x01(\v2\x15.common.MachineIdListH\x00R\n" +
 	"machineIds\x124\n" +
 	"\n" +
 	"switch_ids\x18\x02 \x01(\v2\x13.forge.SwitchIdListH\x00R\tswitchIds\x12A\n" +
 	"\x0fpower_shelf_ids\x18\x03 \x01(\v2\x17.forge.PowerShelfIdListH\x00R\rpowerShelfIds\x12A\n" +
-	"\x10compute_bmc_macs\x18\x06 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacs\x122\n" +
+	"\x10compute_bmc_macs\x18\x06 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacs\x12?\n" +
+	"\x0fswitch_bmc_macs\x18\a \x01(\v2\x15.forge.MacAddressListH\x00R\rswitchBmcMacs\x122\n" +
 	"\x06action\x18\x04 \x01(\x0e2\x1a.common.SystemPowerControlR\x06action\x126\n" +
 	"\x17bypass_state_controller\x18\x05 \x01(\bR\x15bypassStateControllerB\b\n" +
 	"\x06target\"Q\n" +
@@ -70800,13 +70881,14 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\n" +
 	"components\x18\x02 \x03(\x0e2\x1b.forge.ComputeTrayComponentR\n" +
 	"components\x120\n" +
-	"\bbmc_macs\x18\x03 \x01(\v2\x15.forge.MacAddressListR\abmcMacs\"\x8a\x01\n" +
+	"\bbmc_macs\x18\x03 \x01(\v2\x15.forge.MacAddressListR\abmcMacs\"\xbc\x01\n" +
 	"\x1aUpdateSwitchFirmwareTarget\x122\n" +
 	"\n" +
 	"switch_ids\x18\x01 \x01(\v2\x13.forge.SwitchIdListR\tswitchIds\x128\n" +
 	"\n" +
 	"components\x18\x02 \x03(\x0e2\x18.forge.NvSwitchComponentR\n" +
-	"components\"\x9d\x01\n" +
+	"components\x120\n" +
+	"\bbmc_macs\x18\x03 \x01(\v2\x15.forge.MacAddressListR\abmcMacs\"\x9d\x01\n" +
 	"\x1eUpdatePowerShelfFirmwareTarget\x12?\n" +
 	"\x0fpower_shelf_ids\x18\x01 \x01(\v2\x17.forge.PowerShelfIdListR\rpowerShelfIds\x12:\n" +
 	"\n" +
@@ -70826,7 +70908,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x06targetB\x0f\n" +
 	"\r_access_token\"S\n" +
 	"\x1fUpdateComponentFirmwareResponse\x120\n" +
-	"\aresults\x18\x01 \x03(\v2\x16.forge.ComponentResultR\aresults\"\xd3\x02\n" +
+	"\aresults\x18\x01 \x03(\v2\x16.forge.ComponentResultR\aresults\"\x94\x03\n" +
 	"!GetComponentFirmwareStatusRequest\x128\n" +
 	"\vmachine_ids\x18\x01 \x01(\v2\x15.common.MachineIdListH\x00R\n" +
 	"machineIds\x124\n" +
@@ -70834,10 +70916,11 @@ const file_nico_nico_proto_rawDesc = "" +
 	"switch_ids\x18\x02 \x01(\v2\x13.forge.SwitchIdListH\x00R\tswitchIds\x12A\n" +
 	"\x0fpower_shelf_ids\x18\x03 \x01(\v2\x17.forge.PowerShelfIdListH\x00R\rpowerShelfIds\x12.\n" +
 	"\brack_ids\x18\x04 \x01(\v2\x11.forge.RackIdListH\x00R\arackIds\x12A\n" +
-	"\x10compute_bmc_macs\x18\x05 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacsB\b\n" +
+	"\x10compute_bmc_macs\x18\x05 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacs\x12?\n" +
+	"\x0fswitch_bmc_macs\x18\x06 \x01(\v2\x15.forge.MacAddressListH\x00R\rswitchBmcMacsB\b\n" +
 	"\x06target\"]\n" +
 	"\"GetComponentFirmwareStatusResponse\x127\n" +
-	"\bstatuses\x18\x01 \x03(\v2\x1b.forge.FirmwareUpdateStatusR\bstatuses\"\xd6\x02\n" +
+	"\bstatuses\x18\x01 \x03(\v2\x1b.forge.FirmwareUpdateStatusR\bstatuses\"\x97\x03\n" +
 	"$ListComponentFirmwareVersionsRequest\x128\n" +
 	"\vmachine_ids\x18\x01 \x01(\v2\x15.common.MachineIdListH\x00R\n" +
 	"machineIds\x124\n" +
@@ -70845,7 +70928,8 @@ const file_nico_nico_proto_rawDesc = "" +
 	"switch_ids\x18\x02 \x01(\v2\x13.forge.SwitchIdListH\x00R\tswitchIds\x12A\n" +
 	"\x0fpower_shelf_ids\x18\x03 \x01(\v2\x17.forge.PowerShelfIdListH\x00R\rpowerShelfIds\x12.\n" +
 	"\brack_ids\x18\x04 \x01(\v2\x11.forge.RackIdListH\x00R\arackIds\x12A\n" +
-	"\x10compute_bmc_macs\x18\x05 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacsB\b\n" +
+	"\x10compute_bmc_macs\x18\x05 \x01(\v2\x15.forge.MacAddressListH\x00R\x0ecomputeBmcMacs\x12?\n" +
+	"\x0fswitch_bmc_macs\x18\x06 \x01(\v2\x15.forge.MacAddressListH\x00R\rswitchBmcMacsB\b\n" +
 	"\x06target\"t\n" +
 	"\x1bComputeTrayFirmwareVersions\x129\n" +
 	"\tcomponent\x18\x01 \x01(\x0e2\x1b.forge.ComputeTrayComponentR\tcomponent\x12\x1a\n" +
@@ -74630,1136 +74714,1141 @@ var file_nico_nico_proto_depIdxs = []int32{
 	945,  // 1142: forge.GetComponentInventoryRequest.switch_ids:type_name -> forge.SwitchIdList
 	946,  // 1143: forge.GetComponentInventoryRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
 	947,  // 1144: forge.GetComponentInventoryRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	944,  // 1145: forge.ComponentInventoryEntry.result:type_name -> forge.ComponentResult
-	1123, // 1146: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
-	949,  // 1147: forge.GetComponentInventoryResponse.entries:type_name -> forge.ComponentInventoryEntry
-	1122, // 1148: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
-	945,  // 1149: forge.ComponentPowerControlRequest.switch_ids:type_name -> forge.SwitchIdList
-	946,  // 1150: forge.ComponentPowerControlRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	947,  // 1151: forge.ComponentPowerControlRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	1124, // 1152: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
-	944,  // 1153: forge.ComponentPowerControlResponse.results:type_name -> forge.ComponentResult
-	945,  // 1154: forge.ComponentConfigureSwitchCertificateRequest.switch_ids:type_name -> forge.SwitchIdList
-	944,  // 1155: forge.ComponentConfigureSwitchCertificateResponse.results:type_name -> forge.ComponentResult
-	944,  // 1156: forge.FirmwareUpdateStatus.result:type_name -> forge.ComponentResult
-	81,   // 1157: forge.FirmwareUpdateStatus.state:type_name -> forge.FirmwareUpdateState
-	1061, // 1158: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
-	1122, // 1159: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
-	84,   // 1160: forge.UpdateComputeTrayFirmwareTarget.components:type_name -> forge.ComputeTrayComponent
-	947,  // 1161: forge.UpdateComputeTrayFirmwareTarget.bmc_macs:type_name -> forge.MacAddressList
-	945,  // 1162: forge.UpdateSwitchFirmwareTarget.switch_ids:type_name -> forge.SwitchIdList
-	82,   // 1163: forge.UpdateSwitchFirmwareTarget.components:type_name -> forge.NvSwitchComponent
-	946,  // 1164: forge.UpdatePowerShelfFirmwareTarget.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	83,   // 1165: forge.UpdatePowerShelfFirmwareTarget.components:type_name -> forge.PowerShelfComponent
-	782,  // 1166: forge.UpdateFirmwareObjectTarget.rack_ids:type_name -> forge.RackIdList
-	956,  // 1167: forge.UpdateComponentFirmwareRequest.compute_trays:type_name -> forge.UpdateComputeTrayFirmwareTarget
-	957,  // 1168: forge.UpdateComponentFirmwareRequest.switches:type_name -> forge.UpdateSwitchFirmwareTarget
-	958,  // 1169: forge.UpdateComponentFirmwareRequest.power_shelves:type_name -> forge.UpdatePowerShelfFirmwareTarget
-	959,  // 1170: forge.UpdateComponentFirmwareRequest.racks:type_name -> forge.UpdateFirmwareObjectTarget
-	944,  // 1171: forge.UpdateComponentFirmwareResponse.results:type_name -> forge.ComponentResult
-	1122, // 1172: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
-	945,  // 1173: forge.GetComponentFirmwareStatusRequest.switch_ids:type_name -> forge.SwitchIdList
-	946,  // 1174: forge.GetComponentFirmwareStatusRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	782,  // 1175: forge.GetComponentFirmwareStatusRequest.rack_ids:type_name -> forge.RackIdList
-	947,  // 1176: forge.GetComponentFirmwareStatusRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	955,  // 1177: forge.GetComponentFirmwareStatusResponse.statuses:type_name -> forge.FirmwareUpdateStatus
-	1122, // 1178: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
-	945,  // 1179: forge.ListComponentFirmwareVersionsRequest.switch_ids:type_name -> forge.SwitchIdList
-	946,  // 1180: forge.ListComponentFirmwareVersionsRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	782,  // 1181: forge.ListComponentFirmwareVersionsRequest.rack_ids:type_name -> forge.RackIdList
-	947,  // 1182: forge.ListComponentFirmwareVersionsRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	84,   // 1183: forge.ComputeTrayFirmwareVersions.component:type_name -> forge.ComputeTrayComponent
-	944,  // 1184: forge.DeviceFirmwareVersions.result:type_name -> forge.ComponentResult
-	965,  // 1185: forge.DeviceFirmwareVersions.compute_fw_versions:type_name -> forge.ComputeTrayFirmwareVersions
-	966,  // 1186: forge.ListComponentFirmwareVersionsResponse.devices:type_name -> forge.DeviceFirmwareVersions
-	287,  // 1187: forge.SpxPartitionCreationRequest.metadata:type_name -> forge.Metadata
-	1083, // 1188: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
-	287,  // 1189: forge.SpxPartition.metadata:type_name -> forge.Metadata
-	1083, // 1190: forge.SpxPartition.id:type_name -> common.SpxPartitionId
-	1083, // 1191: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
-	1083, // 1192: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
-	286,  // 1193: forge.SpxPartitionSearchFilter.label:type_name -> forge.Label
-	969,  // 1194: forge.SpxPartitionList.spx_partitions:type_name -> forge.SpxPartition
-	1083, // 1195: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
-	1074, // 1196: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
-	1071, // 1197: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1082, // 1198: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
-	85,   // 1199: forge.OperatingSystem.type:type_name -> forge.OperatingSystemType
-	9,    // 1200: forge.OperatingSystem.status:type_name -> forge.TenantState
-	1081, // 1201: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
-	294,  // 1202: forge.OperatingSystem.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
-	295,  // 1203: forge.OperatingSystem.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
-	1082, // 1204: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1081, // 1205: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
-	294,  // 1206: forge.CreateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
-	295,  // 1207: forge.CreateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
-	294,  // 1208: forge.IpxeTemplateParameters.items:type_name -> forge.IpxeTemplateParameter
-	295,  // 1209: forge.IpxeTemplateArtifacts.items:type_name -> forge.IpxeTemplateArtifact
-	1082, // 1210: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1081, // 1211: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
-	982,  // 1212: forge.UpdateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameters
-	983,  // 1213: forge.UpdateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifacts
-	1082, // 1214: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1082, // 1215: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
-	1082, // 1216: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
-	980,  // 1217: forge.OperatingSystemList.operating_systems:type_name -> forge.OperatingSystem
-	1082, // 1218: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
-	295,  // 1219: forge.IpxeTemplateArtifactList.artifacts:type_name -> forge.IpxeTemplateArtifact
-	1082, // 1220: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
-	993,  // 1221: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.updates:type_name -> forge.IpxeTemplateArtifactUpdateRequest
-	1060, // 1222: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
-	1084, // 1223: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
-	1061, // 1224: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
-	1060, // 1225: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
-	999,  // 1226: forge.GetMachineBootInterfacesResponse.machine_interfaces:type_name -> forge.MachineInterfaceBootInterface
-	1000, // 1227: forge.GetMachineBootInterfacesResponse.predicted_interfaces:type_name -> forge.PredictedBootInterface
-	1001, // 1228: forge.GetMachineBootInterfacesResponse.explored_endpoints:type_name -> forge.ExploredBootInterface
-	1002, // 1229: forge.GetMachineBootInterfacesResponse.retained_interfaces:type_name -> forge.RetainedBootInterface
-	998,  // 1230: forge.GetMachineBootInterfacesResponse.default_boot_interface:type_name -> forge.MachineBootInterface
-	998,  // 1231: forge.GetMachineBootInterfacesResponse.predicted_boot_interface:type_name -> forge.MachineBootInterface
-	1059, // 1232: forge.GetMachineBootInterfacesResponse.reconciliation:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation
-	1067, // 1233: forge.SitePrefix.id:type_name -> common.SitePrefixId
-	1008, // 1234: forge.SitePrefix.config:type_name -> forge.SitePrefixConfig
-	1009, // 1235: forge.SitePrefix.status:type_name -> forge.SitePrefixStatus
-	287,  // 1236: forge.SitePrefix.metadata:type_name -> forge.Metadata
-	1061, // 1237: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
-	1061, // 1238: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
-	90,   // 1239: forge.SitePrefixConfig.routing_scope:type_name -> forge.SitePrefixRoutingScope
-	89,   // 1240: forge.SitePrefixStatus.authority:type_name -> forge.SitePrefixAuthority
-	91,   // 1241: forge.SitePrefixStatus.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
-	1010, // 1242: forge.SitePrefixStatus.quota:type_name -> forge.SitePrefixQuotaUsage
-	1067, // 1243: forge.SitePrefixCreationRequest.id:type_name -> common.SitePrefixId
-	287,  // 1244: forge.SitePrefixCreationRequest.metadata:type_name -> forge.Metadata
-	1067, // 1245: forge.SitePrefixUpdateRequest.id:type_name -> common.SitePrefixId
-	287,  // 1246: forge.SitePrefixUpdateRequest.metadata:type_name -> forge.Metadata
-	1067, // 1247: forge.SitePrefixDeletionRequest.id:type_name -> common.SitePrefixId
-	1007, // 1248: forge.SitePrefixDeletionResult.site_prefix:type_name -> forge.SitePrefix
-	1067, // 1249: forge.SitePrefixStateHistoriesRequest.site_prefix_ids:type_name -> common.SitePrefixId
-	89,   // 1250: forge.SitePrefixSearchFilter.authority:type_name -> forge.SitePrefixAuthority
-	90,   // 1251: forge.SitePrefixSearchFilter.routing_scope:type_name -> forge.SitePrefixRoutingScope
-	91,   // 1252: forge.SitePrefixSearchFilter.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
-	8,    // 1253: forge.SitePrefixSearchFilter.prefix_match_type:type_name -> forge.PrefixMatchType
-	1067, // 1254: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
-	1067, // 1255: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
-	1007, // 1256: forge.SitePrefixList.site_prefixes:type_name -> forge.SitePrefix
-	30,   // 1257: forge.InterfaceAddressConfig.address_family:type_name -> forge.AddressFamily
-	1024, // 1258: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
-	251,  // 1259: forge.StateHistories.HistoriesEntry.value:type_name -> forge.StateHistoryRecords
-	346,  // 1260: forge.MachineStateHistories.HistoriesEntry.value:type_name -> forge.MachineStateHistoryRecords
-	349,  // 1261: forge.HealthHistories.HistoriesEntry.value:type_name -> forge.HealthHistoryRecords
-	96,   // 1262: forge.MachineCredentialsUpdateRequest.Credentials.credential_purpose:type_name -> forge.MachineCredentialsUpdateRequest.CredentialPurpose
-	1048, // 1263: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
-	1090, // 1264: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
-	1039, // 1265: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
-	1087, // 1266: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
-	1041, // 1267: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
-	1042, // 1268: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
-	1043, // 1269: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
-	1044, // 1270: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
-	1045, // 1271: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
-	1046, // 1272: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
-	1125, // 1273: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
-	1126, // 1274: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
-	1127, // 1275: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
-	98,   // 1276: forge.MachineCleanupInfo.CleanupStepResult.result:type_name -> forge.MachineCleanupInfo.CleanupResult
-	1060, // 1277: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
-	1061, // 1278: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1061, // 1279: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	1060, // 1280: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
-	1061, // 1281: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1061, // 1282: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	660,  // 1283: forge.MachineValidationTestUpdateRequest.Payload.plugin:type_name -> forge.MachineValidationPlugin
-	1060, // 1284: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
-	998,  // 1285: forge.GetMachineBootInterfacesResponse.Reconciliation.desired_boot_interface:type_name -> forge.MachineBootInterface
-	1061, // 1286: forge.GetMachineBootInterfacesResponse.Reconciliation.observed_at:type_name -> google.protobuf.Timestamp
-	108,  // 1287: forge.GetMachineBootInterfacesResponse.Reconciliation.reconciliation_state:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation.State
-	88,   // 1288: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_source:type_name -> forge.BootInterfaceSelectionSource
-	1061, // 1289: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_updated_at:type_name -> google.protobuf.Timestamp
-	157,  // 1290: forge.Forge.Version:input_type -> forge.VersionRequest
-	1128, // 1291: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
-	1129, // 1292: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
-	1130, // 1293: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
-	1131, // 1294: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
-	919,  // 1295: forge.Forge.CreateDomainLegacy:input_type -> forge.DomainLegacy
-	919,  // 1296: forge.Forge.UpdateDomainLegacy:input_type -> forge.DomainLegacy
-	921,  // 1297: forge.Forge.DeleteDomainLegacy:input_type -> forge.DomainDeletionLegacy
-	923,  // 1298: forge.Forge.FindDomainLegacy:input_type -> forge.DomainSearchQueryLegacy
-	179,  // 1299: forge.Forge.CreateVpc:input_type -> forge.VpcCreationRequest
-	180,  // 1300: forge.Forge.UpdateVpc:input_type -> forge.VpcUpdateRequest
-	182,  // 1301: forge.Forge.UpdateVpcVirtualization:input_type -> forge.VpcUpdateVirtualizationRequest
-	184,  // 1302: forge.Forge.DeleteVpc:input_type -> forge.VpcDeletionRequest
-	169,  // 1303: forge.Forge.FindVpcIds:input_type -> forge.VpcSearchFilter
-	171,  // 1304: forge.Forge.FindVpcsByIds:input_type -> forge.VpcsByIdsRequest
-	968,  // 1305: forge.Forge.CreateSpxPartition:input_type -> forge.SpxPartitionCreationRequest
-	971,  // 1306: forge.Forge.DeleteSpxPartition:input_type -> forge.SpxPartitionDeletionRequest
-	973,  // 1307: forge.Forge.FindSpxPartitionIds:input_type -> forge.SpxPartitionSearchFilter
-	975,  // 1308: forge.Forge.FindSpxPartitionsByIds:input_type -> forge.SpxPartitionsByIdsRequest
-	190,  // 1309: forge.Forge.CreateVpcPrefix:input_type -> forge.VpcPrefixCreationRequest
-	191,  // 1310: forge.Forge.SearchVpcPrefixes:input_type -> forge.VpcPrefixSearchQuery
-	192,  // 1311: forge.Forge.GetVpcPrefixes:input_type -> forge.VpcPrefixGetRequest
-	195,  // 1312: forge.Forge.UpdateVpcPrefix:input_type -> forge.VpcPrefixUpdateRequest
-	196,  // 1313: forge.Forge.DeleteVpcPrefix:input_type -> forge.VpcPrefixDeletionRequest
-	1011, // 1314: forge.Forge.CreateSitePrefix:input_type -> forge.SitePrefixCreationRequest
-	1012, // 1315: forge.Forge.UpdateSitePrefix:input_type -> forge.SitePrefixUpdateRequest
-	1013, // 1316: forge.Forge.DeleteSitePrefix:input_type -> forge.SitePrefixDeletionRequest
-	1016, // 1317: forge.Forge.FindSitePrefixIds:input_type -> forge.SitePrefixSearchFilter
-	1017, // 1318: forge.Forge.FindSitePrefixesByIds:input_type -> forge.SitePrefixesByIdsRequest
-	202,  // 1319: forge.Forge.CreateVpcPeering:input_type -> forge.VpcPeeringCreationRequest
-	203,  // 1320: forge.Forge.FindVpcPeeringIds:input_type -> forge.VpcPeeringSearchFilter
-	204,  // 1321: forge.Forge.FindVpcPeeringsByIds:input_type -> forge.VpcPeeringsByIdsRequest
-	205,  // 1322: forge.Forge.DeleteVpcPeering:input_type -> forge.VpcPeeringDeletionRequest
-	278,  // 1323: forge.Forge.FindNetworkSegmentIds:input_type -> forge.NetworkSegmentSearchFilter
-	280,  // 1324: forge.Forge.FindNetworkSegmentsByIds:input_type -> forge.NetworkSegmentsByIdsRequest
-	272,  // 1325: forge.Forge.CreateNetworkSegment:input_type -> forge.NetworkSegmentCreationRequest
-	274,  // 1326: forge.Forge.AttachNetworkSegmentToVpc:input_type -> forge.AttachNetworkSegmentToVpcRequest
-	273,  // 1327: forge.Forge.DeleteNetworkSegment:input_type -> forge.NetworkSegmentDeletionRequest
-	168,  // 1328: forge.Forge.NetworkSegmentsForVpc:input_type -> forge.VpcSearchQuery
-	215,  // 1329: forge.Forge.FindIBPartitionIds:input_type -> forge.IBPartitionSearchFilter
-	216,  // 1330: forge.Forge.FindIBPartitionsByIds:input_type -> forge.IBPartitionsByIdsRequest
-	211,  // 1331: forge.Forge.CreateIBPartition:input_type -> forge.IBPartitionCreationRequest
-	212,  // 1332: forge.Forge.UpdateIBPartition:input_type -> forge.IBPartitionUpdateRequest
-	213,  // 1333: forge.Forge.DeleteIBPartition:input_type -> forge.IBPartitionDeletionRequest
-	172,  // 1334: forge.Forge.IBPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	230,  // 1335: forge.Forge.FindPowerShelves:input_type -> forge.PowerShelfQuery
-	231,  // 1336: forge.Forge.FindPowerShelfIds:input_type -> forge.PowerShelfSearchFilter
-	232,  // 1337: forge.Forge.FindPowerShelvesByIds:input_type -> forge.PowerShelvesByIdsRequest
-	223,  // 1338: forge.Forge.DecommissionPowerShelf:input_type -> forge.DecommissionPowerShelfRequest
-	225,  // 1339: forge.Forge.DeletePowerShelf:input_type -> forge.PowerShelfDeletionRequest
-	978,  // 1340: forge.Forge.AdminForceDeletePowerShelf:input_type -> forge.AdminForceDeletePowerShelfRequest
-	227,  // 1341: forge.Forge.SetPowerShelfMaintenance:input_type -> forge.PowerShelfMaintenanceRequest
-	255,  // 1342: forge.Forge.FindSwitches:input_type -> forge.SwitchQuery
-	256,  // 1343: forge.Forge.FindSwitchIds:input_type -> forge.SwitchSearchFilter
-	257,  // 1344: forge.Forge.FindSwitchesByIds:input_type -> forge.SwitchesByIdsRequest
-	246,  // 1345: forge.Forge.DeleteSwitch:input_type -> forge.SwitchDeletionRequest
-	248,  // 1346: forge.Forge.DecommissionSwitch:input_type -> forge.DecommissionSwitchRequest
-	976,  // 1347: forge.Forge.AdminForceDeleteSwitch:input_type -> forge.AdminForceDeleteSwitchRequest
-	266,  // 1348: forge.Forge.FindIBFabricIds:input_type -> forge.IBFabricSearchFilter
-	291,  // 1349: forge.Forge.AllocateInstance:input_type -> forge.InstanceAllocationRequest
-	292,  // 1350: forge.Forge.AllocateInstances:input_type -> forge.BatchInstanceAllocationRequest
-	337,  // 1351: forge.Forge.ReleaseInstance:input_type -> forge.InstanceReleaseRequest
-	339,  // 1352: forge.Forge.ReleaseInstances:input_type -> forge.BatchInstanceReleaseRequest
-	309,  // 1353: forge.Forge.UpdateInstanceOperatingSystem:input_type -> forge.InstanceOperatingSystemUpdateRequest
-	310,  // 1354: forge.Forge.UpdateInstanceConfig:input_type -> forge.InstanceConfigUpdateRequest
-	288,  // 1355: forge.Forge.FindInstanceIds:input_type -> forge.InstanceSearchFilter
-	290,  // 1356: forge.Forge.FindInstancesByIds:input_type -> forge.InstancesByIdsRequest
-	1060, // 1357: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
-	413,  // 1358: forge.Forge.GetManagedHostNetworkConfig:input_type -> forge.ManagedHostNetworkConfigRequest
-	478,  // 1359: forge.Forge.RecordDpuNetworkStatus:input_type -> forge.DpuNetworkStatus
-	1060, // 1360: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
-	484,  // 1361: forge.Forge.InsertMachineHealthReport:input_type -> forge.InsertMachineHealthReportRequest
-	495,  // 1362: forge.Forge.RemoveMachineHealthReport:input_type -> forge.RemoveMachineHealthReportRequest
-	487,  // 1363: forge.Forge.ListRackHealthReports:input_type -> forge.ListRackHealthReportsRequest
-	485,  // 1364: forge.Forge.InsertRackHealthReport:input_type -> forge.InsertRackHealthReportRequest
-	486,  // 1365: forge.Forge.RemoveRackHealthReport:input_type -> forge.RemoveRackHealthReportRequest
-	490,  // 1366: forge.Forge.ListSwitchHealthReports:input_type -> forge.ListSwitchHealthReportsRequest
-	488,  // 1367: forge.Forge.InsertSwitchHealthReport:input_type -> forge.InsertSwitchHealthReportRequest
-	489,  // 1368: forge.Forge.RemoveSwitchHealthReport:input_type -> forge.RemoveSwitchHealthReportRequest
-	493,  // 1369: forge.Forge.ListPowerShelfHealthReports:input_type -> forge.ListPowerShelfHealthReportsRequest
-	491,  // 1370: forge.Forge.InsertPowerShelfHealthReport:input_type -> forge.InsertPowerShelfHealthReportRequest
-	492,  // 1371: forge.Forge.RemovePowerShelfHealthReport:input_type -> forge.RemovePowerShelfHealthReportRequest
-	496,  // 1372: forge.Forge.ListNVLinkDomainHealthReports:input_type -> forge.ListNVLinkDomainHealthReportsRequest
-	497,  // 1373: forge.Forge.InsertNVLinkDomainHealthReport:input_type -> forge.InsertNVLinkDomainHealthReportRequest
-	498,  // 1374: forge.Forge.RemoveNVLinkDomainHealthReport:input_type -> forge.RemoveNVLinkDomainHealthReportRequest
-	1060, // 1375: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
-	484,  // 1376: forge.Forge.InsertHealthReportOverride:input_type -> forge.InsertMachineHealthReportRequest
-	495,  // 1377: forge.Forge.RemoveHealthReportOverride:input_type -> forge.RemoveMachineHealthReportRequest
-	430,  // 1378: forge.Forge.DpuAgentUpgradeCheck:input_type -> forge.DpuAgentUpgradeCheckRequest
-	432,  // 1379: forge.Forge.DpuAgentUpgradePolicyAction:input_type -> forge.DpuAgentUpgradePolicyRequest
-	1132, // 1380: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
-	1133, // 1381: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
-	1134, // 1382: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
-	283,  // 1383: forge.Forge.InvokeInstancePower:input_type -> forge.InstancePowerRequest
-	459,  // 1384: forge.Forge.ForgeAgentControl:input_type -> forge.ForgeAgentControlRequest
-	461,  // 1385: forge.Forge.DiscoverMachine:input_type -> forge.MachineDiscoveryInfo
-	465,  // 1386: forge.Forge.RenewMachineCertificate:input_type -> forge.MachineCertificateRenewRequest
-	462,  // 1387: forge.Forge.DiscoveryCompleted:input_type -> forge.MachineDiscoveryCompletedRequest
-	463,  // 1388: forge.Forge.CleanupMachineCompleted:input_type -> forge.MachineCleanupInfo
-	470,  // 1389: forge.Forge.ReportForgeScoutError:input_type -> forge.ForgeScoutErrorReport
-	389,  // 1390: forge.Forge.DiscoverDhcp:input_type -> forge.DhcpDiscovery
-	390,  // 1391: forge.Forge.ExpireDhcpLease:input_type -> forge.ExpireDhcpLeaseRequest
-	359,  // 1392: forge.Forge.AssignStaticAddress:input_type -> forge.AssignStaticAddressRequest
-	361,  // 1393: forge.Forge.RemoveStaticAddress:input_type -> forge.RemoveStaticAddressRequest
-	363,  // 1394: forge.Forge.FindInterfaceAddresses:input_type -> forge.FindInterfaceAddressesRequest
-	358,  // 1395: forge.Forge.FindInterfaces:input_type -> forge.InterfaceSearchQuery
-	357,  // 1396: forge.Forge.DeleteInterface:input_type -> forge.InterfaceDeleteQuery
-	534,  // 1397: forge.Forge.FindIpAddress:input_type -> forge.FindIpAddressRequest
-	343,  // 1398: forge.Forge.FindMachineIds:input_type -> forge.MachineSearchConfig
-	342,  // 1399: forge.Forge.FindMachinesByIds:input_type -> forge.MachinesByIdsRequest
-	344,  // 1400: forge.Forge.FindMachineStateHistories:input_type -> forge.MachineStateHistoriesRequest
-	347,  // 1401: forge.Forge.FindMachineHealthHistories:input_type -> forge.MachineHealthHistoriesRequest
-	228,  // 1402: forge.Forge.FindPowerShelfStateHistories:input_type -> forge.PowerShelfStateHistoriesRequest
-	229,  // 1403: forge.Forge.FindPowerShelfHealthHistories:input_type -> forge.PowerShelfHealthHistoriesRequest
-	787,  // 1404: forge.Forge.FindRackStateHistories:input_type -> forge.RackStateHistoriesRequest
-	788,  // 1405: forge.Forge.FindRackHealthHistories:input_type -> forge.RackHealthHistoriesRequest
-	252,  // 1406: forge.Forge.FindSwitchStateHistories:input_type -> forge.SwitchStateHistoriesRequest
-	253,  // 1407: forge.Forge.FindSwitchHealthHistories:input_type -> forge.SwitchHealthHistoriesRequest
-	276,  // 1408: forge.Forge.FindNetworkSegmentStateHistories:input_type -> forge.NetworkSegmentStateHistoriesRequest
-	198,  // 1409: forge.Forge.FindVpcPrefixStateHistories:input_type -> forge.VpcPrefixStateHistoriesRequest
-	1015, // 1410: forge.Forge.FindSitePrefixStateHistories:input_type -> forge.SitePrefixStateHistoriesRequest
-	352,  // 1411: forge.Forge.FindTenantOrganizationIds:input_type -> forge.TenantSearchFilter
-	351,  // 1412: forge.Forge.FindTenantsByOrganizationIds:input_type -> forge.TenantByOrganizationIdsRequest
-	1122, // 1413: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
-	562,  // 1414: forge.Forge.FindMachineIdsByBmcIps:input_type -> forge.BmcIpList
-	563,  // 1415: forge.Forge.FindMacAddressByBmcIp:input_type -> forge.BmcIp
-	538,  // 1416: forge.Forge.FindBmcIps:input_type -> forge.FindBmcIpsRequest
-	536,  // 1417: forge.Forge.IdentifyUuid:input_type -> forge.IdentifyUuidRequest
-	539,  // 1418: forge.Forge.IdentifyMac:input_type -> forge.IdentifyMacRequest
-	541,  // 1419: forge.Forge.IdentifySerial:input_type -> forge.IdentifySerialRequest
-	455,  // 1420: forge.Forge.GetBMCMetaData:input_type -> forge.BMCMetaDataGetRequest
-	457,  // 1421: forge.Forge.UpdateMachineCredentials:input_type -> forge.MachineCredentialsUpdateRequest
-	472,  // 1422: forge.Forge.GetPxeInstructions:input_type -> forge.PxeInstructionRequest
-	476,  // 1423: forge.Forge.GetCloudInitInstructions:input_type -> forge.CloudInitInstructionsRequest
-	160,  // 1424: forge.Forge.Echo:input_type -> forge.EchoRequest
-	503,  // 1425: forge.Forge.CreateTenant:input_type -> forge.CreateTenantRequest
-	507,  // 1426: forge.Forge.FindTenant:input_type -> forge.FindTenantRequest
-	505,  // 1427: forge.Forge.UpdateTenant:input_type -> forge.UpdateTenantRequest
-	513,  // 1428: forge.Forge.CreateTenantKeyset:input_type -> forge.CreateTenantKeysetRequest
-	520,  // 1429: forge.Forge.FindTenantKeysetIds:input_type -> forge.TenantKeysetSearchFilter
-	522,  // 1430: forge.Forge.FindTenantKeysetsByIds:input_type -> forge.TenantKeysetsByIdsRequest
-	516,  // 1431: forge.Forge.UpdateTenantKeyset:input_type -> forge.UpdateTenantKeysetRequest
-	518,  // 1432: forge.Forge.DeleteTenantKeyset:input_type -> forge.DeleteTenantKeysetRequest
-	523,  // 1433: forge.Forge.ValidateTenantPublicKey:input_type -> forge.ValidateTenantPublicKeyRequest
-	396,  // 1434: forge.Forge.GetBmcCredentials:input_type -> forge.GetBmcCredentialsRequest
-	397,  // 1435: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
-	428,  // 1436: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
-	400,  // 1437: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
-	1135, // 1438: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
-	401,  // 1439: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
-	407,  // 1440: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
-	407,  // 1441: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
-	407,  // 1442: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
-	402,  // 1443: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
-	403,  // 1444: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
-	404,  // 1445: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
-	405,  // 1446: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
-	1136, // 1447: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
-	1137, // 1448: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
-	1138, // 1449: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
-	1139, // 1450: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
-	1140, // 1451: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
-	1141, // 1452: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
-	411,  // 1453: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
-	434,  // 1454: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
-	435,  // 1455: forge.Forge.DecommissionManagedHost:input_type -> forge.DecommissionManagedHostRequest
-	525,  // 1456: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
-	528,  // 1457: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
-	373,  // 1458: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
-	374,  // 1459: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
-	375,  // 1460: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
-	376,  // 1461: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
-	804,  // 1462: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
-	532,  // 1463: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
-	533,  // 1464: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
-	543,  // 1465: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
-	544,  // 1466: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
-	546,  // 1467: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
-	550,  // 1468: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
-	547,  // 1469: forge.Forge.TriggerBmcCredentialRotation:input_type -> forge.BmcCredentialRotationRequest
-	548,  // 1470: forge.Forge.TriggerUefiCredentialRotation:input_type -> forge.UefiCredentialRotationRequest
-	549,  // 1471: forge.Forge.TriggerNicLockdownCredentialRotation:input_type -> forge.NicLockdownCredentialRotationRequest
-	1060, // 1472: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
-	603,  // 1473: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
-	556,  // 1474: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
-	1084, // 1475: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
-	559,  // 1476: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
-	1084, // 1477: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
-	997,  // 1478: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
-	568,  // 1479: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
-	569,  // 1480: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
-	148,  // 1481: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
-	149,  // 1482: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
-	152,  // 1483: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
-	154,  // 1484: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
-	1004, // 1485: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
-	1006, // 1486: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
-	1135, // 1487: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
-	571,  // 1488: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
-	571,  // 1489: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
-	571,  // 1490: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
-	377,  // 1491: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
-	332,  // 1492: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
-	574,  // 1493: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
-	576,  // 1494: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
-	578,  // 1495: forge.Forge.SetDpuUefiPassword:input_type -> forge.SetDpuUefiPasswordRequest
-	591,  // 1496: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
-	592,  // 1497: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	591,  // 1498: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
-	592,  // 1499: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	1135, // 1500: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
-	593,  // 1501: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
-	1135, // 1502: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
-	1135, // 1503: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
-	1135, // 1504: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
-	598,  // 1505: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	598,  // 1506: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	233,  // 1507: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	234,  // 1508: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	233,  // 1509: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	234,  // 1510: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	1135, // 1511: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	235,  // 1512: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
-	1135, // 1513: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	1135, // 1514: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
-	258,  // 1515: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
-	259,  // 1516: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	258,  // 1517: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
-	259,  // 1518: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	1135, // 1519: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
-	260,  // 1520: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
-	1135, // 1521: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
-	1135, // 1522: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
-	263,  // 1523: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
-	264,  // 1524: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
-	263,  // 1525: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
-	264,  // 1526: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
-	1135, // 1527: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
-	265,  // 1528: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
-	1135, // 1529: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
-	146,  // 1530: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
-	680,  // 1531: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
-	682,  // 1532: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
-	684,  // 1533: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
-	689,  // 1534: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
-	686,  // 1535: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
-	690,  // 1536: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
-	692,  // 1537: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
-	1142, // 1538: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
-	1143, // 1539: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
-	1144, // 1540: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
-	1145, // 1541: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
-	1146, // 1542: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
-	1147, // 1543: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
-	1148, // 1544: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
-	1149, // 1545: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
-	1150, // 1546: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
-	1151, // 1547: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
-	1152, // 1548: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
-	1153, // 1549: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
-	1154, // 1550: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
-	1155, // 1551: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
-	1156, // 1552: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
-	1157, // 1553: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
-	1158, // 1554: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
-	1159, // 1555: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
-	1160, // 1556: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
-	1161, // 1557: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
-	1162, // 1558: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
-	1163, // 1559: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
-	1164, // 1560: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
-	1165, // 1561: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
-	1166, // 1562: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
-	1167, // 1563: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
-	1168, // 1564: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
-	1169, // 1565: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
-	1170, // 1566: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
-	1171, // 1567: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
-	1172, // 1568: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
-	1173, // 1569: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
-	1174, // 1570: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
-	1175, // 1571: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
-	1176, // 1572: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
-	1177, // 1573: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
-	1178, // 1574: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
-	1179, // 1575: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
-	1180, // 1576: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
-	1181, // 1577: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
-	1182, // 1578: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
-	1183, // 1579: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
-	1184, // 1580: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
-	711,  // 1581: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
-	713,  // 1582: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
-	715,  // 1583: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
-	718,  // 1584: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
-	719,  // 1585: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
-	725,  // 1586: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
-	728,  // 1587: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
-	580,  // 1588: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
-	584,  // 1589: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
-	582,  // 1590: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
-	1073, // 1591: forge.Forge.GetOsImage:input_type -> common.UUID
-	580,  // 1592: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
-	586,  // 1593: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
-	587,  // 1594: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
-	602,  // 1595: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
-	607,  // 1596: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
-	609,  // 1597: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
-	604,  // 1598: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
-	612,  // 1599: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
-	614,  // 1600: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
-	617,  // 1601: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
-	619,  // 1602: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
-	640,  // 1603: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
-	641,  // 1604: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
-	643,  // 1605: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
-	646,  // 1606: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
-	648,  // 1607: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
-	620,  // 1608: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
-	652,  // 1609: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
-	654,  // 1610: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
-	653,  // 1611: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
-	657,  // 1612: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
-	664,  // 1613: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
-	665,  // 1614: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
-	661,  // 1615: forge.Forge.MachineValidationTestApproveFullHost:input_type -> forge.MachineValidationTestFullHostApprovalRequest
-	667,  // 1616: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
-	449,  // 1617: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
-	633,  // 1618: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
-	635,  // 1619: forge.Forge.AdminGpuReset:input_type -> forge.AdminGpuResetRequest
-	407,  // 1620: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
-	439,  // 1621: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
-	441,  // 1622: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
-	443,  // 1623: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
-	445,  // 1624: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
-	837,  // 1625: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
-	839,  // 1626: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
-	841,  // 1627: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
-	843,  // 1628: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
-	451,  // 1629: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
-	453,  // 1630: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
-	621,  // 1631: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
-	629,  // 1632: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
-	631,  // 1633: forge.Forge.TerminateRackMaintenance:input_type -> forge.RackMaintenanceTerminateRequest
-	142,  // 1634: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
-	1135, // 1635: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
-	1135, // 1636: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
-	139,  // 1637: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
-	694,  // 1638: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
-	696,  // 1639: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
-	701,  // 1640: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
-	703,  // 1641: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
-	703,  // 1642: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
-	703,  // 1643: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
-	707,  // 1644: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
-	731,  // 1645: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
-	847,  // 1646: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
-	848,  // 1647: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
-	747,  // 1648: forge.Forge.CreateSku:input_type -> forge.SkuList
-	1060, // 1649: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
-	1060, // 1650: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
-	745,  // 1651: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
-	746,  // 1652: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
-	748,  // 1653: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
-	1135, // 1654: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
-	750,  // 1655: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
-	760,  // 1656: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
-	744,  // 1657: forge.Forge.ReplaceSku:input_type -> forge.Sku
-	417,  // 1658: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
-	419,  // 1659: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
-	421,  // 1660: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
-	1060, // 1661: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
-	410,  // 1662: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
-	1135, // 1663: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
-	755,  // 1664: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
-	753,  // 1665: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	753,  // 1666: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	758,  // 1667: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
-	761,  // 1668: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
-	762,  // 1669: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
-	407,  // 1670: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
-	407,  // 1671: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
-	781,  // 1672: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
-	783,  // 1673: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
-	778,  // 1674: forge.Forge.GetRack:input_type -> forge.GetRackRequest
-	789,  // 1675: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
-	790,  // 1676: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
-	797,  // 1677: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
-	1135, // 1678: forge.Forge.ListRackProfiles:input_type -> google.protobuf.Empty
-	767,  // 1679: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
-	769,  // 1680: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
-	771,  // 1681: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
-	774,  // 1682: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
-	775,  // 1683: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
-	845,  // 1684: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
-	854,  // 1685: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
-	1185, // 1686: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
-	1186, // 1687: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
-	857,  // 1688: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
-	1135, // 1689: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
-	859,  // 1690: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	859,  // 1691: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	861,  // 1692: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
-	862,  // 1693: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
-	867,  // 1694: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
-	868,  // 1695: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
-	869,  // 1696: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
-	870,  // 1697: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
-	1135, // 1698: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
-	864,  // 1699: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
-	871,  // 1700: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
-	873,  // 1701: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
-	876,  // 1702: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
-	878,  // 1703: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
-	880,  // 1704: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
-	881,  // 1705: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
-	887,  // 1706: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
-	888,  // 1707: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
-	889,  // 1708: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
-	891,  // 1709: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
-	893,  // 1710: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
-	895,  // 1711: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
-	897,  // 1712: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
-	114,  // 1713: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
-	1060, // 1714: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
-	115,  // 1715: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
-	1060, // 1716: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
-	117,  // 1717: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
-	119,  // 1718: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	122,  // 1719: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
-	119,  // 1720: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	127,  // 1721: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	129,  // 1722: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
-	127,  // 1723: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	130,  // 1724: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
-	135,  // 1725: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
-	136,  // 1726: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
-	904,  // 1727: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
-	907,  // 1728: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
-	909,  // 1729: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
-	911,  // 1730: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
-	1187, // 1731: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
-	1188, // 1732: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
-	1189, // 1733: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
-	1190, // 1734: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
-	1191, // 1735: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
-	1192, // 1736: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
-	1193, // 1737: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
-	1194, // 1738: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
-	1195, // 1739: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
-	1196, // 1740: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
-	1197, // 1741: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
-	1198, // 1742: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
-	1199, // 1743: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
-	1200, // 1744: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
-	1201, // 1745: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
-	821,  // 1746: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
-	822,  // 1747: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
-	172,  // 1748: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	832,  // 1749: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
-	833,  // 1750: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
-	829,  // 1751: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
-	835,  // 1752: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
-	830,  // 1753: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
-	172,  // 1754: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	925,  // 1755: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
-	815,  // 1756: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
-	928,  // 1757: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
-	930,  // 1758: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
-	931,  // 1759: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
-	933,  // 1760: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
-	939,  // 1761: forge.Forge.FindPendingDPUServiceSyncIds:input_type -> forge.FindPendingDPUServiceSyncIdsRequest
-	940,  // 1762: forge.Forge.FindPendingDPUServiceSyncsByIds:input_type -> forge.FindPendingDPUServiceSyncsByIdsRequest
-	941,  // 1763: forge.Forge.ListDPUServiceSyncHistory:input_type -> forge.ListDPUServiceSyncHistoryRequest
-	936,  // 1764: forge.Forge.ReleaseDPUServiceSyncHold:input_type -> forge.ReleaseDPUServiceSyncHoldRequest
-	951,  // 1765: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
-	953,  // 1766: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
-	948,  // 1767: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
-	960,  // 1768: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
-	962,  // 1769: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
-	964,  // 1770: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
-	981,  // 1771: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
-	1082, // 1772: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
-	984,  // 1773: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
-	985,  // 1774: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
-	987,  // 1775: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
-	989,  // 1776: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
-	991,  // 1777: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	994,  // 1778: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	995,  // 1779: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
-	158,  // 1780: forge.Forge.Version:output_type -> forge.BuildInfo
-	1121, // 1781: forge.Forge.CreateDomain:output_type -> dns.Domain
-	1121, // 1782: forge.Forge.UpdateDomain:output_type -> dns.Domain
-	1202, // 1783: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
-	1203, // 1784: forge.Forge.FindDomain:output_type -> dns.DomainList
-	919,  // 1785: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
-	919,  // 1786: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
-	922,  // 1787: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
-	920,  // 1788: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
-	178,  // 1789: forge.Forge.CreateVpc:output_type -> forge.Vpc
-	181,  // 1790: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
-	183,  // 1791: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
-	185,  // 1792: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
-	170,  // 1793: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
-	186,  // 1794: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
-	969,  // 1795: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
-	972,  // 1796: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
-	970,  // 1797: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
-	974,  // 1798: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
-	187,  // 1799: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
-	193,  // 1800: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
-	194,  // 1801: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
-	187,  // 1802: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
-	197,  // 1803: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
-	1007, // 1804: forge.Forge.CreateSitePrefix:output_type -> forge.SitePrefix
-	1007, // 1805: forge.Forge.UpdateSitePrefix:output_type -> forge.SitePrefix
-	1014, // 1806: forge.Forge.DeleteSitePrefix:output_type -> forge.SitePrefixDeletionResult
-	1018, // 1807: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
-	1019, // 1808: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
-	199,  // 1809: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
-	200,  // 1810: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
-	201,  // 1811: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
-	206,  // 1812: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
-	279,  // 1813: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
-	393,  // 1814: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
-	271,  // 1815: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
-	271,  // 1816: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
-	275,  // 1817: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
-	393,  // 1818: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
-	217,  // 1819: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
-	210,  // 1820: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
-	209,  // 1821: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
-	209,  // 1822: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
-	214,  // 1823: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
-	210,  // 1824: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
-	221,  // 1825: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
-	946,  // 1826: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
-	221,  // 1827: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
-	224,  // 1828: forge.Forge.DecommissionPowerShelf:output_type -> forge.DecommissionPowerShelfResponse
-	226,  // 1829: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
-	979,  // 1830: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
-	1135, // 1831: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
-	244,  // 1832: forge.Forge.FindSwitches:output_type -> forge.SwitchList
-	945,  // 1833: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
-	244,  // 1834: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
-	247,  // 1835: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
-	249,  // 1836: forge.Forge.DecommissionSwitch:output_type -> forge.DecommissionSwitchResponse
-	977,  // 1837: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
-	267,  // 1838: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
-	320,  // 1839: forge.Forge.AllocateInstance:output_type -> forge.Instance
-	293,  // 1840: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
-	338,  // 1841: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
-	341,  // 1842: forge.Forge.ReleaseInstances:output_type -> forge.BatchInstanceReleaseResponse
-	320,  // 1843: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
-	320,  // 1844: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
-	289,  // 1845: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
-	285,  // 1846: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
-	285,  // 1847: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
-	414,  // 1848: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
-	1135, // 1849: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
-	494,  // 1850: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
-	1135, // 1851: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
-	1135, // 1852: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1853: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
-	1135, // 1854: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
-	1135, // 1855: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1856: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
-	1135, // 1857: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
-	1135, // 1858: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1859: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
-	1135, // 1860: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
-	1135, // 1861: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1862: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
-	1135, // 1863: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	1135, // 1864: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1865: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
-	1135, // 1866: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
-	1135, // 1867: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
-	431,  // 1868: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
-	433,  // 1869: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
-	1204, // 1870: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
-	1205, // 1871: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
-	1206, // 1872: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
-	284,  // 1873: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
-	460,  // 1874: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
-	467,  // 1875: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
-	466,  // 1876: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
-	468,  // 1877: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
-	469,  // 1878: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
-	471,  // 1879: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
-	392,  // 1880: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
-	391,  // 1881: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
-	360,  // 1882: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
-	362,  // 1883: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
-	365,  // 1884: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
-	355,  // 1885: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
-	1135, // 1886: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
-	535,  // 1887: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
-	1122, // 1888: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
-	356,  // 1889: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
-	345,  // 1890: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
-	348,  // 1891: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1892: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
-	348,  // 1893: forge.Forge.FindPowerShelfHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1894: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
-	348,  // 1895: forge.Forge.FindRackHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1896: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
-	348,  // 1897: forge.Forge.FindSwitchHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1898: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
-	254,  // 1899: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
-	254,  // 1900: forge.Forge.FindSitePrefixStateHistories:output_type -> forge.StateHistories
-	354,  // 1901: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
-	353,  // 1902: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
-	561,  // 1903: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
-	565,  // 1904: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
-	564,  // 1905: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
-	562,  // 1906: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
-	537,  // 1907: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
-	540,  // 1908: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
-	542,  // 1909: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
-	456,  // 1910: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
-	458,  // 1911: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
-	473,  // 1912: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
-	477,  // 1913: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
-	161,  // 1914: forge.Forge.Echo:output_type -> forge.EchoResponse
-	504,  // 1915: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
-	508,  // 1916: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
-	506,  // 1917: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
-	514,  // 1918: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
-	521,  // 1919: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
-	515,  // 1920: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
-	517,  // 1921: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
-	519,  // 1922: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
-	524,  // 1923: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
-	398,  // 1924: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
-	398,  // 1925: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
-	429,  // 1926: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
-	1207, // 1927: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
-	1208, // 1928: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
-	1135, // 1929: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
-	650,  // 1930: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
-	651,  // 1931: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
-	1123, // 1932: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
-	1135, // 1933: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
-	1209, // 1934: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
-	406,  // 1935: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
-	1135, // 1936: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
-	1210, // 1937: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
-	1211, // 1938: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
-	1212, // 1939: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
-	1213, // 1940: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
-	1214, // 1941: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
-	1215, // 1942: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
-	1135, // 1943: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
-	437,  // 1944: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
-	436,  // 1945: forge.Forge.DecommissionManagedHost:output_type -> forge.DecommissionManagedHostResponse
-	526,  // 1946: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
-	529,  // 1947: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
-	1135, // 1948: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
-	1135, // 1949: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
-	1135, // 1950: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
-	1135, // 1951: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
-	1135, // 1952: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
-	1135, // 1953: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
-	1135, // 1954: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
-	1135, // 1955: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
-	545,  // 1956: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
-	1135, // 1957: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
-	551,  // 1958: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
-	1135, // 1959: forge.Forge.TriggerBmcCredentialRotation:output_type -> google.protobuf.Empty
-	1135, // 1960: forge.Forge.TriggerUefiCredentialRotation:output_type -> google.protobuf.Empty
-	1135, // 1961: forge.Forge.TriggerNicLockdownCredentialRotation:output_type -> google.protobuf.Empty
-	1135, // 1962: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
-	1135, // 1963: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
-	557,  // 1964: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
-	559,  // 1965: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
-	1135, // 1966: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
-	1135, // 1967: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
-	1003, // 1968: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
-	570,  // 1969: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
-	570,  // 1970: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
-	150,  // 1971: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
-	151,  // 1972: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
-	153,  // 1973: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
-	156,  // 1974: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
-	1005, // 1975: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
-	1135, // 1976: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
-	572,  // 1977: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
-	1135, // 1978: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
-	1135, // 1979: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
-	1135, // 1980: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
-	1135, // 1981: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
-	333,  // 1982: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
-	575,  // 1983: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
-	577,  // 1984: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
-	579,  // 1985: forge.Forge.SetDpuUefiPassword:output_type -> forge.SetDpuUefiPasswordResponse
-	1135, // 1986: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
-	1135, // 1987: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
-	1135, // 1988: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
-	591,  // 1989: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
-	593,  // 1990: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
-	1135, // 1991: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
-	1135, // 1992: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
-	594,  // 1993: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
-	596,  // 1994: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
-	600,  // 1995: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	600,  // 1996: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	1135, // 1997: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1135, // 1998: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1135, // 1999: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
-	233,  // 2000: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
-	235,  // 2001: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
-	1135, // 2002: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	1135, // 2003: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	236,  // 2004: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
-	1135, // 2005: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
-	1135, // 2006: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
-	1135, // 2007: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
-	258,  // 2008: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
-	260,  // 2009: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
-	1135, // 2010: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
-	1135, // 2011: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
-	261,  // 2012: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
-	1135, // 2013: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
-	1135, // 2014: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
-	1135, // 2015: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
-	263,  // 2016: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
-	265,  // 2017: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
-	1135, // 2018: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
-	1135, // 2019: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
-	147,  // 2020: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
-	681,  // 2021: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
-	683,  // 2022: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
-	685,  // 2023: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
-	688,  // 2024: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
-	687,  // 2025: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
-	691,  // 2026: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
-	693,  // 2027: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
-	1216, // 2028: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
-	1217, // 2029: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
-	1218, // 2030: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
-	1219, // 2031: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
-	1220, // 2032: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1221, // 2033: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
-	1222, // 2034: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
-	1223, // 2035: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
-	1220, // 2036: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1224, // 2037: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
-	1225, // 2038: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
-	1226, // 2039: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
-	1227, // 2040: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
-	1228, // 2041: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
-	1229, // 2042: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
-	1230, // 2043: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
-	1231, // 2044: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
-	1232, // 2045: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
-	1233, // 2046: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
-	1234, // 2047: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
-	1235, // 2048: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
-	1236, // 2049: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
-	1237, // 2050: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
-	1238, // 2051: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
-	1239, // 2052: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
-	1240, // 2053: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
-	1241, // 2054: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
-	1242, // 2055: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
-	1243, // 2056: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
-	1244, // 2057: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
-	1245, // 2058: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
-	1246, // 2059: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
-	1247, // 2060: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
-	1248, // 2061: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
-	1249, // 2062: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
-	1250, // 2063: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
-	1251, // 2064: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
-	1252, // 2065: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
-	1253, // 2066: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
-	1254, // 2067: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
-	1255, // 2068: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
-	1256, // 2069: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
-	1257, // 2070: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
-	712,  // 2071: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
-	714,  // 2072: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
-	716,  // 2073: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
-	717,  // 2074: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
-	720,  // 2075: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
-	723,  // 2076: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
-	730,  // 2077: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
-	581,  // 2078: forge.Forge.CreateOsImage:output_type -> forge.OsImage
-	585,  // 2079: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
-	583,  // 2080: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
-	581,  // 2081: forge.Forge.GetOsImage:output_type -> forge.OsImage
-	581,  // 2082: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
-	296,  // 2083: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
-	588,  // 2084: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
-	601,  // 2085: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
-	1135, // 2086: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
-	608,  // 2087: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
-	605,  // 2088: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
-	613,  // 2089: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
-	616,  // 2090: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
-	618,  // 2091: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
-	1135, // 2092: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	639,  // 2093: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
-	642,  // 2094: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
-	644,  // 2095: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
-	647,  // 2096: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
-	649,  // 2097: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
-	1135, // 2098: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	656,  // 2099: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
-	655,  // 2100: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	655,  // 2101: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	658,  // 2102: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
-	663,  // 2103: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
-	666,  // 2104: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
-	662,  // 2105: forge.Forge.MachineValidationTestApproveFullHost:output_type -> forge.MachineValidationTestFullHostApprovalResponse
-	668,  // 2106: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
-	450,  // 2107: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
-	634,  // 2108: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
-	636,  // 2109: forge.Forge.AdminGpuReset:output_type -> forge.AdminGpuResetResponse
-	438,  // 2110: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
-	440,  // 2111: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
-	1258, // 2112: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
-	444,  // 2113: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
-	446,  // 2114: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
-	838,  // 2115: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
-	840,  // 2116: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
-	842,  // 2117: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
-	844,  // 2118: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
-	452,  // 2119: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
-	454,  // 2120: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
-	622,  // 2121: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
-	630,  // 2122: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
-	632,  // 2123: forge.Forge.TerminateRackMaintenance:output_type -> forge.RackMaintenanceTerminateResponse
-	138,  // 2124: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
-	144,  // 2125: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
-	141,  // 2126: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
-	1135, // 2127: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
-	695,  // 2128: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
-	697,  // 2129: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
-	702,  // 2130: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
-	704,  // 2131: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
-	705,  // 2132: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
-	706,  // 2133: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
-	708,  // 2134: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
-	732,  // 2135: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
-	853,  // 2136: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
-	1135, // 2137: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
-	748,  // 2138: forge.Forge.CreateSku:output_type -> forge.SkuIdList
-	744,  // 2139: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
-	1135, // 2140: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
-	1135, // 2141: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
-	1135, // 2142: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
-	1135, // 2143: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
-	748,  // 2144: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
-	747,  // 2145: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
-	1135, // 2146: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
-	744,  // 2147: forge.Forge.ReplaceSku:output_type -> forge.Sku
-	418,  // 2148: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
-	420,  // 2149: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
-	422,  // 2150: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
-	1135, // 2151: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
-	1135, // 2152: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
-	754,  // 2153: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
-	756,  // 2154: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
-	752,  // 2155: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
-	752,  // 2156: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
-	759,  // 2157: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
-	764,  // 2158: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
-	764,  // 2159: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
-	1135, // 2160: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
-	137,  // 2161: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
-	782,  // 2162: forge.Forge.FindRackIds:output_type -> forge.RackIdList
-	780,  // 2163: forge.Forge.FindRacksByIds:output_type -> forge.RackList
-	779,  // 2164: forge.Forge.GetRack:output_type -> forge.GetRackResponse
-	1135, // 2165: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
-	791,  // 2166: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
-	798,  // 2167: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
-	800,  // 2168: forge.Forge.ListRackProfiles:output_type -> forge.ListRackProfilesResponse
-	768,  // 2169: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
-	770,  // 2170: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
-	772,  // 2171: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
-	773,  // 2172: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
-	776,  // 2173: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
-	846,  // 2174: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
-	855,  // 2175: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
-	1259, // 2176: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
-	1260, // 2177: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
-	858,  // 2178: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
-	860,  // 2179: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
-	859,  // 2180: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	859,  // 2181: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	1135, // 2182: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
-	863,  // 2183: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
-	1135, // 2184: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
-	1135, // 2185: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
-	1135, // 2186: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
-	1135, // 2187: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
-	864,  // 2188: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
-	865,  // 2189: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
-	872,  // 2190: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
-	875,  // 2191: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
-	877,  // 2192: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
-	1135, // 2193: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
-	1135, // 2194: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
-	1135, // 2195: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
-	886,  // 2196: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
-	886,  // 2197: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
-	890,  // 2198: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
-	892,  // 2199: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
-	894,  // 2200: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
-	896,  // 2201: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
-	898,  // 2202: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
-	111,  // 2203: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
-	1135, // 2204: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
-	116,  // 2205: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
-	113,  // 2206: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
-	118,  // 2207: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
-	123,  // 2208: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	123,  // 2209: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	1135, // 2210: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
-	126,  // 2211: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	126,  // 2212: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	1135, // 2213: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
-	132,  // 2214: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
-	133,  // 2215: forge.Forge.GetJWKS:output_type -> forge.Jwks
-	134,  // 2216: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
-	905,  // 2217: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
-	908,  // 2218: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
-	910,  // 2219: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
-	912,  // 2220: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
-	1261, // 2221: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
-	1262, // 2222: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
-	1263, // 2223: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
-	1264, // 2224: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
-	1265, // 2225: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
-	1266, // 2226: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
-	1267, // 2227: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
-	1268, // 2228: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
-	1269, // 2229: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
-	1270, // 2230: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
-	1271, // 2231: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
-	1272, // 2232: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
-	1273, // 2233: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
-	1274, // 2234: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
-	1275, // 2235: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
-	823,  // 2236: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
-	818,  // 2237: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
-	818,  // 2238: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
-	834,  // 2239: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
-	828,  // 2240: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
-	827,  // 2241: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
-	836,  // 2242: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
-	831,  // 2243: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
-	828,  // 2244: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
-	926,  // 2245: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
-	816,  // 2246: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
-	1135, // 2247: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
-	929,  // 2248: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
-	932,  // 2249: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
-	935,  // 2250: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
-	1122, // 2251: forge.Forge.FindPendingDPUServiceSyncIds:output_type -> common.MachineIdList
-	943,  // 2252: forge.Forge.FindPendingDPUServiceSyncsByIds:output_type -> forge.ListPendingDPUServiceSyncsResponse
-	943,  // 2253: forge.Forge.ListDPUServiceSyncHistory:output_type -> forge.ListPendingDPUServiceSyncsResponse
-	938,  // 2254: forge.Forge.ReleaseDPUServiceSyncHold:output_type -> forge.ReleaseDPUServiceSyncHoldResponse
-	952,  // 2255: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
-	954,  // 2256: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
-	950,  // 2257: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
-	961,  // 2258: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
-	963,  // 2259: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
-	967,  // 2260: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
-	980,  // 2261: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
-	980,  // 2262: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
-	980,  // 2263: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
-	986,  // 2264: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
-	988,  // 2265: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
-	990,  // 2266: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
-	992,  // 2267: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	992,  // 2268: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	996,  // 2269: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
-	1780, // [1780:2270] is the sub-list for method output_type
-	1290, // [1290:1780] is the sub-list for method input_type
-	1290, // [1290:1290] is the sub-list for extension type_name
-	1290, // [1290:1290] is the sub-list for extension extendee
-	0,    // [0:1290] is the sub-list for field type_name
+	947,  // 1145: forge.GetComponentInventoryRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	944,  // 1146: forge.ComponentInventoryEntry.result:type_name -> forge.ComponentResult
+	1123, // 1147: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
+	949,  // 1148: forge.GetComponentInventoryResponse.entries:type_name -> forge.ComponentInventoryEntry
+	1122, // 1149: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
+	945,  // 1150: forge.ComponentPowerControlRequest.switch_ids:type_name -> forge.SwitchIdList
+	946,  // 1151: forge.ComponentPowerControlRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	947,  // 1152: forge.ComponentPowerControlRequest.compute_bmc_macs:type_name -> forge.MacAddressList
+	947,  // 1153: forge.ComponentPowerControlRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	1124, // 1154: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
+	944,  // 1155: forge.ComponentPowerControlResponse.results:type_name -> forge.ComponentResult
+	945,  // 1156: forge.ComponentConfigureSwitchCertificateRequest.switch_ids:type_name -> forge.SwitchIdList
+	944,  // 1157: forge.ComponentConfigureSwitchCertificateResponse.results:type_name -> forge.ComponentResult
+	944,  // 1158: forge.FirmwareUpdateStatus.result:type_name -> forge.ComponentResult
+	81,   // 1159: forge.FirmwareUpdateStatus.state:type_name -> forge.FirmwareUpdateState
+	1061, // 1160: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
+	1122, // 1161: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
+	84,   // 1162: forge.UpdateComputeTrayFirmwareTarget.components:type_name -> forge.ComputeTrayComponent
+	947,  // 1163: forge.UpdateComputeTrayFirmwareTarget.bmc_macs:type_name -> forge.MacAddressList
+	945,  // 1164: forge.UpdateSwitchFirmwareTarget.switch_ids:type_name -> forge.SwitchIdList
+	82,   // 1165: forge.UpdateSwitchFirmwareTarget.components:type_name -> forge.NvSwitchComponent
+	947,  // 1166: forge.UpdateSwitchFirmwareTarget.bmc_macs:type_name -> forge.MacAddressList
+	946,  // 1167: forge.UpdatePowerShelfFirmwareTarget.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	83,   // 1168: forge.UpdatePowerShelfFirmwareTarget.components:type_name -> forge.PowerShelfComponent
+	782,  // 1169: forge.UpdateFirmwareObjectTarget.rack_ids:type_name -> forge.RackIdList
+	956,  // 1170: forge.UpdateComponentFirmwareRequest.compute_trays:type_name -> forge.UpdateComputeTrayFirmwareTarget
+	957,  // 1171: forge.UpdateComponentFirmwareRequest.switches:type_name -> forge.UpdateSwitchFirmwareTarget
+	958,  // 1172: forge.UpdateComponentFirmwareRequest.power_shelves:type_name -> forge.UpdatePowerShelfFirmwareTarget
+	959,  // 1173: forge.UpdateComponentFirmwareRequest.racks:type_name -> forge.UpdateFirmwareObjectTarget
+	944,  // 1174: forge.UpdateComponentFirmwareResponse.results:type_name -> forge.ComponentResult
+	1122, // 1175: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
+	945,  // 1176: forge.GetComponentFirmwareStatusRequest.switch_ids:type_name -> forge.SwitchIdList
+	946,  // 1177: forge.GetComponentFirmwareStatusRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	782,  // 1178: forge.GetComponentFirmwareStatusRequest.rack_ids:type_name -> forge.RackIdList
+	947,  // 1179: forge.GetComponentFirmwareStatusRequest.compute_bmc_macs:type_name -> forge.MacAddressList
+	947,  // 1180: forge.GetComponentFirmwareStatusRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	955,  // 1181: forge.GetComponentFirmwareStatusResponse.statuses:type_name -> forge.FirmwareUpdateStatus
+	1122, // 1182: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
+	945,  // 1183: forge.ListComponentFirmwareVersionsRequest.switch_ids:type_name -> forge.SwitchIdList
+	946,  // 1184: forge.ListComponentFirmwareVersionsRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	782,  // 1185: forge.ListComponentFirmwareVersionsRequest.rack_ids:type_name -> forge.RackIdList
+	947,  // 1186: forge.ListComponentFirmwareVersionsRequest.compute_bmc_macs:type_name -> forge.MacAddressList
+	947,  // 1187: forge.ListComponentFirmwareVersionsRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	84,   // 1188: forge.ComputeTrayFirmwareVersions.component:type_name -> forge.ComputeTrayComponent
+	944,  // 1189: forge.DeviceFirmwareVersions.result:type_name -> forge.ComponentResult
+	965,  // 1190: forge.DeviceFirmwareVersions.compute_fw_versions:type_name -> forge.ComputeTrayFirmwareVersions
+	966,  // 1191: forge.ListComponentFirmwareVersionsResponse.devices:type_name -> forge.DeviceFirmwareVersions
+	287,  // 1192: forge.SpxPartitionCreationRequest.metadata:type_name -> forge.Metadata
+	1083, // 1193: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
+	287,  // 1194: forge.SpxPartition.metadata:type_name -> forge.Metadata
+	1083, // 1195: forge.SpxPartition.id:type_name -> common.SpxPartitionId
+	1083, // 1196: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
+	1083, // 1197: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
+	286,  // 1198: forge.SpxPartitionSearchFilter.label:type_name -> forge.Label
+	969,  // 1199: forge.SpxPartitionList.spx_partitions:type_name -> forge.SpxPartition
+	1083, // 1200: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
+	1074, // 1201: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
+	1071, // 1202: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1082, // 1203: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
+	85,   // 1204: forge.OperatingSystem.type:type_name -> forge.OperatingSystemType
+	9,    // 1205: forge.OperatingSystem.status:type_name -> forge.TenantState
+	1081, // 1206: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
+	294,  // 1207: forge.OperatingSystem.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
+	295,  // 1208: forge.OperatingSystem.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
+	1082, // 1209: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1081, // 1210: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	294,  // 1211: forge.CreateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
+	295,  // 1212: forge.CreateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
+	294,  // 1213: forge.IpxeTemplateParameters.items:type_name -> forge.IpxeTemplateParameter
+	295,  // 1214: forge.IpxeTemplateArtifacts.items:type_name -> forge.IpxeTemplateArtifact
+	1082, // 1215: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1081, // 1216: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	982,  // 1217: forge.UpdateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameters
+	983,  // 1218: forge.UpdateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifacts
+	1082, // 1219: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1082, // 1220: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
+	1082, // 1221: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
+	980,  // 1222: forge.OperatingSystemList.operating_systems:type_name -> forge.OperatingSystem
+	1082, // 1223: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
+	295,  // 1224: forge.IpxeTemplateArtifactList.artifacts:type_name -> forge.IpxeTemplateArtifact
+	1082, // 1225: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
+	993,  // 1226: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.updates:type_name -> forge.IpxeTemplateArtifactUpdateRequest
+	1060, // 1227: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
+	1084, // 1228: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
+	1061, // 1229: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
+	1060, // 1230: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
+	999,  // 1231: forge.GetMachineBootInterfacesResponse.machine_interfaces:type_name -> forge.MachineInterfaceBootInterface
+	1000, // 1232: forge.GetMachineBootInterfacesResponse.predicted_interfaces:type_name -> forge.PredictedBootInterface
+	1001, // 1233: forge.GetMachineBootInterfacesResponse.explored_endpoints:type_name -> forge.ExploredBootInterface
+	1002, // 1234: forge.GetMachineBootInterfacesResponse.retained_interfaces:type_name -> forge.RetainedBootInterface
+	998,  // 1235: forge.GetMachineBootInterfacesResponse.default_boot_interface:type_name -> forge.MachineBootInterface
+	998,  // 1236: forge.GetMachineBootInterfacesResponse.predicted_boot_interface:type_name -> forge.MachineBootInterface
+	1059, // 1237: forge.GetMachineBootInterfacesResponse.reconciliation:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation
+	1067, // 1238: forge.SitePrefix.id:type_name -> common.SitePrefixId
+	1008, // 1239: forge.SitePrefix.config:type_name -> forge.SitePrefixConfig
+	1009, // 1240: forge.SitePrefix.status:type_name -> forge.SitePrefixStatus
+	287,  // 1241: forge.SitePrefix.metadata:type_name -> forge.Metadata
+	1061, // 1242: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
+	1061, // 1243: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
+	90,   // 1244: forge.SitePrefixConfig.routing_scope:type_name -> forge.SitePrefixRoutingScope
+	89,   // 1245: forge.SitePrefixStatus.authority:type_name -> forge.SitePrefixAuthority
+	91,   // 1246: forge.SitePrefixStatus.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
+	1010, // 1247: forge.SitePrefixStatus.quota:type_name -> forge.SitePrefixQuotaUsage
+	1067, // 1248: forge.SitePrefixCreationRequest.id:type_name -> common.SitePrefixId
+	287,  // 1249: forge.SitePrefixCreationRequest.metadata:type_name -> forge.Metadata
+	1067, // 1250: forge.SitePrefixUpdateRequest.id:type_name -> common.SitePrefixId
+	287,  // 1251: forge.SitePrefixUpdateRequest.metadata:type_name -> forge.Metadata
+	1067, // 1252: forge.SitePrefixDeletionRequest.id:type_name -> common.SitePrefixId
+	1007, // 1253: forge.SitePrefixDeletionResult.site_prefix:type_name -> forge.SitePrefix
+	1067, // 1254: forge.SitePrefixStateHistoriesRequest.site_prefix_ids:type_name -> common.SitePrefixId
+	89,   // 1255: forge.SitePrefixSearchFilter.authority:type_name -> forge.SitePrefixAuthority
+	90,   // 1256: forge.SitePrefixSearchFilter.routing_scope:type_name -> forge.SitePrefixRoutingScope
+	91,   // 1257: forge.SitePrefixSearchFilter.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
+	8,    // 1258: forge.SitePrefixSearchFilter.prefix_match_type:type_name -> forge.PrefixMatchType
+	1067, // 1259: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
+	1067, // 1260: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
+	1007, // 1261: forge.SitePrefixList.site_prefixes:type_name -> forge.SitePrefix
+	30,   // 1262: forge.InterfaceAddressConfig.address_family:type_name -> forge.AddressFamily
+	1024, // 1263: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
+	251,  // 1264: forge.StateHistories.HistoriesEntry.value:type_name -> forge.StateHistoryRecords
+	346,  // 1265: forge.MachineStateHistories.HistoriesEntry.value:type_name -> forge.MachineStateHistoryRecords
+	349,  // 1266: forge.HealthHistories.HistoriesEntry.value:type_name -> forge.HealthHistoryRecords
+	96,   // 1267: forge.MachineCredentialsUpdateRequest.Credentials.credential_purpose:type_name -> forge.MachineCredentialsUpdateRequest.CredentialPurpose
+	1048, // 1268: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
+	1090, // 1269: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
+	1039, // 1270: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
+	1087, // 1271: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
+	1041, // 1272: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
+	1042, // 1273: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
+	1043, // 1274: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
+	1044, // 1275: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
+	1045, // 1276: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
+	1046, // 1277: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
+	1125, // 1278: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
+	1126, // 1279: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
+	1127, // 1280: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
+	98,   // 1281: forge.MachineCleanupInfo.CleanupStepResult.result:type_name -> forge.MachineCleanupInfo.CleanupResult
+	1060, // 1282: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
+	1061, // 1283: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1061, // 1284: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	1060, // 1285: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
+	1061, // 1286: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1061, // 1287: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	660,  // 1288: forge.MachineValidationTestUpdateRequest.Payload.plugin:type_name -> forge.MachineValidationPlugin
+	1060, // 1289: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
+	998,  // 1290: forge.GetMachineBootInterfacesResponse.Reconciliation.desired_boot_interface:type_name -> forge.MachineBootInterface
+	1061, // 1291: forge.GetMachineBootInterfacesResponse.Reconciliation.observed_at:type_name -> google.protobuf.Timestamp
+	108,  // 1292: forge.GetMachineBootInterfacesResponse.Reconciliation.reconciliation_state:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation.State
+	88,   // 1293: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_source:type_name -> forge.BootInterfaceSelectionSource
+	1061, // 1294: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_updated_at:type_name -> google.protobuf.Timestamp
+	157,  // 1295: forge.Forge.Version:input_type -> forge.VersionRequest
+	1128, // 1296: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
+	1129, // 1297: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
+	1130, // 1298: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
+	1131, // 1299: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
+	919,  // 1300: forge.Forge.CreateDomainLegacy:input_type -> forge.DomainLegacy
+	919,  // 1301: forge.Forge.UpdateDomainLegacy:input_type -> forge.DomainLegacy
+	921,  // 1302: forge.Forge.DeleteDomainLegacy:input_type -> forge.DomainDeletionLegacy
+	923,  // 1303: forge.Forge.FindDomainLegacy:input_type -> forge.DomainSearchQueryLegacy
+	179,  // 1304: forge.Forge.CreateVpc:input_type -> forge.VpcCreationRequest
+	180,  // 1305: forge.Forge.UpdateVpc:input_type -> forge.VpcUpdateRequest
+	182,  // 1306: forge.Forge.UpdateVpcVirtualization:input_type -> forge.VpcUpdateVirtualizationRequest
+	184,  // 1307: forge.Forge.DeleteVpc:input_type -> forge.VpcDeletionRequest
+	169,  // 1308: forge.Forge.FindVpcIds:input_type -> forge.VpcSearchFilter
+	171,  // 1309: forge.Forge.FindVpcsByIds:input_type -> forge.VpcsByIdsRequest
+	968,  // 1310: forge.Forge.CreateSpxPartition:input_type -> forge.SpxPartitionCreationRequest
+	971,  // 1311: forge.Forge.DeleteSpxPartition:input_type -> forge.SpxPartitionDeletionRequest
+	973,  // 1312: forge.Forge.FindSpxPartitionIds:input_type -> forge.SpxPartitionSearchFilter
+	975,  // 1313: forge.Forge.FindSpxPartitionsByIds:input_type -> forge.SpxPartitionsByIdsRequest
+	190,  // 1314: forge.Forge.CreateVpcPrefix:input_type -> forge.VpcPrefixCreationRequest
+	191,  // 1315: forge.Forge.SearchVpcPrefixes:input_type -> forge.VpcPrefixSearchQuery
+	192,  // 1316: forge.Forge.GetVpcPrefixes:input_type -> forge.VpcPrefixGetRequest
+	195,  // 1317: forge.Forge.UpdateVpcPrefix:input_type -> forge.VpcPrefixUpdateRequest
+	196,  // 1318: forge.Forge.DeleteVpcPrefix:input_type -> forge.VpcPrefixDeletionRequest
+	1011, // 1319: forge.Forge.CreateSitePrefix:input_type -> forge.SitePrefixCreationRequest
+	1012, // 1320: forge.Forge.UpdateSitePrefix:input_type -> forge.SitePrefixUpdateRequest
+	1013, // 1321: forge.Forge.DeleteSitePrefix:input_type -> forge.SitePrefixDeletionRequest
+	1016, // 1322: forge.Forge.FindSitePrefixIds:input_type -> forge.SitePrefixSearchFilter
+	1017, // 1323: forge.Forge.FindSitePrefixesByIds:input_type -> forge.SitePrefixesByIdsRequest
+	202,  // 1324: forge.Forge.CreateVpcPeering:input_type -> forge.VpcPeeringCreationRequest
+	203,  // 1325: forge.Forge.FindVpcPeeringIds:input_type -> forge.VpcPeeringSearchFilter
+	204,  // 1326: forge.Forge.FindVpcPeeringsByIds:input_type -> forge.VpcPeeringsByIdsRequest
+	205,  // 1327: forge.Forge.DeleteVpcPeering:input_type -> forge.VpcPeeringDeletionRequest
+	278,  // 1328: forge.Forge.FindNetworkSegmentIds:input_type -> forge.NetworkSegmentSearchFilter
+	280,  // 1329: forge.Forge.FindNetworkSegmentsByIds:input_type -> forge.NetworkSegmentsByIdsRequest
+	272,  // 1330: forge.Forge.CreateNetworkSegment:input_type -> forge.NetworkSegmentCreationRequest
+	274,  // 1331: forge.Forge.AttachNetworkSegmentToVpc:input_type -> forge.AttachNetworkSegmentToVpcRequest
+	273,  // 1332: forge.Forge.DeleteNetworkSegment:input_type -> forge.NetworkSegmentDeletionRequest
+	168,  // 1333: forge.Forge.NetworkSegmentsForVpc:input_type -> forge.VpcSearchQuery
+	215,  // 1334: forge.Forge.FindIBPartitionIds:input_type -> forge.IBPartitionSearchFilter
+	216,  // 1335: forge.Forge.FindIBPartitionsByIds:input_type -> forge.IBPartitionsByIdsRequest
+	211,  // 1336: forge.Forge.CreateIBPartition:input_type -> forge.IBPartitionCreationRequest
+	212,  // 1337: forge.Forge.UpdateIBPartition:input_type -> forge.IBPartitionUpdateRequest
+	213,  // 1338: forge.Forge.DeleteIBPartition:input_type -> forge.IBPartitionDeletionRequest
+	172,  // 1339: forge.Forge.IBPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	230,  // 1340: forge.Forge.FindPowerShelves:input_type -> forge.PowerShelfQuery
+	231,  // 1341: forge.Forge.FindPowerShelfIds:input_type -> forge.PowerShelfSearchFilter
+	232,  // 1342: forge.Forge.FindPowerShelvesByIds:input_type -> forge.PowerShelvesByIdsRequest
+	223,  // 1343: forge.Forge.DecommissionPowerShelf:input_type -> forge.DecommissionPowerShelfRequest
+	225,  // 1344: forge.Forge.DeletePowerShelf:input_type -> forge.PowerShelfDeletionRequest
+	978,  // 1345: forge.Forge.AdminForceDeletePowerShelf:input_type -> forge.AdminForceDeletePowerShelfRequest
+	227,  // 1346: forge.Forge.SetPowerShelfMaintenance:input_type -> forge.PowerShelfMaintenanceRequest
+	255,  // 1347: forge.Forge.FindSwitches:input_type -> forge.SwitchQuery
+	256,  // 1348: forge.Forge.FindSwitchIds:input_type -> forge.SwitchSearchFilter
+	257,  // 1349: forge.Forge.FindSwitchesByIds:input_type -> forge.SwitchesByIdsRequest
+	246,  // 1350: forge.Forge.DeleteSwitch:input_type -> forge.SwitchDeletionRequest
+	248,  // 1351: forge.Forge.DecommissionSwitch:input_type -> forge.DecommissionSwitchRequest
+	976,  // 1352: forge.Forge.AdminForceDeleteSwitch:input_type -> forge.AdminForceDeleteSwitchRequest
+	266,  // 1353: forge.Forge.FindIBFabricIds:input_type -> forge.IBFabricSearchFilter
+	291,  // 1354: forge.Forge.AllocateInstance:input_type -> forge.InstanceAllocationRequest
+	292,  // 1355: forge.Forge.AllocateInstances:input_type -> forge.BatchInstanceAllocationRequest
+	337,  // 1356: forge.Forge.ReleaseInstance:input_type -> forge.InstanceReleaseRequest
+	339,  // 1357: forge.Forge.ReleaseInstances:input_type -> forge.BatchInstanceReleaseRequest
+	309,  // 1358: forge.Forge.UpdateInstanceOperatingSystem:input_type -> forge.InstanceOperatingSystemUpdateRequest
+	310,  // 1359: forge.Forge.UpdateInstanceConfig:input_type -> forge.InstanceConfigUpdateRequest
+	288,  // 1360: forge.Forge.FindInstanceIds:input_type -> forge.InstanceSearchFilter
+	290,  // 1361: forge.Forge.FindInstancesByIds:input_type -> forge.InstancesByIdsRequest
+	1060, // 1362: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
+	413,  // 1363: forge.Forge.GetManagedHostNetworkConfig:input_type -> forge.ManagedHostNetworkConfigRequest
+	478,  // 1364: forge.Forge.RecordDpuNetworkStatus:input_type -> forge.DpuNetworkStatus
+	1060, // 1365: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
+	484,  // 1366: forge.Forge.InsertMachineHealthReport:input_type -> forge.InsertMachineHealthReportRequest
+	495,  // 1367: forge.Forge.RemoveMachineHealthReport:input_type -> forge.RemoveMachineHealthReportRequest
+	487,  // 1368: forge.Forge.ListRackHealthReports:input_type -> forge.ListRackHealthReportsRequest
+	485,  // 1369: forge.Forge.InsertRackHealthReport:input_type -> forge.InsertRackHealthReportRequest
+	486,  // 1370: forge.Forge.RemoveRackHealthReport:input_type -> forge.RemoveRackHealthReportRequest
+	490,  // 1371: forge.Forge.ListSwitchHealthReports:input_type -> forge.ListSwitchHealthReportsRequest
+	488,  // 1372: forge.Forge.InsertSwitchHealthReport:input_type -> forge.InsertSwitchHealthReportRequest
+	489,  // 1373: forge.Forge.RemoveSwitchHealthReport:input_type -> forge.RemoveSwitchHealthReportRequest
+	493,  // 1374: forge.Forge.ListPowerShelfHealthReports:input_type -> forge.ListPowerShelfHealthReportsRequest
+	491,  // 1375: forge.Forge.InsertPowerShelfHealthReport:input_type -> forge.InsertPowerShelfHealthReportRequest
+	492,  // 1376: forge.Forge.RemovePowerShelfHealthReport:input_type -> forge.RemovePowerShelfHealthReportRequest
+	496,  // 1377: forge.Forge.ListNVLinkDomainHealthReports:input_type -> forge.ListNVLinkDomainHealthReportsRequest
+	497,  // 1378: forge.Forge.InsertNVLinkDomainHealthReport:input_type -> forge.InsertNVLinkDomainHealthReportRequest
+	498,  // 1379: forge.Forge.RemoveNVLinkDomainHealthReport:input_type -> forge.RemoveNVLinkDomainHealthReportRequest
+	1060, // 1380: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
+	484,  // 1381: forge.Forge.InsertHealthReportOverride:input_type -> forge.InsertMachineHealthReportRequest
+	495,  // 1382: forge.Forge.RemoveHealthReportOverride:input_type -> forge.RemoveMachineHealthReportRequest
+	430,  // 1383: forge.Forge.DpuAgentUpgradeCheck:input_type -> forge.DpuAgentUpgradeCheckRequest
+	432,  // 1384: forge.Forge.DpuAgentUpgradePolicyAction:input_type -> forge.DpuAgentUpgradePolicyRequest
+	1132, // 1385: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
+	1133, // 1386: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
+	1134, // 1387: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
+	283,  // 1388: forge.Forge.InvokeInstancePower:input_type -> forge.InstancePowerRequest
+	459,  // 1389: forge.Forge.ForgeAgentControl:input_type -> forge.ForgeAgentControlRequest
+	461,  // 1390: forge.Forge.DiscoverMachine:input_type -> forge.MachineDiscoveryInfo
+	465,  // 1391: forge.Forge.RenewMachineCertificate:input_type -> forge.MachineCertificateRenewRequest
+	462,  // 1392: forge.Forge.DiscoveryCompleted:input_type -> forge.MachineDiscoveryCompletedRequest
+	463,  // 1393: forge.Forge.CleanupMachineCompleted:input_type -> forge.MachineCleanupInfo
+	470,  // 1394: forge.Forge.ReportForgeScoutError:input_type -> forge.ForgeScoutErrorReport
+	389,  // 1395: forge.Forge.DiscoverDhcp:input_type -> forge.DhcpDiscovery
+	390,  // 1396: forge.Forge.ExpireDhcpLease:input_type -> forge.ExpireDhcpLeaseRequest
+	359,  // 1397: forge.Forge.AssignStaticAddress:input_type -> forge.AssignStaticAddressRequest
+	361,  // 1398: forge.Forge.RemoveStaticAddress:input_type -> forge.RemoveStaticAddressRequest
+	363,  // 1399: forge.Forge.FindInterfaceAddresses:input_type -> forge.FindInterfaceAddressesRequest
+	358,  // 1400: forge.Forge.FindInterfaces:input_type -> forge.InterfaceSearchQuery
+	357,  // 1401: forge.Forge.DeleteInterface:input_type -> forge.InterfaceDeleteQuery
+	534,  // 1402: forge.Forge.FindIpAddress:input_type -> forge.FindIpAddressRequest
+	343,  // 1403: forge.Forge.FindMachineIds:input_type -> forge.MachineSearchConfig
+	342,  // 1404: forge.Forge.FindMachinesByIds:input_type -> forge.MachinesByIdsRequest
+	344,  // 1405: forge.Forge.FindMachineStateHistories:input_type -> forge.MachineStateHistoriesRequest
+	347,  // 1406: forge.Forge.FindMachineHealthHistories:input_type -> forge.MachineHealthHistoriesRequest
+	228,  // 1407: forge.Forge.FindPowerShelfStateHistories:input_type -> forge.PowerShelfStateHistoriesRequest
+	229,  // 1408: forge.Forge.FindPowerShelfHealthHistories:input_type -> forge.PowerShelfHealthHistoriesRequest
+	787,  // 1409: forge.Forge.FindRackStateHistories:input_type -> forge.RackStateHistoriesRequest
+	788,  // 1410: forge.Forge.FindRackHealthHistories:input_type -> forge.RackHealthHistoriesRequest
+	252,  // 1411: forge.Forge.FindSwitchStateHistories:input_type -> forge.SwitchStateHistoriesRequest
+	253,  // 1412: forge.Forge.FindSwitchHealthHistories:input_type -> forge.SwitchHealthHistoriesRequest
+	276,  // 1413: forge.Forge.FindNetworkSegmentStateHistories:input_type -> forge.NetworkSegmentStateHistoriesRequest
+	198,  // 1414: forge.Forge.FindVpcPrefixStateHistories:input_type -> forge.VpcPrefixStateHistoriesRequest
+	1015, // 1415: forge.Forge.FindSitePrefixStateHistories:input_type -> forge.SitePrefixStateHistoriesRequest
+	352,  // 1416: forge.Forge.FindTenantOrganizationIds:input_type -> forge.TenantSearchFilter
+	351,  // 1417: forge.Forge.FindTenantsByOrganizationIds:input_type -> forge.TenantByOrganizationIdsRequest
+	1122, // 1418: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
+	562,  // 1419: forge.Forge.FindMachineIdsByBmcIps:input_type -> forge.BmcIpList
+	563,  // 1420: forge.Forge.FindMacAddressByBmcIp:input_type -> forge.BmcIp
+	538,  // 1421: forge.Forge.FindBmcIps:input_type -> forge.FindBmcIpsRequest
+	536,  // 1422: forge.Forge.IdentifyUuid:input_type -> forge.IdentifyUuidRequest
+	539,  // 1423: forge.Forge.IdentifyMac:input_type -> forge.IdentifyMacRequest
+	541,  // 1424: forge.Forge.IdentifySerial:input_type -> forge.IdentifySerialRequest
+	455,  // 1425: forge.Forge.GetBMCMetaData:input_type -> forge.BMCMetaDataGetRequest
+	457,  // 1426: forge.Forge.UpdateMachineCredentials:input_type -> forge.MachineCredentialsUpdateRequest
+	472,  // 1427: forge.Forge.GetPxeInstructions:input_type -> forge.PxeInstructionRequest
+	476,  // 1428: forge.Forge.GetCloudInitInstructions:input_type -> forge.CloudInitInstructionsRequest
+	160,  // 1429: forge.Forge.Echo:input_type -> forge.EchoRequest
+	503,  // 1430: forge.Forge.CreateTenant:input_type -> forge.CreateTenantRequest
+	507,  // 1431: forge.Forge.FindTenant:input_type -> forge.FindTenantRequest
+	505,  // 1432: forge.Forge.UpdateTenant:input_type -> forge.UpdateTenantRequest
+	513,  // 1433: forge.Forge.CreateTenantKeyset:input_type -> forge.CreateTenantKeysetRequest
+	520,  // 1434: forge.Forge.FindTenantKeysetIds:input_type -> forge.TenantKeysetSearchFilter
+	522,  // 1435: forge.Forge.FindTenantKeysetsByIds:input_type -> forge.TenantKeysetsByIdsRequest
+	516,  // 1436: forge.Forge.UpdateTenantKeyset:input_type -> forge.UpdateTenantKeysetRequest
+	518,  // 1437: forge.Forge.DeleteTenantKeyset:input_type -> forge.DeleteTenantKeysetRequest
+	523,  // 1438: forge.Forge.ValidateTenantPublicKey:input_type -> forge.ValidateTenantPublicKeyRequest
+	396,  // 1439: forge.Forge.GetBmcCredentials:input_type -> forge.GetBmcCredentialsRequest
+	397,  // 1440: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
+	428,  // 1441: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
+	400,  // 1442: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
+	1135, // 1443: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
+	401,  // 1444: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
+	407,  // 1445: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
+	407,  // 1446: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
+	407,  // 1447: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
+	402,  // 1448: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
+	403,  // 1449: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
+	404,  // 1450: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
+	405,  // 1451: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
+	1136, // 1452: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
+	1137, // 1453: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
+	1138, // 1454: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
+	1139, // 1455: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
+	1140, // 1456: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
+	1141, // 1457: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
+	411,  // 1458: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
+	434,  // 1459: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
+	435,  // 1460: forge.Forge.DecommissionManagedHost:input_type -> forge.DecommissionManagedHostRequest
+	525,  // 1461: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
+	528,  // 1462: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
+	373,  // 1463: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
+	374,  // 1464: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
+	375,  // 1465: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
+	376,  // 1466: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
+	804,  // 1467: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
+	532,  // 1468: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
+	533,  // 1469: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
+	543,  // 1470: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
+	544,  // 1471: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
+	546,  // 1472: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
+	550,  // 1473: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
+	547,  // 1474: forge.Forge.TriggerBmcCredentialRotation:input_type -> forge.BmcCredentialRotationRequest
+	548,  // 1475: forge.Forge.TriggerUefiCredentialRotation:input_type -> forge.UefiCredentialRotationRequest
+	549,  // 1476: forge.Forge.TriggerNicLockdownCredentialRotation:input_type -> forge.NicLockdownCredentialRotationRequest
+	1060, // 1477: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
+	603,  // 1478: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
+	556,  // 1479: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
+	1084, // 1480: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
+	559,  // 1481: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
+	1084, // 1482: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
+	997,  // 1483: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
+	568,  // 1484: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
+	569,  // 1485: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
+	148,  // 1486: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
+	149,  // 1487: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
+	152,  // 1488: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
+	154,  // 1489: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
+	1004, // 1490: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
+	1006, // 1491: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
+	1135, // 1492: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
+	571,  // 1493: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
+	571,  // 1494: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
+	571,  // 1495: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
+	377,  // 1496: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
+	332,  // 1497: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
+	574,  // 1498: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
+	576,  // 1499: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
+	578,  // 1500: forge.Forge.SetDpuUefiPassword:input_type -> forge.SetDpuUefiPasswordRequest
+	591,  // 1501: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
+	592,  // 1502: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	591,  // 1503: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
+	592,  // 1504: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	1135, // 1505: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
+	593,  // 1506: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
+	1135, // 1507: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
+	1135, // 1508: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
+	1135, // 1509: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
+	598,  // 1510: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	598,  // 1511: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	233,  // 1512: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	234,  // 1513: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	233,  // 1514: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	234,  // 1515: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	1135, // 1516: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	235,  // 1517: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
+	1135, // 1518: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	1135, // 1519: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
+	258,  // 1520: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
+	259,  // 1521: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	258,  // 1522: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
+	259,  // 1523: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	1135, // 1524: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
+	260,  // 1525: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
+	1135, // 1526: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
+	1135, // 1527: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
+	263,  // 1528: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
+	264,  // 1529: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
+	263,  // 1530: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
+	264,  // 1531: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
+	1135, // 1532: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
+	265,  // 1533: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
+	1135, // 1534: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
+	146,  // 1535: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
+	680,  // 1536: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
+	682,  // 1537: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
+	684,  // 1538: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
+	689,  // 1539: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
+	686,  // 1540: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
+	690,  // 1541: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
+	692,  // 1542: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
+	1142, // 1543: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
+	1143, // 1544: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
+	1144, // 1545: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
+	1145, // 1546: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
+	1146, // 1547: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
+	1147, // 1548: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
+	1148, // 1549: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
+	1149, // 1550: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
+	1150, // 1551: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
+	1151, // 1552: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
+	1152, // 1553: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
+	1153, // 1554: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
+	1154, // 1555: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
+	1155, // 1556: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
+	1156, // 1557: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
+	1157, // 1558: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
+	1158, // 1559: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
+	1159, // 1560: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
+	1160, // 1561: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
+	1161, // 1562: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
+	1162, // 1563: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
+	1163, // 1564: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
+	1164, // 1565: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
+	1165, // 1566: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
+	1166, // 1567: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
+	1167, // 1568: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
+	1168, // 1569: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
+	1169, // 1570: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
+	1170, // 1571: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
+	1171, // 1572: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
+	1172, // 1573: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
+	1173, // 1574: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
+	1174, // 1575: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
+	1175, // 1576: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
+	1176, // 1577: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
+	1177, // 1578: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
+	1178, // 1579: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
+	1179, // 1580: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
+	1180, // 1581: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
+	1181, // 1582: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
+	1182, // 1583: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
+	1183, // 1584: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
+	1184, // 1585: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
+	711,  // 1586: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
+	713,  // 1587: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
+	715,  // 1588: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
+	718,  // 1589: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
+	719,  // 1590: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
+	725,  // 1591: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
+	728,  // 1592: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
+	580,  // 1593: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
+	584,  // 1594: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
+	582,  // 1595: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
+	1073, // 1596: forge.Forge.GetOsImage:input_type -> common.UUID
+	580,  // 1597: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
+	586,  // 1598: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
+	587,  // 1599: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
+	602,  // 1600: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
+	607,  // 1601: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
+	609,  // 1602: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
+	604,  // 1603: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
+	612,  // 1604: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
+	614,  // 1605: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
+	617,  // 1606: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
+	619,  // 1607: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
+	640,  // 1608: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
+	641,  // 1609: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
+	643,  // 1610: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
+	646,  // 1611: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
+	648,  // 1612: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
+	620,  // 1613: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
+	652,  // 1614: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
+	654,  // 1615: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
+	653,  // 1616: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
+	657,  // 1617: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
+	664,  // 1618: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
+	665,  // 1619: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
+	661,  // 1620: forge.Forge.MachineValidationTestApproveFullHost:input_type -> forge.MachineValidationTestFullHostApprovalRequest
+	667,  // 1621: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
+	449,  // 1622: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
+	633,  // 1623: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
+	635,  // 1624: forge.Forge.AdminGpuReset:input_type -> forge.AdminGpuResetRequest
+	407,  // 1625: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
+	439,  // 1626: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
+	441,  // 1627: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
+	443,  // 1628: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
+	445,  // 1629: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
+	837,  // 1630: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
+	839,  // 1631: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
+	841,  // 1632: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
+	843,  // 1633: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
+	451,  // 1634: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
+	453,  // 1635: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
+	621,  // 1636: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
+	629,  // 1637: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
+	631,  // 1638: forge.Forge.TerminateRackMaintenance:input_type -> forge.RackMaintenanceTerminateRequest
+	142,  // 1639: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
+	1135, // 1640: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
+	1135, // 1641: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
+	139,  // 1642: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
+	694,  // 1643: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
+	696,  // 1644: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
+	701,  // 1645: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
+	703,  // 1646: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
+	703,  // 1647: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
+	703,  // 1648: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
+	707,  // 1649: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
+	731,  // 1650: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
+	847,  // 1651: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
+	848,  // 1652: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
+	747,  // 1653: forge.Forge.CreateSku:input_type -> forge.SkuList
+	1060, // 1654: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
+	1060, // 1655: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
+	745,  // 1656: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
+	746,  // 1657: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
+	748,  // 1658: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
+	1135, // 1659: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
+	750,  // 1660: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
+	760,  // 1661: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
+	744,  // 1662: forge.Forge.ReplaceSku:input_type -> forge.Sku
+	417,  // 1663: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
+	419,  // 1664: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
+	421,  // 1665: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
+	1060, // 1666: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
+	410,  // 1667: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
+	1135, // 1668: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
+	755,  // 1669: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
+	753,  // 1670: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	753,  // 1671: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	758,  // 1672: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
+	761,  // 1673: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
+	762,  // 1674: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
+	407,  // 1675: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
+	407,  // 1676: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
+	781,  // 1677: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
+	783,  // 1678: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
+	778,  // 1679: forge.Forge.GetRack:input_type -> forge.GetRackRequest
+	789,  // 1680: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
+	790,  // 1681: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
+	797,  // 1682: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
+	1135, // 1683: forge.Forge.ListRackProfiles:input_type -> google.protobuf.Empty
+	767,  // 1684: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
+	769,  // 1685: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
+	771,  // 1686: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
+	774,  // 1687: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
+	775,  // 1688: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
+	845,  // 1689: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
+	854,  // 1690: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
+	1185, // 1691: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
+	1186, // 1692: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
+	857,  // 1693: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
+	1135, // 1694: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
+	859,  // 1695: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	859,  // 1696: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	861,  // 1697: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
+	862,  // 1698: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
+	867,  // 1699: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
+	868,  // 1700: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
+	869,  // 1701: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
+	870,  // 1702: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
+	1135, // 1703: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
+	864,  // 1704: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
+	871,  // 1705: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
+	873,  // 1706: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
+	876,  // 1707: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
+	878,  // 1708: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
+	880,  // 1709: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
+	881,  // 1710: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
+	887,  // 1711: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
+	888,  // 1712: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
+	889,  // 1713: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
+	891,  // 1714: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
+	893,  // 1715: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
+	895,  // 1716: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
+	897,  // 1717: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
+	114,  // 1718: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
+	1060, // 1719: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
+	115,  // 1720: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
+	1060, // 1721: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
+	117,  // 1722: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
+	119,  // 1723: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	122,  // 1724: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
+	119,  // 1725: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	127,  // 1726: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	129,  // 1727: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
+	127,  // 1728: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	130,  // 1729: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
+	135,  // 1730: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
+	136,  // 1731: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
+	904,  // 1732: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
+	907,  // 1733: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
+	909,  // 1734: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
+	911,  // 1735: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
+	1187, // 1736: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
+	1188, // 1737: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
+	1189, // 1738: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
+	1190, // 1739: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
+	1191, // 1740: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
+	1192, // 1741: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
+	1193, // 1742: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
+	1194, // 1743: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
+	1195, // 1744: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
+	1196, // 1745: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
+	1197, // 1746: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
+	1198, // 1747: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
+	1199, // 1748: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
+	1200, // 1749: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
+	1201, // 1750: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
+	821,  // 1751: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
+	822,  // 1752: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
+	172,  // 1753: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	832,  // 1754: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
+	833,  // 1755: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
+	829,  // 1756: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
+	835,  // 1757: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
+	830,  // 1758: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
+	172,  // 1759: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	925,  // 1760: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
+	815,  // 1761: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
+	928,  // 1762: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
+	930,  // 1763: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
+	931,  // 1764: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
+	933,  // 1765: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
+	939,  // 1766: forge.Forge.FindPendingDPUServiceSyncIds:input_type -> forge.FindPendingDPUServiceSyncIdsRequest
+	940,  // 1767: forge.Forge.FindPendingDPUServiceSyncsByIds:input_type -> forge.FindPendingDPUServiceSyncsByIdsRequest
+	941,  // 1768: forge.Forge.ListDPUServiceSyncHistory:input_type -> forge.ListDPUServiceSyncHistoryRequest
+	936,  // 1769: forge.Forge.ReleaseDPUServiceSyncHold:input_type -> forge.ReleaseDPUServiceSyncHoldRequest
+	951,  // 1770: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
+	953,  // 1771: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
+	948,  // 1772: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
+	960,  // 1773: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
+	962,  // 1774: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
+	964,  // 1775: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
+	981,  // 1776: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
+	1082, // 1777: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
+	984,  // 1778: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
+	985,  // 1779: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
+	987,  // 1780: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
+	989,  // 1781: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
+	991,  // 1782: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	994,  // 1783: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	995,  // 1784: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
+	158,  // 1785: forge.Forge.Version:output_type -> forge.BuildInfo
+	1121, // 1786: forge.Forge.CreateDomain:output_type -> dns.Domain
+	1121, // 1787: forge.Forge.UpdateDomain:output_type -> dns.Domain
+	1202, // 1788: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
+	1203, // 1789: forge.Forge.FindDomain:output_type -> dns.DomainList
+	919,  // 1790: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
+	919,  // 1791: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
+	922,  // 1792: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
+	920,  // 1793: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
+	178,  // 1794: forge.Forge.CreateVpc:output_type -> forge.Vpc
+	181,  // 1795: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
+	183,  // 1796: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
+	185,  // 1797: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
+	170,  // 1798: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
+	186,  // 1799: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
+	969,  // 1800: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
+	972,  // 1801: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
+	970,  // 1802: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
+	974,  // 1803: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
+	187,  // 1804: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
+	193,  // 1805: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
+	194,  // 1806: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
+	187,  // 1807: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
+	197,  // 1808: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
+	1007, // 1809: forge.Forge.CreateSitePrefix:output_type -> forge.SitePrefix
+	1007, // 1810: forge.Forge.UpdateSitePrefix:output_type -> forge.SitePrefix
+	1014, // 1811: forge.Forge.DeleteSitePrefix:output_type -> forge.SitePrefixDeletionResult
+	1018, // 1812: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
+	1019, // 1813: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
+	199,  // 1814: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
+	200,  // 1815: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
+	201,  // 1816: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
+	206,  // 1817: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
+	279,  // 1818: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
+	393,  // 1819: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
+	271,  // 1820: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
+	271,  // 1821: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
+	275,  // 1822: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
+	393,  // 1823: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
+	217,  // 1824: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
+	210,  // 1825: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
+	209,  // 1826: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
+	209,  // 1827: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
+	214,  // 1828: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
+	210,  // 1829: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
+	221,  // 1830: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
+	946,  // 1831: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
+	221,  // 1832: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
+	224,  // 1833: forge.Forge.DecommissionPowerShelf:output_type -> forge.DecommissionPowerShelfResponse
+	226,  // 1834: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
+	979,  // 1835: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
+	1135, // 1836: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
+	244,  // 1837: forge.Forge.FindSwitches:output_type -> forge.SwitchList
+	945,  // 1838: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
+	244,  // 1839: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
+	247,  // 1840: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
+	249,  // 1841: forge.Forge.DecommissionSwitch:output_type -> forge.DecommissionSwitchResponse
+	977,  // 1842: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
+	267,  // 1843: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
+	320,  // 1844: forge.Forge.AllocateInstance:output_type -> forge.Instance
+	293,  // 1845: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
+	338,  // 1846: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
+	341,  // 1847: forge.Forge.ReleaseInstances:output_type -> forge.BatchInstanceReleaseResponse
+	320,  // 1848: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
+	320,  // 1849: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
+	289,  // 1850: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
+	285,  // 1851: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
+	285,  // 1852: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
+	414,  // 1853: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
+	1135, // 1854: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
+	494,  // 1855: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
+	1135, // 1856: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
+	1135, // 1857: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
+	494,  // 1858: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
+	1135, // 1859: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
+	1135, // 1860: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
+	494,  // 1861: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
+	1135, // 1862: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
+	1135, // 1863: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
+	494,  // 1864: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
+	1135, // 1865: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
+	1135, // 1866: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
+	494,  // 1867: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
+	1135, // 1868: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	1135, // 1869: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	494,  // 1870: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
+	1135, // 1871: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
+	1135, // 1872: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
+	431,  // 1873: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
+	433,  // 1874: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
+	1204, // 1875: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
+	1205, // 1876: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
+	1206, // 1877: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
+	284,  // 1878: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
+	460,  // 1879: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
+	467,  // 1880: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
+	466,  // 1881: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
+	468,  // 1882: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
+	469,  // 1883: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
+	471,  // 1884: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
+	392,  // 1885: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
+	391,  // 1886: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
+	360,  // 1887: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
+	362,  // 1888: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
+	365,  // 1889: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
+	355,  // 1890: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
+	1135, // 1891: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
+	535,  // 1892: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
+	1122, // 1893: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
+	356,  // 1894: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
+	345,  // 1895: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
+	348,  // 1896: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
+	254,  // 1897: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
+	348,  // 1898: forge.Forge.FindPowerShelfHealthHistories:output_type -> forge.HealthHistories
+	254,  // 1899: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
+	348,  // 1900: forge.Forge.FindRackHealthHistories:output_type -> forge.HealthHistories
+	254,  // 1901: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
+	348,  // 1902: forge.Forge.FindSwitchHealthHistories:output_type -> forge.HealthHistories
+	254,  // 1903: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
+	254,  // 1904: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
+	254,  // 1905: forge.Forge.FindSitePrefixStateHistories:output_type -> forge.StateHistories
+	354,  // 1906: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
+	353,  // 1907: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
+	561,  // 1908: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
+	565,  // 1909: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
+	564,  // 1910: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
+	562,  // 1911: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
+	537,  // 1912: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
+	540,  // 1913: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
+	542,  // 1914: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
+	456,  // 1915: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
+	458,  // 1916: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
+	473,  // 1917: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
+	477,  // 1918: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
+	161,  // 1919: forge.Forge.Echo:output_type -> forge.EchoResponse
+	504,  // 1920: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
+	508,  // 1921: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
+	506,  // 1922: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
+	514,  // 1923: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
+	521,  // 1924: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
+	515,  // 1925: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
+	517,  // 1926: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
+	519,  // 1927: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
+	524,  // 1928: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
+	398,  // 1929: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
+	398,  // 1930: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
+	429,  // 1931: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
+	1207, // 1932: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
+	1208, // 1933: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
+	1135, // 1934: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
+	650,  // 1935: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
+	651,  // 1936: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
+	1123, // 1937: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
+	1135, // 1938: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
+	1209, // 1939: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
+	406,  // 1940: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
+	1135, // 1941: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
+	1210, // 1942: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
+	1211, // 1943: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
+	1212, // 1944: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
+	1213, // 1945: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
+	1214, // 1946: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
+	1215, // 1947: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
+	1135, // 1948: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
+	437,  // 1949: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
+	436,  // 1950: forge.Forge.DecommissionManagedHost:output_type -> forge.DecommissionManagedHostResponse
+	526,  // 1951: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
+	529,  // 1952: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
+	1135, // 1953: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
+	1135, // 1954: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
+	1135, // 1955: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
+	1135, // 1956: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
+	1135, // 1957: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
+	1135, // 1958: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
+	1135, // 1959: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
+	1135, // 1960: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
+	545,  // 1961: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
+	1135, // 1962: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
+	551,  // 1963: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
+	1135, // 1964: forge.Forge.TriggerBmcCredentialRotation:output_type -> google.protobuf.Empty
+	1135, // 1965: forge.Forge.TriggerUefiCredentialRotation:output_type -> google.protobuf.Empty
+	1135, // 1966: forge.Forge.TriggerNicLockdownCredentialRotation:output_type -> google.protobuf.Empty
+	1135, // 1967: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
+	1135, // 1968: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
+	557,  // 1969: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
+	559,  // 1970: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
+	1135, // 1971: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
+	1135, // 1972: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
+	1003, // 1973: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
+	570,  // 1974: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
+	570,  // 1975: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
+	150,  // 1976: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
+	151,  // 1977: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
+	153,  // 1978: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
+	156,  // 1979: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
+	1005, // 1980: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
+	1135, // 1981: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
+	572,  // 1982: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
+	1135, // 1983: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
+	1135, // 1984: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
+	1135, // 1985: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
+	1135, // 1986: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
+	333,  // 1987: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
+	575,  // 1988: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
+	577,  // 1989: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
+	579,  // 1990: forge.Forge.SetDpuUefiPassword:output_type -> forge.SetDpuUefiPasswordResponse
+	1135, // 1991: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
+	1135, // 1992: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
+	1135, // 1993: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
+	591,  // 1994: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
+	593,  // 1995: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
+	1135, // 1996: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
+	1135, // 1997: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
+	594,  // 1998: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
+	596,  // 1999: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
+	600,  // 2000: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	600,  // 2001: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	1135, // 2002: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1135, // 2003: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1135, // 2004: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
+	233,  // 2005: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
+	235,  // 2006: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
+	1135, // 2007: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	1135, // 2008: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	236,  // 2009: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
+	1135, // 2010: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
+	1135, // 2011: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
+	1135, // 2012: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
+	258,  // 2013: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
+	260,  // 2014: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
+	1135, // 2015: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
+	1135, // 2016: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
+	261,  // 2017: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
+	1135, // 2018: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
+	1135, // 2019: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
+	1135, // 2020: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
+	263,  // 2021: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
+	265,  // 2022: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
+	1135, // 2023: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
+	1135, // 2024: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
+	147,  // 2025: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
+	681,  // 2026: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
+	683,  // 2027: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
+	685,  // 2028: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
+	688,  // 2029: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
+	687,  // 2030: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
+	691,  // 2031: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
+	693,  // 2032: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
+	1216, // 2033: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
+	1217, // 2034: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
+	1218, // 2035: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
+	1219, // 2036: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
+	1220, // 2037: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1221, // 2038: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
+	1222, // 2039: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
+	1223, // 2040: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
+	1220, // 2041: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1224, // 2042: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
+	1225, // 2043: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
+	1226, // 2044: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
+	1227, // 2045: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
+	1228, // 2046: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
+	1229, // 2047: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
+	1230, // 2048: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
+	1231, // 2049: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
+	1232, // 2050: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
+	1233, // 2051: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
+	1234, // 2052: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
+	1235, // 2053: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
+	1236, // 2054: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
+	1237, // 2055: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
+	1238, // 2056: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
+	1239, // 2057: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
+	1240, // 2058: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
+	1241, // 2059: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
+	1242, // 2060: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
+	1243, // 2061: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
+	1244, // 2062: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
+	1245, // 2063: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
+	1246, // 2064: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
+	1247, // 2065: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
+	1248, // 2066: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
+	1249, // 2067: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
+	1250, // 2068: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
+	1251, // 2069: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
+	1252, // 2070: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
+	1253, // 2071: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
+	1254, // 2072: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
+	1255, // 2073: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
+	1256, // 2074: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
+	1257, // 2075: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
+	712,  // 2076: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
+	714,  // 2077: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
+	716,  // 2078: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
+	717,  // 2079: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
+	720,  // 2080: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
+	723,  // 2081: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
+	730,  // 2082: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
+	581,  // 2083: forge.Forge.CreateOsImage:output_type -> forge.OsImage
+	585,  // 2084: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
+	583,  // 2085: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
+	581,  // 2086: forge.Forge.GetOsImage:output_type -> forge.OsImage
+	581,  // 2087: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
+	296,  // 2088: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
+	588,  // 2089: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
+	601,  // 2090: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
+	1135, // 2091: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
+	608,  // 2092: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
+	605,  // 2093: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
+	613,  // 2094: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
+	616,  // 2095: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
+	618,  // 2096: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
+	1135, // 2097: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	639,  // 2098: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
+	642,  // 2099: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
+	644,  // 2100: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
+	647,  // 2101: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
+	649,  // 2102: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
+	1135, // 2103: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	656,  // 2104: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
+	655,  // 2105: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	655,  // 2106: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	658,  // 2107: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
+	663,  // 2108: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
+	666,  // 2109: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
+	662,  // 2110: forge.Forge.MachineValidationTestApproveFullHost:output_type -> forge.MachineValidationTestFullHostApprovalResponse
+	668,  // 2111: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
+	450,  // 2112: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
+	634,  // 2113: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
+	636,  // 2114: forge.Forge.AdminGpuReset:output_type -> forge.AdminGpuResetResponse
+	438,  // 2115: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
+	440,  // 2116: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
+	1258, // 2117: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
+	444,  // 2118: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
+	446,  // 2119: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
+	838,  // 2120: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
+	840,  // 2121: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
+	842,  // 2122: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
+	844,  // 2123: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
+	452,  // 2124: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
+	454,  // 2125: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
+	622,  // 2126: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
+	630,  // 2127: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
+	632,  // 2128: forge.Forge.TerminateRackMaintenance:output_type -> forge.RackMaintenanceTerminateResponse
+	138,  // 2129: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
+	144,  // 2130: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
+	141,  // 2131: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
+	1135, // 2132: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
+	695,  // 2133: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
+	697,  // 2134: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
+	702,  // 2135: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
+	704,  // 2136: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
+	705,  // 2137: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
+	706,  // 2138: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
+	708,  // 2139: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
+	732,  // 2140: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
+	853,  // 2141: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
+	1135, // 2142: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
+	748,  // 2143: forge.Forge.CreateSku:output_type -> forge.SkuIdList
+	744,  // 2144: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
+	1135, // 2145: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
+	1135, // 2146: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
+	1135, // 2147: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
+	1135, // 2148: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
+	748,  // 2149: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
+	747,  // 2150: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
+	1135, // 2151: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
+	744,  // 2152: forge.Forge.ReplaceSku:output_type -> forge.Sku
+	418,  // 2153: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
+	420,  // 2154: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
+	422,  // 2155: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
+	1135, // 2156: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
+	1135, // 2157: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
+	754,  // 2158: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
+	756,  // 2159: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
+	752,  // 2160: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
+	752,  // 2161: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
+	759,  // 2162: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
+	764,  // 2163: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
+	764,  // 2164: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
+	1135, // 2165: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
+	137,  // 2166: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
+	782,  // 2167: forge.Forge.FindRackIds:output_type -> forge.RackIdList
+	780,  // 2168: forge.Forge.FindRacksByIds:output_type -> forge.RackList
+	779,  // 2169: forge.Forge.GetRack:output_type -> forge.GetRackResponse
+	1135, // 2170: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
+	791,  // 2171: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
+	798,  // 2172: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
+	800,  // 2173: forge.Forge.ListRackProfiles:output_type -> forge.ListRackProfilesResponse
+	768,  // 2174: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
+	770,  // 2175: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
+	772,  // 2176: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
+	773,  // 2177: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
+	776,  // 2178: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
+	846,  // 2179: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
+	855,  // 2180: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
+	1259, // 2181: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
+	1260, // 2182: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
+	858,  // 2183: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
+	860,  // 2184: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
+	859,  // 2185: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	859,  // 2186: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	1135, // 2187: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
+	863,  // 2188: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
+	1135, // 2189: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
+	1135, // 2190: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
+	1135, // 2191: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
+	1135, // 2192: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
+	864,  // 2193: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
+	865,  // 2194: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
+	872,  // 2195: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
+	875,  // 2196: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
+	877,  // 2197: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
+	1135, // 2198: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
+	1135, // 2199: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
+	1135, // 2200: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
+	886,  // 2201: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
+	886,  // 2202: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
+	890,  // 2203: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
+	892,  // 2204: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
+	894,  // 2205: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
+	896,  // 2206: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
+	898,  // 2207: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
+	111,  // 2208: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
+	1135, // 2209: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
+	116,  // 2210: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
+	113,  // 2211: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
+	118,  // 2212: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
+	123,  // 2213: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	123,  // 2214: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	1135, // 2215: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
+	126,  // 2216: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	126,  // 2217: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	1135, // 2218: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
+	132,  // 2219: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
+	133,  // 2220: forge.Forge.GetJWKS:output_type -> forge.Jwks
+	134,  // 2221: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
+	905,  // 2222: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
+	908,  // 2223: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
+	910,  // 2224: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
+	912,  // 2225: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
+	1261, // 2226: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
+	1262, // 2227: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
+	1263, // 2228: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
+	1264, // 2229: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
+	1265, // 2230: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
+	1266, // 2231: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
+	1267, // 2232: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
+	1268, // 2233: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
+	1269, // 2234: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
+	1270, // 2235: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
+	1271, // 2236: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
+	1272, // 2237: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
+	1273, // 2238: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
+	1274, // 2239: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
+	1275, // 2240: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
+	823,  // 2241: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
+	818,  // 2242: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
+	818,  // 2243: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
+	834,  // 2244: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
+	828,  // 2245: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
+	827,  // 2246: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
+	836,  // 2247: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
+	831,  // 2248: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
+	828,  // 2249: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
+	926,  // 2250: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
+	816,  // 2251: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
+	1135, // 2252: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
+	929,  // 2253: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
+	932,  // 2254: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
+	935,  // 2255: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
+	1122, // 2256: forge.Forge.FindPendingDPUServiceSyncIds:output_type -> common.MachineIdList
+	943,  // 2257: forge.Forge.FindPendingDPUServiceSyncsByIds:output_type -> forge.ListPendingDPUServiceSyncsResponse
+	943,  // 2258: forge.Forge.ListDPUServiceSyncHistory:output_type -> forge.ListPendingDPUServiceSyncsResponse
+	938,  // 2259: forge.Forge.ReleaseDPUServiceSyncHold:output_type -> forge.ReleaseDPUServiceSyncHoldResponse
+	952,  // 2260: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
+	954,  // 2261: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
+	950,  // 2262: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
+	961,  // 2263: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
+	963,  // 2264: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
+	967,  // 2265: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
+	980,  // 2266: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
+	980,  // 2267: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
+	980,  // 2268: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
+	986,  // 2269: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
+	988,  // 2270: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
+	990,  // 2271: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
+	992,  // 2272: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	992,  // 2273: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	996,  // 2274: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
+	1785, // [1785:2275] is the sub-list for method output_type
+	1295, // [1295:1785] is the sub-list for method input_type
+	1295, // [1295:1295] is the sub-list for extension type_name
+	1295, // [1295:1295] is the sub-list for extension extendee
+	0,    // [0:1295] is the sub-list for field type_name
 }
 
 func init() { file_nico_nico_proto_init() }
@@ -76165,6 +76254,7 @@ func file_nico_nico_proto_init() {
 		(*GetComponentInventoryRequest_SwitchIds)(nil),
 		(*GetComponentInventoryRequest_PowerShelfIds)(nil),
 		(*GetComponentInventoryRequest_ComputeBmcMacs)(nil),
+		(*GetComponentInventoryRequest_SwitchBmcMacs)(nil),
 	}
 	file_nico_nico_proto_msgTypes[840].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[842].OneofWrappers = []any{
@@ -76172,6 +76262,7 @@ func file_nico_nico_proto_init() {
 		(*ComponentPowerControlRequest_SwitchIds)(nil),
 		(*ComponentPowerControlRequest_PowerShelfIds)(nil),
 		(*ComponentPowerControlRequest_ComputeBmcMacs)(nil),
+		(*ComponentPowerControlRequest_SwitchBmcMacs)(nil),
 	}
 	file_nico_nico_proto_msgTypes[844].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[851].OneofWrappers = []any{
@@ -76186,6 +76277,7 @@ func file_nico_nico_proto_init() {
 		(*GetComponentFirmwareStatusRequest_PowerShelfIds)(nil),
 		(*GetComponentFirmwareStatusRequest_RackIds)(nil),
 		(*GetComponentFirmwareStatusRequest_ComputeBmcMacs)(nil),
+		(*GetComponentFirmwareStatusRequest_SwitchBmcMacs)(nil),
 	}
 	file_nico_nico_proto_msgTypes[855].OneofWrappers = []any{
 		(*ListComponentFirmwareVersionsRequest_MachineIds)(nil),
@@ -76193,6 +76285,7 @@ func file_nico_nico_proto_init() {
 		(*ListComponentFirmwareVersionsRequest_PowerShelfIds)(nil),
 		(*ListComponentFirmwareVersionsRequest_RackIds)(nil),
 		(*ListComponentFirmwareVersionsRequest_ComputeBmcMacs)(nil),
+		(*ListComponentFirmwareVersionsRequest_SwitchBmcMacs)(nil),
 	}
 	file_nico_nico_proto_msgTypes[859].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[864].OneofWrappers = []any{}

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -9552,6 +9552,7 @@ message GetComponentInventoryRequest {
     SwitchIdList switch_ids = 2;
     PowerShelfIdList power_shelf_ids = 3;
     MacAddressList compute_bmc_macs = 4;
+    MacAddressList switch_bmc_macs = 5;
   }
 }
 
@@ -9572,6 +9573,7 @@ message ComponentPowerControlRequest {
     SwitchIdList switch_ids = 2;
     PowerShelfIdList power_shelf_ids = 3;
     MacAddressList compute_bmc_macs = 6;
+    MacAddressList switch_bmc_macs = 7;
   }
   common.SystemPowerControl action = 4;
   // When true, bypass the state controller and dispatch directly to the
@@ -9654,8 +9656,14 @@ message UpdateComputeTrayFirmwareTarget {
 }
 
 message UpdateSwitchFirmwareTarget {
+  // Exactly one of switch_ids or bmc_macs must be set (the server rejects
+  // neither/both). switch_ids targets ingested switches; bmc_macs targets by
+  // BMC MAC, including pre-ingestion. These are plain fields rather than a oneof
+  // so field 1 stays wire-compatible with earlier releases that predate
+  // bmc_macs.
   SwitchIdList switch_ids = 1;
   repeated NvSwitchComponent components = 2;
+  MacAddressList bmc_macs = 3;
 }
 
 message UpdatePowerShelfFirmwareTarget {
@@ -9703,6 +9711,7 @@ message GetComponentFirmwareStatusRequest {
     PowerShelfIdList power_shelf_ids = 3;
     RackIdList rack_ids = 4;
     MacAddressList compute_bmc_macs = 5;
+    MacAddressList switch_bmc_macs = 6;
   }
 }
 
@@ -9717,6 +9726,7 @@ message ListComponentFirmwareVersionsRequest {
     PowerShelfIdList power_shelf_ids = 3;
     RackIdList rack_ids = 4;
     MacAddressList compute_bmc_macs = 5;
+    MacAddressList switch_bmc_macs = 6;
   }
 }
 


### PR DESCRIPTION
## Related issues
https://github.com/dsx-ai-factory/infra-controller/issues/5620

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

