### PR TITLE
fix(bmc-mock): honor persistent libvirt boot selection

### DIFF
--- a/crates/bmc-mock/README.md
+++ b/crates/bmc-mock/README.md
@@ -83,6 +83,20 @@ Confirm those targets are unused with `virsh domblklist DOMAIN --details` before
 inserting media. HTTP or HTTPS ISO URLs must be reachable from the host running
 the QEMU process. File paths must exist in that host's filesystem.
 
+## Apply boot-order changes with libvirt
+
+Persistent Redfish boot-order updates change the saved libvirt domain
+configuration. For a running VM, request `PowerCycle` to apply a changed order,
+or shut it down and then request `On`. Starting a stopped VM with `On` or
+`ForceOn` also applies the effective boot selection.
+
+`GracefulRestart` and `ForceRestart` retain their normal libvirt reboot and
+reset behavior: they keep the running VM's boot configuration. They do not
+activate a newly saved boot order. Temporary boot-source overrides likewise
+need a cold start to take effect; after a one-shot override, the backend
+restores the persistent selection in the saved configuration for a subsequent
+cold start.
+
 ## Run a separate DPU endpoint
 
 A DPU is independently addressable hardware, so expose it through its own

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -26,7 +26,9 @@ use quick_xml::{Reader, Writer};
 use url::Url;
 
 use crate::redfish::computer_system::{SingleSystemState, SystemState};
