### PR TITLE
fix(observability): state handler latency alert

### DIFF
--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -121,11 +121,13 @@ histogram_quantile(0.95,
 ) / 1000 < 1
 ```
 
-**State update / reconciliation** uses `carbide_machines_handler_latency_in_state_milliseconds`
-histogram. The production alert threshold (120s) is more lenient than the SLO target (60s) to
-reduce noise. Related metrics include `carbide_machines_iteration_latency_milliseconds` for
-full iteration time and `carbide_machines_per_state_above_sla` for objects exceeding configured
-per-state thresholds.
+**State controller iteration latency** uses `carbide_machines_iteration_latency_milliseconds`,
+`carbide_network_segments_iteration_latency_milliseconds`, and
+`carbide_ib_partitions_iteration_latency_milliseconds` histograms. The production alert
+(`NicoStateHandlerLatency`) fires when p95 iteration latency exceeds 120 seconds (120000ms) for
+10 minutes. Related metrics include `carbide_machines_handler_latency_in_state_milliseconds` for
+per-state handler time and `carbide_machines_per_state_above_sla` for objects exceeding
+configured per-state thresholds.
 
 ## 3. Site-related thresholds
 

--- a/docs/observability/alerts.md
+++ b/docs/observability/alerts.md
@@ -65,15 +65,13 @@ Use percentage-based thresholds for IP availability, not absolute counts.
 | Warning |  < 10 stuck | 60m |
 | Critical | >= 10 stuck | 60m |
 
-### State-handler latency
+### State-controller iteration latency
 
-Alert when average iteration latency exceeds the threshold.
-
-| Metric | Threshold | Duration |
-|--------|-----------|----------|
-| State-handler latency | > 120 seconds | 10m |
-
-Applies to machine, network-segment and IB-partition state handlers.
+The `NicoStateHandlerLatency` alert fires when average iteration latency exceeds 120 seconds
+(120000ms) for 10 minutes, or if any of the iteration latency metrics are absent. It monitors
+`carbide_machines_iteration_latency_milliseconds`, `carbide_network_segments_iteration_latency_milliseconds`,
+and `carbide_ib_partitions_iteration_latency_milliseconds` histograms using `rate(_sum)/rate(_count)`
+because the default histogram buckets max at 10 seconds.
 
 ### API availability
 
@@ -121,13 +119,10 @@ histogram_quantile(0.95,
 ) / 1000 < 1
 ```
 
