### PR TITLE
Lower find-by-ids paging to 25 in the admin CLI and gRPC clients

### DIFF
--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -32,6 +32,15 @@ use crate::{
 
 const MAX_INTERNAL_PAGE_SIZE: usize = 100;
 
+/// Default number of ids per internal `*ByIds` page. The gRPC client refuses
+/// replies above 4 MiB (tonic's default `max_decoding_message_size`), and a
+/// 100-machine page has exceeded that in the field: 4.6 MiB, about 46 KB per
+/// machine. Instances have measured about 78 KB each, so 25 keeps a page of
+/// either under half the limit. Raise it per invocation with
+/// `--internal-page-size`, or raise the limit itself with
+/// `TONIC_MAX_DECODING_MESSAGE_SIZE`.
+const DEFAULT_INTERNAL_PAGE_SIZE: usize = 25;
+
 fn parse_internal_page_size(value: &str) -> Result<usize, String> {
     let page_size = value
         .parse::<usize>()
@@ -130,7 +139,7 @@ pub(crate) struct CliOptions {
     #[clap(
         short = 'p',
         long,
-        default_value_t = 100,
+        default_value_t = DEFAULT_INTERNAL_PAGE_SIZE,
         value_parser = parse_internal_page_size
     )]
     #[clap(help = "For commands that internally retrieve data with paging, use this page size.")]
@@ -549,5 +558,15 @@ mod tests {
             .expect("valid page size should parse");
 
         assert_eq!(opts.internal_page_size, 100);
+    }
+
+    #[test]
+    fn internal_page_size_defaults_below_the_grpc_receive_limit() {
+        let opts = CliOptions::try_parse_from(["nico-admin-cli"]).expect("bare invocation parses");
+
+        // A 100-id page of machines has exceeded tonic's 4 MiB receive limit in
+        // the field, so the default must keep a page of the largest records seen
+        // (instances, about 78 KB each) comfortably under it.
+        assert_eq!(opts.internal_page_size, 25);
     }
 }

--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -144,8 +144,9 @@ pub(crate) struct CliOptions {
     )]
     #[clap(
         help = "For commands that internally retrieve data with paging, use this page size (1-100). \
-                Smaller pages keep each gRPC reply under the client's 4 MiB receive limit, which \
-                TONIC_MAX_DECODING_MESSAGE_SIZE can raise."
+                Smaller pages keep each gRPC reply under the client's 4 MiB receive limit; to raise \
+                that limit instead, set TONIC_MAX_DECODING_MESSAGE_SIZE to a byte count, for \
+                example 33554432 for 32 MiB."
     )]
     pub(crate) internal_page_size: usize,
 

--- a/crates/admin-cli/src/cfg/cli_options.rs
+++ b/crates/admin-cli/src/cfg/cli_options.rs
@@ -142,7 +142,11 @@ pub(crate) struct CliOptions {
         default_value_t = DEFAULT_INTERNAL_PAGE_SIZE,
         value_parser = parse_internal_page_size
     )]
-    #[clap(help = "For commands that internally retrieve data with paging, use this page size.")]
+    #[clap(
+        help = "For commands that internally retrieve data with paging, use this page size (1-100). \
+                Smaller pages keep each gRPC reply under the client's 4 MiB receive limit, which \
+                TONIC_MAX_DECODING_MESSAGE_SIZE can raise."
+    )]
     pub(crate) internal_page_size: usize,
 
     #[clap(