-use crate::{BmcState, Callbacks, MockPowerState, SetSystemPowerError, SystemPowerControl};
+use crate::{
+    BmcState, BootOptionKind, Callbacks, MockPowerState, SetSystemPowerError, SystemPowerControl,
+};
 
 #[derive(Debug, thiserror::Error)]
 enum VirtualMediaError {
@@ -56,6 +58,7 @@ pub struct LibvirtCallbacks {
 
 #[derive(Clone, Debug, Default, Eq, PartialEq)]
 struct AppliedState {
+    persistent_boot_selection: Option<BootOptionKind>,
     boot_source_override: serde_json::Value,
     virtual_media: BTreeMap<String, serde_json::Value>,
 }
@@ -70,15 +73,18 @@ impl LibvirtCallbacks {
         }
     }
 
-    pub fn bind_state(&self, state: &BmcState) -> Result<(), &'static str> {
+    pub fn bind_state(&self, state: &BmcState) -> Result<(), String> {
         let controlled_system = state
             .system_state
             .controlled_system()
-            .ok_or("libvirt backend has no controlled ComputerSystem")?;
+            .ok_or_else(|| "libvirt backend has no controlled ComputerSystem".to_string())?;
         self.system_state
             .set(Arc::downgrade(&state.system_state))
-            .map_err(|_| "libvirt backend state is already bound")?;
-        *self.applied_state.lock().unwrap() = AppliedState::from(controlled_system);
+            .map_err(|_| "libvirt backend state is already bound".to_string())?;
+        let applied = AppliedState::from(controlled_system);
+        self.set_persistent_boot_selection(applied.persistent_boot_selection)
+            .map_err(|error| error.to_string())?;
+        *self.applied_state.lock().unwrap() = applied;
         Ok(())
     }
 
@@ -122,9 +128,52 @@ impl LibvirtCallbacks {
             std::mem::take(&mut *restore_boot_after_power_on)
         };
         if restore_boot {
-            self.set_boot_devices(&["hd"])?;
+            self.restore_persistent_boot_order()?;
         }
         Ok(())
+    }
+
+    fn restore_persistent_boot_order(&self) -> Result<(), SetSystemPowerError> {
+        let selection = self
+            .system_state
+            .get()
+            .and_then(Weak::upgrade)
+            .and_then(|state| {
+                state
+                    .controlled_system()
+                    .and_then(SingleSystemState::resolve_persistent_boot_selection)
+            });
+        self.set_persistent_boot_selection(selection)
+    }
+
+    fn reapply_effective_boot_order(&self) -> Result<(), SetSystemPowerError> {
+        let Some(state) = self.system_state.get().and_then(Weak::upgrade) else {
+            return Err(SetSystemPowerError::CommandSendError(
+                "libvirt backend is not bound to BMC mock state".to_string(),
+            ));
+        };
+        let Some(system) = state.controlled_system() else {
+            return Err(SetSystemPowerError::CommandSendError(
+                "BMC mock state has no controlled ComputerSystem".to_string(),
+            ));
+        };
+        let boot_source_override = system.boot_source_override();
+        if boot_source_override_is_active(&boot_source_override) {
+            self.set_boot_source_override(&boot_source_override)
+        } else {
+            self.set_persistent_boot_selection(system.resolve_persistent_boot_selection())
+        }
+    }
+
+    fn set_persistent_boot_selection(
+        &self,
+        selection: Option<BootOptionKind>,
+    ) -> Result<(), SetSystemPowerError> {
+        match selection {
+            Some(BootOptionKind::Disk) => self.set_boot_devices(&["hd"]),
+            Some(BootOptionKind::Network) => self.set_boot_devices(&["network", "hd"]),
+            None => Ok(()),
+        }
     }
 
     fn set_boot_devices(&self, devices: &[&str]) -> Result<(), SetSystemPowerError> {
@@ -277,11 +326,19 @@ impl LibvirtCallbacks {
 
     fn reconcile_state(&self, desired: AppliedState) -> Result<(), String> {
         let mut applied = self.applied_state.lock().unwrap();
-        if desired.boot_source_override != applied.boot_source_override {
+        let desired_override_active = boot_source_override_is_active(&desired.boot_source_override);
+        if desired.boot_source_override != applied.boot_source_override && desired_override_active {
             self.set_boot_source_override(&desired.boot_source_override)
                 .map_err(|error| error.to_string())?;
-            applied.boot_source_override = desired.boot_source_override;
+        } else if !desired_override_active
+            && (desired.boot_source_override != applied.boot_source_override
+                || desired.persistent_boot_selection != applied.persistent_boot_selection)
+        {
+            self.set_persistent_boot_selection(desired.persistent_boot_selection)
+                .map_err(|error| error.to_string())?;
         }
+        applied.boot_source_override = desired.boot_source_override;
+        applied.persistent_boot_selection = desired.persistent_boot_selection;
         for (device_id, desired_device) in desired.virtual_media {
             if applied.virtual_media.get(&device_id) == Some(&desired_device) {
                 continue;
@@ -309,10 +366,21 @@ impl From<&SingleSystemState> for AppliedState {
             })
             .collect();
         Self {
+            persistent_boot_selection: system.resolve_persistent_boot_selection(),
             boot_source_override: system.boot_source_override(),
             virtual_media,
         }
     }
+}
+
+fn boot_source_override_is_active(boot_source_override: &serde_json::Value) -> bool {
+    let enabled = boot_source_override
+        .get("BootSourceOverrideEnabled")
+        .and_then(serde_json::Value::as_str);
+    let target = boot_source_override
+        .get("BootSourceOverrideTarget")
+        .and_then(serde_json::Value::as_str);
+    enabled != Some("Disabled") && !matches!(target, None | Some("None"))
 }
 
 impl Callbacks for LibvirtCallbacks {
@@ -340,6 +408,12 @@ impl Callbacks for LibvirtCallbacks {
         reset_type: SystemPowerControl,
     ) -> Result<(), SetSystemPowerError> {
         use SystemPowerControl::*;
+        if matches!(
+            reset_type,
+            On | ForceOn | GracefulRestart | ForceRestart | PowerCycle
+        ) {
+            self.reapply_effective_boot_order()?;
+        }
         match reset_type {
             On | ForceOn => self.start(),
             GracefulShutdown => self.domain_command("shutdown"),
@@ -618,11 +692,16 @@ mod tests {
         let log_path = directory.path().join("virsh.log");
         let defined_xml_path = directory.path().join("defined.xml");
         let attached_xml_path = directory.path().join("attached.xml");
+        let state_path = directory.path().join("domain-state");
+        fs::write(&state_path, "shut off\n").unwrap();
         let script = format!(
             r#"#!/bin/sh
 printf '%s\n' "$*" >> '{}'
 case "$3" in
-  domstate) printf 'shut off\n' ;;
+  domstate) cat '{}' ;;
+  start) printf 'running\n' > '{}' ;;
+  reset) [ "$(cat '{}')" = running ] ;;
+  destroy) printf 'shut off\n' > '{}' ;;
   dumpxml) printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices/></domain>\n' ;;
   domblklist) printf 'Type Device Target Source\nnetwork cdrom sdb http://example/old.iso\n' ;;
   define) cp "$4" '{}' ;;
@@ -630,6 +709,10 @@ case "$3" in
 esac
 "#,
             log_path.display(),
+            state_path.display(),
+            state_path.display(),
+            state_path.display(),
+            state_path.display(),
             defined_xml_path.display(),
             attached_xml_path.display(),
         );
@@ -661,6 +744,68 @@ esac
         callbacks.bind_state(&state).unwrap();
         let system = "/redfish/v1/Systems/System.Embedded.1";
 
