### PR TITLE
fix(rest-api): recover Keycloak JWKs after startup race

### DIFF
--- a/rest-api/api/internal/config/config.go
+++ b/rest-api/api/internal/config/config.go
@@ -520,8 +520,9 @@ func (c *Config) GetOrInitTokenOriginConfig() *cauth.TokenOriginConfig {
 			} else {
 				jwksConfig, err := keycloakConfig.GetJwksConfig()
 				if err != nil {
-					log.Warn().Err(err).Msg("Failed to get Keycloak JWKS config, skipping Keycloak JWT origin")
-				} else {
+					log.Warn().Err(err).Msg("Failed to initialize Keycloak JWKS; continuing with an empty key cache")
+				}
+				if jwksConfig != nil {
 					c.TokenOriginConfig.AddJwksConfig(jwksConfig)
 				}
 			}
@@ -530,7 +531,6 @@ func (c *Config) GetOrInitTokenOriginConfig() *cauth.TokenOriginConfig {
 		// Initialize JWKS data
 		if err := c.TokenOriginConfig.UpdateAllJWKS(); err != nil {
 			log.Warn().Err(err).Msg("Failed to update JWKS data")
-			return nil
 		} else {
 			log.Info().Msg("Successfully updated JWKS data")
 		}

--- a/rest-api/api/internal/config/config_test.go
+++ b/rest-api/api/internal/config/config_test.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
@@ -324,6 +326,29 @@ func TestConfig_ValidateIssuersConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetOrInitTokenOriginConfig_KeycloakUnavailable(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer testServer.Close()
+
+	v := viper.New()
+	v.Set(ConfigKeycloakEnabled, true)
+	v.Set(ConfigKeycloakBaseURL, testServer.URL)
+	v.Set(ConfigKeycloakExternalBaseURL, "https://keycloak.example.com")
+	v.Set(ConfigKeycloakRealm, "test-realm")
+	v.Set(ConfigKeycloakClientID, "test-client")
+	v.Set(ConfigKeycloakClientSecret, "test-secret")
+
+	c := &Config{v: v}
+	tokenOriginConfig := c.GetOrInitTokenOriginConfig()
+
+	require.NotNil(t, tokenOriginConfig)
+	jwksConfig := tokenOriginConfig.GetConfig("https://keycloak.example.com/realms/test-realm")
+	require.NotNil(t, jwksConfig)
+	assert.Nil(t, jwksConfig.GetJWKS())
 }
 
 func TestConfig_WatchConfigFile(t *testing.T) {

--- a/rest-api/api/internal/config/config_test.go
+++ b/rest-api/api/internal/config/config_test.go
@@ -328,27 +328,29 @@ func TestConfig_ValidateIssuersConfig(t *testing.T) {
 	}
 }
 
-func TestGetOrInitTokenOriginConfig_KeycloakUnavailable(t *testing.T) {
-	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		res.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer testServer.Close()
+func TestGetOrInitTokenOriginConfig(t *testing.T) {
+	t.Run("retains Keycloak config when JWKS is unavailable", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer testServer.Close()
 
-	v := viper.New()
-	v.Set(ConfigKeycloakEnabled, true)
-	v.Set(ConfigKeycloakBaseURL, testServer.URL)
-	v.Set(ConfigKeycloakExternalBaseURL, "https://keycloak.example.com")
-	v.Set(ConfigKeycloakRealm, "test-realm")
-	v.Set(ConfigKeycloakClientID, "test-client")
-	v.Set(ConfigKeycloakClientSecret, "test-secret")
+		v := viper.New()
+		v.Set(ConfigKeycloakEnabled, true)
+		v.Set(ConfigKeycloakBaseURL, testServer.URL)
+		v.Set(ConfigKeycloakExternalBaseURL, "https://keycloak.example.com")
+		v.Set(ConfigKeycloakRealm, "test-realm")
+		v.Set(ConfigKeycloakClientID, "test-client")
+		v.Set(ConfigKeycloakClientSecret, "test-secret")
 
-	c := &Config{v: v}
-	tokenOriginConfig := c.GetOrInitTokenOriginConfig()
+		c := &Config{v: v}
+		tokenOriginConfig := c.GetOrInitTokenOriginConfig()
 
-	require.NotNil(t, tokenOriginConfig)
-	jwksConfig := tokenOriginConfig.GetConfig("https://keycloak.example.com/realms/test-realm")
-	require.NotNil(t, jwksConfig)
-	assert.Nil(t, jwksConfig.GetJWKS())
+		require.NotNil(t, tokenOriginConfig)
+		jwksConfig := tokenOriginConfig.GetConfig("https://keycloak.example.com/realms/test-realm")
+		require.NotNil(t, jwksConfig)
+		assert.Nil(t, jwksConfig.GetJWKS())
+	})
 }
 
 func TestConfig_WatchConfigFile(t *testing.T) {

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -151,6 +151,7 @@ type JwksConfig struct {
 	LastUpdated   time.Time     // last successful JWKS update timestamp
 	LastAttempted time.Time     // last JWKS update attempt timestamp
 	jwks          *core.JWKS    // cached JWKS keys
+	updateDone    chan struct{} // closed when the current JWKS update finishes
 	JWKSTimeout   time.Duration // fetch timeout (default: 5s)
 
 	Audiences []string // allowed audience values (token must have at least one)
@@ -249,6 +250,10 @@ func (jcfg *JwksConfig) UpdateJWKS() error {
 		return core.ErrJWKSURLEmpty
 	}
 	if !jcfg.LastAttempted.IsZero() && time.Since(jcfg.LastAttempted) < minUpdateInterval {
+		if atomic.LoadUint32(&jcfg.IsUpdating) != 0 {
+			jcfg.Unlock()
+			return core.ErrJWKSUpdateInProgress
+		}
 		hasCachedKeys := jcfg.jwks != nil
 		jcfg.Unlock()
 		if !hasCachedKeys {
@@ -260,10 +265,17 @@ func (jcfg *JwksConfig) UpdateJWKS() error {
 		jcfg.Unlock()
 		return core.ErrJWKSUpdateInProgress
 	}
+	jcfg.updateDone = make(chan struct{})
 	urlCopy, timeout := jcfg.URL, jcfg.JWKSTimeout
 	jcfg.LastAttempted = time.Now()
 	jcfg.Unlock()
-	defer atomic.StoreUint32(&jcfg.IsUpdating, 0)
+	defer func() {
+		jcfg.Lock()
+		atomic.StoreUint32(&jcfg.IsUpdating, 0)
+		close(jcfg.updateDone)
+		jcfg.updateDone = nil
+		jcfg.Unlock()
+	}()
 
 	jwks, err := core.NewJWKSFromURL(urlCopy, timeout)
 	if err != nil {
@@ -363,30 +375,25 @@ func (jcfg *JwksConfig) getPublicKey(token *jwt.Token) (interface{}, error) {
 
 // tryUpdateJWKSWithRetry attempts to update JWKS with retry logic for concurrent updates
 func (jcfg *JwksConfig) tryUpdateJWKSWithRetry() error {
-	const maxRetries = 5
-	const retryDelay = 1 * time.Second
-
-	for attempt := 1; attempt <= maxRetries; attempt++ {
-		if attempt == 1 {
-			updateErr := jcfg.UpdateJWKS()
-			if updateErr == nil {
-				return nil
-			}
-			if !errors.Is(updateErr, core.ErrJWKSUpdateInProgress) {
-				return updateErr
-			}
-		}
-
-		if attempt < maxRetries {
-			time.Sleep(retryDelay)
-		}
-
-		if jcfg.GetJWKS() != nil {
-			return nil
-		}
+	updateErr := jcfg.UpdateJWKS()
+	if updateErr == nil {
+		return nil
+	}
+	if !errors.Is(updateErr, core.ErrJWKSUpdateInProgress) {
+		return updateErr
 	}
 
-	return core.ErrJWKSUpdateInProgress
+	jcfg.RLock()
+	updateDone := jcfg.updateDone
+	jcfg.RUnlock()
+	if updateDone != nil {
+		<-updateDone
+	}
+
+	if jcfg.GetJWKS() == nil {
+		return core.ErrJWKSNotInitialized
+	}
+	return nil
 }
 
 // tryMultipleKeysForValidation tries all candidate keys for algorithm-only validation

--- a/rest-api/auth/pkg/config/jwks.go
+++ b/rest-api/auth/pkg/config/jwks.go
@@ -142,15 +142,16 @@ func (cm *ClaimMapping) GetOrgNameAndDisplayName(claims jwt.MapClaims) (orgName 
 
 // JwksConfig holds configuration for a JWKS endpoint and token validation.
 type JwksConfig struct {
-	Name         string
-	IsUpdating   uint32        // atomic flag for concurrent JWKS updates
-	sync.RWMutex               // protects JWKS access
-	URL          string        // JWKS endpoint URL
-	Issuer       string        // expected "iss" claim value
-	Origin       string        // token origin type (e.g., "kas-legacy", "kas-ssa", "keycloak", "custom", "kas")
-	LastUpdated  time.Time     // last JWKS update timestamp
-	jwks         *core.JWKS    // cached JWKS keys
-	JWKSTimeout  time.Duration // fetch timeout (default: 5s)
+	Name          string
+	IsUpdating    uint32        // atomic flag for concurrent JWKS updates
+	sync.RWMutex                // protects JWKS access
+	URL           string        // JWKS endpoint URL
+	Issuer        string        // expected "iss" claim value
+	Origin        string        // token origin type (e.g., "kas-legacy", "kas-ssa", "keycloak", "custom", "kas")
+	LastUpdated   time.Time     // last successful JWKS update timestamp
+	LastAttempted time.Time     // last JWKS update attempt timestamp
+	jwks          *core.JWKS    // cached JWKS keys
+	JWKSTimeout   time.Duration // fetch timeout (default: 5s)
 
 	Audiences []string // allowed audience values (token must have at least one)
 	Scopes    []string // required scopes (token must have ALL)
@@ -240,36 +241,29 @@ func (jcfg *JwksConfig) MatchesIssuer(issuer string) bool {
 	return issuer == jcfg.Issuer
 }
 
-// shouldAllowJWKSUpdate checks if we should allow JWKS update based on throttling
-func (jcfg *JwksConfig) shouldAllowJWKSUpdate() bool {
-	jcfg.RLock()
-	defer jcfg.RUnlock()
-
-	// Always allow if we've never updated
-	if jcfg.LastUpdated.IsZero() {
-		return true
-	}
-
-	// Allow if enough time has passed since last update (regardless of success/failure)
-	return time.Since(jcfg.LastUpdated) >= minUpdateInterval
-}
-
 // UpdateJWKS fetches and validates JWKS from the configured URL. Throttled to minUpdateInterval.
 func (jcfg *JwksConfig) UpdateJWKS() error {
+	jcfg.Lock()
 	if jcfg.URL == "" {
+		jcfg.Unlock()
 		return core.ErrJWKSURLEmpty
 	}
-	if !jcfg.shouldAllowJWKSUpdate() {
+	if !jcfg.LastAttempted.IsZero() && time.Since(jcfg.LastAttempted) < minUpdateInterval {
+		hasCachedKeys := jcfg.jwks != nil
+		jcfg.Unlock()
+		if !hasCachedKeys {
+			return core.ErrJWKSNotInitialized
+		}
 		return nil
 	}
 	if !atomic.CompareAndSwapUint32(&jcfg.IsUpdating, 0, 1) {
+		jcfg.Unlock()
 		return core.ErrJWKSUpdateInProgress
 	}
-	defer atomic.StoreUint32(&jcfg.IsUpdating, 0)
-
-	jcfg.RLock()
 	urlCopy, timeout := jcfg.URL, jcfg.JWKSTimeout
-	jcfg.RUnlock()
+	jcfg.LastAttempted = time.Now()
+	jcfg.Unlock()
+	defer atomic.StoreUint32(&jcfg.IsUpdating, 0)
 
 	jwks, err := core.NewJWKSFromURL(urlCopy, timeout)
 	if err != nil {

--- a/rest-api/auth/pkg/config/jwks_test.go
+++ b/rest-api/auth/pkg/config/jwks_test.go
@@ -241,6 +241,34 @@ func TestJwksConfig_UpdateJWKs(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("failed update is throttled while cache is empty", func(t *testing.T) {
+		requestCount := 0
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			requestCount++
+			w.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer server.Close()
+
+		config := &JwksConfig{
+			URL:    server.URL,
+			Issuer: "test.example.com",
+		}
+
+		require.Error(t, config.UpdateJWKS())
+		assert.False(t, config.LastAttempted.IsZero())
+		assert.True(t, config.LastUpdated.IsZero())
+
+		assert.ErrorIs(t, config.UpdateJWKS(), core.ErrJWKSNotInitialized)
+		assert.Equal(t, 1, requestCount)
+
+		config.Lock()
+		config.LastAttempted = time.Now().Add(-minUpdateInterval)
+		config.Unlock()
+
+		require.Error(t, config.UpdateJWKS())
+		assert.Equal(t, 2, requestCount)
+	})
 }
 
 // TestJwksConfig_Concurrency tests thread safety of JWKS operations
@@ -291,17 +319,23 @@ func TestJwksConfig_Concurrency(t *testing.T) {
 	// Check for errors - allow "update already in progress" as this is expected concurrent behavior
 	var unexpectedErrors []error
 	var updateInProgressCount int
+	var notInitializedCount int
 	for err := range errors {
-		if err == core.ErrJWKSUpdateInProgress {
+		switch err {
+		case core.ErrJWKSUpdateInProgress:
 			updateInProgressCount++
-		} else {
+		case core.ErrJWKSNotInitialized:
+			notInitializedCount++
+		default:
 			unexpectedErrors = append(unexpectedErrors, err)
 		}
 	}
 
-	// Should have at most 9 "update in progress" errors (since 10 goroutines, 1 succeeds)
-	if updateInProgressCount > numGoroutines-1 {
-		t.Errorf("Too many 'update in progress' errors: expected at most %d, got %d", numGoroutines-1, updateInProgressCount)
+	// At least one goroutine performs the update; the others may observe either
+	// the in-progress state or the still-empty cache.
+	transientErrorCount := updateInProgressCount + notInitializedCount
+	if transientErrorCount > numGoroutines-1 {
+		t.Errorf("Too many transient update errors: expected at most %d, got %d", numGoroutines-1, transientErrorCount)
 	}
 
 	// Should not have any other types of errors

--- a/rest-api/auth/pkg/config/jwks_test.go
+++ b/rest-api/auth/pkg/config/jwks_test.go
@@ -269,6 +269,114 @@ func TestJwksConfig_UpdateJWKs(t *testing.T) {
 		require.Error(t, config.UpdateJWKS())
 		assert.Equal(t, 2, requestCount)
 	})
+
+	t.Run("in-flight update remains retryable", func(t *testing.T) {
+		tests := []struct {
+			name      string
+			warmCache bool
+		}{
+			{name: "cold cache"},
+			{name: "warm cache", warmCache: true},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+				require.NoError(t, err)
+
+				requestStarted := make(chan struct{})
+				releaseResponse := make(chan struct{})
+				responseResult := make(chan error, 2)
+				var requestStartedOnce sync.Once
+				var releaseResponseOnce sync.Once
+				release := func() {
+					releaseResponseOnce.Do(func() { close(releaseResponse) })
+				}
+
+				server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+					requestStartedOnce.Do(func() { close(requestStarted) })
+					<-releaseResponse
+					w.Header().Set("Content-Type", "application/json")
+					w.WriteHeader(http.StatusOK)
+					_, writeErr := w.Write([]byte(createJWKSResponse(privateKey.Public().(*rsa.PublicKey), "new-key-id", "RS256", "sig")))
+					responseResult <- writeErr
+				}))
+				defer server.Close()
+				defer release()
+
+				config := &JwksConfig{
+					URL:    server.URL,
+					Issuer: "test.example.com",
+				}
+				if tt.warmCache {
+					oldPrivateKey, keyErr := rsa.GenerateKey(rand.Reader, 2048)
+					require.NoError(t, keyErr)
+					config.jwks = &core.JWKS{Set: &jose.JSONWebKeySet{Keys: []jose.JSONWebKey{{
+						Key:       oldPrivateKey.Public(),
+						KeyID:     "old-key-id",
+						Algorithm: "RS256",
+						Use:       "sig",
+					}}}}
+				}
+
+				tokenString, err := createTokenWithGoJose(privateKey, true, "new-key-id")
+				require.NoError(t, err)
+				updateResult := make(chan error, 1)
+				go func() {
+					updateResult <- config.UpdateJWKS()
+				}()
+
+				select {
+				case <-requestStarted:
+				case <-time.After(2 * time.Second):
+					t.Fatal("timed out waiting for JWKS request to start")
+				}
+
+				type validationResult struct {
+					token *jwt.Token
+					err   error
+				}
+				validationDone := make(chan validationResult, 1)
+				go func() {
+					token, validationErr := config.ValidateToken(tokenString, jwt.MapClaims{})
+					validationDone <- validationResult{token: token, err: validationErr}
+				}()
+
+				select {
+				case result := <-validationDone:
+					t.Fatalf("validation returned before the in-flight update completed: %v", result.err)
+				case <-time.After(50 * time.Millisecond):
+				}
+
+				release()
+				select {
+				case err := <-responseResult:
+					require.NoError(t, err)
+				case <-time.After(2 * time.Second):
+					t.Fatal("timed out waiting for JWKS response")
+				}
+				select {
+				case err := <-updateResult:
+					require.NoError(t, err)
+				case <-time.After(2 * time.Second):
+					t.Fatal("timed out waiting for JWKS update")
+				}
+				select {
+				case result := <-validationDone:
+					require.NoError(t, result.err)
+					require.NotNil(t, result.token)
+					assert.True(t, result.token.Valid)
+				case <-time.After(2 * time.Second):
+					t.Fatal("timed out waiting for token validation")
+				}
+				select {
+				case err := <-responseResult:
+					t.Fatalf("token validation started an unexpected second JWKS request: %v", err)
+				default:
+				}
+			})
+		}
+	})
 }
 
 // TestJwksConfig_Concurrency tests thread safety of JWKS operations
@@ -319,23 +427,17 @@ func TestJwksConfig_Concurrency(t *testing.T) {
 	// Check for errors - allow "update already in progress" as this is expected concurrent behavior
 	var unexpectedErrors []error
 	var updateInProgressCount int
-	var notInitializedCount int
 	for err := range errors {
-		switch err {
-		case core.ErrJWKSUpdateInProgress:
+		if err == core.ErrJWKSUpdateInProgress {
 			updateInProgressCount++
-		case core.ErrJWKSNotInitialized:
-			notInitializedCount++
-		default:
+		} else {
 			unexpectedErrors = append(unexpectedErrors, err)
 		}
 	}
 
-	// At least one goroutine performs the update; the others may observe either
-	// the in-progress state or the still-empty cache.
-	transientErrorCount := updateInProgressCount + notInitializedCount
-	if transientErrorCount > numGoroutines-1 {
-		t.Errorf("Too many transient update errors: expected at most %d, got %d", numGoroutines-1, transientErrorCount)
+	// Should have at most 9 "update in progress" errors (since 10 goroutines, 1 succeeds)
+	if updateInProgressCount > numGoroutines-1 {
+		t.Errorf("Too many 'update in progress' errors: expected at most %d, got %d", numGoroutines-1, updateInProgressCount)
 	}
 
 	// Should not have any other types of errors

--- a/rest-api/auth/pkg/config/keycloak.go
+++ b/rest-api/auth/pkg/config/keycloak.go
@@ -52,7 +52,7 @@ func NewKeycloakConfig(baseURL, externalBaseURL, clientID, clientSecret, realm s
 func (kc *KeycloakConfig) initializeJWKS() bool {
 	jwksURL := fmt.Sprintf("%s/realms/%s/protocol/openid-connect/certs", kc.BaseURL, kc.Realm)
 
-	tempJwksConfig := &JwksConfig{
+	jwksConfig := &JwksConfig{
 		Name:           fmt.Sprintf("keycloak-%s", kc.Realm),
 		URL:            jwksURL,
 		Issuer:         kc.Issuer,
@@ -60,20 +60,22 @@ func (kc *KeycloakConfig) initializeJWKS() bool {
 		ServiceAccount: kc.ServiceAccountEnabled,
 	}
 
+	// Retain the configuration even when the initial fetch fails so token
+	// validation can refresh the key set after Keycloak becomes available.
+	kc.jwksConfig = jwksConfig
+
 	// Attempt to fetch JWKS during initialization
-	err := tempJwksConfig.UpdateJWKS()
+	err := jwksConfig.UpdateJWKS()
 	if err != nil {
 		log.Warn().Err(err).Msgf("Failed to fetch JWKS during initialization from URL %s for realm %s", jwksURL, kc.Realm)
 		return false
-	} else {
-		log.Info().Msgf("Successfully initialized JWKS for realm %s from URL %s", kc.Realm, jwksURL)
-		// Only set jwksConfig if fetch succeeds
-		kc.jwksConfig = tempJwksConfig
-		return true
 	}
+
+	log.Info().Msgf("Successfully initialized JWKS for realm %s from URL %s", kc.Realm, jwksURL)
+	return true
 }
 
-// GetJwksConfig gets the JWKS configuration, retrying fetch if needed
+// GetJwksConfig returns the stable JWKS configuration, initializing it if needed.
 func (kc *KeycloakConfig) GetJwksConfig() (*JwksConfig, error) {
 	kc.mu.RLock()
 	if kc.jwksConfig != nil {
@@ -92,7 +94,7 @@ func (kc *KeycloakConfig) GetJwksConfig() (*JwksConfig, error) {
 
 	success := kc.initializeJWKS()
 	if !success || kc.jwksConfig == nil {
-		return nil, fmt.Errorf("failed to fetch JWKS for realm %s", kc.Realm)
+		return kc.jwksConfig, fmt.Errorf("failed to fetch JWKS for realm %s", kc.Realm)
 	}
 
 	return kc.jwksConfig, nil

--- a/rest-api/auth/pkg/config/keycloak.go
+++ b/rest-api/auth/pkg/config/keycloak.go
@@ -79,8 +79,12 @@ func (kc *KeycloakConfig) initializeJWKS() bool {
 func (kc *KeycloakConfig) GetJwksConfig() (*JwksConfig, error) {
 	kc.mu.RLock()
 	if kc.jwksConfig != nil {
+		jwksConfig := kc.jwksConfig
 		kc.mu.RUnlock()
-		return kc.jwksConfig, nil
+		if jwksConfig.GetJWKS() == nil {
+			return jwksConfig, fmt.Errorf("failed to fetch JWKS for realm %s", kc.Realm)
+		}
+		return jwksConfig, nil
 	}
 	kc.mu.RUnlock()
 
@@ -89,6 +93,9 @@ func (kc *KeycloakConfig) GetJwksConfig() (*JwksConfig, error) {
 
 	// Double-check in case another goroutine initialized it
 	if kc.jwksConfig != nil {
+		if kc.jwksConfig.GetJWKS() == nil {
+			return kc.jwksConfig, fmt.Errorf("failed to fetch JWKS for realm %s", kc.Realm)
+		}
 		return kc.jwksConfig, nil
 	}
 

--- a/rest-api/auth/pkg/config/keycloak_test.go
+++ b/rest-api/auth/pkg/config/keycloak_test.go
@@ -4,11 +4,15 @@
 package config
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync/atomic"
 	"testing"
 
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -77,8 +81,10 @@ func TestNewKeycloakConfig(t *testing.T) {
 			assert.Equal(t, tt.want.ClientSecret, got.ClientSecret)
 			assert.Equal(t, tt.want.Realm, got.Realm)
 
-			// Verify initial state
-			assert.Nil(t, got.jwksConfig)
+			// The key cache can be empty, but its configuration must remain
+			// available for request-time refresh.
+			require.NotNil(t, got.jwksConfig)
+			assert.Nil(t, got.jwksConfig.GetJWKS())
 		})
 	}
 }
@@ -145,7 +151,8 @@ func TestKeycloakConfig_GetJwksConfig(t *testing.T) {
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.Nil(t, jwksConfig)
+				assert.NotNil(t, jwksConfig)
+				assert.Nil(t, jwksConfig.GetJWKS())
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, jwksConfig)
@@ -156,6 +163,51 @@ func TestKeycloakConfig_GetJwksConfig(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestKeycloakConfig_RecoversAfterInitialJWKSFailure(t *testing.T) {
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+
+	var keycloakReady atomic.Bool
+	var requestCount atomic.Int32
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		requestCount.Add(1)
+		if !keycloakReady.Load() {
+			res.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+
+		res.Header().Set("Content-Type", "application/json")
+		res.WriteHeader(http.StatusOK)
+		res.Write([]byte(createJWKSResponse(privateKey.Public().(*rsa.PublicKey), "test-key-id", "RS256", "sig")))
+	}))
+	defer testServer.Close()
+
+	keycloakConfig := NewKeycloakConfig(
+		testServer.URL,
+		"https://keycloak.example.com",
+		"test-client",
+		"test-secret",
+		"test-realm",
+		true,
+	)
+
+	jwksConfig, err := keycloakConfig.GetJwksConfig()
+	require.NoError(t, err)
+	require.NotNil(t, jwksConfig)
+	assert.Nil(t, jwksConfig.GetJWKS())
+	assert.Equal(t, int32(1), requestCount.Load())
+
+	keycloakReady.Store(true)
+	tokenString, err := createTokenWithGoJose(privateKey, true, "test-key-id")
+	require.NoError(t, err)
+
+	token, err := jwksConfig.ValidateToken(tokenString, jwt.MapClaims{})
+	require.NoError(t, err)
+	require.NotNil(t, token)
+	assert.True(t, token.Valid)
+	assert.Equal(t, int32(2), requestCount.Load())
 }
 
 func TestKeycloakConfig_GetJwksConfig_Caching(t *testing.T) {
@@ -343,7 +395,8 @@ func TestKeycloakConfig_Integration(t *testing.T) {
 			wantErr: true,
 			validate: func(t *testing.T, jwks *JwksConfig, err error) {
 				assert.Error(t, err)
-				assert.Nil(t, jwks)
+				assert.NotNil(t, jwks)
+				assert.Nil(t, jwks.GetJWKS())
 				assert.Contains(t, err.Error(), "failed to fetch JWKS")
 			},
 		},
@@ -353,7 +406,8 @@ func TestKeycloakConfig_Integration(t *testing.T) {
 			wantErr: true,
 			validate: func(t *testing.T, jwks *JwksConfig, err error) {
 				assert.Error(t, err)
-				assert.Nil(t, jwks)
+				assert.NotNil(t, jwks)
+				assert.Nil(t, jwks.GetJWKS())
 			},
 		},
 	}
@@ -372,7 +426,7 @@ func TestKeycloakConfig_Integration(t *testing.T) {
 			} else {
 				if tt.wantErr {
 					assert.Error(t, err)
-					assert.Nil(t, jwksConfig)
+					assert.NotNil(t, jwksConfig)
 				} else {
 					assert.NoError(t, err)
 					assert.NotNil(t, jwksConfig)
@@ -473,7 +527,8 @@ func TestKeycloakConfig_ErrorHandling(t *testing.T) {
 
 			if tt.wantErr {
 				assert.Error(t, err)
-				assert.Nil(t, jwksConfig)
+				assert.NotNil(t, jwksConfig)
+				assert.Nil(t, jwksConfig.GetJWKS())
 			} else {
 				assert.NoError(t, err)
 				assert.NotNil(t, jwksConfig)

--- a/rest-api/auth/pkg/config/keycloak_test.go
+++ b/rest-api/auth/pkg/config/keycloak_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/stretchr/testify/assert"
@@ -163,51 +164,62 @@ func TestKeycloakConfig_GetJwksConfig(t *testing.T) {
 			}
 		})
 	}
-}
 
-func TestKeycloakConfig_RecoversAfterInitialJWKSFailure(t *testing.T) {
-	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
-	require.NoError(t, err)
+	t.Run("recovers after initial JWKS failure", func(t *testing.T) {
+		privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+		require.NoError(t, err)
 
-	var keycloakReady atomic.Bool
-	var requestCount atomic.Int32
-	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		requestCount.Add(1)
-		if !keycloakReady.Load() {
-			res.WriteHeader(http.StatusServiceUnavailable)
-			return
-		}
+		var keycloakReady atomic.Bool
+		var requestCount atomic.Int32
+		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			requestCount.Add(1)
+			if !keycloakReady.Load() {
+				res.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
 
-		res.Header().Set("Content-Type", "application/json")
-		res.WriteHeader(http.StatusOK)
-		res.Write([]byte(createJWKSResponse(privateKey.Public().(*rsa.PublicKey), "test-key-id", "RS256", "sig")))
-	}))
-	defer testServer.Close()
+			res.Header().Set("Content-Type", "application/json")
+			res.WriteHeader(http.StatusOK)
+			_, err := res.Write([]byte(createJWKSResponse(privateKey.Public().(*rsa.PublicKey), "test-key-id", "RS256", "sig")))
+			assert.NoError(t, err)
+		}))
+		defer testServer.Close()
 
-	keycloakConfig := NewKeycloakConfig(
-		testServer.URL,
-		"https://keycloak.example.com",
-		"test-client",
-		"test-secret",
-		"test-realm",
-		true,
-	)
+		keycloakConfig := NewKeycloakConfig(
+			testServer.URL,
+			"https://keycloak.example.com",
+			"test-client",
+			"test-secret",
+			"test-realm",
+			true,
+		)
 
-	jwksConfig, err := keycloakConfig.GetJwksConfig()
-	require.NoError(t, err)
-	require.NotNil(t, jwksConfig)
-	assert.Nil(t, jwksConfig.GetJWKS())
-	assert.Equal(t, int32(1), requestCount.Load())
+		jwksConfig, err := keycloakConfig.GetJwksConfig()
+		require.Error(t, err)
+		require.NotNil(t, jwksConfig)
+		assert.Nil(t, jwksConfig.GetJWKS())
+		assert.Equal(t, int32(1), requestCount.Load())
 
-	keycloakReady.Store(true)
-	tokenString, err := createTokenWithGoJose(privateKey, true, "test-key-id")
-	require.NoError(t, err)
+		tokenString, err := createTokenWithGoJose(privateKey, true, "test-key-id")
+		require.NoError(t, err)
+		_, err = jwksConfig.ValidateToken(tokenString, jwt.MapClaims{})
+		require.Error(t, err)
+		assert.Equal(t, int32(1), requestCount.Load())
 
-	token, err := jwksConfig.ValidateToken(tokenString, jwt.MapClaims{})
-	require.NoError(t, err)
-	require.NotNil(t, token)
-	assert.True(t, token.Valid)
-	assert.Equal(t, int32(2), requestCount.Load())
+		keycloakReady.Store(true)
+		jwksConfig.Lock()
+		jwksConfig.LastAttempted = time.Now().Add(-minUpdateInterval)
+		jwksConfig.Unlock()
+
+		token, err := jwksConfig.ValidateToken(tokenString, jwt.MapClaims{})
+		require.NoError(t, err)
+		require.NotNil(t, token)
+		assert.True(t, token.Valid)
+		assert.Equal(t, int32(2), requestCount.Load())
+
+		_, err = keycloakConfig.GetJwksConfig()
+		require.NoError(t, err)
+	})
 }
 
 func TestKeycloakConfig_GetJwksConfig_Caching(t *testing.T) {

--- a/rest-api/auth/pkg/config/keycloak_test.go
+++ b/rest-api/auth/pkg/config/keycloak_test.go
@@ -202,6 +202,9 @@ func TestKeycloakConfig_GetJwksConfig(t *testing.T) {
 
 		tokenString, err := createTokenWithGoJose(privateKey, true, "test-key-id")
 		require.NoError(t, err)
+		jwksConfig.Lock()
+		jwksConfig.LastAttempted = time.Now()
+		jwksConfig.Unlock()
 		_, err = jwksConfig.ValidateToken(tokenString, jwt.MapClaims{})
 		require.Error(t, err)
 		assert.Equal(t, int32(1), requestCount.Load())

--- a/rest-api/auth/pkg/config/tokenorigin.go
+++ b/rest-api/auth/pkg/config/tokenorigin.go
@@ -4,6 +4,7 @@
 package config
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
@@ -180,14 +181,14 @@ func (toc *TokenOriginConfig) UpdateAllJWKS() error {
 	wg.Wait()
 	close(errChan)
 
-	// Collect errors - panic if ALL updates failed (at least 1 must work)
+	// Collect errors and report when all configured issuers were unavailable.
 	var errs []error
 	for err := range errChan {
 		errs = append(errs, err)
 	}
 
 	if len(errs) == len(jwksConfigs) {
-		log.Panic().Msgf("all JWKS updates failed (%d issuers) - at least one issuer must be reachable at startup", len(errs))
+		return fmt.Errorf("all JWKS updates failed (%d issuers)", len(errs))
 	}
 
 	if len(errs) > 0 {

--- a/rest-api/auth/pkg/config/tokenorigin_test.go
+++ b/rest-api/auth/pkg/config/tokenorigin_test.go
@@ -89,6 +89,21 @@ func TestNewTokenOriginConfig(t *testing.T) {
 	}
 }
 
+func TestTokenOriginConfig_UpdateAllJWKS_AllUnavailable(t *testing.T) {
+	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer testServer.Close()
+
+	config := NewTokenOriginConfig()
+	config.AddConfig("keycloak", "test-issuer", testServer.URL, TokenOriginKeycloak, false, nil, nil)
+
+	err := config.UpdateAllJWKS()
+	require.EqualError(t, err, "all JWKS updates failed (1 issuers)")
+	assert.NotNil(t, config.GetConfig("test-issuer"))
+	assert.Nil(t, config.GetConfig("test-issuer").GetJWKS())
+}
+
 // TestJWTOptionalKID_GoJose tests JWT validation with tokens created using the actual go-jose library
 func TestJWTOptionalKID_GoJose(t *testing.T) {
 	// Generate RSA key pair for signing

--- a/rest-api/auth/pkg/config/tokenorigin_test.go
+++ b/rest-api/auth/pkg/config/tokenorigin_test.go
@@ -89,19 +89,43 @@ func TestNewTokenOriginConfig(t *testing.T) {
 	}
 }
 
-func TestTokenOriginConfig_UpdateAllJWKS_AllUnavailable(t *testing.T) {
-	testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
-		res.WriteHeader(http.StatusServiceUnavailable)
-	}))
-	defer testServer.Close()
+func TestTokenOriginConfig_UpdateAllJWKS(t *testing.T) {
+	t.Run("all issuers unavailable", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			res.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer testServer.Close()
 
-	config := NewTokenOriginConfig()
-	config.AddConfig("keycloak", "test-issuer", testServer.URL, TokenOriginKeycloak, false, nil, nil)
+		config := NewTokenOriginConfig()
+		config.AddConfig("keycloak", "test-issuer", testServer.URL, TokenOriginKeycloak, false, nil, nil)
 
-	err := config.UpdateAllJWKS()
-	require.EqualError(t, err, "all JWKS updates failed (1 issuers)")
-	assert.NotNil(t, config.GetConfig("test-issuer"))
-	assert.Nil(t, config.GetConfig("test-issuer").GetJWKS())
+		err := config.UpdateAllJWKS()
+		require.EqualError(t, err, "all JWKS updates failed (1 issuers)")
+		assert.NotNil(t, config.GetConfig("test-issuer"))
+		assert.Nil(t, config.GetConfig("test-issuer").GetJWKS())
+	})
+
+	t.Run("partial failure keeps healthy issuer available", func(t *testing.T) {
+		testServer := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			if req.URL.Path == "/healthy" {
+				res.Header().Set("Content-Type", "application/json")
+				res.WriteHeader(http.StatusOK)
+				_, err := res.Write([]byte(ssaJwks))
+				assert.NoError(t, err)
+				return
+			}
+			res.WriteHeader(http.StatusServiceUnavailable)
+		}))
+		defer testServer.Close()
+
+		config := NewTokenOriginConfig()
+		config.AddConfig("healthy", "healthy-issuer", testServer.URL+"/healthy", TokenOriginKasSsa, false, nil, nil)
+		config.AddConfig("unavailable", "unavailable-issuer", testServer.URL+"/unavailable", TokenOriginKeycloak, false, nil, nil)
+
+		require.NoError(t, config.UpdateAllJWKS())
+		assert.NotNil(t, config.GetConfig("healthy-issuer").GetJWKS())
+		assert.Nil(t, config.GetConfig("unavailable-issuer").GetJWKS())
+	})
 }
 
 // TestJWTOptionalKID_GoJose tests JWT validation with tokens created using the actual go-jose library


### PR DESCRIPTION
When NICo REST starts before Keycloak is ready, the initial JWKS fetch can fail and discard the issuer configuration. That makes a transient startup ordering problem persist after Keycloak becomes healthy, and the all-issuers-unavailable path can panic.

This change retains the configured Keycloak issuer with an empty key cache, lets initialization continue after a logged startup fetch failure, and changes the all-JWKS failure path to return an error instead of panicking. Request-time token validation can then refresh the keys and recover automatically once Keycloak becomes available.

## Related issues

Fixes #5868

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Added coverage for:

- startup with an unavailable Keycloak JWKS endpoint;
- returning an error rather than panicking when all JWKS endpoints are unavailable; and
- successful request-time recovery after Keycloak becomes available.

## Additional Notes

The PR intentionally targets `dsx-ai-factory/infra-controller:main` from `ahunnargikar-nvidia/infra-controller:fix/keycloak-jwks-startup-race` following the upstream repository transfer.