-**State controller iteration latency** uses `carbide_machines_iteration_latency_milliseconds`,
-`carbide_network_segments_iteration_latency_milliseconds`, and
-`carbide_ib_partitions_iteration_latency_milliseconds` histograms. The production alert
-(`NicoStateHandlerLatency`) fires when p95 iteration latency exceeds 120 seconds (120000ms) for
-10 minutes. Related metrics include `carbide_machines_handler_latency_in_state_milliseconds` for
-per-state handler time and `carbide_machines_per_state_above_sla` for objects exceeding
-configured per-state thresholds.
+**State controller iteration latency** is covered by `NicoStateHandlerLatency` described
+[above](#state-controller-iteration-latency). Related metrics include
+`carbide_machines_handler_latency_in_state_milliseconds` for per-state handler time and
+`carbide_machines_per_state_above_sla` for objects exceeding configured per-state thresholds.
 
 ## 3. Site-related thresholds
 

--- a/helm/observability/alerts/nico-alerts.yaml
+++ b/helm/observability/alerts/nico-alerts.yaml
@@ -34,20 +34,21 @@ spec:
             summary: "NICo API is fluctuating"
             description: "nico-api ready state changed more than 5 times in 15 minutes."
 
-        # Production-validated: State-controller iteration latency p95 >120s for 10m
+        # Production-validated: State-controller average iteration latency >120s for 10m
+        # Uses rate(_sum)/rate(_count) because default histogram buckets max at 10s.
         - alert: NicoStateHandlerLatency
           expr: |
             absent(carbide_machines_iteration_latency_milliseconds_count)
             or absent(carbide_network_segments_iteration_latency_milliseconds_count)
             or absent(carbide_ib_partitions_iteration_latency_milliseconds_count)
-            or histogram_quantile(0.95, sum(rate(carbide_machines_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
-            or histogram_quantile(0.95, sum(rate(carbide_network_segments_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
-            or histogram_quantile(0.95, sum(rate(carbide_ib_partitions_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
+            or (sum(rate(carbide_machines_iteration_latency_milliseconds_sum[5m])) / sum(rate(carbide_machines_iteration_latency_milliseconds_count[5m]))) / 1000 > 120
+            or (sum(rate(carbide_network_segments_iteration_latency_milliseconds_sum[5m])) / sum(rate(carbide_network_segments_iteration_latency_milliseconds_count[5m]))) / 1000 > 120
+            or (sum(rate(carbide_ib_partitions_iteration_latency_milliseconds_sum[5m])) / sum(rate(carbide_ib_partitions_iteration_latency_milliseconds_count[5m]))) / 1000 > 120
           for: 10m
           labels:
             severity: warning
           annotations:
-            summary: "State controller iteration latency p95 exceeds 120 seconds"
+            summary: "State controller average iteration latency exceeds 120 seconds"
             description: "State controller iteration latency is high, indicating processing bottlenecks."
 
     - name: nico-sla

--- a/helm/observability/alerts/nico-alerts.yaml
+++ b/helm/observability/alerts/nico-alerts.yaml
@@ -37,7 +37,10 @@ spec:
         # Production-validated: State-controller iteration latency p95 >120s for 10m
         - alert: NicoStateHandlerLatency
           expr: |
-            histogram_quantile(0.95, sum(rate(carbide_machines_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
+            absent(carbide_machines_iteration_latency_milliseconds_count)
+            or absent(carbide_network_segments_iteration_latency_milliseconds_count)
+            or absent(carbide_ib_partitions_iteration_latency_milliseconds_count)
+            or histogram_quantile(0.95, sum(rate(carbide_machines_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
             or histogram_quantile(0.95, sum(rate(carbide_network_segments_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
             or histogram_quantile(0.95, sum(rate(carbide_ib_partitions_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
           for: 10m

--- a/helm/observability/alerts/nico-alerts.yaml
+++ b/helm/observability/alerts/nico-alerts.yaml
@@ -34,17 +34,17 @@ spec:
             summary: "NICo API is fluctuating"
             description: "nico-api ready state changed more than 5 times in 15 minutes."
 
-        # Production-validated: State-handler latency >120s for 10m
+        # Production-validated: State-controller iteration latency p95 >120s for 10m
         - alert: NicoStateHandlerLatency
           expr: |
-            avg(carbide_machines_state_handler_latency_seconds) > 120
-            or avg(carbide_network_segments_state_handler_latency_seconds) > 120
-            or avg(carbide_ib_partitions_state_handler_latency_seconds) > 120
+            histogram_quantile(0.95, sum(rate(carbide_machines_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
+            or histogram_quantile(0.95, sum(rate(carbide_network_segments_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
+            or histogram_quantile(0.95, sum(rate(carbide_ib_partitions_iteration_latency_milliseconds_bucket[5m])) by (le)) > 120000
           for: 10m
           labels:
             severity: warning
           annotations:
-            summary: "State handler latency exceeds 120 seconds"
+            summary: "State controller iteration latency p95 exceeds 120 seconds"
             description: "State controller iteration latency is high, indicating processing bottlenecks."
 
     - name: nico-sla


### PR DESCRIPTION
The `NicoStateHandlerLatency` alert (added by #3628) could never fire because it references incorrect metrics.

Fixed problems:
1. Wrong metric names: `carbide_*_state_handler_latency_seconds` changed to `carbide_*_iteration_latency_milliseconds_bucket`
2. Wrong unit: threshold was in sec but metrics in ms,  changed to ms
3. Wrong expression: `avg()` on a histogram returns nothing, changed to `histogram_quantile(0.95...`

## Related issues
- #2826 
- #3628

## Type of Change
- [x] **Fix** - Bug fixes

## Testing
- [x] Manual testing performed

Verified on nico v2.1.0-rc.3: the fixed expression evaluates correctly

## Additional Notes
Also updated `docs/observability/alerts.md` to match the actual alert