+        let defined_xml = fs::read_to_string(&defined_xml_path).unwrap();
+        assert!(defined_xml.contains("<boot dev=\"network\"/><boot dev=\"hd\"/>"));
+        let bind_log = fs::read_to_string(&log_path).unwrap();
+        assert!(!bind_log.contains("domblklist"));
+
+        fs::write(&log_path, "").unwrap();
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/Actions/ComputerSystem.Reset"),
+            json!({"ResetType": "On"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let power_log = fs::read_to_string(&log_path).unwrap();
+        let define = power_log
+            .find(" define ")
+            .expect("persistent boot order was not re-applied before power on");
+        let start = power_log.find(" start ").expect("start was not sent");
+        assert!(define < start);
+
+        for _ in 0..2 {
+            fs::write(&log_path, "").unwrap();
+            let status = request(
+                &router,
+                Method::POST,
+                &format!("{system}/Actions/ComputerSystem.Reset"),
+                json!({"ResetType": "ForceRestart"}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            let power_log = fs::read_to_string(&log_path).unwrap();
+            let define = power_log
+                .find(" define ")
+                .expect("persistent boot order was not re-applied before reset");
+            let reset = power_log.find(" reset ").expect("reset was not sent");
+            assert!(define < reset);
+        }
+
+        let status = request(
+            &router,
+            Method::PATCH,
+            system,
+            json!({"Boot": {"BootOrder": ["Boot0001", "Boot0000"]}}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let defined_xml = fs::read_to_string(&defined_xml_path).unwrap();
+        assert!(defined_xml.contains("<boot dev=\"hd\"/>"));
+        assert!(!defined_xml.contains("<boot dev=\"network\"/>"));
+
+        let status = request(
+            &router,
+            Method::PATCH,
+            system,
+            json!({"Boot": {"BootOrder": ["Boot0000", "Boot0001"]}}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let defined_xml = fs::read_to_string(&defined_xml_path).unwrap();
+        assert!(defined_xml.contains("<boot dev=\"network\"/><boot dev=\"hd\"/>"));
+
         let status = request(
             &router,
             Method::PATCH,
@@ -678,7 +823,7 @@ esac
             &router,
             Method::POST,
             &format!("{system}/Actions/ComputerSystem.Reset"),
-            json!({"ResetType": "On"}),
+            json!({"ResetType": "ForceRestart"}),
         )
         .await;
         assert_eq!(status, StatusCode::OK);
@@ -718,14 +863,14 @@ esac
 
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("--connect qemu:///system dumpxml --inactive dsx-node"));
-        assert!(log.contains("--connect qemu:///system start dsx-node"));
+        assert!(log.contains("--connect qemu:///system reset dsx-node"));
         assert!(log.contains("--connect qemu:///system detach-disk dsx-node sdb --persistent"));
         assert!(log.contains("--connect qemu:///system attach-device dsx-node"));
         let attached_xml = fs::read_to_string(attached_xml_path).unwrap();
         assert!(attached_xml.contains("protocol=\"http\""));
         assert!(attached_xml.contains("dev=\"sdb\""));
         let defined_xml = fs::read_to_string(defined_xml_path).unwrap();
-        assert!(defined_xml.contains("<boot dev=\"hd\"/>"));
+        assert!(defined_xml.contains("<boot dev=\"network\"/><boot dev=\"hd\"/>"));
         assert!(!defined_xml.contains("<boot dev=\"cdrom\"/>"));
     }
 }

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -629,6 +629,80 @@ mod tests {
     use crate::test_support::host_info;
     use crate::{HardwareType, MachineRouterOptions, VirtualMediaDeviceConfig, machine_router};
 
+    #[tokio::test]
+    async fn hpe_persistent_boot_settings_reconcile_libvirt() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        let defined_xml_path = directory.path().join("defined.xml");
+        fs::write(
+            &virsh_path,
+            format!(
+                r#"#!/bin/sh
+case "$3" in
+  dumpxml) printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices/></domain>\n' ;;
+  define) cp "$4" '{}' ;;
+  *) exit 1 ;;
+esac
+"#,
+                defined_xml_path.display()
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&virsh_path, fs::Permissions::from_mode(0o755)).unwrap();
+        let callbacks = Arc::new(LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "hpe-node".to_string(),
+            virtual_media_targets: BTreeMap::new(),
+        }));
+        let (router, state) = machine_router(
+            &host_info(HardwareType::HpeProliantDl380aGen11),
+            callbacks.clone(),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions::default(),
+        );
+        callbacks.bind_state(&state).unwrap();
+        assert!(
+            fs::read_to_string(&defined_xml_path)
+                .unwrap()
+                .contains("<boot dev=\"network\"/><boot dev=\"hd\"/>")
+        );
+
+        for (order, expected_xml, expected_selection) in [
+            (
+                ["HD.BootOption.Boot0001", "NIC.BootOption.Boot0000"],
+                "<boot dev=\"hd\"/>",
+                BootOptionKind::Disk,
+            ),
+            (
+                ["NIC.BootOption.Boot0000", "HD.BootOption.Boot0001"],
+                "<boot dev=\"network\"/><boot dev=\"hd\"/>",
+                BootOptionKind::Network,
+            ),
+        ] {
+            let status = request(
+                &router,
+                Method::PATCH,
+                "/redfish/v1/Systems/1/Bios/oem/hpe/boot/settings",
+                json!({"PersistentBootConfigOrder": order}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            assert_eq!(
+                state.system_state.resolve_current_boot_selection(),
+                Some(expected_selection)
+            );
+            let xml = fs::read_to_string(&defined_xml_path).unwrap();
+            assert!(xml.contains(expected_xml), "unexpected domain XML: {xml}");
+            if expected_selection == BootOptionKind::Disk {
+                assert!(!xml.contains("<boot dev=\"network\"/>"));
+            }
+        }
+    }
+
     async fn request(
         router: &Router,
         method: Method,

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -408,10 +408,9 @@ impl Callbacks for LibvirtCallbacks {
         reset_type: SystemPowerControl,
     ) -> Result<(), SetSystemPowerError> {
         use SystemPowerControl::*;
-        if matches!(
-            reset_type,
-            On | ForceOn | GracefulRestart | ForceRestart | PowerCycle
-        ) {
+        // Only a cold start loads the saved domain XML. Reboot and reset keep
+        // the running domain's boot configuration and their existing semantics.
+        if matches!(reset_type, On | ForceOn | PowerCycle) {
             self.reapply_effective_boot_order()?;
         }
         match reset_type {
@@ -766,6 +765,7 @@ esac
         let log_path = directory.path().join("virsh.log");
         let defined_xml_path = directory.path().join("defined.xml");
         let attached_xml_path = directory.path().join("attached.xml");
+        let active_xml_path = directory.path().join("active.xml");
         let state_path = directory.path().join("domain-state");
         fs::write(&state_path, "shut off\n").unwrap();
         let script = format!(
@@ -773,8 +773,8 @@ esac
 printf '%s\n' "$*" >> '{}'
 case "$3" in
   domstate) cat '{}' ;;
-  start) printf 'running\n' > '{}' ;;
-  reset) [ "$(cat '{}')" = running ] ;;
+  start) printf 'running\n' > '{}'; cp '{}' '{}' ;;
+  reset|reboot) [ "$(cat '{}')" = running ] ;;
   destroy) printf 'shut off\n' > '{}' ;;
   dumpxml) printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices/></domain>\n' ;;
   domblklist) printf 'Type Device Target Source\nnetwork cdrom sdb http://example/old.iso\n' ;;
