### PR TITLE
feat(bmc-mock): configure generated DPU firmware inventory

### DIFF
--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -141,9 +141,9 @@ and NIC values retain the profile inventory; omitting BSP leaves it absent. An e
 DPU reports the configured versions. A generated host also adds the primary DPU's
 explicitly configured versions without replacing colliding host inventory IDs.
 
-The current inventory mapping supports BlueField-3 profiles. Overrides on an unmapped
-profile are rejected. The profile must resolve to at least one DPU; set --dpu-count to
-a positive value for variable-count profiles. Explicit internal mode also requires
+The inventory mapping supports generated BlueField-3 and BlueField-4 profiles. The
+profile must resolve to at least one DPU; set --dpu-count to a positive value for
+variable-count profiles. Explicit internal mode also requires
 --machine-role and --state-backend=internal. The libvirt shorthand uses
 --hardware-profile with --libvirt-domain and implies the host role and libvirt state
 backend. Firmware overrides cannot be combined with --targz or --ip-router.

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -17,8 +17,8 @@
 use std::path::PathBuf;
 use std::str::FromStr;
 
-use bmc_mock::HardwareType;
-use clap::{Parser, ValueEnum};
+use bmc_mock::{DpuFirmwareVersions, HardwareType};
+use clap::{Args as ClapArgs, Parser, ValueEnum};
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, ValueEnum)]
 pub(super) enum MachineRole {
@@ -66,7 +66,88 @@ impl From<String> for IpRouterPair {
     }
 }
 
+#[derive(Clone, ClapArgs, Debug, Default)]
+pub(super) struct DpuFirmwareArgs {
+    #[clap(
+        long = "dpu-bmc-firmware",
+        value_name = "VERSION",
+        requires = "hardware_profile",
+        help = "Override the DPU BMC version in generated firmware inventory"
+    )]
+    bmc: Option<String>,
+
+    #[clap(
+        long = "dpu-uefi-firmware",
+        value_name = "VERSION",
+        requires = "hardware_profile",
+        help = "Override the DPU UEFI version in generated firmware inventory"
+    )]
+    uefi: Option<String>,
+
+    #[clap(
+        long = "dpu-bsp-firmware",
+        value_name = "VERSION",
+        requires = "hardware_profile",
+        help = "Add the DPU BSP version to generated firmware inventory"
+    )]
+    bsp: Option<String>,
+
+    #[clap(
+        long = "dpu-cec-firmware",
+        value_name = "VERSION",
+        requires = "hardware_profile",
+        help = "Override the DPU CEC version in generated firmware inventory"
+    )]
+    cec: Option<String>,
+
+    #[clap(
+        long = "dpu-nic-firmware",
+        value_name = "VERSION",
+        requires = "hardware_profile",
+        help = "Override the DPU NIC version in generated firmware inventory"
+    )]
+    nic: Option<String>,
+}
+
+impl DpuFirmwareArgs {
+    pub(super) fn is_empty(&self) -> bool {
+        self.bmc.is_none()
+            && self.uefi.is_none()
+            && self.bsp.is_none()
+            && self.cec.is_none()
+            && self.nic.is_none()
+    }
+}
+
+impl From<DpuFirmwareArgs> for DpuFirmwareVersions {
+    fn from(value: DpuFirmwareArgs) -> Self {
+        Self {
+            bmc: value.bmc,
+            uefi: value.uefi,
+            bsp: value.bsp,
+            cec: value.cec,
+            nic: value.nic,
+        }
+    }
+}
+
 #[derive(Clone, Parser, Debug)]
+#[command(after_long_help = "\
+DPU FIRMWARE OVERRIDES:
+
+Firmware overrides are optional, opaque version strings for generated DPU endpoints.
+The hardware profile determines their Redfish inventory IDs. Omitted BMC, UEFI, CEC,
+and NIC values retain the profile inventory; omitting BSP leaves it absent. An exposed
+DPU reports the configured versions. A generated host also adds the primary DPU's
+explicitly configured versions without replacing colliding host inventory IDs.
+
+The current inventory mapping supports BlueField-3 profiles. Overrides on an unmapped
+profile are rejected. The profile must resolve to at least one DPU; set --dpu-count to
+a positive value for variable-count profiles. Explicit internal mode also requires
+--machine-role and --state-backend=internal. The libvirt shorthand uses
+--hardware-profile with --libvirt-domain and implies the host role and libvirt state
+backend. Firmware overrides cannot be combined with --targz or --ip-router.
+")]
 pub(super) struct Args {
     #[clap(short, long)]
     pub(super) cert_path: Option<String>,
@@ -125,41 +206,6 @@ pub(super) struct Args {
 
     #[clap(
         long,
-        requires = "hardware_profile",
-        help = "DPU BMC firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
-    )]
-    pub(super) dpu_bmc_firmware: Option<String>,
-
-    #[clap(
-        long,
-        requires = "hardware_profile",
-        help = "DPU UEFI firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
-    )]
-    pub(super) dpu_uefi_firmware: Option<String>,
-
-    #[clap(
-        long,
-        requires = "hardware_profile",
-        help = "DPU BSP version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router. Omission leaves DPU_BSP absent."
-    )]
-    pub(super) dpu_bsp_firmware: Option<String>,
-
-    #[clap(
-        long,
-        requires = "hardware_profile",
-        help = "DPU CEC firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
-    )]
-    pub(super) dpu_cec_firmware: Option<String>,
-
-    #[clap(
-        long,
-        requires = "hardware_profile",
-        help = "DPU NIC firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
-    )]
-    pub(super) dpu_nic_firmware: Option<String>,
-
-    #[clap(
-        long,
         default_value_t = 0,
         help = "Stable instance number used to make generated identities unique"
     )]
@@ -170,6 +216,9 @@ pub(super) struct Args {
 
     #[clap(long, default_value = "virsh", requires = "libvirt_domain")]
     pub(super) virsh_path: PathBuf,
+
+    #[clap(flatten, next_help_heading = "DPU firmware overrides")]
+    pub(super) dpu_firmware: DpuFirmwareArgs,
 }
 
 pub(super) fn parse_args() -> Args {
@@ -231,6 +280,51 @@ mod tests {
         assert_eq!(args.state_backend, Some(StateBackend::Internal));
         assert_eq!(args.dpu_index, Some(1));
         assert_eq!(args.instance_index, 3);
+    }
+
+    #[test]
+    fn parses_dpu_firmware_overrides() {
+        let args = Args::try_parse_from([
+            "bmc-mock",
+            "--machine-role",
+            "host",
+            "--state-backend",
+            "internal",
+            "--hardware-profile",
+            "dell_poweredge_r750",
+            "--dpu-count",
+            "1",
+            "--dpu-bmc-firmware",
+            "bmc-version",
+            "--dpu-uefi-firmware",
+            "uefi-version",
+            "--dpu-bsp-firmware",
+            "bsp-version",
+            "--dpu-cec-firmware",
+            "cec-version",
+            "--dpu-nic-firmware",
+            "nic-version",
+        ])
+        .unwrap();
+
+        assert_eq!(
+            DpuFirmwareVersions::from(args.dpu_firmware),
+            DpuFirmwareVersions {
+                bmc: Some("bmc-version".to_string()),
+                uefi: Some("uefi-version".to_string()),
+                bsp: Some("bsp-version".to_string()),
+                cec: Some("cec-version".to_string()),
+                nic: Some("nic-version".to_string()),
+            }
+        );
+    }
+
+    #[test]
+    fn dpu_firmware_overrides_require_a_hardware_profile() {
+        let error =
+            Args::try_parse_from(["bmc-mock", "--dpu-bmc-firmware", "bmc-version"]).unwrap_err();
+
+        assert_eq!(error.kind(), ErrorKind::MissingRequiredArgument);
     }
 
     #[test]

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -126,35 +126,35 @@ pub(super) struct Args {
     #[clap(
         long,
         requires = "hardware_profile",
-        help = "DPU BMC firmware version reported by generated Redfish inventory"
+        help = "DPU BMC firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
     )]
     pub(super) dpu_bmc_firmware: Option<String>,
 
     #[clap(
         long,
         requires = "hardware_profile",
-        help = "DPU UEFI firmware version reported by generated Redfish inventory"
+        help = "DPU UEFI firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
     )]
     pub(super) dpu_uefi_firmware: Option<String>,
 
     #[clap(
         long,
         requires = "hardware_profile",
-        help = "DPU BSP version reported by generated Redfish inventory"
+        help = "DPU BSP version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router. Omission leaves DPU_BSP absent."
     )]
     pub(super) dpu_bsp_firmware: Option<String>,
 
     #[clap(
         long,
         requires = "hardware_profile",
-        help = "DPU CEC firmware version reported by generated Redfish inventory"
+        help = "DPU CEC firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
     )]
     pub(super) dpu_cec_firmware: Option<String>,
 
     #[clap(
         long,
         requires = "hardware_profile",
-        help = "DPU NIC firmware version reported by generated Redfish inventory"
+        help = "DPU NIC firmware version reported by generated Redfish inventory. Requires --hardware-profile and at least one generated DPU (set --dpu-count for variable-count profiles). Cannot be combined with --targz or --ip-router."
     )]
     pub(super) dpu_nic_firmware: Option<String>,
 

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -125,6 +125,41 @@ pub(super) struct Args {
 
     #[clap(
         long,
+        requires = "hardware_profile",
+        help = "DPU BMC firmware version reported by generated Redfish inventory"
+    )]
+    pub(super) dpu_bmc_firmware: Option<String>,
+
+    #[clap(
+        long,
+        requires = "hardware_profile",
+        help = "DPU UEFI firmware version reported by generated Redfish inventory"
+    )]
+    pub(super) dpu_uefi_firmware: Option<String>,
+
+    #[clap(
+        long,
+        requires = "hardware_profile",
+        help = "DPU BSP version reported by generated Redfish inventory"
+    )]
+    pub(super) dpu_bsp_firmware: Option<String>,
+
+    #[clap(
+        long,
+        requires = "hardware_profile",
+        help = "DPU CEC firmware version reported by generated Redfish inventory"
+    )]
+    pub(super) dpu_cec_firmware: Option<String>,
+
+    #[clap(
+        long,
+        requires = "hardware_profile",
+        help = "DPU NIC firmware version reported by generated Redfish inventory"
+    )]
+    pub(super) dpu_nic_firmware: Option<String>,
+
+    #[clap(
+        long,
         default_value_t = 0,
         help = "Stable instance number used to make generated identities unique"
     )]

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -141,8 +141,8 @@ and NIC values retain the profile inventory; omitting BSP leaves it absent. An e
 DPU reports the configured versions. A generated host also adds the primary DPU's
 explicitly configured versions without replacing colliding host inventory IDs.
 
-The inventory mapping supports BlueField-3 profiles. Overrides for other DPU
-generations are rejected. The profile must resolve to at least one DPU; set
+The inventory mapping supports generated BlueField-3 and BlueField-4 profiles using
+generation-specific Redfish IDs. The profile must resolve to at least one DPU; set
 --dpu-count to a positive value for variable-count profiles. Explicit internal mode
 also requires --machine-role and --state-backend=internal. The libvirt shorthand uses
 --hardware-profile with --libvirt-domain and implies the host role and libvirt state

