### PR TITLE
fix(bmc-mock): satisfy libredfish expectations for SerialConsole

### DIFF
--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -1464,6 +1464,7 @@ mod tests {
             let system = get_json(&router, &resource(system_id).odata_id).await;
             assert_eq!(system["SerialConsole"]["SSH"]["ServiceEnabled"], true);
             assert_eq!(system["SerialConsole"]["SSH"]["Port"], 3222);
+            assert_eq!(system["SerialConsole"]["IPMI"]["ServiceEnabled"], false);
         }
     }
 }

--- a/crates/bmc-mock/src/redfish/serial_console.rs
+++ b/crates/bmc-mock/src/redfish/serial_console.rs
@@ -52,6 +52,9 @@ pub(crate) fn builder() -> SerialConsoleBuilder {
 pub(crate) fn simulated_ssh(port: u16) -> SerialConsole {
     builder()
         .ssh(&protocol_builder().service_enabled(true).port(port).build())
+        // Legacy libredfish requires both SSH and IPMI whenever SerialConsole is present,
+        // even though Redfish permits unsupported protocols to be omitted.
+        .ipmi(&protocol_builder().service_enabled(false).build())
         .build()
 }
 


### PR DESCRIPTION
libredfish requires the IPMI field whenever SerialConsole is present, but bmc-mock omits it for simulated SSH consoles.

This fix adds a disabled IPMI field to the simulated SerialConsole response.

## Related issues

Introduced by: #5330 

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