@@ -785,6 +785,8 @@ esac
             log_path.display(),
             state_path.display(),
             state_path.display(),
+            defined_xml_path.display(),
+            active_xml_path.display(),
             state_path.display(),
             state_path.display(),
             defined_xml_path.display(),
@@ -839,24 +841,6 @@ esac
         let start = power_log.find(" start ").expect("start was not sent");
         assert!(define < start);
 
-        for _ in 0..2 {
-            fs::write(&log_path, "").unwrap();
-            let status = request(
-                &router,
-                Method::POST,
-                &format!("{system}/Actions/ComputerSystem.Reset"),
-                json!({"ResetType": "ForceRestart"}),
-            )
-            .await;
-            assert_eq!(status, StatusCode::OK);
-            let power_log = fs::read_to_string(&log_path).unwrap();
-            let define = power_log
-                .find(" define ")
-                .expect("persistent boot order was not re-applied before reset");
-            let reset = power_log.find(" reset ").expect("reset was not sent");
-            assert!(define < reset);
-        }
-
         let status = request(
             &router,
             Method::PATCH,
@@ -868,6 +852,58 @@ esac
         let defined_xml = fs::read_to_string(&defined_xml_path).unwrap();
         assert!(defined_xml.contains("<boot dev=\"hd\"/>"));
         assert!(!defined_xml.contains("<boot dev=\"network\"/>"));
+
+        // The saved disk-first selection must not turn a warm restart into a
+        // cold start. The fixture loads saved XML only when start is called.
+        for (reset_type, command) in [("ForceRestart", "reset"), ("GracefulRestart", "reboot")] {
+            fs::write(&log_path, "").unwrap();
+            let status = request(
+                &router,
+                Method::POST,
+                &format!("{system}/Actions/ComputerSystem.Reset"),
+                json!({"ResetType": reset_type}),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK);
+            let power_log = fs::read_to_string(&log_path).unwrap();
+            assert!(power_log.contains(&format!(" {command} dsx-node")));
+            for unexpected in [" define ", " destroy ", " start "] {
+                assert!(
+                    !power_log.contains(unexpected),
+                    "unexpected {unexpected} during {reset_type}"
+                );
+            }
+            assert!(
+                fs::read_to_string(&active_xml_path)
+                    .unwrap()
+                    .contains("<boot dev=\"network\"/><boot dev=\"hd\"/>")
+            );
+            assert!(
+                !fs::read_to_string(&defined_xml_path)
+                    .unwrap()
+                    .contains("<boot dev=\"network\"/>")
+            );
+        }
+
+        fs::write(&log_path, "").unwrap();
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/Actions/ComputerSystem.Reset"),
+            json!({"ResetType": "PowerCycle"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let power_log = fs::read_to_string(&log_path).unwrap();
+        let define = power_log
+            .find(" define ")
+            .expect("boot order was not reapplied");
+        let destroy = power_log.find(" destroy ").expect("power off was not sent");
+        let start = power_log.find(" start ").expect("power on was not sent");
+        assert!(define < destroy && destroy < start);
+        let active_xml = fs::read_to_string(&active_xml_path).unwrap();
+        assert!(active_xml.contains("<boot dev=\"hd\"/>"));
+        assert!(!active_xml.contains("<boot dev=\"network\"/>"));
 
         let status = request(
             &router,
@@ -897,7 +933,7 @@ esac
             &router,
             Method::POST,
             &format!("{system}/Actions/ComputerSystem.Reset"),
-            json!({"ResetType": "ForceRestart"}),
+            json!({"ResetType": "PowerCycle"}),
         )
         .await;
         assert_eq!(status, StatusCode::OK);
@@ -937,7 +973,7 @@ esac
 
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("--connect qemu:///system dumpxml --inactive dsx-node"));
-        assert!(log.contains("--connect qemu:///system reset dsx-node"));
+        assert!(log.contains("--connect qemu:///system start dsx-node"));
         assert!(log.contains("--connect qemu:///system detach-disk dsx-node sdb --persistent"));
         assert!(log.contains("--connect qemu:///system attach-device dsx-node"));
         let attached_xml = fs::read_to_string(attached_xml_path).unwrap();

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -260,8 +260,7 @@ impl LibvirtCallbacks {
             (_, None) => return Ok(()),
         };
         self.set_boot_devices(devices)?;
-        *self.restore_boot_after_power_on.lock().unwrap() =
-            enabled == Some("Once") && target != Some("Hdd");
+        *self.restore_boot_after_power_on.lock().unwrap() = enabled == Some("Once");
         Ok(())
     }
 
@@ -681,6 +680,11 @@ esac
                 "<boot dev=\"network\"/><boot dev=\"hd\"/>",
                 BootOptionKind::Network,
             ),