--- a/crates/bmc-mock/src/command_line.rs
+++ b/crates/bmc-mock/src/command_line.rs
@@ -141,10 +141,10 @@ and NIC values retain the profile inventory; omitting BSP leaves it absent. An e
 DPU reports the configured versions. A generated host also adds the primary DPU's
 explicitly configured versions without replacing colliding host inventory IDs.
 
-The inventory mapping supports generated BlueField-3 and BlueField-4 profiles. The
-profile must resolve to at least one DPU; set --dpu-count to a positive value for
-variable-count profiles. Explicit internal mode also requires
---machine-role and --state-backend=internal. The libvirt shorthand uses
+The inventory mapping supports BlueField-3 profiles. Overrides for other DPU
+generations are rejected. The profile must resolve to at least one DPU; set
+--dpu-count to a positive value for variable-count profiles. Explicit internal mode
+also requires --machine-role and --state-backend=internal. The libvirt shorthand uses
 --hardware-profile with --libvirt-domain and implies the host role and libvirt state
 backend. Firmware overrides cannot be combined with --targz or --ip-router.
 ")]

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -121,6 +121,9 @@ pub struct DpuFirmwareVersions {
 pub struct DpuSettings {
     pub nic_mode: bool,
     pub firmware_versions: DpuFirmwareVersions,
+    /// Optional BSP version exposed as DPU_BSP firmware inventory; omitted by default.
+    #[serde(default)]
+    pub bsp_version: Option<String>,
     #[serde(default = "default_true")]
     pub exposes_oob_eth: bool,
 }
@@ -139,6 +142,7 @@ impl Default for DpuSettings {
         Self {
             nic_mode: false,
             firmware_versions: Default::default(),
+            bsp_version: None,
             exposes_oob_eth: true,
         }
     }
@@ -290,10 +294,20 @@ impl DpuMachineInfo {
     }
 
     fn update_service_config(&self) -> UpdateServiceConfig {
-        match self.dpu_type() {
+        let mut config = match self.dpu_type() {
             DpuType::Bluefield3 => self.bluefield3().update_service_config(),
             DpuType::Bluefield4 => self.bluefield4().update_service_config(),
+        };
+        if let Some(bsp) = &self.settings.bsp_version {
+            config.firmware_inventory.push(
+                redfish::software_inventory::builder(
+                    &redfish::software_inventory::firmware_inventory_resource("DPU_BSP"),
+                )
+                .version(bsp)
+                .build(),
+            );
         }
+        config
     }
 
     fn oem_state(&self) -> redfish::oem::State {
@@ -599,6 +613,29 @@ impl HostMachineInfo {
         // carbide needs to upgrade from.
         if let Some(ref fw) = self.initial_host_firmware {
             config.apply_host_firmware_versions(fw);
+        }
+
+        // Generated host and DPU endpoints model two BMC views of the same
+        // BlueField. When explicit DPU versions are configured, expose that
+        // inventory through the host endpoint as well so both views agree.
+        if let Some(dpu) = self.primary_dpu().filter(|dpu| {
+            let fw = &dpu.settings.firmware_versions;
+            fw.bmc.is_some()
+                || fw.uefi.is_some()
+                || dpu.settings.bsp_version.is_some()
+                || fw.cec.is_some()
+                || fw.nic.is_some()
+        }) {
+            for inventory in dpu.update_service_config().firmware_inventory {
+                let inventory_id = inventory.id.as_ref();
+                if !config
+                    .firmware_inventory
+                    .iter()
+                    .any(|existing| existing.id.as_ref() == inventory_id)
+                {
+                    config.firmware_inventory.push(inventory);
+                }
+            }
         }
 
         // Populate the ordered pending_upgrades map so UpdateServiceState knows

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -169,14 +169,13 @@ enum DpuType {
 impl DpuType {
     fn firmware_inventory_id(self, component: DpuFirmwareComponent) -> Option<&'static str> {
         match self {
-            Self::Bluefield3 => Some(match component {
+            Self::Bluefield3 | Self::Bluefield4 => Some(match component {
                 DpuFirmwareComponent::Bmc => "BMC_Firmware",
                 DpuFirmwareComponent::Uefi => "DPU_UEFI",
                 DpuFirmwareComponent::Bsp => "DPU_BSP",
                 DpuFirmwareComponent::Cec => "Bluefield_FW_ERoT",
                 DpuFirmwareComponent::Nic => "DPU_NIC",
             }),
-            Self::Bluefield4 => None,
         }
     }
 }
@@ -1289,12 +1288,13 @@ mod tests {
     use super::*;
     use crate::mac_address_pool::{Config, PoolConfig};
 
-    fn bf3_dpu(
+    fn dpu(
+        hw_type: HardwareType,
         pool: &mut MacAddressPool,
         firmware_versions: DpuFirmwareVersions,
     ) -> DpuMachineInfo {
         DpuMachineInfo::new(
-            HardwareType::DellPowerEdgeR750,
+            hw_type,
             pool,
             DpuSettings {
                 firmware_versions,
@@ -1359,38 +1359,49 @@ mod tests {
     }
 
     #[test]
-    fn configured_bf3_firmware_uses_the_expected_inventory_ids() {
-        let pool_config =
-            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
-        let mut pool = MacAddressPool::new(Config {
-            ranges: None,
-            pool: Some(pool_config),
-        });
-        let dpu = bf3_dpu(
-            &mut pool,
-            DpuFirmwareVersions {
-                bmc: Some("bmc-version".to_string()),
-                uefi: Some("uefi-version".to_string()),
-                bsp: Some("bsp-version".to_string()),
-                cec: Some("cec-version".to_string()),
-                nic: Some("nic-version".to_string()),
-            },
-        );
-        let config = dpu.update_service_config();
-
-        for (id, expected) in [
-            ("BMC_Firmware", "bmc-version"),
-            ("DPU_UEFI", "uefi-version"),
-            ("DPU_BSP", "bsp-version"),
-            ("Bluefield_FW_ERoT", "cec-version"),
-            ("DPU_NIC", "nic-version"),
+    fn configured_dpu_firmware_uses_the_expected_inventory_ids() {
+        for hardware_type in [
+            HardwareType::DellPowerEdgeR750,
+            HardwareType::DellPowerEdgeR760Bf4,
+            HardwareType::NvidiaDgxVr,
         ] {
-            let inventory = config
-                .firmware_inventory
-                .iter()
-                .find(|inventory| inventory.id == id)
-                .unwrap_or_else(|| panic!("missing {id}"));
-            assert_eq!(inventory.to_json()["Version"].as_str(), Some(expected));
+            let pool_config =
+                PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+            let mut pool = MacAddressPool::new(Config {
+                ranges: None,
+                pool: Some(pool_config),
+            });
+            let dpu = dpu(
+                hardware_type,
+                &mut pool,
+                DpuFirmwareVersions {
+                    bmc: Some("bmc-version".to_string()),
+                    uefi: Some("uefi-version".to_string()),
+                    bsp: Some("bsp-version".to_string()),
+                    cec: Some("cec-version".to_string()),
+                    nic: Some("nic-version".to_string()),
+                },
+            );
+            let config = dpu.update_service_config();
+
+            for (id, expected) in [
+                ("BMC_Firmware", "bmc-version"),
+                ("DPU_UEFI", "uefi-version"),
+                ("DPU_BSP", "bsp-version"),
+                ("Bluefield_FW_ERoT", "cec-version"),
+                ("DPU_NIC", "nic-version"),
+            ] {
+                let inventory = config
+                    .firmware_inventory
+                    .iter()
+                    .find(|inventory| inventory.id == id)
+                    .unwrap_or_else(|| panic!("missing {id} for {hardware_type}"));
+                assert_eq!(
+                    inventory.to_json()["Version"].as_str(),
+                    Some(expected),
+                    "{hardware_type}",
+                );
+            }
         }
     }
 
@@ -1402,7 +1413,8 @@ mod tests {
             ranges: None,
             pool: Some(pool_config),
         });
-        let dpu = bf3_dpu(
+        let dpu = dpu(
+            HardwareType::DellPowerEdgeR750,
             &mut pool,
             DpuFirmwareVersions {
                 bsp: Some("bsp-version".to_string()),

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -109,21 +109,49 @@ pub struct DpuMachineInfo {
     pub settings: DpuSettings,
 }
 
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+/// Optional firmware inventory overrides for a generated BlueField DPU.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DpuFirmwareVersions {
+    /// DPU BMC firmware version.
     pub bmc: Option<String>,
+    /// DPU UEFI firmware version.
     pub uefi: Option<String>,
+    /// DPU BSP version.
+    #[serde(default)]
+    pub bsp: Option<String>,
+    /// DPU CEC firmware version.
     pub cec: Option<String>,
+    /// DPU NIC firmware version.
     pub nic: Option<String>,
+}
+
+#[derive(Clone, Copy)]
+enum DpuFirmwareComponent {
+    Bmc,
+    Uefi,
+    Bsp,
+    Cec,
+    Nic,
+}
+
+impl DpuFirmwareVersions {
+    fn configured(&self) -> impl Iterator<Item = (DpuFirmwareComponent, &str)> {
+        [
+            (DpuFirmwareComponent::Bmc, self.bmc.as_deref()),
+            (DpuFirmwareComponent::Uefi, self.uefi.as_deref()),
+            (DpuFirmwareComponent::Bsp, self.bsp.as_deref()),
+            (DpuFirmwareComponent::Cec, self.cec.as_deref()),
+            (DpuFirmwareComponent::Nic, self.nic.as_deref()),
+        ]
+        .into_iter()
+        .filter_map(|(component, version)| version.map(|version| (component, version)))
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DpuSettings {
     pub nic_mode: bool,
     pub firmware_versions: DpuFirmwareVersions,
-    /// Optional BSP version exposed as DPU_BSP firmware inventory; omitted by default.
-    #[serde(default)]
-    pub bsp_version: Option<String>,
     #[serde(default = "default_true")]
     pub exposes_oob_eth: bool,
 }
@@ -132,9 +160,25 @@ fn default_true() -> bool {
     true
 }
 
+#[derive(Clone, Copy)]
 enum DpuType {
     Bluefield3,
     Bluefield4,
+}
+
+impl DpuType {
+    fn firmware_inventory_id(self, component: DpuFirmwareComponent) -> Option<&'static str> {
+        match self {
+            Self::Bluefield3 => Some(match component {
+                DpuFirmwareComponent::Bmc => "BMC_Firmware",
+                DpuFirmwareComponent::Uefi => "DPU_UEFI",
+                DpuFirmwareComponent::Bsp => "DPU_BSP",
+                DpuFirmwareComponent::Cec => "Bluefield_FW_ERoT",
+                DpuFirmwareComponent::Nic => "DPU_NIC",
+            }),
+            Self::Bluefield4 => None,
+        }
+    }
 }
 
 impl Default for DpuSettings {
@@ -142,7 +186,6 @@ impl Default for DpuSettings {
         Self {
             nic_mode: false,
             firmware_versions: Default::default(),
-            bsp_version: None,
             exposes_oob_eth: true,
         }
     }
@@ -296,38 +339,33 @@ impl DpuMachineInfo {
     fn update_service_config(&self) -> UpdateServiceConfig {
         let mut config = match self.dpu_type() {
             DpuType::Bluefield3 => self.bluefield3().update_service_config(),
-            DpuType::Bluefield4 => {
-                let mut config = self.bluefield4().update_service_config();
-                let fw = &self.settings.firmware_versions;
-                for (id, version) in [
-                    ("BMC_Firmware", &fw.bmc),
-                    ("DPU_UEFI", &fw.uefi),
-                    ("Bluefield_FW_ERoT", &fw.cec),
-                    ("DPU_NIC", &fw.nic),
-                ] {
-                    if let Some(version) = version {
-                        config.firmware_inventory.push(
-                            redfish::software_inventory::builder(
-                                &redfish::software_inventory::firmware_inventory_resource(id),
-                            )
-                            .version(version)
-                            .build(),
-                        );
-                    }
-                }
-                config
-            }
+            DpuType::Bluefield4 => self.bluefield4().update_service_config(),
         };
-        if let Some(bsp) = &self.settings.bsp_version {
+        self.append_configured_firmware_inventory(&mut config);
+        config
+    }
+
+    fn append_configured_firmware_inventory(&self, config: &mut UpdateServiceConfig) {
+        let dpu_type = self.dpu_type();
+        for (component, version) in self.settings.firmware_versions.configured() {
+            let Some(id) = dpu_type.firmware_inventory_id(component) else {
+                continue;
+            };
+            if config
+                .firmware_inventory
+                .iter()
+                .any(|existing| existing.id == id)
+            {
+                continue;
+            }
             config.firmware_inventory.push(
                 redfish::software_inventory::builder(
-                    &redfish::software_inventory::firmware_inventory_resource("DPU_BSP"),
+                    &redfish::software_inventory::firmware_inventory_resource(id),
                 )
-                .version(bsp)
+                .version(version)
                 .build(),
             );
         }
-        config
     }
 
     fn oem_state(&self) -> redfish::oem::State {
@@ -635,27 +673,10 @@ impl HostMachineInfo {
             config.apply_host_firmware_versions(fw);
         }
 
-        // Generated host and DPU endpoints model two BMC views of the same
-        // BlueField. When explicit DPU versions are configured, expose that
-        // inventory through the host endpoint as well so both views agree.
-        if let Some(dpu) = self.primary_dpu().filter(|dpu| {
-            let fw = &dpu.settings.firmware_versions;
-            fw.bmc.is_some()
-                || fw.uefi.is_some()
-                || dpu.settings.bsp_version.is_some()
-                || fw.cec.is_some()
-                || fw.nic.is_some()
-        }) {
-            for inventory in dpu.update_service_config().firmware_inventory {
-                let inventory_id = inventory.id.as_ref();
-                if !config
-                    .firmware_inventory
-                    .iter()
-                    .any(|existing| existing.id.as_ref() == inventory_id)
-                {
-                    config.firmware_inventory.push(inventory);
-                }
-            }
+        // Host inventory owns any colliding ID; only explicitly configured DPU
+        // entries are appended, rather than the DPU's complete baseline inventory.
+        if let Some(dpu) = self.primary_dpu() {
+            dpu.append_configured_firmware_inventory(&mut config);
         }
 
         // Populate the ordered pending_upgrades map so UpdateServiceState knows
@@ -1268,6 +1289,20 @@ mod tests {
     use super::*;
     use crate::mac_address_pool::{Config, PoolConfig};
 
+    fn bf3_dpu(
+        pool: &mut MacAddressPool,
+        firmware_versions: DpuFirmwareVersions,
+    ) -> DpuMachineInfo {
+        DpuMachineInfo::new(
+            HardwareType::DellPowerEdgeR750,
+            pool,
+            DpuSettings {
+                firmware_versions,
+                ..DpuSettings::default()
+            },
+        )
+    }
+
     fn gb300_host_info(hw_type: HardwareType, pool: &mut MacAddressPool) -> HostMachineInfo {
         let hw_mac_addr_pool = PoolConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 16)
             .expect("valid hardware MAC pool");
@@ -1321,5 +1356,85 @@ mod tests {
             assert!(host.switch_serial_number.is_some(), "{hardware_type}");
             assert_eq!(host.non_dpu_mac_address, None, "{hardware_type}");
         }
+    }
+
+    #[test]
+    fn configured_bf3_firmware_uses_the_expected_inventory_ids() {
+        let pool_config =
+            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+        let mut pool = MacAddressPool::new(Config {
+            ranges: None,
+            pool: Some(pool_config),
+        });
+        let dpu = bf3_dpu(
+            &mut pool,
+            DpuFirmwareVersions {
+                bmc: Some("bmc-version".to_string()),
+                uefi: Some("uefi-version".to_string()),
+                bsp: Some("bsp-version".to_string()),
+                cec: Some("cec-version".to_string()),
+                nic: Some("nic-version".to_string()),
+            },
+        );
+        let config = dpu.update_service_config();
+
+        for (id, expected) in [
+            ("BMC_Firmware", "bmc-version"),
+            ("DPU_UEFI", "uefi-version"),
+            ("DPU_BSP", "bsp-version"),
+            ("Bluefield_FW_ERoT", "cec-version"),
+            ("DPU_NIC", "nic-version"),
+        ] {
+            let inventory = config
+                .firmware_inventory
+                .iter()
+                .find(|inventory| inventory.id == id)
+                .unwrap_or_else(|| panic!("missing {id}"));
+            assert_eq!(inventory.to_json()["Version"].as_str(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn host_adds_only_explicit_primary_dpu_firmware() {
+        let pool_config =
+            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+        let mut pool = MacAddressPool::new(Config {
+            ranges: None,
+            pool: Some(pool_config),
+        });
+        let dpu = bf3_dpu(
+            &mut pool,
+            DpuFirmwareVersions {
+                bsp: Some("bsp-version".to_string()),
+                ..DpuFirmwareVersions::default()
+            },
+        );
+        let hw_mac_addr_pool = PoolConfig::new(MacAddress::new([6, 0, 0, 0, 0, 0]), 16)
+            .expect("valid hardware MAC pool");
+        let host = HostMachineInfo::new(
+            HardwareType::DellPowerEdgeR750,
+            vec![dpu],
+            &mut pool,
+            hw_mac_addr_pool,
+        );
+        let config = host.update_service_config();
+        let mut ids = config
+            .firmware_inventory
+            .iter()
+            .map(|inventory| inventory.id.as_ref())
+            .collect::<Vec<_>>();
+        ids.sort_unstable();
+
+        assert_eq!(ids, ["DPU_BSP", "HostBIOS_0", "HostBMC_0"]);
+        assert_eq!(
+            config
+                .firmware_inventory
+                .iter()
+                .find(|inventory| inventory.id == "DPU_BSP")
+                .expect("DPU_BSP must be present")
+                .to_json()["Version"]
+                .as_str(),
+            Some("bsp-version"),
+        );
     }
 }

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -296,7 +296,27 @@ impl DpuMachineInfo {
     fn update_service_config(&self) -> UpdateServiceConfig {
         let mut config = match self.dpu_type() {
             DpuType::Bluefield3 => self.bluefield3().update_service_config(),
-            DpuType::Bluefield4 => self.bluefield4().update_service_config(),
+            DpuType::Bluefield4 => {
+                let mut config = self.bluefield4().update_service_config();
+                let fw = &self.settings.firmware_versions;
+                for (id, version) in [
+                    ("BMC_Firmware", &fw.bmc),
+                    ("DPU_UEFI", &fw.uefi),
+                    ("Bluefield_FW_ERoT", &fw.cec),
+                    ("DPU_NIC", &fw.nic),
+                ] {
+                    if let Some(version) = version {
+                        config.firmware_inventory.push(
+                            redfish::software_inventory::builder(
+                                &redfish::software_inventory::firmware_inventory_resource(id),
+                            )
+                            .version(version)
+                            .build(),
+                        );
+                    }
+                }
+                config
+            }
         };
         if let Some(bsp) = &self.settings.bsp_version {
             config.firmware_inventory.push(

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -110,6 +110,8 @@ pub struct DpuMachineInfo {
 }
 
 /// Optional firmware inventory overrides for a generated BlueField DPU.
+///
+/// Redfish inventory IDs are selected separately for each modeled DPU generation.
 #[derive(Debug, Clone, Default, Serialize, Deserialize, Eq, PartialEq)]
 pub struct DpuFirmwareVersions {
     /// DPU BMC firmware version.
@@ -169,13 +171,16 @@ enum DpuType {
 impl DpuType {
     fn firmware_inventory_id(self, component: DpuFirmwareComponent) -> Option<&'static str> {
         match self {
-            Self::Bluefield3 | Self::Bluefield4 => Some(match component {
+            Self::Bluefield3 => Some(match component {
                 DpuFirmwareComponent::Bmc => "BMC_Firmware",
                 DpuFirmwareComponent::Uefi => "DPU_UEFI",
                 DpuFirmwareComponent::Bsp => "DPU_BSP",
                 DpuFirmwareComponent::Cec => "Bluefield_FW_ERoT",
                 DpuFirmwareComponent::Nic => "DPU_NIC",
             }),
+            // BF4 uses a distinct FirmwareInventory schema. No mapping is
+            // defined without an authoritative inventory for every component.
+            Self::Bluefield4 => None,
         }
     }
 }
@@ -1288,13 +1293,12 @@ mod tests {
     use super::*;
     use crate::mac_address_pool::{Config, PoolConfig};
 
-    fn dpu(
-        hw_type: HardwareType,
+    fn bf3_dpu(
         pool: &mut MacAddressPool,
         firmware_versions: DpuFirmwareVersions,
     ) -> DpuMachineInfo {
         DpuMachineInfo::new(
-            hw_type,
+            HardwareType::DellPowerEdgeR750,
             pool,
             DpuSettings {
                 firmware_versions,
@@ -1359,49 +1363,79 @@ mod tests {
     }
 
     #[test]
-    fn configured_dpu_firmware_uses_the_expected_inventory_ids() {
-        for hardware_type in [
-            HardwareType::DellPowerEdgeR750,
-            HardwareType::DellPowerEdgeR760Bf4,
-            HardwareType::NvidiaDgxVr,
+    fn configured_bf3_firmware_uses_the_expected_inventory_ids() {
+        let pool_config =
+            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+        let mut pool = MacAddressPool::new(Config {
+            ranges: None,
+            pool: Some(pool_config),
+        });
+        let dpu = bf3_dpu(
+            &mut pool,
+            DpuFirmwareVersions {
+                bmc: Some("bmc-version".to_string()),
+                uefi: Some("uefi-version".to_string()),
+                bsp: Some("bsp-version".to_string()),
+                cec: Some("cec-version".to_string()),
+                nic: Some("nic-version".to_string()),
+            },
+        );
+        let config = dpu.update_service_config();
+
+        for (id, expected) in [
+            ("BMC_Firmware", "bmc-version"),
+            ("DPU_UEFI", "uefi-version"),
+            ("DPU_BSP", "bsp-version"),
+            ("Bluefield_FW_ERoT", "cec-version"),
+            ("DPU_NIC", "nic-version"),
         ] {
-            let pool_config =
-                PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
-            let mut pool = MacAddressPool::new(Config {
-                ranges: None,
-                pool: Some(pool_config),
-            });
-            let dpu = dpu(
-                hardware_type,
-                &mut pool,
-                DpuFirmwareVersions {
+            let inventory = config
+                .firmware_inventory
+                .iter()
+                .find(|inventory| inventory.id == id)
+                .unwrap_or_else(|| panic!("missing {id}"));
+            assert_eq!(inventory.to_json()["Version"].as_str(), Some(expected));
+        }
+    }
+
+    #[test]
+    fn bf4_does_not_reuse_bf3_firmware_inventory_ids() {
+        let pool_config =
+            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+        let mut pool = MacAddressPool::new(Config {
+            ranges: None,
+            pool: Some(pool_config),
+        });
+        let dpu = DpuMachineInfo::new(
+            HardwareType::DellPowerEdgeR760Bf4,
+            &mut pool,
+            DpuSettings {
+                firmware_versions: DpuFirmwareVersions {
                     bmc: Some("bmc-version".to_string()),
                     uefi: Some("uefi-version".to_string()),
                     bsp: Some("bsp-version".to_string()),
                     cec: Some("cec-version".to_string()),
                     nic: Some("nic-version".to_string()),
                 },
-            );
-            let config = dpu.update_service_config();
+                ..DpuSettings::default()
+            },
+        );
 
-            for (id, expected) in [
-                ("BMC_Firmware", "bmc-version"),
-                ("DPU_UEFI", "uefi-version"),
-                ("DPU_BSP", "bsp-version"),
-                ("Bluefield_FW_ERoT", "cec-version"),
-                ("DPU_NIC", "nic-version"),
-            ] {
-                let inventory = config
+        let config = dpu.update_service_config();
+        for bf3_id in [
+            "BMC_Firmware",
+            "DPU_UEFI",
+            "DPU_BSP",
+            "Bluefield_FW_ERoT",
+            "DPU_NIC",
+        ] {
+            assert!(
+                config
                     .firmware_inventory
                     .iter()
-                    .find(|inventory| inventory.id == id)
-                    .unwrap_or_else(|| panic!("missing {id} for {hardware_type}"));
-                assert_eq!(
-                    inventory.to_json()["Version"].as_str(),
-                    Some(expected),
-                    "{hardware_type}",
-                );
-            }
+                    .all(|inventory| inventory.id != bf3_id),
+                "unexpected BF3 inventory ID {bf3_id}",
+            );
         }
     }
 
@@ -1413,8 +1447,7 @@ mod tests {
             ranges: None,
             pool: Some(pool_config),
         });
-        let dpu = dpu(
-            HardwareType::DellPowerEdgeR750,
+        let dpu = bf3_dpu(
             &mut pool,
             DpuFirmwareVersions {
                 bsp: Some("bsp-version".to_string()),

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -118,7 +118,13 @@ pub struct DpuFirmwareVersions {
     pub bmc: Option<String>,
     /// DPU UEFI firmware version.
     pub uefi: Option<String>,
-    /// DPU BSP version.
+    /// Optional opaque DPU BSP firmware version.
+    ///
+    /// Any string is accepted verbatim, including an empty string. The default,
+    /// `None`, omits `DPU_BSP` from generated firmware inventory; `Some("")`
+    /// explicitly configures that inventory entry with an empty version. This is
+    /// supported for generated BlueField-3 and BlueField-4 DPU profiles; profiles
+    /// without a generated DPU do not expose the entry.
     #[serde(default)]
     pub bsp: Option<String>,
     /// DPU CEC firmware version.

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -178,11 +178,14 @@ impl DpuType {
                 DpuFirmwareComponent::Cec => "Bluefield_FW_ERoT",
                 DpuFirmwareComponent::Nic => "DPU_NIC",
             }),
-            // TODO: Populate BF4 component IDs from captured B4240/B4240V
-            // FirmwareInventory responses. BF4 uses generation-specific names;
-            // its known BMC inventory ID is `BlueField_FW_BMC_0`:
-            // https://github.com/NVIDIA/infra-controller/issues/2862
-            Self::Bluefield4 => None,
+            Self::Bluefield4 => Some(match component {
+                DpuFirmwareComponent::Bmc => "BlueField_FW_BMC_0",
+                DpuFirmwareComponent::Uefi => "BlueField_FW_CPU_0",
+                // NVIDIA's Redfish client uses this ID for both generations.
+                DpuFirmwareComponent::Bsp => "DPU_BSP",
+                DpuFirmwareComponent::Cec => "BlueField_FW_ERoT_BMC_0",
+                DpuFirmwareComponent::Nic => "BlueField_FW_NIC_0",
+            }),
         }
     }
 }
@@ -1295,12 +1298,13 @@ mod tests {
     use super::*;
     use crate::mac_address_pool::{Config, PoolConfig};
 
-    fn bf3_dpu(
+    fn dpu(
+        hw_type: HardwareType,
         pool: &mut MacAddressPool,
         firmware_versions: DpuFirmwareVersions,
     ) -> DpuMachineInfo {
         DpuMachineInfo::new(
-            HardwareType::DellPowerEdgeR750,
+            hw_type,
             pool,
             DpuSettings {
                 firmware_versions,
@@ -1365,79 +1369,72 @@ mod tests {
     }
 
     #[test]
-    fn configured_bf3_firmware_uses_the_expected_inventory_ids() {
-        let pool_config =
-            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
-        let mut pool = MacAddressPool::new(Config {
-            ranges: None,
-            pool: Some(pool_config),
-        });
-        let dpu = bf3_dpu(
-            &mut pool,
-            DpuFirmwareVersions {
-                bmc: Some("bmc-version".to_string()),
-                uefi: Some("uefi-version".to_string()),
-                bsp: Some("bsp-version".to_string()),
-                cec: Some("cec-version".to_string()),
-                nic: Some("nic-version".to_string()),
-            },
-        );
-        let config = dpu.update_service_config();
-
-        for (id, expected) in [
-            ("BMC_Firmware", "bmc-version"),
-            ("DPU_UEFI", "uefi-version"),
-            ("DPU_BSP", "bsp-version"),
-            ("Bluefield_FW_ERoT", "cec-version"),
-            ("DPU_NIC", "nic-version"),
+    fn configured_dpu_firmware_uses_generation_specific_inventory_ids() {
+        for (hardware_type, expected_inventory) in [
+            (
+                HardwareType::DellPowerEdgeR750,
+                [
+                    ("BMC_Firmware", "bmc-version"),
+                    ("DPU_UEFI", "uefi-version"),
+                    ("DPU_BSP", "bsp-version"),
+                    ("Bluefield_FW_ERoT", "cec-version"),
+                    ("DPU_NIC", "nic-version"),
+                ],
+            ),
+            (
+                HardwareType::DellPowerEdgeR760Bf4,
+                [
+                    ("BlueField_FW_BMC_0", "bmc-version"),
+                    ("BlueField_FW_CPU_0", "uefi-version"),
+                    ("DPU_BSP", "bsp-version"),
+                    ("BlueField_FW_ERoT_BMC_0", "cec-version"),
+                    ("BlueField_FW_NIC_0", "nic-version"),
+                ],
+            ),
         ] {
-            let inventory = config
-                .firmware_inventory
-                .iter()
-                .find(|inventory| inventory.id == id)
-                .unwrap_or_else(|| panic!("missing {id}"));
-            assert_eq!(inventory.to_json()["Version"].as_str(), Some(expected));
-        }
-    }
-
-    #[test]
-    fn bf4_does_not_reuse_bf3_firmware_inventory_ids() {
-        let pool_config =
-            PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
-        let mut pool = MacAddressPool::new(Config {
-            ranges: None,
-            pool: Some(pool_config),
-        });
-        let dpu = DpuMachineInfo::new(
-            HardwareType::DellPowerEdgeR760Bf4,
-            &mut pool,
-            DpuSettings {
-                firmware_versions: DpuFirmwareVersions {
+            let pool_config =
+                PoolConfig::new(MacAddress::new([2, 0, 0, 0, 0, 0]), 16).expect("valid MAC pool");
+            let mut pool = MacAddressPool::new(Config {
+                ranges: None,
+                pool: Some(pool_config),
+            });
+            let dpu = dpu(
+                hardware_type,
+                &mut pool,
+                DpuFirmwareVersions {
                     bmc: Some("bmc-version".to_string()),
                     uefi: Some("uefi-version".to_string()),
                     bsp: Some("bsp-version".to_string()),
                     cec: Some("cec-version".to_string()),
                     nic: Some("nic-version".to_string()),
                 },
-                ..DpuSettings::default()
-            },
-        );
+            );
+            let config = dpu.update_service_config();
 
-        let config = dpu.update_service_config();
-        for bf3_id in [
-            "BMC_Firmware",
-            "DPU_UEFI",
-            "DPU_BSP",
-            "Bluefield_FW_ERoT",
-            "DPU_NIC",
-        ] {
-            assert!(
-                config
+            for (id, expected) in expected_inventory {
+                let inventory = config
                     .firmware_inventory
                     .iter()
-                    .all(|inventory| inventory.id != bf3_id),
-                "unexpected BF3 inventory ID {bf3_id}",
-            );
+                    .find(|inventory| inventory.id == id)
+                    .unwrap_or_else(|| panic!("missing {id} for {hardware_type}"));
+                assert_eq!(
+                    inventory.to_json()["Version"].as_str(),
+                    Some(expected),
+                    "{hardware_type}",
+                );
+            }
+
+            if matches!(hardware_type, HardwareType::DellPowerEdgeR760Bf4) {
+                for bf3_only_id in ["BMC_Firmware", "DPU_UEFI", "Bluefield_FW_ERoT", "DPU_NIC"] {
+                    assert!(
+                        config
+                            .firmware_inventory
+                            .iter()
+                            .all(|inventory| inventory.id != bf3_only_id),
+                        "unexpected BF3-only inventory ID {bf3_only_id}",
+                    );
+                }
+            }
         }
     }
 
@@ -1449,7 +1446,8 @@ mod tests {
             ranges: None,
             pool: Some(pool_config),
         });
-        let dpu = bf3_dpu(
+        let dpu = dpu(
+            HardwareType::DellPowerEdgeR750,
             &mut pool,
             DpuFirmwareVersions {
                 bsp: Some("bsp-version".to_string()),

--- a/crates/bmc-mock/src/machine_info.rs
+++ b/crates/bmc-mock/src/machine_info.rs
@@ -178,8 +178,10 @@ impl DpuType {
                 DpuFirmwareComponent::Cec => "Bluefield_FW_ERoT",
                 DpuFirmwareComponent::Nic => "DPU_NIC",
             }),
-            // BF4 uses a distinct FirmwareInventory schema. No mapping is
-            // defined without an authoritative inventory for every component.
+            // TODO: Populate BF4 component IDs from captured B4240/B4240V
+            // FirmwareInventory responses. BF4 uses generation-specific names;
+            // its known BMC inventory ID is `BlueField_FW_BMC_0`:
+            // https://github.com/NVIDIA/infra-controller/issues/2862
             Self::Bluefield4 => None,
         }
     }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -32,9 +32,9 @@ use bmc_mock::mac_address_pool::{
     RangesConfig as MacAddressRangesConfig,
 };
 use bmc_mock::{
-    BmcCommand, BmcState, Callbacks, DpuMachineInfo, DpuSettings, HardwareType, HostMachineInfo,
-    ListenerOrAddress, MachineInfo, MachineRouterOptions, MockPowerState, SetSystemPowerError,
-    SystemPowerControl, VirtualMediaDeviceConfig,
+    BmcCommand, BmcState, Callbacks, DpuFirmwareVersions, DpuMachineInfo, DpuSettings,
+    HardwareType, HostMachineInfo, ListenerOrAddress, MachineInfo, MachineRouterOptions,
+    MockPowerState, SetSystemPowerError, SystemPowerControl, VirtualMediaDeviceConfig,
 };
 use command_line::{MachineRole, StateBackend};
 use mac_address::MacAddress;
@@ -86,7 +86,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         || args.state_backend.is_some()
         || args.dpu_count.is_some()
         || args.dpu_index.is_some()
-        || args.instance_index != 0;
+        || args.instance_index != 0
+        || args.dpu_bmc_firmware.is_some()
+        || args.dpu_uefi_firmware.is_some()
+        || args.dpu_bsp_firmware.is_some()
+        || args.dpu_cec_firmware.is_some()
+        || args.dpu_nic_firmware.is_some();
     if has_generated_options && (args.targz.is_some() || args.ip_router.is_some()) {
         return Err(
             "generated-machine options cannot be combined with archive-backed routers".into(),
@@ -223,6 +228,8 @@ struct GeneratedMockConfig {
     dpu_count: u8,
     dpu_index: usize,
     instance_index: u8,
+    dpu_firmware: DpuFirmwareVersions,
+    dpu_bsp_firmware: Option<String>,
     libvirt_config: Option<bmc_mock::libvirt::Config>,
     use_channel_callbacks: bool,
 }
@@ -246,6 +253,8 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
             dpu_count: 2,
             dpu_index: 0,
             instance_index: 0,
+            dpu_firmware: DpuFirmwareVersions::default(),
+            dpu_bsp_firmware: None,
             libvirt_config: None,
             use_channel_callbacks: true,
         });
@@ -325,6 +334,13 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         dpu_count,
         dpu_index,
         instance_index: args.instance_index,
+        dpu_firmware: DpuFirmwareVersions {
+            bmc: args.dpu_bmc_firmware.clone(),
+            uefi: args.dpu_uefi_firmware.clone(),
+            cec: args.dpu_cec_firmware.clone(),
+            nic: args.dpu_nic_firmware.clone(),
+        },
+        dpu_bsp_firmware: args.dpu_bsp_firmware.clone(),
         libvirt_config,
         use_channel_callbacks: false,
     })
@@ -349,6 +365,8 @@ fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
         config.dpu_count,
         config.dpu_index,
         config.instance_index,
+        config.dpu_firmware,
+        config.dpu_bsp_firmware,
     );
     let result = if config.machine_role == MachineRole::Host
         && config.state_backend == StateBackend::Libvirt
@@ -397,6 +415,8 @@ fn generated_machine_info(
     dpu_count: u8,
     dpu_index: usize,
     instance_index: u8,
+    dpu_firmware: DpuFirmwareVersions,
+    dpu_bsp_firmware: Option<String>,
 ) -> MachineInfo {
     let mut pool = MacAddressPool::new(MacAddressConfig {
         pool: Some(
@@ -413,7 +433,17 @@ fn generated_machine_info(
         .allocate_range_config()
         .expect("MAC address pool should be allocated");
     let dpus = (0..dpu_count)
-        .map(|_| DpuMachineInfo::new(hardware_type, &mut pool, DpuSettings::default()))
+        .map(|_| {
+            DpuMachineInfo::new(
+                hardware_type,
+                &mut pool,
+                DpuSettings {
+                    firmware_versions: dpu_firmware.clone(),
+                    bsp_version: dpu_bsp_firmware.clone(),
+                    ..DpuSettings::default()
+                },
+            )
+        })
         .collect::<Vec<_>>();
     match machine_role {
         MachineRole::Host => MachineInfo::Host(HostMachineInfo::new(
@@ -534,8 +564,24 @@ mod tests {
 
     #[test]
     fn host_and_dpu_endpoints_share_deterministic_dpu_identity() {
-        let host = generated_machine_info(MachineRole::Host, HardwareType::WiwynnGB200Nvl, 2, 0, 3);
-        let dpu = generated_machine_info(MachineRole::Dpu, HardwareType::WiwynnGB200Nvl, 2, 1, 3);
+        let host = generated_machine_info(
+            MachineRole::Host,
+            HardwareType::WiwynnGB200Nvl,
+            2,
+            0,
+            3,
+            DpuFirmwareVersions::default(),
+            None,
+        );
+        let dpu = generated_machine_info(
+            MachineRole::Dpu,
+            HardwareType::WiwynnGB200Nvl,
+            2,
+            1,
+            3,
+            DpuFirmwareVersions::default(),
+            None,
+        );
         let MachineInfo::Host(host) = host else {
             panic!("expected host machine info");
         };
@@ -545,5 +591,78 @@ mod tests {
 
         assert_eq!(host.dpus[1].serial, dpu.serial);
         assert_eq!(host.dpus[1].bmc_mac_address, dpu.bmc_mac_address);
+    }
+
+    #[test]
+    fn reports_configured_dpu_firmware_versions() {
+        for machine_role in ["host", "dpu"] {
+            let config = config(&[
+                "bmc-mock",
+                "--machine-role",
+                machine_role,
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                "hpe_proliant_dl380a_gen11",
+                "--dpu-count",
+                "1",
+                "--dpu-bmc-firmware",
+                "BF-25.10-20",
+                "--dpu-uefi-firmware",
+                "4.13.2-12-g943a91640d",
+                "--dpu-bsp-firmware",
+                "4.13.2",
+                "--dpu-cec-firmware",
+                "00.02.0195.0000_n02",
+                "--dpu-nic-firmware",
+                "32.47.2682",
+            ])
+            .unwrap();
+            let (_, state) = generated_mock(config);
+
+            for (inventory_id, expected) in [
+                ("BMC_Firmware", "BF-25.10-20"),
+                ("DPU_UEFI", "4.13.2-12-g943a91640d"),
+                ("DPU_BSP", "4.13.2"),
+                ("Bluefield_FW_ERoT", "00.02.0195.0000_n02"),
+                ("DPU_NIC", "32.47.2682"),
+            ] {
+                let inventory = state
+                    .update_service_state
+                    .find_firmware_inventory(inventory_id)
+                    .unwrap_or_else(|| {
+                        panic!("missing {inventory_id} firmware inventory for {machine_role}")
+                    });
+                assert_eq!(inventory["Version"].as_str(), Some(expected));
+            }
+        }
+    }
+
+    #[test]
+    fn bsp_inventory_is_optional_and_can_be_configured_independently() {
+        for bsp in [None, Some("4.13.2")] {
+            let mut arguments = vec![
+                "bmc-mock",
+                "--machine-role",
+                "dpu",
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                "hpe_proliant_dl380a_gen11",
+                "--dpu-count",
+                "1",
+            ];
+            if let Some(version) = bsp {
+                arguments.extend(["--dpu-bsp-firmware", version]);
+            }
+            let (_, state) = generated_mock(config(&arguments).unwrap());
+            let inventory = state
+                .update_service_state
+                .find_firmware_inventory("DPU_BSP");
+            assert_eq!(
+                inventory.as_ref().and_then(|item| item["Version"].as_str()),
+                bsp
+            );
+        }
     }
 }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -86,12 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         || args.state_backend.is_some()
         || args.dpu_count.is_some()
         || args.dpu_index.is_some()
-        || args.instance_index != 0
-        || args.dpu_bmc_firmware.is_some()
-        || args.dpu_uefi_firmware.is_some()
-        || args.dpu_bsp_firmware.is_some()
-        || args.dpu_cec_firmware.is_some()
-        || args.dpu_nic_firmware.is_some();
+        || args.instance_index != 0;
     if has_generated_options && (args.targz.is_some() || args.ip_router.is_some()) {
         return Err(
             "generated-machine options cannot be combined with archive-backed routers".into(),
@@ -229,7 +224,6 @@ struct GeneratedMockConfig {
     dpu_index: usize,
     instance_index: u8,
     dpu_firmware: DpuFirmwareVersions,
-    dpu_bsp_firmware: Option<String>,
     libvirt_config: Option<bmc_mock::libvirt::Config>,
     use_channel_callbacks: bool,
 }
@@ -254,7 +248,6 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
             dpu_index: 0,
             instance_index: 0,
             dpu_firmware: DpuFirmwareVersions::default(),
-            dpu_bsp_firmware: None,
             libvirt_config: None,
             use_channel_callbacks: true,
         });
@@ -296,17 +289,22 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         (None, requested) => requested.unwrap_or(0),
     };
     let dpu_index = args.dpu_index.unwrap_or(0);
-    if dpu_count == 0
-        && (args.dpu_bmc_firmware.is_some()
-            || args.dpu_uefi_firmware.is_some()
-            || args.dpu_bsp_firmware.is_some()
-            || args.dpu_cec_firmware.is_some()
-            || args.dpu_nic_firmware.is_some())
-    {
-        return Err(
-            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
-                .to_string(),
-        );
+    if !args.dpu_firmware.is_empty() {
+        if matches!(
+            hardware_type,
+            HardwareType::DellPowerEdgeR760Bf4 | HardwareType::NvidiaDgxVr
+        ) {
+            return Err(
+                "DPU firmware options are not supported for BlueField-4 hardware profiles"
+                    .to_string(),
+            );
+        }
+        if dpu_count == 0 {
+            return Err(
+                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
+                    .to_string(),
+            );
+        }
     }
     match machine_role {
         MachineRole::Host if args.dpu_index.is_some() => {
@@ -346,19 +344,14 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         dpu_count,
         dpu_index,
         instance_index: args.instance_index,
-        dpu_firmware: DpuFirmwareVersions {
-            bmc: args.dpu_bmc_firmware.clone(),
-            uefi: args.dpu_uefi_firmware.clone(),
-            cec: args.dpu_cec_firmware.clone(),
-            nic: args.dpu_nic_firmware.clone(),
-        },
-        dpu_bsp_firmware: args.dpu_bsp_firmware.clone(),
+        dpu_firmware: args.dpu_firmware.clone().into(),
         libvirt_config,
         use_channel_callbacks: false,
     })
 }
 
 fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
+    let machine_info = generated_machine_info(&config);
     let libvirt_callbacks = config
         .libvirt_config
         .map(bmc_mock::libvirt::LibvirtCallbacks::new)
@@ -371,15 +364,6 @@ fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
     } else {
         Arc::new(bmc_mock::simulated::SimulatedCallbacks::new())
     };
-    let machine_info = generated_machine_info(
-        config.machine_role,
-        config.hardware_type,
-        config.dpu_count,
-        config.dpu_index,
-        config.instance_index,
-        config.dpu_firmware,
-        config.dpu_bsp_firmware,
-    );
     let result = if config.machine_role == MachineRole::Host
         && config.state_backend == StateBackend::Libvirt
     {
@@ -421,50 +405,45 @@ fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
     result
 }
 
-fn generated_machine_info(
-    machine_role: MachineRole,
-    hardware_type: HardwareType,
-    dpu_count: u8,
-    dpu_index: usize,
-    instance_index: u8,
-    dpu_firmware: DpuFirmwareVersions,
-    dpu_bsp_firmware: Option<String>,
-) -> MachineInfo {
+fn generated_machine_info(config: &GeneratedMockConfig) -> MachineInfo {
     let mut pool = MacAddressPool::new(MacAddressConfig {
         pool: Some(
-            MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, instance_index, 0, 0]), 16)
+            MacAddressPoolConfig::new(MacAddress::new([2, 0, 0, config.instance_index, 0, 0]), 16)
                 .expect("Must be constructed with these parameters"),
         ),
         ranges: Some(
-            MacAddressRangesConfig::new(MacAddress::new([6, 0, 0, instance_index, 0, 0]), 16, 8)
-                .expect("Must be constructed with these parameters"),
+            MacAddressRangesConfig::new(
+                MacAddress::new([6, 0, 0, config.instance_index, 0, 0]),
+                16,
+                8,
+            )
+            .expect("Must be constructed with these parameters"),
         ),
     });
 
     let mac_range = pool
         .allocate_range_config()
         .expect("MAC address pool should be allocated");
-    let dpus = (0..dpu_count)
+    let dpus = (0..config.dpu_count)
         .map(|_| {
             DpuMachineInfo::new(
-                hardware_type,
+                config.hardware_type,
                 &mut pool,
                 DpuSettings {
-                    firmware_versions: dpu_firmware.clone(),
-                    bsp_version: dpu_bsp_firmware.clone(),
+                    firmware_versions: config.dpu_firmware.clone(),
                     ..DpuSettings::default()
                 },
             )
         })
         .collect::<Vec<_>>();
-    match machine_role {
+    match config.machine_role {
         MachineRole::Host => MachineInfo::Host(HostMachineInfo::new(
-            hardware_type,
+            config.hardware_type,
             dpus,
             &mut pool,
             mac_range,
         )),
-        MachineRole::Dpu => MachineInfo::Dpu(dpus[dpu_index].clone()),
+        MachineRole::Dpu => MachineInfo::Dpu(dpus[config.dpu_index].clone()),
     }
 }
 
@@ -575,25 +554,75 @@ mod tests {
     }
 
     #[test]
+    fn rejects_unsupported_dpu_firmware_overrides() {
+        let cases: &[(&str, &[&str], &str)] = &[
+            (
+                "variable-count profile without a DPU",
+                &[
+                    "bmc-mock",
+                    "--machine-role",
+                    "host",
+                    "--state-backend",
+                    "internal",
+                    "--hardware-profile",
+                    "dell_poweredge_r750",
+                    "--dpu-bmc-firmware",
+                    "bmc-version",
+                ],
+                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value",
+            ),
+            (
+                "BlueField-4 profile",
+                &[
+                    "bmc-mock",
+                    "--machine-role",
+                    "dpu",
+                    "--state-backend",
+                    "internal",
+                    "--hardware-profile",
+                    "dell_poweredge_r760_bf4",
+                    "--dpu-bmc-firmware",
+                    "bmc-version",
+                ],
+                "DPU firmware options are not supported for BlueField-4 hardware profiles",
+            ),
+        ];
+
+        for (scenario, arguments, expected) in cases {
+            assert_eq!(config(arguments).unwrap_err(), *expected, "{scenario}");
+        }
+    }
+
+    #[test]
     fn host_and_dpu_endpoints_share_deterministic_dpu_identity() {
-        let host = generated_machine_info(
-            MachineRole::Host,
-            HardwareType::WiwynnGB200Nvl,
-            2,
-            0,
-            3,
-            DpuFirmwareVersions::default(),
-            None,
-        );
-        let dpu = generated_machine_info(
-            MachineRole::Dpu,
-            HardwareType::WiwynnGB200Nvl,
-            2,
-            1,
-            3,
-            DpuFirmwareVersions::default(),
-            None,
-        );
+        let host_config = config(&[
+            "bmc-mock",
+            "--machine-role",
+            "host",
+            "--state-backend",
+            "internal",
+            "--hardware-profile",
+            "wiwynn_gb200_nvl",
+            "--instance-index",
+            "3",
+        ])
+        .unwrap();
+        let dpu_config = config(&[
+            "bmc-mock",
+            "--machine-role",
+            "dpu",
+            "--state-backend",
+            "internal",
+            "--hardware-profile",
+            "wiwynn_gb200_nvl",
+            "--dpu-index",
+            "1",
+            "--instance-index",
+            "3",
+        ])
+        .unwrap();
+        let host = generated_machine_info(&host_config);
+        let dpu = generated_machine_info(&dpu_config);
         let MachineInfo::Host(host) = host else {
             panic!("expected host machine info");
         };
@@ -606,164 +635,46 @@ mod tests {
     }
 
     #[test]
-    fn reports_configured_dpu_firmware_versions() {
-        for (hardware_profile, machine_role) in [
-            ("hpe_proliant_dl380a_gen11", "host"),
-            ("hpe_proliant_dl380a_gen11", "dpu"),
-            ("dell_poweredge_r760_bf4", "host"),
-            ("dell_poweredge_r760_bf4", "dpu"),
-            ("nvidia_dgx_vr", "host"),
-            ("nvidia_dgx_vr", "dpu"),
-        ] {
-            let config = config(&[
-                "bmc-mock",
-                "--machine-role",
-                machine_role,
-                "--state-backend",
-                "internal",
-                "--hardware-profile",
-                hardware_profile,
-                "--dpu-count",
-                "1",
-                "--dpu-bmc-firmware",
-                "BF-25.10-20",
-                "--dpu-uefi-firmware",
-                "4.13.2-12-g943a91640d",
-                "--dpu-bsp-firmware",
-                "4.13.2",
-                "--dpu-cec-firmware",
-                "00.02.0195.0000_n02",
-                "--dpu-nic-firmware",
-                "32.47.2682",
-            ])
-            .unwrap();
-            let (_, state) = generated_mock(config);
-
-            for (inventory_id, expected) in [
-                ("BMC_Firmware", "BF-25.10-20"),
-                ("DPU_UEFI", "4.13.2-12-g943a91640d"),
-                ("DPU_BSP", "4.13.2"),
-                ("Bluefield_FW_ERoT", "00.02.0195.0000_n02"),
-                ("DPU_NIC", "32.47.2682"),
-            ] {
-                let inventory = state
-                    .update_service_state
-                    .find_firmware_inventory(inventory_id)
-                    .unwrap_or_else(|| {
-                        panic!("missing {inventory_id} firmware inventory for {hardware_profile} {machine_role}")
-                    });
-                assert_eq!(inventory["Version"].as_str(), Some(expected));
-            }
-        }
-    }
-
-    #[test]
-    fn bsp_inventory_is_optional_and_can_be_configured_independently() {
-        for bsp in [None, Some("4.13.2")] {
-            let mut arguments = vec![
-                "bmc-mock",
-                "--machine-role",
-                "dpu",
-                "--state-backend",
-                "internal",
-                "--hardware-profile",
-                "hpe_proliant_dl380a_gen11",
-                "--dpu-count",
-                "1",
-            ];
-            if let Some(version) = bsp {
-                arguments.extend(["--dpu-bsp-firmware", version]);
-            }
-            let (_, state) = generated_mock(config(&arguments).unwrap());
-            let inventory = state
-                .update_service_state
-                .find_firmware_inventory("DPU_BSP");
-            assert_eq!(
-                inventory.as_ref().and_then(|item| item["Version"].as_str()),
-                bsp
-            );
-        }
-    }
-
-    #[test]
-    fn rejects_firmware_options_without_generated_dpus() {
-        for flag in [
+    fn configured_dpu_firmware_reaches_the_generated_host() {
+        let config = config(&[
+            "bmc-mock",
+            "--machine-role",
+            "host",
+            "--state-backend",
+            "internal",
+            "--hardware-profile",
+            "dell_poweredge_r750",
+            "--dpu-count",
+            "1",
             "--dpu-bmc-firmware",
+            "bmc-version",
             "--dpu-uefi-firmware",
+            "uefi-version",
             "--dpu-bsp-firmware",
+            "bsp-version",
             "--dpu-cec-firmware",
+            "cec-version",
             "--dpu-nic-firmware",
-        ] {
-            for count in [None, Some("0")] {
-                let mut arguments = vec![
-                    "bmc-mock",
-                    "--machine-role",
-                    "host",
-                    "--state-backend",
-                    "internal",
-                    "--hardware-profile",
-                    "hpe_proliant_dl380a_gen11",
-                    flag,
-                    "test-version",
-                ];
-                if let Some(count) = count {
-                    arguments.extend(["--dpu-count", count]);
-                }
-                let error = config(&arguments)
-                    .err()
-                    .expect("firmware without a DPU must fail");
-                assert_eq!(
-                    error,
-                    "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
-                );
-            }
-        }
-        assert!(
-            config(&[
-                "bmc-mock",
-                "--machine-role",
-                "host",
-                "--state-backend",
-                "internal",
-                "--hardware-profile",
-                "hpe_proliant_dl380a_gen11",
-            ])
-            .is_ok()
-        );
-    }
+            "nic-version",
+        ])
+        .unwrap();
+        let (_, state) = generated_mock(config);
 
-    #[test]
-    fn bf4_inventory_contains_only_explicit_versions() {
-        for version in [None, Some("test-bmc")] {
-            let mut arguments = vec![
-                "bmc-mock",
-                "--machine-role",
-                "dpu",
-                "--state-backend",
-                "internal",
-                "--hardware-profile",
-                "dell_poweredge_r760_bf4",
-            ];
-            if let Some(version) = version {
-                arguments.extend(["--dpu-bmc-firmware", version]);
-            }
-            let (_, state) = generated_mock(config(&arguments).unwrap());
-            let inventory = state
-                .update_service_state
-                .find_firmware_inventory("BMC_Firmware");
+        for (id, expected) in [
+            ("BMC_Firmware", "bmc-version"),
+            ("DPU_UEFI", "uefi-version"),
+            ("DPU_BSP", "bsp-version"),
+            ("Bluefield_FW_ERoT", "cec-version"),
+            ("DPU_NIC", "nic-version"),
+        ] {
             assert_eq!(
-                inventory.as_ref().and_then(|item| item["Version"].as_str()),
-                version
+                state
+                    .update_service_state
+                    .find_firmware_inventory(id)
+                    .and_then(|inventory| inventory["Version"].as_str().map(str::to_owned)),
+                Some(expected.to_string()),
+                "{id}",
             );
-            for id in ["DPU_UEFI", "DPU_BSP", "Bluefield_FW_ERoT", "DPU_NIC"] {
-                assert!(
-                    state
-                        .update_service_state
-                        .find_firmware_inventory(id)
-                        .is_none(),
-                    "unexpected {id}"
-                );
-            }
         }
     }
 }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -296,6 +296,18 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         (None, requested) => requested.unwrap_or(0),
     };
     let dpu_index = args.dpu_index.unwrap_or(0);
+    if dpu_count == 0
+        && (args.dpu_bmc_firmware.is_some()
+            || args.dpu_uefi_firmware.is_some()
+            || args.dpu_bsp_firmware.is_some()
+            || args.dpu_cec_firmware.is_some()
+            || args.dpu_nic_firmware.is_some())
+    {
+        return Err(
+            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
+                .to_string(),
+        );
+    }
     match machine_role {
         MachineRole::Host if args.dpu_index.is_some() => {
             return Err("--dpu-index is valid only with --machine-role=dpu".to_string());
@@ -595,7 +607,14 @@ mod tests {
 
     #[test]
     fn reports_configured_dpu_firmware_versions() {
-        for machine_role in ["host", "dpu"] {
+        for (hardware_profile, machine_role) in [
+            ("hpe_proliant_dl380a_gen11", "host"),
+            ("hpe_proliant_dl380a_gen11", "dpu"),
+            ("dell_poweredge_r760_bf4", "host"),
+            ("dell_poweredge_r760_bf4", "dpu"),
+            ("nvidia_dgx_vr", "host"),
+            ("nvidia_dgx_vr", "dpu"),
+        ] {
             let config = config(&[
                 "bmc-mock",
                 "--machine-role",
@@ -603,7 +622,7 @@ mod tests {
                 "--state-backend",
                 "internal",
                 "--hardware-profile",
-                "hpe_proliant_dl380a_gen11",
+                hardware_profile,
                 "--dpu-count",
                 "1",
                 "--dpu-bmc-firmware",
@@ -631,7 +650,7 @@ mod tests {
                     .update_service_state
                     .find_firmware_inventory(inventory_id)
                     .unwrap_or_else(|| {
-                        panic!("missing {inventory_id} firmware inventory for {machine_role}")
+                        panic!("missing {inventory_id} firmware inventory for {hardware_profile} {machine_role}")
                     });
                 assert_eq!(inventory["Version"].as_str(), Some(expected));
             }
@@ -663,6 +682,88 @@ mod tests {
                 inventory.as_ref().and_then(|item| item["Version"].as_str()),
                 bsp
             );
+        }
+    }
+
+    #[test]
+    fn rejects_firmware_options_without_generated_dpus() {
+        for flag in [
+            "--dpu-bmc-firmware",
+            "--dpu-uefi-firmware",
+            "--dpu-bsp-firmware",
+            "--dpu-cec-firmware",
+            "--dpu-nic-firmware",
+        ] {
+            for count in [None, Some("0")] {
+                let mut arguments = vec![
+                    "bmc-mock",
+                    "--machine-role",
+                    "host",
+                    "--state-backend",
+                    "internal",
+                    "--hardware-profile",
+                    "hpe_proliant_dl380a_gen11",
+                    flag,
+                    "test-version",
+                ];
+                if let Some(count) = count {
+                    arguments.extend(["--dpu-count", count]);
+                }
+                let error = config(&arguments)
+                    .err()
+                    .expect("firmware without a DPU must fail");
+                assert_eq!(
+                    error,
+                    "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
+                );
+            }
+        }
+        assert!(
+            config(&[
+                "bmc-mock",
+                "--machine-role",
+                "host",
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                "hpe_proliant_dl380a_gen11",
+            ])
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn bf4_inventory_contains_only_explicit_versions() {
+        for version in [None, Some("test-bmc")] {
+            let mut arguments = vec![
+                "bmc-mock",
+                "--machine-role",
+                "dpu",
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                "dell_poweredge_r760_bf4",
+            ];
+            if let Some(version) = version {
+                arguments.extend(["--dpu-bmc-firmware", version]);
+            }
+            let (_, state) = generated_mock(config(&arguments).unwrap());
+            let inventory = state
+                .update_service_state
+                .find_firmware_inventory("BMC_Firmware");
+            assert_eq!(
+                inventory.as_ref().and_then(|item| item["Version"].as_str()),
+                version
+            );
+            for id in ["DPU_UEFI", "DPU_BSP", "Bluefield_FW_ERoT", "DPU_NIC"] {
+                assert!(
+                    state
+                        .update_service_state
+                        .find_firmware_inventory(id)
+                        .is_none(),
+                    "unexpected {id}"
+                );
+            }
         }
     }
 }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -289,22 +289,11 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         (None, requested) => requested.unwrap_or(0),
     };
     let dpu_index = args.dpu_index.unwrap_or(0);
-    if !args.dpu_firmware.is_empty() {
-        if matches!(
-            hardware_type,
-            HardwareType::DellPowerEdgeR760Bf4 | HardwareType::NvidiaDgxVr
-        ) {
-            return Err(
-                "DPU firmware options are not supported for BlueField-4 hardware profiles"
-                    .to_string(),
-            );
-        }
-        if dpu_count == 0 {
-            return Err(
-                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
-                    .to_string(),
-            );
-        }
+    if !args.dpu_firmware.is_empty() && dpu_count == 0 {
+        return Err(
+            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
+                .to_string(),
+        );
     }
     match machine_role {
         MachineRole::Host if args.dpu_index.is_some() => {
@@ -554,43 +543,24 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_dpu_firmware_overrides() {
-        let cases: &[(&str, &[&str], &str)] = &[
-            (
-                "variable-count profile without a DPU",
-                &[
-                    "bmc-mock",
-                    "--machine-role",
-                    "host",
-                    "--state-backend",
-                    "internal",
-                    "--hardware-profile",
-                    "dell_poweredge_r750",
-                    "--dpu-bmc-firmware",
-                    "bmc-version",
-                ],
-                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value",
-            ),
-            (
-                "BlueField-4 profile",
-                &[
-                    "bmc-mock",
-                    "--machine-role",
-                    "dpu",
-                    "--state-backend",
-                    "internal",
-                    "--hardware-profile",
-                    "dell_poweredge_r760_bf4",
-                    "--dpu-bmc-firmware",
-                    "bmc-version",
-                ],
-                "DPU firmware options are not supported for BlueField-4 hardware profiles",
-            ),
-        ];
+    fn rejects_dpu_firmware_overrides_without_generated_dpus() {
+        let error = config(&[
+            "bmc-mock",
+            "--machine-role",
+            "host",
+            "--state-backend",
+            "internal",
+            "--hardware-profile",
+            "dell_poweredge_r750",
+            "--dpu-bmc-firmware",
+            "bmc-version",
+        ])
+        .unwrap_err();
 
-        for (scenario, arguments, expected) in cases {
-            assert_eq!(config(arguments).unwrap_err(), *expected, "{scenario}");
-        }
+        assert_eq!(
+            error,
+            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value",
+        );
     }
 
     #[test]
@@ -675,6 +645,55 @@ mod tests {
                 Some(expected.to_string()),
                 "{id}",
             );
+        }
+    }
+
+    #[test]
+    fn configured_dpu_firmware_reaches_generated_bf4_endpoints() {
+        for (hardware_profile, machine_role) in [
+            ("dell_poweredge_r760_bf4", "host"),
+            ("dell_poweredge_r760_bf4", "dpu"),
+            ("nvidia_dgx_vr", "host"),
+            ("nvidia_dgx_vr", "dpu"),
+        ] {
+            let config = config(&[
+                "bmc-mock",
+                "--machine-role",
+                machine_role,
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                hardware_profile,
+                "--dpu-bmc-firmware",
+                "bmc-version",
+                "--dpu-uefi-firmware",
+                "uefi-version",
+                "--dpu-bsp-firmware",
+                "bsp-version",
+                "--dpu-cec-firmware",
+                "cec-version",
+                "--dpu-nic-firmware",
+                "nic-version",
+            ])
+            .unwrap();
+            let (_, state) = generated_mock(config);
+
+            for (id, expected) in [
+                ("BMC_Firmware", "bmc-version"),
+                ("DPU_UEFI", "uefi-version"),
+                ("DPU_BSP", "bsp-version"),
+                ("Bluefield_FW_ERoT", "cec-version"),
+                ("DPU_NIC", "nic-version"),
+            ] {
+                assert_eq!(
+                    state
+                        .update_service_state
+                        .find_firmware_inventory(id)
+                        .and_then(|inventory| inventory["Version"].as_str().map(str::to_owned)),
+                    Some(expected.to_string()),
+                    "{hardware_profile} {machine_role} {id}",
+                );
+            }
         }
     }
 }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -289,11 +289,22 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         (None, requested) => requested.unwrap_or(0),
     };
     let dpu_index = args.dpu_index.unwrap_or(0);
-    if !args.dpu_firmware.is_empty() && dpu_count == 0 {
-        return Err(
-            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
-                .to_string(),
-        );
+    if !args.dpu_firmware.is_empty() {
+        if matches!(
+            hardware_type,
+            HardwareType::DellPowerEdgeR760Bf4 | HardwareType::NvidiaDgxVr
+        ) {
+            return Err(
+                "DPU firmware options are supported only for BlueField-3 hardware profiles"
+                    .to_string(),
+            );
+        }
+        if dpu_count == 0 {
+            return Err(
+                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
+                    .to_string(),
+            );
+        }
     }
     match machine_role {
         MachineRole::Host if args.dpu_index.is_some() => {
@@ -543,24 +554,43 @@ mod tests {
     }
 
     #[test]
-    fn rejects_dpu_firmware_overrides_without_generated_dpus() {
-        let error = config(&[
-            "bmc-mock",
-            "--machine-role",
-            "host",
-            "--state-backend",
-            "internal",
-            "--hardware-profile",
-            "dell_poweredge_r750",
-            "--dpu-bmc-firmware",
-            "bmc-version",
-        ])
-        .unwrap_err();
+    fn rejects_unsupported_dpu_firmware_overrides() {
+        let cases: &[(&str, &[&str], &str)] = &[
+            (
+                "variable-count profile without a DPU",
+                &[
+                    "bmc-mock",
+                    "--machine-role",
+                    "host",
+                    "--state-backend",
+                    "internal",
+                    "--hardware-profile",
+                    "dell_poweredge_r750",
+                    "--dpu-bmc-firmware",
+                    "bmc-version",
+                ],
+                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value",
+            ),
+            (
+                "BlueField-4 profile",
+                &[
+                    "bmc-mock",
+                    "--machine-role",
+                    "dpu",
+                    "--state-backend",
+                    "internal",
+                    "--hardware-profile",
+                    "dell_poweredge_r760_bf4",
+                    "--dpu-bmc-firmware",
+                    "bmc-version",
+                ],
+                "DPU firmware options are supported only for BlueField-3 hardware profiles",
+            ),
+        ];
 
-        assert_eq!(
-            error,
-            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value",
-        );
+        for (scenario, arguments, expected) in cases {
+            assert_eq!(config(arguments).unwrap_err(), *expected, "{scenario}");
+        }
     }
 
     #[test]
@@ -645,55 +675,6 @@ mod tests {
                 Some(expected.to_string()),
                 "{id}",
             );
-        }
-    }
-
-    #[test]
-    fn configured_dpu_firmware_reaches_generated_bf4_endpoints() {
-        for (hardware_profile, machine_role) in [
-            ("dell_poweredge_r760_bf4", "host"),
-            ("dell_poweredge_r760_bf4", "dpu"),
-            ("nvidia_dgx_vr", "host"),
-            ("nvidia_dgx_vr", "dpu"),
-        ] {
-            let config = config(&[
-                "bmc-mock",
-                "--machine-role",
-                machine_role,
-                "--state-backend",
-                "internal",
-                "--hardware-profile",
-                hardware_profile,
-                "--dpu-bmc-firmware",
-                "bmc-version",
-                "--dpu-uefi-firmware",
-                "uefi-version",
-                "--dpu-bsp-firmware",
-                "bsp-version",
-                "--dpu-cec-firmware",
-                "cec-version",
-                "--dpu-nic-firmware",
-                "nic-version",
-            ])
-            .unwrap();
-            let (_, state) = generated_mock(config);
-
-            for (id, expected) in [
-                ("BMC_Firmware", "bmc-version"),
-                ("DPU_UEFI", "uefi-version"),
-                ("DPU_BSP", "bsp-version"),
-                ("Bluefield_FW_ERoT", "cec-version"),
-                ("DPU_NIC", "nic-version"),
-            ] {
-                assert_eq!(
-                    state
-                        .update_service_state
-                        .find_firmware_inventory(id)
-                        .and_then(|inventory| inventory["Version"].as_str().map(str::to_owned)),
-                    Some(expected.to_string()),
-                    "{hardware_profile} {machine_role} {id}",
-                );
-            }
         }
     }
 }

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -289,22 +289,11 @@ fn generated_mock_config(args: &command_line::Args) -> Result<GeneratedMockConfi
         (None, requested) => requested.unwrap_or(0),
     };
     let dpu_index = args.dpu_index.unwrap_or(0);
-    if !args.dpu_firmware.is_empty() {
-        if matches!(
-            hardware_type,
-            HardwareType::DellPowerEdgeR760Bf4 | HardwareType::NvidiaDgxVr
-        ) {
-            return Err(
-                "DPU firmware options are supported only for BlueField-3 hardware profiles"
-                    .to_string(),
-            );
-        }
-        if dpu_count == 0 {
-            return Err(
-                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
-                    .to_string(),
-            );
-        }
+    if !args.dpu_firmware.is_empty() && dpu_count == 0 {
+        return Err(
+            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value"
+                .to_string(),
+        );
     }
     match machine_role {
         MachineRole::Host if args.dpu_index.is_some() => {
@@ -554,43 +543,24 @@ mod tests {
     }
 
     #[test]
-    fn rejects_unsupported_dpu_firmware_overrides() {
-        let cases: &[(&str, &[&str], &str)] = &[
-            (
-                "variable-count profile without a DPU",
-                &[
-                    "bmc-mock",
-                    "--machine-role",
-                    "host",
-                    "--state-backend",
-                    "internal",
-                    "--hardware-profile",
-                    "dell_poweredge_r750",
-                    "--dpu-bmc-firmware",
-                    "bmc-version",
-                ],
-                "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value",
-            ),
-            (
-                "BlueField-4 profile",
-                &[
-                    "bmc-mock",
-                    "--machine-role",
-                    "dpu",
-                    "--state-backend",
-                    "internal",
-                    "--hardware-profile",
-                    "dell_poweredge_r760_bf4",
-                    "--dpu-bmc-firmware",
-                    "bmc-version",
-                ],
-                "DPU firmware options are supported only for BlueField-3 hardware profiles",
-            ),
-        ];
+    fn rejects_dpu_firmware_overrides_without_generated_dpus() {
+        let error = config(&[
+            "bmc-mock",
+            "--machine-role",
+            "host",
+            "--state-backend",
+            "internal",
+            "--hardware-profile",
+            "dell_poweredge_r750",
+            "--dpu-bmc-firmware",
+            "bmc-version",
+        ])
+        .unwrap_err();
 
-        for (scenario, arguments, expected) in cases {
-            assert_eq!(config(arguments).unwrap_err(), *expected, "{scenario}");
-        }
+        assert_eq!(
+            error,
+            "DPU firmware options require at least one generated DPU; set --dpu-count to a positive value",
+        );
     }
 
     #[test]
@@ -675,6 +645,55 @@ mod tests {
                 Some(expected.to_string()),
                 "{id}",
             );
+        }
+    }
+
+    #[test]
+    fn configured_dpu_firmware_reaches_generated_bf4_endpoints() {
+        for (hardware_profile, machine_role) in [
+            ("dell_poweredge_r760_bf4", "host"),
+            ("dell_poweredge_r760_bf4", "dpu"),
+            ("nvidia_dgx_vr", "host"),
+            ("nvidia_dgx_vr", "dpu"),
+        ] {
+            let config = config(&[
+                "bmc-mock",
+                "--machine-role",
+                machine_role,
+                "--state-backend",
+                "internal",
+                "--hardware-profile",
+                hardware_profile,
+                "--dpu-bmc-firmware",
+                "bmc-version",
+                "--dpu-uefi-firmware",
+                "uefi-version",
+                "--dpu-bsp-firmware",
+                "bsp-version",
+                "--dpu-cec-firmware",
+                "cec-version",
+                "--dpu-nic-firmware",
+                "nic-version",
+            ])
+            .unwrap();
+            let (_, state) = generated_mock(config);
+
+            for (id, expected) in [
+                ("BlueField_FW_BMC_0", "bmc-version"),
+                ("BlueField_FW_CPU_0", "uefi-version"),
+                ("DPU_BSP", "bsp-version"),
+                ("BlueField_FW_ERoT_BMC_0", "cec-version"),
+                ("BlueField_FW_NIC_0", "nic-version"),
+            ] {
+                assert_eq!(
+                    state
+                        .update_service_state
+                        .find_firmware_inventory(id)
+                        .and_then(|inventory| inventory["Version"].as_str().map(str::to_owned)),
+                    Some(expected.to_string()),
+                    "{hardware_profile} {machine_role} {id}",
+                );
+            }
         }
     }
 }

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -417,6 +417,9 @@ pub struct DpuFirmwareVersions {
     pub cec: Option<String>,
     pub uefi: Option<String>,
     pub nic: Option<String>,
+    /// DPU BSP version.
+    #[serde(default)]
+    pub bsp: Option<String>,
 }
 
 /// BMC-mock has its own version of this data structure to avoid cyclic dependencies
@@ -427,6 +430,7 @@ impl From<DpuFirmwareVersions> for bmc_mock::DpuFirmwareVersions {
             cec: value.cec,
             uefi: value.uefi,
             nic: value.nic,
+            bsp: value.bsp,
         }
     }
 }
@@ -457,6 +461,7 @@ impl DpuFirmwareVersions {
             cec: self.cec.or_else(|| bf3_firmware_map.get("cec").cloned()),
             uefi: self.uefi.or_else(|| bf3_firmware_map.get("uefi").cloned()),
             nic: self.nic.or_else(|| bf3_firmware_map.get("nic").cloned()),
+            bsp: self.bsp,
         }
     }
 }

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -440,6 +440,10 @@ impl DpuFirmwareVersions {
         self,
         desired_firmware: &[DesiredFirmwareVersionEntry],
     ) -> Self {
+        // TODO: Pass the emulated DPU generation into this lookup and select its
+        // desired-firmware model before enabling BF4 firmware overrides. BF4
+        // version strings use the `BF4-` convention:
+        // https://github.com/NVIDIA/infra-controller/pull/3477
         // We emulate bf3 DPU's, find those from the desired firmware.
         let Some(bf3_firmware_map) = desired_firmware
             .iter()

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -440,11 +440,11 @@ impl DpuFirmwareVersions {
         self,
         desired_firmware: &[DesiredFirmwareVersionEntry],
     ) -> Self {
-        // TODO: Pass the emulated DPU generation into this lookup and select its
-        // desired-firmware model before enabling BF4 firmware overrides. BF4
-        // version strings use the `BF4-` convention:
+        // TODO: Pass the emulated DPU generation into this lookup and select the
+        // matching desired-firmware model. This currently always uses BlueField-3,
+        // so missing BF4 values can be filled from the BF3 entry; explicit overrides
+        // still take precedence. BF4 BMC version strings use the `BF4-` convention:
         // https://github.com/NVIDIA/infra-controller/pull/3477
-        // We emulate bf3 DPU's, find those from the desired firmware.
         let Some(bf3_firmware_map) = desired_firmware
             .iter()
             .find(|entry| {

--- a/crates/machine-a-tron/src/config.rs
+++ b/crates/machine-a-tron/src/config.rs
@@ -417,7 +417,13 @@ pub struct DpuFirmwareVersions {
     pub cec: Option<String>,
     pub uefi: Option<String>,
     pub nic: Option<String>,
-    /// DPU BSP version.
+    /// Optional opaque DPU BSP firmware version.
+    ///
+    /// Any string is accepted verbatim, including an empty string. The default,
+    /// `None`, omits `DPU_BSP` from generated firmware inventory; `Some("")`
+    /// explicitly configures that inventory entry with an empty version. This is
+    /// supported for generated BlueField-3 and BlueField-4 DPU profiles; profiles
+    /// without a generated DPU do not expose the entry.
     #[serde(default)]
     pub bsp: Option<String>,
 }


### PR DESCRIPTION
Generated BMC endpoints cannot select the DPU firmware inventory needed to exercise provisioning against a specific firmware/BSP version. Expose five optional CLI arguments for BMC, UEFI, BSP, CEC, and NIC versions, and carry them into generated DPU inventory. Explicitly configured primary-DPU inventory is also visible through the host endpoint, without replacing existing host inventory IDs.

The four existing firmware versions use DpuFirmwareVersions. BSP adds an optional, serde-defaulted DpuSettings.bsp_version and a DPU_BSP inventory entry. Omitting it preserves the absence of that entry. All five CLI options require a hardware profile and at least one generated DPU; generated options remain incompatible with archive-backed routers. BlueField-4 profiles expose explicitly configured versions and retain their empty inventory when no versions are supplied.

## Type of Change

- [x] **Add** - New feature or capability

## Breaking Changes

Existing CLI defaults are preserved. Rust callers constructing DpuSettings with exhaustive struct literals must supply bsp_version; existing workspace callers use Default for remaining fields. Existing serialized settings can omit the new field.

## Testing

- [x] Unit tests added/updated
- Regression checks all five inventory versions through generated host and DPU state for BF3 and both BF4 profiles.
- Additional coverage checks omitted/partial BF4 inventory, omitted and independently configured BSP, and rejection of each firmware flag with an omitted or zero DPU count.
- Rust formatting applied with the pinned stable toolchain; nightly-only formatting options were unavailable.
- cargo test --locked -p bmc-mock -- --skip real_ipmitool_resets_chassis: 104 tests passed (92 library and 12 binary). The real-ipmitool test was skipped because ipmitool is not installed.
- Negative regression check: retaining the new tests but removing the BF4 and zero-DPU fixes produces three expected failures (missing BF4 inventory and accepted zero-DPU overrides); the fixed sources pass.