--- a/crates/health/src/api_client.rs
+++ b/crates/health/src/api_client.rs
@@ -417,7 +417,11 @@ impl ApiEndpointSource {
 
         let mut endpoints = Vec::new();
 
-        for ids_chunk in machine_ids.machine_ids.chunks(100) {
+        // Page by id count, but keep each reply well under tonic's 4 MiB receive
+        // limit: a page of 100 machines has exceeded it in the field at about
+        // 46 KB per machine.
+        const MACHINES_PAGE_SIZE: usize = 25;
+        for ids_chunk in machine_ids.machine_ids.chunks(MACHINES_PAGE_SIZE) {
             let request = ::rpc::forge::MachinesByIdsRequest {
                 machine_ids: Vec::from(ids_chunk),
                 ..Default::default()

--- a/crates/machine-a-tron/src/api_throttler.rs
+++ b/crates/machine-a-tron/src/api_throttler.rs
@@ -49,9 +49,12 @@ pub fn run(mut interval: Interval, api_client: ApiClient) -> ApiThrottler {
                                 .into_iter()
                                 .collect::<Vec<_>>();
 
-                            // Max of 100 machine IDs at a time
+                            // Page the lookup so each reply stays well under tonic's
+                            // 4 MiB receive limit: a page of 100 machines has exceeded
+                            // it in the field at about 46 KB per machine.
+                            const MACHINES_PAGE_SIZE: usize = 25;
                             let mut machines_by_id = HashMap::new();
-                            for chunk in machine_ids.chunks(100) {
+                            for chunk in machine_ids.chunks(MACHINES_PAGE_SIZE) {
                                 let machines = api_client.get_machines(
                                     chunk.iter().map(|id| **id).collect(),
                                 )

--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -3,17 +3,20 @@
 ## Summary
 
 For local development on macOS, this setup runs the full stack (core+rest) on macOS:
+
 - core: dependencies in docker but `nico-api` runs natively on macOS
 - rest: everything runs in docker
 
 **Usage:**
+
 - start NICo API (core) with `dev/mac-local-dev/run-nico-api.sh`<br>
-  You can access `nico-api` admin at https://localhost:1079/admin
+  You can access `nico-api` admin at [https://localhost:1079/admin](https://localhost:1079/admin)
 - start NICo REST API (rest) with `cd rest-api && make kind-reset LOCAL_CORE=true`<br>
   `make` will display all relevant URLs and credentials for the REST API, Temporal, and Keycloak.
 - you can test the full-stack integration (REST API client -> REST API -> NICo API) by running `dev/mac-local-dev/check-rest-core-integration.sh`.
 
 > **Limitations**
+>
 > - TPM / attestation features require Linux and a physical TPM — they are disabled in this setup.
 > - `machine-a-tron` relies on Linux-specific features and is unusable on macOS (can build).
 
@@ -40,11 +43,11 @@ Run from **any directory** — the script resolves the repo root automatically:
 ./dev/mac-local-dev/run-nico-api.sh
 ```
 
-The script is fully self-contained and idempotent.  On each run it:
+The script is fully self-contained and idempotent. On each run it:
 
 1. Checks prerequisites (`docker`, `cargo`, `jq`, `curl`).
 2. Starts a **Vault** container (`nico-vault`) on port **8201** and initialises it
-   (KV secrets + PKI) if not already running.  The root token is cached at
+   (KV secrets + PKI) if not already running. The root token is cached at
    `/tmp/nico-localdev-vault-root-token`.
 3. Regenerates **TLS certificates** under `dev/certs/localhost/` if they are
    missing or stale (`gen-certs.sh` is idempotent).
@@ -156,6 +159,7 @@ In a **second terminal**, use the wrapper script to talk to the running API:
 ```
 
 The script:
+
 - Builds `nico-admin-cli` automatically if `target/debug/nico-admin-cli`
   does not exist.
 - Wires up TLS using the locally-generated certs from `dev/certs/localhost/`
@@ -173,7 +177,7 @@ The script:
 | `--extended` | | Include internal UUIDs and extra fields |
 | `--sort-by <field>` | | `primary-id` (default) or `state` |
 | `--debug` | `-d` | Increase log verbosity (repeat for trace) |
-| `--internal-page-size N` | `-p` | Paging size for list calls (default 100) |
+| `--internal-page-size N` | `-p` | Paging size for list calls (default 25) |
 
 ### Common subcommands
 
@@ -223,7 +227,7 @@ Then restart `run-nico-api.sh` (the API must load the new server cert).
 
 > **Note:** `dev/certs/server_identity.pem` and
 > `dev/certs/nico_developer_local_only_root_cert_pem` are checked-in certs
-> that expired in 2023/2024.  Do **not** use them — the scripts default to the
+> that expired in 2023/2024. Do **not** use them — the scripts default to the
 > locally-generated `localhost/` certs instead.
 
 ---
@@ -250,11 +254,11 @@ echo "VAULT_TOKEN=$(cat /tmp/nico-localdev-vault-root-token)"
 
 Cargo run parameters:
 
-```
+```text
 run --package nico-api --no-default-features -- run
 --config-path <absolute-path-to-repo>/dev/mac-local-dev/nico-api-config.toml
 ```
 
-> The config file uses CWD-relative TLS paths.  Set the IDE run configuration's
+> The config file uses CWD-relative TLS paths. Set the IDE run configuration's
 > **Working Directory** to the repository root, or use the absolute-path temp
 > config that `run-nico-api.sh` writes to `/tmp/nico-api-config-<PID>.toml`.

--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -3,20 +3,17 @@
 ## Summary
 
 For local development on macOS, this setup runs the full stack (core+rest) on macOS:
-
 - core: dependencies in docker but `nico-api` runs natively on macOS
 - rest: everything runs in docker
 
 **Usage:**
-
 - start NICo API (core) with `dev/mac-local-dev/run-nico-api.sh`<br>
-  You can access `nico-api` admin at [https://localhost:1079/admin](https://localhost:1079/admin)
+  You can access `nico-api` admin at https://localhost:1079/admin
 - start NICo REST API (rest) with `cd rest-api && make kind-reset LOCAL_CORE=true`<br>
   `make` will display all relevant URLs and credentials for the REST API, Temporal, and Keycloak.
 - you can test the full-stack integration (REST API client -> REST API -> NICo API) by running `dev/mac-local-dev/check-rest-core-integration.sh`.
 
 > **Limitations**
->
 > - TPM / attestation features require Linux and a physical TPM — they are disabled in this setup.
 > - `machine-a-tron` relies on Linux-specific features and is unusable on macOS (can build).
 
@@ -43,11 +40,11 @@ Run from **any directory** — the script resolves the repo root automatically:
 ./dev/mac-local-dev/run-nico-api.sh
 ```
 
-The script is fully self-contained and idempotent. On each run it:
+The script is fully self-contained and idempotent.  On each run it:
 
 1. Checks prerequisites (`docker`, `cargo`, `jq`, `curl`).
 2. Starts a **Vault** container (`nico-vault`) on port **8201** and initialises it
-   (KV secrets + PKI) if not already running. The root token is cached at
+   (KV secrets + PKI) if not already running.  The root token is cached at
    `/tmp/nico-localdev-vault-root-token`.
 3. Regenerates **TLS certificates** under `dev/certs/localhost/` if they are
    missing or stale (`gen-certs.sh` is idempotent).
@@ -159,7 +156,6 @@ In a **second terminal**, use the wrapper script to talk to the running API:
 ```
 
 The script:
-
 - Builds `nico-admin-cli` automatically if `target/debug/nico-admin-cli`
   does not exist.
 - Wires up TLS using the locally-generated certs from `dev/certs/localhost/`
@@ -177,7 +173,7 @@ The script:
 | `--extended` | | Include internal UUIDs and extra fields |
 | `--sort-by <field>` | | `primary-id` (default) or `state` |
 | `--debug` | `-d` | Increase log verbosity (repeat for trace) |
-| `--internal-page-size N` | `-p` | Paging size for list calls (default 25) |
+| `--internal-page-size N` | `-p` | Paging size for list calls (default 100) |
 
 ### Common subcommands
 
@@ -227,7 +223,7 @@ Then restart `run-nico-api.sh` (the API must load the new server cert).
 
 > **Note:** `dev/certs/server_identity.pem` and
 > `dev/certs/nico_developer_local_only_root_cert_pem` are checked-in certs
-> that expired in 2023/2024. Do **not** use them — the scripts default to the
+> that expired in 2023/2024.  Do **not** use them — the scripts default to the
 > locally-generated `localhost/` certs instead.
 
 ---
@@ -254,11 +250,11 @@ echo "VAULT_TOKEN=$(cat /tmp/nico-localdev-vault-root-token)"
 
 Cargo run parameters:
 
-```text
+```
 run --package nico-api --no-default-features -- run
 --config-path <absolute-path-to-repo>/dev/mac-local-dev/nico-api-config.toml
 ```
 
-> The config file uses CWD-relative TLS paths. Set the IDE run configuration's
+> The config file uses CWD-relative TLS paths.  Set the IDE run configuration's
 > **Working Directory** to the repository root, or use the absolute-path temp
 > config that `run-nico-api.sh` writes to `/tmp/nico-api-config-<PID>.toml`.


### PR DESCRIPTION
`nico-admin-cli managed-hosts show` fails on sites where machine records are large:

```text
Error, decoded message length too large: found 4644464 bytes, the limit is: 4194304 bytes
```

The CLI already pages its `*ByIds` lookups, but by id count: `--internal-page-size` defaulted to 100, matching the server's `max_find_by_ids` cap. Tonic's client receive limit is 4 MiB of bytes, so once machines reach about 46 KB each a full page of 100 no longer fits, and the whole command fails even though every individual request is valid. The same arithmetic threatens `instance show`, where instances have measured about 78 KB each (see #5266).

This lowers the CLI default page to 25, which keeps a page of machines or instances under half the limit. The flag still accepts explicit values up to 100, and `TONIC_MAX_DECODING_MESSAGE_SIZE` still raises the receive limit itself for anyone who needs it. A test pins the new default so it cannot silently drift back to 100. The flag's `--help` now states the accepted range, the receive limit, and that `TONIC_MAX_DECODING_MESSAGE_SIZE` is a byte count. Documentation that still quotes the old default (the mac-local-dev README) is left for a follow-up PR so this one stays code-only.

The health service and machine-a-tron fetch machines over gRPC with the same fixed 100-id chunks and would fail the same way on such a site, so both now page at 25 as well.

## Related issues
None.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Trade-off: every paged CLI command now makes up to four times as many `*ByIds` requests. Fetches already run four at a time, so wall-clock impact should be modest, and `-p 100` restores the old behavior per invocation. The health service's endpoint refresh and machine-a-tron's lookup throttler make four times as many `find_machines_by_ids` calls for the same reason.

Alternatives considered and deliberately left for follow-up if the smaller pages prove too slow: raising the clients' default receive limit (the site-agent moved to 32 MiB in #5266), or adaptive split-and-retry of a page whose reply is too large.

Checked and not changed: the web UI in `crates/api-web` pages with fixed 100-id chunks too, but it calls the core `Api` in-process, so no reply is encoded or decoded and the receive limit does not apply. `crates/rvs` pages machines at 50 ids, about 2.3 MiB at current sizes, and is left as is.