+            (
+                ["HD.BootOption.Boot9999", "HD.BootOption.Boot0001"],
+                "<boot dev=\"hd\"/>",
+                BootOptionKind::Disk,
+            ),
         ] {
             let status = request(
                 &router,
@@ -937,6 +941,41 @@ esac
         )
         .await;
         assert_eq!(status, StatusCode::OK);
+        let active_xml = fs::read_to_string(&active_xml_path).unwrap();
+        assert!(active_xml.contains("<boot dev=\"cdrom\"/><boot dev=\"hd\"/>"));
+        let defined_xml = fs::read_to_string(&defined_xml_path).unwrap();
+        assert!(defined_xml.contains("<boot dev=\"network\"/><boot dev=\"hd\"/>"));
+        assert!(!defined_xml.contains("<boot dev=\"cdrom\"/>"));
+
+        // Disk can also be a one-shot override when the persistent selection
+        // is network-first. The guest starts disk-first, but the saved domain
+        // must be restored for the next cold start.
+        let status = request(
+            &router,
+            Method::PATCH,
+            system,
+            json!({
+                "Boot": {
+                    "BootSourceOverrideEnabled": "Once",
+                    "BootSourceOverrideTarget": "Hdd",
+                }
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/Actions/ComputerSystem.Reset"),
+            json!({"ResetType": "PowerCycle"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let active_xml = fs::read_to_string(&active_xml_path).unwrap();
+        assert!(active_xml.contains("<boot dev=\"hd\"/>"));
+        assert!(!active_xml.contains("<boot dev=\"network\"/>"));
+        let defined_xml = fs::read_to_string(&defined_xml_path).unwrap();
+        assert!(defined_xml.contains("<boot dev=\"network\"/><boot dev=\"hd\"/>"));
         let status = request(
             &router,
             Method::POST,

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -129,6 +129,9 @@ impl LibvirtCallbacks {
         };
         if restore_boot {
             self.restore_persistent_boot_order()?;
+            if let Some(system_state) = self.system_state.get().and_then(Weak::upgrade) {
+                system_state.on_boot_completed();
+            }
         }
         Ok(())
     }
@@ -976,6 +979,31 @@ esac
         assert!(!active_xml.contains("<boot dev=\"network\"/>"));
         let defined_xml = fs::read_to_string(&defined_xml_path).unwrap();
         assert!(defined_xml.contains("<boot dev=\"network\"/><boot dev=\"hd\"/>"));
+
+        // A one-shot override is consumed by the successful start. A second
+        // cold start without another PATCH must use the persistent selection.
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/Actions/ComputerSystem.Reset"),
+            json!({"ResetType": "PowerCycle"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let active_xml = fs::read_to_string(&active_xml_path).unwrap();
+        assert!(
+            active_xml.contains("<boot dev=\"network\"/><boot dev=\"hd\"/>"),
+            "one-shot disk override was reapplied: {active_xml}"
+        );
+        assert_eq!(
+            state
+                .system_state
+                .controlled_system()
+                .unwrap()
+                .boot_source_override()["BootSourceOverrideEnabled"],
+            "Disabled"
+        );
+
         let status = request(
             &router,
             Method::POST,

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -73,18 +73,32 @@ impl LibvirtCallbacks {
         }
     }
 
+    /// Binds this backend to the generated BMC state and applies its initial
+    /// persistent boot selection to the inactive libvirt domain XML.
+    ///
+    /// Binding succeeds at most once. An initial boot-selection failure leaves
+    /// the backend unbound so the caller can retry.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the BMC has no controlled `ComputerSystem`, this
+    /// backend is already bound, or libvirt cannot apply the initial selection.
     pub fn bind_state(&self, state: &BmcState) -> Result<(), String> {
         let controlled_system = state
             .system_state
             .controlled_system()
             .ok_or_else(|| "libvirt backend has no controlled ComputerSystem".to_string())?;
-        self.system_state
-            .set(Arc::downgrade(&state.system_state))
-            .map_err(|_| "libvirt backend state is already bound".to_string())?;
+        let mut applied_state = self.applied_state.lock().unwrap();
+        if self.system_state.get().is_some() {
+            return Err("libvirt backend state is already bound".to_string());
+        }
         let applied = AppliedState::from(controlled_system);
         self.set_persistent_boot_selection(applied.persistent_boot_selection)
             .map_err(|error| error.to_string())?;
-        *self.applied_state.lock().unwrap() = applied;
+        self.system_state
+            .set(Arc::downgrade(&state.system_state))
+            .map_err(|_| "libvirt backend state is already bound".to_string())?;
+        *applied_state = applied;
         Ok(())
     }
 
@@ -128,10 +142,10 @@ impl LibvirtCallbacks {
             std::mem::take(&mut *restore_boot_after_power_on)
         };
         if restore_boot {
-            self.restore_persistent_boot_order()?;
             if let Some(system_state) = self.system_state.get().and_then(Weak::upgrade) {
                 system_state.on_boot_completed();
             }
+            self.restore_persistent_boot_order()?;
         }
         Ok(())
     }
@@ -728,6 +742,158 @@ esac
             .await
             .unwrap();
         response.status()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_state_can_retry_after_initial_boot_sync_failure() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        let fail_define_path = directory.path().join("fail-define");
+        let defined_xml_path = directory.path().join("defined.xml");
+        fs::write(&fail_define_path, "").unwrap();
+        fs::write(
+            &virsh_path,
+            format!(
+                r#"#!/bin/sh
+case "$3" in
+  dumpxml) printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices/></domain>\n' ;;
+  define)
+    if [ -e '{}' ]; then
+      rm '{}'
+      exit 1
+    fi
+    cp "$4" '{}'
+    ;;
+  *) exit 1 ;;
+esac
+"#,
+                fail_define_path.display(),
+                fail_define_path.display(),
+                defined_xml_path.display(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&virsh_path, fs::Permissions::from_mode(0o755)).unwrap();
+        let callbacks = Arc::new(LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "retry-node".to_string(),
+            virtual_media_targets: BTreeMap::new(),
+        }));
+        let (_router, state) = machine_router(
+            &host_info(HardwareType::DellPowerEdgeR750),
+            callbacks.clone(),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions::default(),
+        );
+
+        assert!(callbacks.bind_state(&state).is_err());
+        callbacks.bind_state(&state).unwrap();
+        assert_eq!(
+            callbacks.bind_state(&state).unwrap_err(),
+            "libvirt backend state is already bound"
+        );
+        assert!(
+            fs::read_to_string(&defined_xml_path)
+                .unwrap()
+                .contains("<boot dev=\"network\"/><boot dev=\"hd\"/>")
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn successful_start_consumes_once_when_boot_restoration_fails() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        let state_path = directory.path().join("domain-state");
+        let fail_restore_path = directory.path().join("fail-restore");
+        let defined_xml_path = directory.path().join("defined.xml");
+        let active_xml_path = directory.path().join("active.xml");
+        fs::write(&state_path, "shut off\n").unwrap();
+        fs::write(
+            &virsh_path,
+            format!(
+                r#"#!/bin/sh
+case "$3" in
+  domstate) cat '{}' ;;
+  start) printf 'running\n' > '{}'; cp '{}' '{}' ;;
+  dumpxml) printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices/></domain>\n' ;;
+  define)
+    if [ -e '{}' ] && [ "$(cat '{}')" = running ]; then
+      exit 1
+    fi
+    cp "$4" '{}'
+    ;;
+  *) exit 1 ;;
+esac
+"#,
+                state_path.display(),
+                state_path.display(),
+                defined_xml_path.display(),
+                active_xml_path.display(),
+                fail_restore_path.display(),
+                state_path.display(),
+                defined_xml_path.display(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&virsh_path, fs::Permissions::from_mode(0o755)).unwrap();
+        let callbacks = Arc::new(LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "restore-failure-node".to_string(),
+            virtual_media_targets: BTreeMap::new(),
+        }));
+        let (router, state) = machine_router(
+            &host_info(HardwareType::DellPowerEdgeR750),
+            callbacks.clone(),
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions::default(),
+        );
+        callbacks.bind_state(&state).unwrap();
+        let system = "/redfish/v1/Systems/System.Embedded.1";
+        let status = request(
+            &router,
+            Method::PATCH,
+            system,
+            json!({
+                "Boot": {
+                    "BootSourceOverrideEnabled": "Once",
+                    "BootSourceOverrideTarget": "Hdd",
+                }
+            }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        fs::write(&fail_restore_path, "").unwrap();
+
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{system}/Actions/ComputerSystem.Reset"),
+            json!({"ResetType": "On"}),
+        )
+        .await;
+
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+        let active_xml = fs::read_to_string(&active_xml_path).unwrap();
+        assert!(active_xml.contains("<boot dev=\"hd\"/>"));
+        assert!(!active_xml.contains("<boot dev=\"network\"/>"));
+        assert_eq!(
+            state
+                .system_state
+                .controlled_system()
+                .unwrap()
+                .boot_source_override()["BootSourceOverrideEnabled"],
+            "Disabled"
+        );
     }
 
     #[test]

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -530,31 +530,33 @@ impl SingleSystemState {
         }
     }
 
-    /// Resolve the leading HPE OEM boot entry, then standard BootOrder, then
-    /// the profile default. Unknown entries fall through to the next source.
-    /// Returns None when no boot option is configured; callers leave domain
-    /// configuration unchanged in that case. Temporary overrides are excluded.
+    /// Resolve the first configured HPE OEM boot entry, then standard
+    /// BootOrder, then the profile default. Unknown or unconfigured HPE entries
+    /// are skipped. Returns None when no boot option is configured; callers
+    /// leave domain configuration unchanged in that case. Temporary overrides
+    /// are excluded.
     pub(crate) fn resolve_persistent_boot_selection(&self) -> Option<BootOptionKind> {
         self.hpe_boot_order_override
             .lock()
             .unwrap()
             .as_ref()
-            .and_then(|order| order.first())
-            .and_then(|entry| {
-                let (kind, reference) = entry
-                    .strip_prefix("HD.BootOption.")
-                    .map(|reference| (BootOptionKind::Disk, reference))
-                    .or_else(|| {
-                        entry
-                            .strip_prefix("NIC.BootOption.")
-                            .map(|reference| (BootOptionKind::Network, reference))
-                    })?;
-                self.config
-                    .boot_options
-                    .iter()
-                    .flatten()
-                    .find(|option| option.kind == kind && option.boot_reference() == reference)
-                    .map(|option| option.kind)
+            .and_then(|order| {
+                order.iter().find_map(|entry| {
+                    let (kind, reference) = entry
+                        .strip_prefix("HD.BootOption.")
+                        .map(|reference| (BootOptionKind::Disk, reference))
+                        .or_else(|| {
+                            entry
+                                .strip_prefix("NIC.BootOption.")
+                                .map(|reference| (BootOptionKind::Network, reference))
+                        })?;
+                    self.config
+                        .boot_options
+                        .iter()
+                        .flatten()
+                        .find(|option| option.kind == kind && option.boot_reference() == reference)
+                        .map(|option| option.kind)
+                })
             })
             .or_else(|| {
                 self.boot_order_override().and_then(|overrides| {

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -530,16 +530,42 @@ impl SingleSystemState {
         }
     }
 
+    /// Resolve the leading HPE OEM boot entry, then standard BootOrder, then
+    /// the profile default. Unknown entries fall through to the next source.
+    /// Returns None when no boot option is configured; callers leave domain
+    /// configuration unchanged in that case. Temporary overrides are excluded.
     pub(crate) fn resolve_persistent_boot_selection(&self) -> Option<BootOptionKind> {
-        self.boot_order_override()
-            .and_then(|overrides| {
-                overrides.first().and_then(|optref| {
-                    self.config
-                        .boot_options
-                        .iter()
-                        .flatten()
-                        .find(|v| v.boot_reference() == optref)
-                        .map(|opt| opt.kind)
+        self.hpe_boot_order_override
+            .lock()
+            .unwrap()
+            .as_ref()
+            .and_then(|order| order.first())
+            .and_then(|entry| {
+                let (kind, reference) = entry
+                    .strip_prefix("HD.BootOption.")
+                    .map(|reference| (BootOptionKind::Disk, reference))
+                    .or_else(|| {
+                        entry
+                            .strip_prefix("NIC.BootOption.")
+                            .map(|reference| (BootOptionKind::Network, reference))
+                    })?;
+                self.config
+                    .boot_options
+                    .iter()
+                    .flatten()
+                    .find(|option| option.kind == kind && option.boot_reference() == reference)
+                    .map(|option| option.kind)
+            })
+            .or_else(|| {
+                self.boot_order_override().and_then(|overrides| {
+                    overrides.first().and_then(|optref| {
+                        self.config
+                            .boot_options
+                            .iter()
+                            .flatten()
+                            .find(|v| v.boot_reference() == optref)
+                            .map(|opt| opt.kind)
+                    })
                 })
             })
             .or_else(|| {

--- a/crates/bmc-mock/src/redfish/computer_system.rs
+++ b/crates/bmc-mock/src/redfish/computer_system.rs
@@ -530,6 +530,27 @@ impl SingleSystemState {
         }
     }
 
+    pub(crate) fn resolve_persistent_boot_selection(&self) -> Option<BootOptionKind> {
+        self.boot_order_override()
+            .and_then(|overrides| {
+                overrides.first().and_then(|optref| {
+                    self.config
+                        .boot_options
+                        .iter()
+                        .flatten()
+                        .find(|v| v.boot_reference() == optref)
+                        .map(|opt| opt.kind)
+                })
+            })
+            .or_else(|| {
+                self.config
+                    .boot_options
+                    .as_ref()?
+                    .first()
+                    .map(|opt| opt.kind)
+            })
+    }
+
     fn resolve_current_boot_selection(&self) -> Option<BootOptionKind> {
         let src = self.boot_source_override.lock().unwrap();
         if src.enabled.as_ref().is_some_and(|v| v != "Disabled")
@@ -551,25 +572,7 @@ impl SingleSystemState {
         } else {
             None
         }
-        .or_else(|| {
-            self.boot_order_override().and_then(|overrides| {
-                overrides.first().and_then(|optref| {
-                    self.config
-                        .boot_options
-                        .iter()
-                        .flatten()
-                        .find(|v| v.boot_reference() == optref)
-                        .map(|opt| opt.kind)
-                })
-            })
-        })
-        .or_else(|| {
-            self.config
-                .boot_options
-                .as_ref()?
-                .first()
-                .map(|opt| opt.kind)
-        })
+        .or_else(|| self.resolve_persistent_boot_selection())
     }
 }
 


### PR DESCRIPTION
Persistent Redfish BootOrder was not applied to the libvirt domain, and completing a one-shot override restored hardcoded disk boot. A network-first selection could therefore be lost during repeated provisioning restarts.

Resolve persistent boot selection independently of temporary overrides, apply it when binding and reconciling state, restore it after a one-shot override, and reapply the effective selection at cold-start boundaries (`On`, `ForceOn`, and `PowerCycle`). `GracefulRestart` and `ForceRestart` retain normal libvirt reboot/reset behavior and the running domain's active boot configuration. An active temporary override retains precedence. Network selection maps to network then disk, disk selection maps to disk, and no selection leaves the domain unchanged.

HPE PersistentBootConfigOrder now participates in the persistent selection: the leading recognized HPE entry takes precedence over standard BootOrder, while both API representations remain separate. The resolver maps the mock's HD.BootOption and NIC.BootOption references to configured boot options.

## Type of Change

- [x] **Fix** - Bug fixes

## Breaking Changes

LibvirtCallbacks::bind_state returns Result<(), String> instead of Result<(), &'static str> so binding can report backend failures while applying the initial boot selection.

## Testing

- [x] Integration tests added/updated
- Router regression with a fake virsh models separate saved and active domain XML. It checks initial network-first configuration, persistent BootOrder changes, warm-restart preservation of the active order, cold-start application through `PowerCycle`, and restoration after a virtual-media override.
- Rust formatting applied with the pinned stable toolchain; nightly-only formatting options were unavailable.
- cargo test --offline --locked -p bmc-mock -- --skip real_ipmitool_resets_chassis: 101 tests passed (93 library, 8 binary). The real-ipmitool test was skipped because ipmitool is not installed.
- The HPE regression exercises the settings PATCH route and checks disk-first and network-first selection and resulting libvirt XML. Removing the HPE resolver fix makes it fail: a disk-first request still resolves to Network.
- Real-libvirt validation used `/usr/bin/virsh` with libvirt 12.0.0, QEMU 10.2.1, KVM, and a CirrOS guest. Guest boot IDs, live/inactive domain XML, and PXE HTTP requests were recorded:
  - After saving disk-first while the VM was running network-first, both `ForceRestart` and `GracefulRestart` produced new guest boot IDs but retained the live network-first order and generated new PXE requests.
  - `PowerCycle` loaded the saved disk-first order and generated no new PXE request.
  - In the reverse direction, saving network-first while running disk-first remained disk-first after `ForceRestart`; `PowerCycle` then loaded network-first and generated a new PXE request.
- The real-libvirt check establishes the cold-start requirement for this BIOS-style domain. UEFI/NVRAM and ConfigCd paths were not covered.
