### PR TITLE
feat(bmc-mock): expose configuration media for generated DPUs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -867,6 +867,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
+ "wait-timeout",
 ]
 
 [[package]]

--- a/crates/bmc-mock/Cargo.toml
+++ b/crates/bmc-mock/Cargo.toml
@@ -60,6 +60,7 @@ tower-http = { features = ["normalize-path"], workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { features = ["env-filter"], workspace = true }
 url = { workspace = true }
+wait-timeout = { workspace = true }
 
 [dev-dependencies]
 carbide-test-support = { path = "../test-support" }

--- a/crates/bmc-mock/src/ipmi_sim.rs
+++ b/crates/bmc-mock/src/ipmi_sim.rs
@@ -592,7 +592,9 @@ mod tests {
             Ok(())
         }
 
-        fn state_refresh_indication(&self) {}
+        fn state_refresh_indication(&self) -> Result<(), String> {
+            Ok(())
+        }
     }
 
     #[test]

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -224,7 +224,7 @@ pub trait Callbacks: std::fmt::Debug + Send + Sync {
         self.send_power_command(reset_type)
     }
 
-    fn state_refresh_indication(&self);
+    fn state_refresh_indication(&self) -> Result<(), String>;
 }
 
 pub trait HostnameQuerying: std::fmt::Debug + Send + Sync {

--- a/crates/bmc-mock/src/lib.rs
+++ b/crates/bmc-mock/src/lib.rs
@@ -16,6 +16,7 @@
  */
 use std::borrow::Cow;
 use std::fmt;
+use std::sync::Arc;
 use std::time::Duration;
 
 use serde::{Deserialize, Serialize};
@@ -224,7 +225,20 @@ pub trait Callbacks: std::fmt::Debug + Send + Sync {
         self.send_power_command(reset_type)
     }
 
+    /// Reconciles the mock's current desired state with its external backend.
+    ///
+    /// Returns an error when the desired state cannot be read or applied. When
+    /// a successful mutating request triggers reconciliation, request handlers
+    /// return HTTP 500 if this method fails. Implementations that perform
+    /// external I/O must bound every attempt.
     fn state_refresh_indication(&self) -> Result<(), String>;
+}
+
+/// Runs potentially blocking backend reconciliation away from Tokio workers.
+pub(crate) async fn refresh_backend_state(callbacks: Arc<dyn Callbacks>) -> Result<(), String> {
+    tokio::task::spawn_blocking(move || callbacks.state_refresh_indication())
+        .await
+        .map_err(|error| format!("backend state reconciliation task failed: {error}"))?
 }
 
 pub trait HostnameQuerying: std::fmt::Debug + Send + Sync {

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -70,16 +70,22 @@ impl LibvirtCallbacks {
         }
     }
 
-    pub fn bind_state(&self, state: &BmcState) -> Result<(), &'static str> {
+    pub fn bind_state(&self, state: &BmcState) -> Result<(), String> {
         let controlled_system = state
             .system_state
             .controlled_system()
-            .ok_or("libvirt backend has no controlled ComputerSystem")?;
+            .ok_or_else(|| "libvirt backend has no controlled ComputerSystem".to_string())?;
         self.system_state
             .set(Arc::downgrade(&state.system_state))
-            .map_err(|_| "libvirt backend state is already bound")?;
-        *self.applied_state.lock().unwrap() = AppliedState::from(controlled_system);
-        Ok(())
+            .map_err(|_| "libvirt backend state is already bound".to_string())?;
+
+        let desired = AppliedState::from(controlled_system);
+        for device_id in desired.virtual_media.keys() {
+            self.ensure_virtual_media_device(device_id)
+                .map_err(|error| error.to_string())?;
+        }
+        *self.applied_state.lock().unwrap() = AppliedState::default();
+        self.reconcile_state(desired)
     }
 
     fn virsh_output(&self, arguments: &[&str]) -> Result<Output, String> {
@@ -165,27 +171,94 @@ impl LibvirtCallbacks {
             })
     }
 
-    fn target_is_attached(&self, target: &str) -> Result<bool, VirtualMediaError> {
-        let output = self
-            .virsh(&["domblklist", "--details", &self.config.domain])
-            .map_err(VirtualMediaError::Command)?;
-        let output = String::from_utf8(output.stdout).map_err(|error| {
-            VirtualMediaError::Command(format!("virsh domblklist returned invalid UTF-8: {error}"))
-        })?;
-        Ok(output.lines().any(|line| {
-            line.split_whitespace()
-                .nth(2)
-                .is_some_and(|value| value == target)
-        }))
+    fn domain_xml(&self, inactive: bool) -> Result<String, VirtualMediaError> {
+        let arguments = if inactive {
+            vec!["dumpxml", "--inactive", self.config.domain.as_str()]
+        } else {
+            vec!["dumpxml", self.config.domain.as_str()]
+        };
+        let output = self.virsh(&arguments).map_err(VirtualMediaError::Command)?;
+        String::from_utf8(output.stdout).map_err(|error| {
+            VirtualMediaError::Command(format!("virsh dumpxml returned invalid UTF-8: {error}"))
+        })
     }
 
-    fn detach_target(&self, target: &str) -> VirtualMediaResult {
-        if !self.target_is_attached(target)? {
-            return Ok(());
+    fn require_owned_target(
+        &self,
+        device_id: &str,
+        target: &str,
+        inactive: bool,
+    ) -> VirtualMediaResult {
+        let xml = self.domain_xml(inactive)?;
+        match virtual_media_target_ownership(&xml, device_id, target)
+            .map_err(VirtualMediaError::Command)?
+        {
+            TargetOwnership::Owned => Ok(()),
+            TargetOwnership::Missing => Err(VirtualMediaError::Command(format!(
+                "libvirt domain {} has no {} virtual-media CD-ROM at target {target}",
+                self.config.domain,
+                if inactive { "persistent" } else { "live" },
+            ))),
+            TargetOwnership::Foreign { device, bus, alias } => {
+                Err(VirtualMediaError::Command(format!(
+                    "libvirt target {target} is already used by an unowned device (device={}, bus={}, alias={})",
+                    device.as_deref().unwrap_or("unknown"),
+                    bus.as_deref().unwrap_or("unknown"),
+                    alias.as_deref().unwrap_or("none"),
+                )))
+            }
         }
-        self.virsh(&["detach-disk", &self.config.domain, target, "--persistent"])
-            .map(drop)
-            .map_err(VirtualMediaError::Command)
+    }
+
+    fn ensure_virtual_media_device(&self, device_id: &str) -> VirtualMediaResult {
+        let target = self.target_for_device(device_id)?;
+        let xml = self.domain_xml(true)?;
+        match virtual_media_target_ownership(&xml, device_id, target)
+            .map_err(VirtualMediaError::Command)?
+        {
+            TargetOwnership::Owned => return Ok(()),
+            TargetOwnership::Foreign { device, bus, alias } => {
+                return Err(VirtualMediaError::Command(format!(
+                    "refusing to claim libvirt target {target}: it is already used by an unowned device (device={}, bus={}, alias={})",
+                    device.as_deref().unwrap_or("unknown"),
+                    bus.as_deref().unwrap_or("unknown"),
+                    alias.as_deref().unwrap_or("none"),
+                )));
+            }
+            TargetOwnership::Missing => {}
+        }
+
+        let xml = empty_virtual_media_xml(device_id, target)?;
+        let mut file = tempfile::NamedTempFile::new().map_err(|error| {
+            VirtualMediaError::Command(format!("could not create temporary device XML: {error}"))
+        })?;
+        file.write_all(xml.as_bytes()).map_err(|error| {
+            VirtualMediaError::Command(format!("could not write temporary device XML: {error}"))
+        })?;
+        self.virsh(&[
+            "attach-device",
+            &self.config.domain,
+            file.path().to_string_lossy().as_ref(),
+            "--config",
+        ])
+        .map(drop)
+        .map_err(VirtualMediaError::Command)
+    }
+
+    fn domain_is_active(&self) -> Result<bool, VirtualMediaError> {
+        let output = self
+            .virsh(&["domstate", &self.config.domain])
+            .map_err(VirtualMediaError::Command)?;
+        let state = String::from_utf8(output.stdout).map_err(|error| {
+            VirtualMediaError::Command(format!("virsh domstate returned invalid UTF-8: {error}"))
+        })?;
+        match state.trim() {
+            "running" | "idle" | "blocked" | "paused" | "in shutdown" | "pmsuspended" => Ok(true),
+            "shut off" | "crashed" => Ok(false),
+            state => Err(VirtualMediaError::Command(format!(
+                "virsh domstate returned an unknown domain state: {state}"
+            ))),
+        }
     }
 
     fn set_boot_source_override(
@@ -223,27 +296,42 @@ impl LibvirtCallbacks {
         write_protected: bool,
     ) -> VirtualMediaResult {
         let target = self.target_for_device(device_id)?;
-        self.detach_target(target)?;
         let xml = virtual_media_xml(device_id, target, image, write_protected)?;
+        self.update_virtual_media(device_id, target, &xml)
+    }
+
+    fn update_virtual_media(&self, device_id: &str, target: &str, xml: &str) -> VirtualMediaResult {
+        self.require_owned_target(device_id, target, true)?;
+        let active = self.domain_is_active()?;
+        if active {
+            self.require_owned_target(device_id, target, false)?;
+        }
+
         let mut file = tempfile::NamedTempFile::new().map_err(|error| {
             VirtualMediaError::Command(format!("could not create temporary device XML: {error}"))
         })?;
         file.write_all(xml.as_bytes()).map_err(|error| {
             VirtualMediaError::Command(format!("could not write temporary device XML: {error}"))
         })?;
-        self.virsh(&[
-            "attach-device",
-            &self.config.domain,
-            file.path().to_string_lossy().as_ref(),
-            "--persistent",
-        ])
-        .map(drop)
-        .map_err(VirtualMediaError::Command)
+        let file_path = file.path().to_string_lossy();
+        let mut arguments = vec![
+            "update-device",
+            self.config.domain.as_str(),
+            file_path.as_ref(),
+        ];
+        if active {
+            arguments.push("--live");
+        }
+        arguments.push("--config");
+        self.virsh(&arguments)
+            .map(drop)
+            .map_err(VirtualMediaError::Command)
     }
 
     fn eject_virtual_media(&self, device_id: &str) -> VirtualMediaResult {
         let target = self.target_for_device(device_id)?;
-        self.detach_target(target)
+        let xml = empty_virtual_media_xml(device_id, target)?;
+        self.update_virtual_media(device_id, target, &xml)
     }
 
     fn apply_virtual_media(&self, state: &serde_json::Value) -> VirtualMediaResult {
@@ -286,8 +374,13 @@ impl LibvirtCallbacks {
             if applied.virtual_media.get(&device_id) == Some(&desired_device) {
                 continue;
             }
-            self.apply_virtual_media(&desired_device)
-                .map_err(|error| error.to_string())?;
+            if let Err(error) = self.apply_virtual_media(&desired_device) {
+                // The command may have failed after changing one libvirt view. Forget the
+                // cached value so a caller restoring its previous Redfish state forces a
+                // compensating update instead of treating the old state as already applied.
+                applied.virtual_media.remove(&device_id);
+                return Err(error.to_string());
+            }
             applied.virtual_media.insert(device_id, desired_device);
         }
         Ok(())
@@ -359,28 +452,14 @@ impl Callbacks for LibvirtCallbacks {
         }
     }
 
-    fn state_refresh_indication(&self) {
+    fn state_refresh_indication(&self) -> Result<(), String> {
         let Some(system_state) = self.system_state.get().and_then(Weak::upgrade) else {
-            tracing::error!(
-                domain = %self.config.domain,
-                "libvirt backend is not bound to BMC mock state",
-            );
-            return;
+            return Err("libvirt backend is not bound to BMC mock state".to_string());
         };
         let Some(controlled_system) = system_state.controlled_system() else {
-            tracing::error!(
-                domain = %self.config.domain,
-                "BMC mock state has no controlled ComputerSystem",
-            );
-            return;
+            return Err("BMC mock state has no controlled ComputerSystem".to_string());
         };
-        if let Err(error) = self.reconcile_state(AppliedState::from(controlled_system)) {
-            tracing::error!(
-                domain = %self.config.domain,
-                error = %error,
-                "could not reconcile libvirt domain with BMC mock state",
-            );
-        }
+        self.reconcile_state(AppliedState::from(controlled_system))
     }
 }
 
@@ -418,6 +497,98 @@ fn set_boot_order_xml(xml: &str, devices: &[&str]) -> Result<String, String> {
     }
     String::from_utf8(writer.into_inner())
         .map_err(|error| format!("generated libvirt domain XML is invalid UTF-8: {error}"))
+}
+
+#[derive(Debug, Eq, PartialEq)]
+enum TargetOwnership {
+    Missing,
+    Owned,
+    Foreign {
+        device: Option<String>,
+        bus: Option<String>,
+        alias: Option<String>,
+    },
+}
+
+fn xml_attribute(element: &BytesStart<'_>, name: &[u8]) -> Result<Option<String>, String> {
+    for attribute in element.attributes() {
+        let attribute = attribute
+            .map_err(|error| format!("could not parse libvirt domain XML attribute: {error}"))?;
+        if attribute.key.as_ref() == name {
+            return String::from_utf8(attribute.value.into_owned())
+                .map(Some)
+                .map_err(|error| {
+                    format!("libvirt domain XML attribute is invalid UTF-8: {error}")
+                });
+        }
+    }
+    Ok(None)
+}
+
+fn virtual_media_target_ownership(
+    xml: &str,
+    device_id: &str,
+    target: &str,
+) -> Result<TargetOwnership, String> {
+    let expected_alias = format!("ua-bmc-mock-vmedia-{device_id}");
+    let mut reader = Reader::from_str(xml);
+    let mut inside_disk = false;
+    let mut disk_device = None;
+    let mut disk_target = None;
+    let mut disk_bus = None;
+    let mut disk_alias = None;
+    let mut ownership = TargetOwnership::Missing;
+
+    loop {
+        let event = reader
+            .read_event()
+            .map_err(|error| format!("could not parse libvirt domain XML: {error}"))?;
+        match event {
+            Event::Start(element) if element.name().as_ref() == b"disk" => {
+                inside_disk = true;
+                disk_device = xml_attribute(&element, b"device")?;
+                disk_target = None;
+                disk_bus = None;
+                disk_alias = None;
+            }
+            Event::Start(element) | Event::Empty(element)
+                if inside_disk && element.name().as_ref() == b"target" =>
+            {
+                disk_target = xml_attribute(&element, b"dev")?;
+                disk_bus = xml_attribute(&element, b"bus")?;
+            }
+            Event::Start(element) | Event::Empty(element)
+                if inside_disk && element.name().as_ref() == b"alias" =>
+            {
+                disk_alias = xml_attribute(&element, b"name")?;
+            }
+            Event::End(element) if element.name().as_ref() == b"disk" => {
+                if disk_target.as_deref() == Some(target) {
+                    if ownership != TargetOwnership::Missing {
+                        return Err(format!(
+                            "libvirt domain has more than one disk at target {target}"
+                        ));
+                    }
+                    ownership = if disk_device.as_deref() == Some("cdrom")
+                        && disk_bus.as_deref() == Some("sata")
+                        && disk_alias.as_deref() == Some(expected_alias.as_str())
+                    {
+                        TargetOwnership::Owned
+                    } else {
+                        TargetOwnership::Foreign {
+                            device: disk_device.take(),
+                            bus: disk_bus.take(),
+                            alias: disk_alias.take(),
+                        }
+                    };
+                }
+                inside_disk = false;
+            }
+            Event::Eof => break,
+            _ => {}
+        }
+    }
+    Ok(ownership)
 }
 
 enum MediaSource {
@@ -539,6 +710,38 @@ fn virtual_media_xml(
     })
 }
 
+fn empty_virtual_media_xml(device_id: &str, target: &str) -> Result<String, VirtualMediaError> {
+    let mut writer = Writer::new(Vec::new());
+    let mut disk = BytesStart::new("disk");
+    disk.push_attribute(("type", "file"));
+    disk.push_attribute(("device", "cdrom"));
+    writer.write_event(Event::Start(disk)).unwrap();
+
+    let mut driver = BytesStart::new("driver");
+    driver.push_attribute(("name", "qemu"));
+    driver.push_attribute(("type", "raw"));
+    writer.write_event(Event::Empty(driver)).unwrap();
+
+    let mut target_element = BytesStart::new("target");
+    target_element.push_attribute(("dev", target));
+    target_element.push_attribute(("bus", "sata"));
+    writer.write_event(Event::Empty(target_element)).unwrap();
+    writer
+        .write_event(Event::Empty(BytesStart::new("readonly")))
+        .unwrap();
+    let mut alias = BytesStart::new("alias");
+    let alias_name = format!("ua-bmc-mock-vmedia-{device_id}");
+    alias.push_attribute(("name", alias_name.as_str()));
+    writer.write_event(Event::Empty(alias)).unwrap();
+    writer
+        .write_event(Event::End(BytesEnd::new("disk")))
+        .unwrap();
+
+    String::from_utf8(writer.into_inner()).map_err(|error| {
+        VirtualMediaError::Command(format!("generated device XML is invalid UTF-8: {error}"))
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use std::borrow::Cow;
@@ -608,30 +811,129 @@ mod tests {
         assert!(!actual.contains("<readonly/>"));
     }
 
+    #[test]
+    fn classifies_virtual_media_target_ownership() {
+        let cases = [
+            (
+                "missing",
+                "<domain><devices/></domain>",
+                TargetOwnership::Missing,
+            ),
+            (
+                "owned",
+                "<domain><devices><disk device='cdrom'><target dev='sdc' bus='sata'/><alias name='ua-bmc-mock-vmedia-ConfigCd'/></disk></devices></domain>",
+                TargetOwnership::Owned,
+            ),
+            (
+                "foreign",
+                "<domain><devices><disk device='disk'><target dev='sdc' bus='scsi'/><alias name='ua-data'/></disk></devices></domain>",
+                TargetOwnership::Foreign {
+                    device: Some("disk".to_string()),
+                    bus: Some("scsi".to_string()),
+                    alias: Some("ua-data".to_string()),
+                },
+            ),
+        ];
+
+        for (name, xml, expected) in cases {
+            assert_eq!(
+                virtual_media_target_ownership(xml, "ConfigCd", "sdc").unwrap(),
+                expected,
+                "{name}"
+            );
+        }
+    }
+
+    fn test_router(callbacks: Arc<LibvirtCallbacks>) -> (Router, BmcState) {
+        machine_router(
+            &host_info(HardwareType::DellPowerEdgeR750),
+            callbacks,
+            "test-host-id".to_string(),
+            false,
+            MachineRouterOptions {
+                bmc_reset_duration: None,
+                virtual_media_devices: Some(vec![VirtualMediaDeviceConfig {
+                    id: Cow::Borrowed("Cd"),
+                    name: Cow::Borrowed("Operating System Virtual CD"),
+                    media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
+                }]),
+            },
+        )
+    }
+
     #[cfg(unix)]
     #[tokio::test]
-    async fn state_refresh_drives_the_configured_domain() {
+    async fn updates_an_owned_cdrom_in_place_for_live_and_persistent_state() {
         use std::os::unix::fs::PermissionsExt;
 
         let directory = tempfile::tempdir().unwrap();
         let virsh_path = directory.path().join("virsh");
         let log_path = directory.path().join("virsh.log");
+        let persistent_xml_path = directory.path().join("persistent.xml");
+        let live_xml_path = directory.path().join("live.xml");
         let defined_xml_path = directory.path().join("defined.xml");
-        let attached_xml_path = directory.path().join("attached.xml");
+        let inserted_xml_path = directory.path().join("inserted.xml");
+        fs::write(
+            &persistent_xml_path,
+            "<domain><os><type>hvm</type><boot dev='hd'/></os><devices/></domain>",
+        )
+        .unwrap();
         let script = format!(
             r#"#!/bin/sh
 printf '%s\n' "$*" >> '{}'
 case "$3" in
-  domstate) printf 'shut off\n' ;;
-  dumpxml) printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices/></domain>\n' ;;
-  domblklist) printf 'Type Device Target Source\nnetwork cdrom sdb http://example/old.iso\n' ;;
-  define) cp "$4" '{}' ;;
-  attach-device) cp "$5" '{}' ;;
+  domstate)
+    if [ -f '{}' ]; then printf 'running\n'; else printf 'shut off\n'; fi
+    ;;
+  dumpxml)
+    if [ "$4" = "--inactive" ]; then cat '{}'; else cat '{}'; fi
+    ;;
+  attach-device)
+    {{
+      printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices>'
+      cat "$5"
+      printf '</devices></domain>\n'
+    }} > '{}.new'
+    mv '{}.new' '{}'
+    ;;
+  update-device)
+    if grep -q '<source' "$5"; then cp "$5" '{}'; fi
+    {{
+      printf '<domain><os><type>hvm</type><boot dev="hd"/></os><devices>'
+      cat "$5"
+      printf '</devices></domain>\n'
+    }} > '{}.new'
+    mv '{}.new' '{}'
+    case "$*" in *--live*) cp '{}' '{}' ;; esac
+    ;;
+  define)
+    cp "$4" '{}'
+    cp "$4" '{}'
+    ;;
+  start)
+    touch '{}'
+    cp '{}' '{}'
+    ;;
 esac
 "#,
             log_path.display(),
+            directory.path().join("running").display(),
+            persistent_xml_path.display(),
+            live_xml_path.display(),
+            persistent_xml_path.display(),
+            persistent_xml_path.display(),
+            persistent_xml_path.display(),
+            inserted_xml_path.display(),
+            persistent_xml_path.display(),
+            persistent_xml_path.display(),
+            persistent_xml_path.display(),
+            persistent_xml_path.display(),
+            live_xml_path.display(),
             defined_xml_path.display(),
-            attached_xml_path.display(),
+            persistent_xml_path.display(),
+            directory.path().join("running").display(),
+            persistent_xml_path.display(),
+            live_xml_path.display(),
         );
         fs::write(&virsh_path, script).unwrap();
         let mut permissions = fs::metadata(&virsh_path).unwrap().permissions();
@@ -644,20 +946,7 @@ esac
             domain: "dsx-node".to_string(),
             virtual_media_targets: BTreeMap::from([("Cd".to_string(), "sdb".to_string())]),
         }));
-        let (router, state) = machine_router(
-            &host_info(HardwareType::DellPowerEdgeR750),
-            callbacks.clone(),
-            "test-host-id".to_string(),
-            false,
-            MachineRouterOptions {
-                bmc_reset_duration: None,
-                virtual_media_devices: Some(vec![VirtualMediaDeviceConfig {
-                    id: Cow::Borrowed("Cd"),
-                    name: Cow::Borrowed("Operating System Virtual CD"),
-                    media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
-                }]),
-            },
-        );
+        let (router, state) = test_router(callbacks.clone());
         callbacks.bind_state(&state).unwrap();
         let system = "/redfish/v1/Systems/System.Embedded.1";
 
@@ -719,13 +1008,117 @@ esac
         let log = fs::read_to_string(log_path).unwrap();
         assert!(log.contains("--connect qemu:///system dumpxml --inactive dsx-node"));
         assert!(log.contains("--connect qemu:///system start dsx-node"));
-        assert!(log.contains("--connect qemu:///system detach-disk dsx-node sdb --persistent"));
         assert!(log.contains("--connect qemu:///system attach-device dsx-node"));
-        let attached_xml = fs::read_to_string(attached_xml_path).unwrap();
-        assert!(attached_xml.contains("protocol=\"http\""));
-        assert!(attached_xml.contains("dev=\"sdb\""));
+        assert!(log.contains("--config"));
+        assert!(log.contains("--live --config"));
+        assert!(log.contains("--connect qemu:///system update-device dsx-node"));
+        assert!(!log.contains("detach-disk"));
+        let inserted_xml = fs::read_to_string(inserted_xml_path).unwrap();
+        assert!(inserted_xml.contains("protocol=\"http\""));
+        assert!(inserted_xml.contains("dev=\"sdb\""));
+        assert!(inserted_xml.contains("alias name=\"ua-bmc-mock-vmedia-Cd\""));
         let defined_xml = fs::read_to_string(defined_xml_path).unwrap();
         assert!(defined_xml.contains("<boot dev=\"hd\"/>"));
         assert!(!defined_xml.contains("<boot dev=\"cdrom\"/>"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn refuses_to_claim_a_foreign_disk_at_the_configured_target() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        let log_path = directory.path().join("virsh.log");
+        let script = format!(
+            r#"#!/bin/sh
+printf '%s\n' "$*" >> '{}'
+case "$3" in
+  dumpxml) printf '<domain><devices><disk device="disk"><target dev="sdb" bus="scsi"/><alias name="ua-data"/></disk></devices></domain>\n' ;;
+esac
+"#,
+            log_path.display(),
+        );
+        fs::write(&virsh_path, script).unwrap();
+        let mut permissions = fs::metadata(&virsh_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&virsh_path, permissions).unwrap();
+
+        let callbacks = Arc::new(LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "dsx-node".to_string(),
+            virtual_media_targets: BTreeMap::from([("Cd".to_string(), "sdb".to_string())]),
+        }));
+        let (_, state) = test_router(callbacks.clone());
+
+        let error = callbacks.bind_state(&state).unwrap_err();
+        assert!(error.contains("refusing to claim libvirt target sdb"));
+        let log = fs::read_to_string(log_path).unwrap();
+        assert!(!log.contains("detach-disk"));
+        assert!(!log.contains("update-device"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn failed_media_update_returns_an_error_and_restores_redfish_state() {
+        use std::os::unix::fs::PermissionsExt;
+
+        use http_body_util::BodyExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        let xml_path = directory.path().join("domain.xml");
+        fs::write(
+            &xml_path,
+            "<domain><devices><disk type='file' device='cdrom'><driver name='qemu' type='raw'/><target dev='sdb' bus='sata'/><readonly/><alias name='ua-bmc-mock-vmedia-Cd'/></disk></devices></domain>",
+        )
+        .unwrap();
+        let script = format!(
+            r#"#!/bin/sh
+case "$3" in
+  domstate) printf 'shut off\n' ;;
+  dumpxml) cat '{}' ;;
+  update-device)
+    if grep -q '<source' "$5"; then printf 'injected update failure\n' >&2; exit 1; fi
+    cp "$5" '{}'
+    ;;
+esac
+"#,
+            xml_path.display(),
+            xml_path.display(),
+        );
+        fs::write(&virsh_path, script).unwrap();
+        let mut permissions = fs::metadata(&virsh_path).unwrap().permissions();
+        permissions.set_mode(0o755);
+        fs::set_permissions(&virsh_path, permissions).unwrap();
+
+        let callbacks = Arc::new(LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "dsx-node".to_string(),
+            virtual_media_targets: BTreeMap::from([("Cd".to_string(), "sdb".to_string())]),
+        }));
+        let (router, state) = test_router(callbacks.clone());
+        callbacks.bind_state(&state).unwrap();
+        let media = "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/Cd";
+
+        let status = request(
+            &router,
+            Method::POST,
+            &format!("{media}/Actions/VirtualMedia.InsertMedia"),
+            json!({"Image": "/tmp/config.iso"}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::INTERNAL_SERVER_ERROR);
+
+        let response = router
+            .oneshot(Request::builder().uri(media).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let body = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(body["Inserted"], false);
+        assert_eq!(body["Image"], serde_json::Value::Null);
     }
 }

--- a/crates/bmc-mock/src/libvirt.rs
+++ b/crates/bmc-mock/src/libvirt.rs
@@ -18,12 +18,14 @@
 use std::collections::BTreeMap;
 use std::io::Write;
 use std::path::PathBuf;
-use std::process::{Command, Output};
+use std::process::{Command, Output, Stdio};
 use std::sync::{Arc, Mutex, OnceLock, Weak};
+use std::time::Duration;
 
 use quick_xml::events::{BytesEnd, BytesStart, Event};
 use quick_xml::{Reader, Writer};
 use url::Url;
+use wait_timeout::ChildExt;
 
 use crate::redfish::computer_system::{SingleSystemState, SystemState};
 use crate::{BmcState, Callbacks, MockPowerState, SetSystemPowerError, SystemPowerControl};
@@ -37,6 +39,11 @@ enum VirtualMediaError {
 }
 
 type VirtualMediaResult = Result<(), VirtualMediaError>;
+
+/// Maximum wall-clock time for one local `virsh` attempt. Libvirt control
+/// commands are expected to return promptly; bounding each attempt at 30
+/// seconds prevents a stuck daemon from pinning a reconciliation worker.
+const VIRSH_COMMAND_TIMEOUT: Duration = Duration::from_secs(30);
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -70,6 +77,11 @@ impl LibvirtCallbacks {
         }
     }
 
+    /// Binds this backend to one BMC state instance, provisions each configured
+    /// persistent CD-ROM with a `ua-bmc-mock-vmedia-*` ownership alias (and its
+    /// live counterpart when the domain is active), then reconciles the desired
+    /// state before returning. A second binding or any provisioning or
+    /// reconciliation failure returns an error.
     pub fn bind_state(&self, state: &BmcState) -> Result<(), String> {
         let controlled_system = state
             .system_state
@@ -89,17 +101,70 @@ impl LibvirtCallbacks {
     }
 
     fn virsh_output(&self, arguments: &[&str]) -> Result<Output, String> {
-        Command::new(&self.config.virsh_path)
+        self.virsh_output_with_timeout(arguments, VIRSH_COMMAND_TIMEOUT)
+    }
+
+    fn virsh_output_with_timeout(
+        &self,
+        arguments: &[&str],
+        timeout: Duration,
+    ) -> Result<Output, String> {
+        let stdout_file = tempfile::NamedTempFile::new()
+            .map_err(|error| format!("could not create temporary virsh stdout file: {error}"))?;
+        let stderr_file = tempfile::NamedTempFile::new()
+            .map_err(|error| format!("could not create temporary virsh stderr file: {error}"))?;
+        let stdout = stdout_file
+            .reopen()
+            .map_err(|error| format!("could not open temporary virsh stdout file: {error}"))?;
+        let stderr = stderr_file
+            .reopen()
+            .map_err(|error| format!("could not open temporary virsh stderr file: {error}"))?;
+        let mut child = Command::new(&self.config.virsh_path)
             .arg("--connect")
             .arg(&self.config.uri)
             .args(arguments)
-            .output()
+            .stdout(Stdio::from(stdout))
+            .stderr(Stdio::from(stderr))
+            .spawn()
             .map_err(|error| {
                 format!(
                     "could not execute {}: {error}",
                     self.config.virsh_path.display()
                 )
-            })
+            })?;
+        let Some(status) = child.wait_timeout(timeout).map_err(|error| {
+            format!(
+                "could not wait for {}: {error}",
+                self.config.virsh_path.display()
+            )
+        })?
+        else {
+            child.kill().map_err(|error| {
+                format!(
+                    "{} timed out after {timeout:?} and could not be stopped: {error}",
+                    self.config.virsh_path.display()
+                )
+            })?;
+            child.wait().map_err(|error| {
+                format!(
+                    "could not reap timed-out {} process: {error}",
+                    self.config.virsh_path.display()
+                )
+            })?;
+            return Err(format!(
+                "{} timed out after {timeout:?}",
+                self.config.virsh_path.display()
+            ));
+        };
+        let stdout = std::fs::read(stdout_file.path())
+            .map_err(|error| format!("could not read virsh stdout: {error}"))?;
+        let stderr = std::fs::read(stderr_file.path())
+            .map_err(|error| format!("could not read virsh stderr: {error}"))?;
+        Ok(Output {
+            status,
+            stdout,
+            stderr,
+        })
     }
 
     fn virsh(&self, arguments: &[&str]) -> Result<Output, String> {
@@ -213,19 +278,42 @@ impl LibvirtCallbacks {
     fn ensure_virtual_media_device(&self, device_id: &str) -> VirtualMediaResult {
         let target = self.target_for_device(device_id)?;
         let xml = self.domain_xml(true)?;
-        match virtual_media_target_ownership(&xml, device_id, target)
+        let persistent_owned = match virtual_media_target_ownership(&xml, device_id, target)
             .map_err(VirtualMediaError::Command)?
         {
-            TargetOwnership::Owned => return Ok(()),
+            TargetOwnership::Owned => true,
             TargetOwnership::Foreign { device, bus, alias } => {
                 return Err(VirtualMediaError::Command(format!(
-                    "refusing to claim libvirt target {target}: it is already used by an unowned device (device={}, bus={}, alias={})",
+                    "refusing to claim libvirt target {target} in persistent configuration: it is already used by an unowned device (device={}, bus={}, alias={})",
                     device.as_deref().unwrap_or("unknown"),
                     bus.as_deref().unwrap_or("unknown"),
                     alias.as_deref().unwrap_or("none"),
                 )));
             }
-            TargetOwnership::Missing => {}
+            TargetOwnership::Missing => false,
+        };
+        let active = self.domain_is_active()?;
+        let live_owned = if active {
+            let xml = self.domain_xml(false)?;
+            match virtual_media_target_ownership(&xml, device_id, target)
+                .map_err(VirtualMediaError::Command)?
+            {
+                TargetOwnership::Owned => true,
+                TargetOwnership::Foreign { device, bus, alias } => {
+                    return Err(VirtualMediaError::Command(format!(
+                        "refusing to claim libvirt target {target} in live configuration: it is already used by an unowned device (device={}, bus={}, alias={})",
+                        device.as_deref().unwrap_or("unknown"),
+                        bus.as_deref().unwrap_or("unknown"),
+                        alias.as_deref().unwrap_or("none"),
+                    )));
+                }
+                TargetOwnership::Missing => false,
+            }
+        } else {
+            false
+        };
+        if persistent_owned && (!active || live_owned) {
+            return Ok(());
         }
 
         let xml = empty_virtual_media_xml(device_id, target)?;
@@ -235,14 +323,21 @@ impl LibvirtCallbacks {
         file.write_all(xml.as_bytes()).map_err(|error| {
             VirtualMediaError::Command(format!("could not write temporary device XML: {error}"))
         })?;
-        self.virsh(&[
+        let file_path = file.path().to_string_lossy();
+        let mut arguments = vec![
             "attach-device",
-            &self.config.domain,
-            file.path().to_string_lossy().as_ref(),
-            "--config",
-        ])
-        .map(drop)
-        .map_err(VirtualMediaError::Command)
+            self.config.domain.as_str(),
+            file_path.as_ref(),
+        ];
+        if active && !live_owned {
+            arguments.push("--live");
+        }
+        if !persistent_owned {
+            arguments.push("--config");
+        }
+        self.virsh(&arguments)
+            .map(drop)
+            .map_err(VirtualMediaError::Command)
     }
 
     fn domain_is_active(&self) -> Result<bool, VirtualMediaError> {
@@ -842,6 +937,73 @@ mod tests {
                 "{name}"
             );
         }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn provisions_a_missing_cdrom_in_live_and_persistent_domains() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        let log_path = directory.path().join("virsh.log");
+        fs::write(
+            &virsh_path,
+            format!(
+                r#"#!/bin/sh
+printf '%s\n' "$*" >> '{}'
+case "$3" in
+  domstate) printf 'running\n' ;;
+  dumpxml) printf '<domain><devices/></domain>\n' ;;
+esac
+"#,
+                log_path.display(),
+            ),
+        )
+        .unwrap();
+        fs::set_permissions(&virsh_path, fs::Permissions::from_mode(0o755)).unwrap();
+
+        let callbacks = LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "dsx-node".to_string(),
+            virtual_media_targets: BTreeMap::from([("Cd".to_string(), "sdb".to_string())]),
+        });
+
+        callbacks.ensure_virtual_media_device("Cd").unwrap();
+
+        let log = fs::read_to_string(log_path).unwrap();
+        let attach = log
+            .lines()
+            .find(|line| line.contains(" attach-device "))
+            .expect("attach-device was not invoked");
+        assert!(attach.ends_with("--live --config"), "{attach}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn terminates_a_virsh_command_after_its_deadline() {
+        use std::os::unix::fs::PermissionsExt;
+        use std::time::Instant;
+
+        let directory = tempfile::tempdir().unwrap();
+        let virsh_path = directory.path().join("virsh");
+        fs::write(&virsh_path, "#!/bin/sh\nexec sleep 1\n").unwrap();
+        fs::set_permissions(&virsh_path, fs::Permissions::from_mode(0o755)).unwrap();
+        let callbacks = LibvirtCallbacks::new(Config {
+            virsh_path,
+            uri: "qemu:///system".to_string(),
+            domain: "dsx-node".to_string(),
+            virtual_media_targets: BTreeMap::new(),
+        });
+
+        let started = Instant::now();
+        let error = callbacks
+            .virsh_output_with_timeout(&["domstate", "dsx-node"], Duration::from_millis(20))
+            .unwrap_err();
+
+        assert!(error.contains("timed out after 20ms"), "{error}");
+        assert!(started.elapsed() < Duration::from_secs(1));
     }
 
     fn test_router(callbacks: Arc<LibvirtCallbacks>) -> (Router, BmcState) {

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -457,10 +457,10 @@ impl Callbacks for ChannelCallbacks {
             .map_err(|err| SetSystemPowerError::CommandSendError(err.to_string()))
     }
 
-    fn state_refresh_indication(&self) {
-        let _ = self
-            .command_channel
-            .send(BmcCommand::StateRefreshIndication);
+    fn state_refresh_indication(&self) -> Result<(), String> {
+        self.command_channel
+            .send(BmcCommand::StateRefreshIndication)
+            .map_err(|error| error.to_string())
     }
 }
 

--- a/crates/bmc-mock/src/main.rs
+++ b/crates/bmc-mock/src/main.rs
@@ -350,45 +350,48 @@ fn generated_mock(config: GeneratedMockConfig) -> (Router, BmcState) {
         config.dpu_index,
         config.instance_index,
     );
-    let result = if config.machine_role == MachineRole::Host
-        && config.state_backend == StateBackend::Libvirt
-    {
-        bmc_mock::machine_router(
-            &machine_info,
-            callbacks,
-            String::default(),
-            false,
-            MachineRouterOptions {
-                bmc_reset_duration: None,
-                virtual_media_devices: Some(vec![
-                    VirtualMediaDeviceConfig {
-                        id: Cow::Borrowed("Cd"),
-                        name: Cow::Borrowed("Operating System Virtual CD"),
-                        media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
-                    },
-                    VirtualMediaDeviceConfig {
-                        id: Cow::Borrowed("ConfigCd"),
-                        name: Cow::Borrowed("Configuration Virtual CD"),
-                        media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
-                    },
-                ]),
-            },
-        )
-    } else {
-        bmc_mock::machine_router(
-            &machine_info,
-            callbacks,
-            String::default(),
-            false,
-            MachineRouterOptions::default(),
-        )
-    };
+    let result = bmc_mock::machine_router(
+        &machine_info,
+        callbacks,
+        String::default(),
+        false,
+        MachineRouterOptions {
+            bmc_reset_duration: None,
+            virtual_media_devices: generated_virtual_media_devices(
+                config.machine_role,
+                config.state_backend,
+            ),
+        },
+    );
     if let Some(callbacks) = libvirt_callbacks {
         callbacks
             .bind_state(&result.1)
             .expect("libvirt backend must bind to generated BMC state");
     }
     result
+}
+
+fn generated_virtual_media_devices(
+    machine_role: MachineRole,
+    state_backend: StateBackend,
+) -> Option<Vec<VirtualMediaDeviceConfig>> {
+    if state_backend != StateBackend::Libvirt {
+        return None;
+    }
+    let mut devices = Vec::new();
+    if machine_role == MachineRole::Host {
+        devices.push(VirtualMediaDeviceConfig {
+            id: Cow::Borrowed("Cd"),
+            name: Cow::Borrowed("Operating System Virtual CD"),
+            media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
+        });
+    }
+    devices.push(VirtualMediaDeviceConfig {
+        id: Cow::Borrowed("ConfigCd"),
+        name: Cow::Borrowed("Configuration Virtual CD"),
+        media_types: vec![Cow::Borrowed("CD"), Cow::Borrowed("DVD")],
+    });
+    Some(devices)
 }
 
 fn generated_machine_info(
@@ -479,6 +482,33 @@ mod tests {
         assert_eq!(config.state_backend, StateBackend::Internal);
         assert!(matches!(config.hardware_type, HardwareType::WiwynnGB200Nvl));
         assert!(config.use_channel_callbacks);
+    }
+
+    #[test]
+    fn generated_virtual_media_matches_role_and_backend() {
+        for (role, backend, expected) in [
+            (
+                MachineRole::Dpu,
+                StateBackend::Libvirt,
+                Some(vec!["ConfigCd"]),
+            ),
+            (
+                MachineRole::Host,
+                StateBackend::Libvirt,
+                Some(vec!["Cd", "ConfigCd"]),
+            ),
+            (MachineRole::Dpu, StateBackend::Internal, None),
+            (MachineRole::Host, StateBackend::Internal, None),
+        ] {
+            let devices = generated_virtual_media_devices(role, backend);
+            let ids = devices.as_ref().map(|devices| {
+                devices
+                    .iter()
+                    .map(|device| device.id.as_ref())
+                    .collect::<Vec<_>>()
+            });
+            assert_eq!(ids, expected, "role {role:?}, backend {backend:?}");
+        }
     }
 
     #[test]

--- a/crates/bmc-mock/src/middleware_router.rs
+++ b/crates/bmc-mock/src/middleware_router.rs
@@ -25,9 +25,9 @@ use axum::routing::any;
 use carbide_axum_utils::router::call_router_with_new_request;
 use tracing::instrument;
 
-use crate::Callbacks;
 use crate::availability::BmcAvailabilityState;
 use crate::injection::InjectionStore;
+use crate::{Callbacks, refresh_backend_state};
 
 #[derive(Clone)]
 pub(crate) struct StateRefreshHandled;
@@ -91,12 +91,12 @@ async fn process(State(mut state): State<Middleware>, request: Request<Body>) ->
     if !is_safe
         && response.status().is_success()
         && response.extensions().get::<StateRefreshHandled>().is_none()
-        && let Err(error) = state.callbacks.state_refresh_indication()
+        && let Err(error) = refresh_backend_state(Arc::clone(&state.callbacks)).await
     {
         tracing::error!(
             method = %method,
             path,
-            error,
+            error = %error,
             "could not reconcile backend state after BMC mock request",
         );
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
@@ -116,5 +116,58 @@ struct Middleware {
 impl Middleware {
     async fn call_inner_router(&mut self, request: Request<Body>) -> axum::response::Response {
         call_router_with_new_request(&mut self.inner, request).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::time::Duration;
+
+    use super::*;
+    use crate::{MockPowerState, SetSystemPowerError, SystemPowerControl};
+
+    #[derive(Debug)]
+    struct BlockingRefresh {
+        started: Arc<AtomicBool>,
+        finished: Arc<AtomicBool>,
+    }
+
+    impl Callbacks for BlockingRefresh {
+        fn get_power_state(&self) -> MockPowerState {
+            MockPowerState::Off
+        }
+
+        fn send_power_command(
+            &self,
+            _reset_type: SystemPowerControl,
+        ) -> Result<(), SetSystemPowerError> {
+            Ok(())
+        }
+
+        fn state_refresh_indication(&self) -> Result<(), String> {
+            self.started.store(true, Ordering::SeqCst);
+            std::thread::sleep(Duration::from_millis(100));
+            self.finished.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn backend_refresh_does_not_block_the_async_executor() {
+        let started = Arc::new(AtomicBool::new(false));
+        let finished = Arc::new(AtomicBool::new(false));
+        let callbacks: Arc<dyn Callbacks> = Arc::new(BlockingRefresh {
+            started: Arc::clone(&started),
+            finished: Arc::clone(&finished),
+        });
+
+        let refresh = tokio::spawn(refresh_backend_state(callbacks));
+        tokio::task::yield_now().await;
+
+        assert!(!finished.load(Ordering::SeqCst));
+        refresh.await.unwrap().unwrap();
+        assert!(started.load(Ordering::SeqCst));
+        assert!(finished.load(Ordering::SeqCst));
     }
 }

--- a/crates/bmc-mock/src/middleware_router.rs
+++ b/crates/bmc-mock/src/middleware_router.rs
@@ -29,6 +29,9 @@ use crate::Callbacks;
 use crate::availability::BmcAvailabilityState;
 use crate::injection::InjectionStore;
 
+#[derive(Clone)]
+pub(crate) struct StateRefreshHandled;
+
 pub(super) fn append(
     mat_host_id: String,
     router: Router,
@@ -85,8 +88,18 @@ async fn process(State(mut state): State<Middleware>, request: Request<Body>) ->
             "BMC mock request returned unsuccessful response"
         );
     }
-    if !is_safe && response.status().is_success() {
-        state.callbacks.state_refresh_indication();
+    if !is_safe
+        && response.status().is_success()
+        && response.extensions().get::<StateRefreshHandled>().is_none()
+        && let Err(error) = state.callbacks.state_refresh_indication()
+    {
+        tracing::error!(
+            method = %method,
+            path,
+            error,
+            "could not reconcile backend state after BMC mock request",
+        );
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
     response
 }

--- a/crates/bmc-mock/src/redfish/expander_router.rs
+++ b/crates/bmc-mock/src/redfish/expander_router.rs
@@ -254,7 +254,9 @@ mod tests {
         fn send_power_command(&self, _: SystemPowerControl) -> Result<(), SetSystemPowerError> {
             Ok(())
         }
-        fn state_refresh_indication(&self) {}
+        fn state_refresh_indication(&self) -> Result<(), String> {
+            Ok(())
+        }
     }
 
     fn test_host_mock() -> Router {

--- a/crates/bmc-mock/src/redfish/virtual_media.rs
+++ b/crates/bmc-mock/src/redfish/virtual_media.rs
@@ -23,11 +23,12 @@ use axum::extract::{Json, Path, State};
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use serde_json::json;
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch};
 use crate::middleware_router::StateRefreshHandled;
-use crate::{http, redfish};
+use crate::{http, redfish, refresh_backend_state};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct DeviceConfig {
@@ -46,6 +47,7 @@ struct Media {
 struct DeviceState {
     config: DeviceConfig,
     media: Mutex<Media>,
+    update: AsyncMutex<()>,
 }
 
 pub(crate) struct VirtualMediaState {
@@ -63,6 +65,7 @@ impl VirtualMediaState {
                         write_protected: true,
                         ..Default::default()
                     }),
+                    update: AsyncMutex::new(()),
                 })
                 .collect(),
         }
@@ -199,6 +202,7 @@ async fn insert_media(
             write_protected,
         },
     )
+    .await
 }
 
 async fn eject_media(
@@ -221,9 +225,11 @@ async fn eject_media(
             ..Default::default()
         },
     )
+    .await
 }
 
-fn update_media(state: &BmcState, device: &DeviceState, desired: Media) -> Response {
+async fn update_media(state: &BmcState, device: &DeviceState, desired: Media) -> Response {
+    let _update = device.update.lock().await;
     let previous = {
         let mut media = device.media.lock().expect("mutex poisoned");
         std::mem::replace(&mut *media, desired)
@@ -232,10 +238,15 @@ fn update_media(state: &BmcState, device: &DeviceState, desired: Media) -> Respo
     let Some(callbacks) = state.callbacks.as_ref() else {
         return http::ok_no_content();
     };
-    if let Err(error) = callbacks.state_refresh_indication() {
+    if let Err(error) = refresh_backend_state(callbacks.clone()).await {
         *device.media.lock().expect("mutex poisoned") = previous;
-        let rollback_error = callbacks.state_refresh_indication().err();
-        tracing::error!(error, rollback_error, "could not apply virtual media state",);
+        let rollback_error = refresh_backend_state(callbacks.clone()).await.err();
+        tracing::error!(
+            device_id = %device.config.id,
+            error = %error,
+            rollback_error,
+            "could not apply virtual media state",
+        );
         return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
     }
 
@@ -276,7 +287,8 @@ impl DeviceState {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
-    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::time::Duration;
 
     use axum::body::Body;
     use axum::http::{Method, Request, StatusCode};
@@ -319,9 +331,14 @@ mod tests {
 
     fn test_router_for(hardware_type: HardwareType) -> (Router, Arc<RecordingCallbacks>) {
         let callbacks = Arc::new(RecordingCallbacks::default());
-        let router = machine_router(
+        let router = router_for_callbacks(hardware_type, callbacks.clone());
+        (router, callbacks)
+    }
+
+    fn router_for_callbacks(hardware_type: HardwareType, callbacks: Arc<dyn Callbacks>) -> Router {
+        machine_router(
             &host_info(hardware_type),
-            callbacks.clone(),
+            callbacks,
             "test-host-id".to_string(),
             false,
             MachineRouterOptions {
@@ -340,8 +357,7 @@ mod tests {
                 ]),
             },
         )
-        .0;
-        (router, callbacks)
+        .0
     }
 
     #[tokio::test]
@@ -459,6 +475,85 @@ mod tests {
         assert_eq!(body.unwrap()["Inserted"], false);
 
         assert_eq!(callbacks.refresh_count.load(Ordering::Relaxed), 3);
+    }
+
+    #[derive(Debug)]
+    struct FailingFirstRefresh {
+        refresh_count: AtomicUsize,
+        first_started: AtomicBool,
+        release_first: AtomicBool,
+    }
+
+    impl Callbacks for FailingFirstRefresh {
+        fn get_power_state(&self) -> MockPowerState {
+            MockPowerState::Off
+        }
+
+        fn send_power_command(
+            &self,
+            _reset_type: SystemPowerControl,
+        ) -> Result<(), SetSystemPowerError> {
+            Ok(())
+        }
+
+        fn state_refresh_indication(&self) -> Result<(), String> {
+            let refresh = self.refresh_count.fetch_add(1, Ordering::SeqCst);
+            if refresh != 0 {
+                return Ok(());
+            }
+            self.first_started.store(true, Ordering::SeqCst);
+            while !self.release_first.load(Ordering::SeqCst) {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            Err("injected reconciliation failure".to_string())
+        }
+    }
+
+    #[tokio::test]
+    async fn failed_update_does_not_overwrite_a_concurrent_media_change() {
+        let callbacks = Arc::new(FailingFirstRefresh {
+            refresh_count: AtomicUsize::new(0),
+            first_started: AtomicBool::new(false),
+            release_first: AtomicBool::new(false),
+        });
+        let router = router_for_callbacks(HardwareType::DellPowerEdgeR750, callbacks.clone());
+        let media = "/redfish/v1/Systems/System.Embedded.1/VirtualMedia/Cd";
+        let first_router = router.clone();
+        let first = tokio::spawn(async move {
+            request(
+                &first_router,
+                Method::POST,
+                &format!("{media}/Actions/VirtualMedia.InsertMedia"),
+                Some(json!({"Image": "/tmp/first.iso"})),
+            )
+            .await
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !callbacks.first_started.load(Ordering::SeqCst) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first reconciliation did not start");
+
+        let second_router = router.clone();
+        let second = tokio::spawn(async move {
+            request(
+                &second_router,
+                Method::POST,
+                &format!("{media}/Actions/VirtualMedia.InsertMedia"),
+                Some(json!({"Image": "/tmp/second.iso"})),
+            )
+            .await
+        });
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        callbacks.release_first.store(true, Ordering::SeqCst);
+
+        assert_eq!(first.await.unwrap().0, StatusCode::INTERNAL_SERVER_ERROR);
+        assert_eq!(second.await.unwrap().0, StatusCode::NO_CONTENT);
+        let (_, body) = request(&router, Method::GET, media, None).await;
+        assert_eq!(body.unwrap()["Image"], "/tmp/second.iso");
+        assert_eq!(callbacks.refresh_count.load(Ordering::SeqCst), 3);
     }
 
     #[tokio::test]

--- a/crates/bmc-mock/src/redfish/virtual_media.rs
+++ b/crates/bmc-mock/src/redfish/virtual_media.rs
@@ -20,12 +20,13 @@ use std::sync::Mutex;
 
 use axum::Router;
 use axum::extract::{Json, Path, State};
-use axum::response::Response;
+use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
 use serde_json::json;
 
 use crate::bmc_state::BmcState;
 use crate::json::{JsonExt, JsonPatch};
+use crate::middleware_router::StateRefreshHandled;
 use crate::{http, redfish};
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -189,12 +190,15 @@ async fn insert_media(
         None => true,
         Some(_) => return http::bad_request("WriteProtected must be a boolean"),
     };
-    *device.media.lock().expect("mutex poisoned") = Media {
-        image: Some(image.to_string()),
-        inserted: true,
-        write_protected,
-    };
-    http::ok_no_content()
+    update_media(
+        &state,
+        device,
+        Media {
+            image: Some(image.to_string()),
+            inserted: true,
+            write_protected,
+        },
+    )
 }
 
 async fn eject_media(
@@ -209,11 +213,35 @@ async fn eject_media(
     else {
         return http::not_found();
     };
-    *device.media.lock().expect("mutex poisoned") = Media {
-        write_protected: true,
-        ..Default::default()
+    update_media(
+        &state,
+        device,
+        Media {
+            write_protected: true,
+            ..Default::default()
+        },
+    )
+}
+
+fn update_media(state: &BmcState, device: &DeviceState, desired: Media) -> Response {
+    let previous = {
+        let mut media = device.media.lock().expect("mutex poisoned");
+        std::mem::replace(&mut *media, desired)
     };
-    http::ok_no_content()
+
+    let Some(callbacks) = state.callbacks.as_ref() else {
+        return http::ok_no_content();
+    };
+    if let Err(error) = callbacks.state_refresh_indication() {
+        *device.media.lock().expect("mutex poisoned") = previous;
+        let rollback_error = callbacks.state_refresh_indication().err();
+        tracing::error!(error, rollback_error, "could not apply virtual media state",);
+        return axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response();
+    }
+
+    let mut response = http::ok_no_content();
+    response.extensions_mut().insert(StateRefreshHandled);
+    response
 }
 
 impl DeviceState {
@@ -279,8 +307,9 @@ mod tests {
             Ok(())
         }
 
-        fn state_refresh_indication(&self) {
+        fn state_refresh_indication(&self) -> Result<(), String> {
             self.refresh_count.fetch_add(1, Ordering::Relaxed);
+            Ok(())
         }
     }
 

--- a/crates/bmc-mock/src/simulated.rs
+++ b/crates/bmc-mock/src/simulated.rs
@@ -68,7 +68,9 @@ impl Callbacks for SimulatedCallbacks {
         Ok(())
     }
 
-    fn state_refresh_indication(&self) {}
+    fn state_refresh_indication(&self) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 #[cfg(test)]

--- a/crates/bmc-mock/src/test_support/mod.rs
+++ b/crates/bmc-mock/src/test_support/mod.rs
@@ -52,7 +52,9 @@ impl Callbacks for NoopCallbacks {
         Ok(())
     }
 
-    fn state_refresh_indication(&self) {}
+    fn state_refresh_indication(&self) -> Result<(), String> {
+        Ok(())
+    }
 }
 
 pub type TestBmc = HttpBmc<AxumRouterHttpClient>;
@@ -674,7 +676,9 @@ mod test {
                 self.0.fetch_add(1, Ordering::SeqCst);
                 Ok(())
             }
-            fn state_refresh_indication(&self) {}
+            fn state_refresh_indication(&self) -> Result<(), String> {
+                Ok(())
+            }
         }
 
         let callbacks = Arc::new(PowerCommandCounter::default());


### PR DESCRIPTION
Generated DPU endpoints using the libvirt backend do not expose configuration virtual media, even though the backend maps `ConfigCd` to a libvirt target. Provisioning clients need that removable-media channel to deliver configuration to the DPU guest.

Expose `ConfigCd` for generated DPU endpoints using libvirt. Host endpoints retain `Cd` and `ConfigCd`; internal simulation retains its existing defaults. Use the system `virsh` executable directly, without a vmctl protocol, custom virsh adapter, fixed deployment domain, or DPF-specific behavior.

The libvirt backend now owns a uniquely aliased, persistent empty CD-ROM and changes its media in place with `virsh update-device`. It refuses to claim an occupied target and propagates reconciliation failures back through Redfish, restoring the previous requested media state when an update fails.

## Type of Change

- [x] **Add** - New feature or capability
- [x] **Fix** - Correct live virtual-media reconciliation and target ownership

## Breaking Changes

No CLI changes. Generated DPU endpoints using libvirt gain `ConfigCd` in their virtual-media inventory.

`Callbacks::state_refresh_indication` now returns `Result<(), String>` so backend reconciliation failures can reach the HTTP boundary. External Rust implementations of this trait must return `Ok(())` when refresh cannot fail.

## Automated testing

Run from the repository root:

```console
cargo fmt -p bmc-mock
CARGO_TARGET_DIR=/tmp/bmc-pr5874-target cargo test --offline --locked -p bmc-mock -- --skip real_ipmitool_resets_chassis
CARGO_TARGET_DIR=/tmp/bmc-pr5874-target cargo clippy --offline --locked -p bmc-mock --all-targets -- -D warnings
```

Results on commit `3098506`:

- [x] 95 library tests passed; the explicitly skipped real-`ipmitool` hardware test was not run.
- [x] 9 binary tests passed.
- [x] Clippy passed for all `bmc-mock` targets with warnings denied.
- [x] A role/backend table verifies DPU `ConfigCd` exposure and preserves host and internal-backend behavior.
- [x] Libvirt regressions verify owned-target detection, refusal to claim a foreign disk, persistent empty-drive provisioning, `update-device --live --config`, and Redfish rollback with HTTP 500 after an injected virsh failure.

## Real libvirt validation with regular virsh

Environment:

- Disposable `library/vmctl-dev:latest` outer VM
- Ubuntu 26.04 amd64 with nested KVM
- `/usr/bin/virsh` 12.0.0 and QEMU 10.2.1
- CirrOS guest plus local, range-capable HTTP, and trusted HTTPS test media
- No downstream `vm-bmc-virsh` adapter

Steps exercised:

1. Start the DPU mock with the libvirt backend and verify that its VirtualMedia collection exposes only `ConfigCd`.
2. Insert local media while the domain is off, power it on, mount the guest CD-ROM, and read a known file.
3. With the domain running, replace and eject media using a pre-existing owned CD-ROM and the same command shape used by the patch:

   ```console
   virsh --connect qemu:///system update-device DOMAIN DEVICE_XML --live --config
   ```

4. Inspect both live and inactive domain XML after each update and read the replacement media from the guest after the media-change notification settles.
5. Repeat insertion with range-capable HTTP and trusted HTTPS sources.
6. Occupy the configured target with a foreign read-only SCSI disk and confirm why target-name-only detach is unsafe.
7. Eject media while the domain is off and confirm the persistent definition has an empty owned CD-ROM.

Results:

- [x] Cold local insertion succeeded and the guest read `/boot/vmlinuz-virt` from the media.
- [x] Local and HTTPS media replacement/ejection succeeded through regular `virsh update-device --live --config`; live and persistent definitions followed the change.
- [x] Range-capable HTTP and trusted HTTPS media were attached on power-on and readable by the guest.
- [x] The original detach/attach implementation reproduced SATA hotplug failure, live replacement/ejection failure, Redfish/libvirt state divergence, and destructive detachment of a foreign disk at the configured target.
- [x] The replacement command sequence used by this patch was validated without the downstream virsh adapter.

All disposable inner and outer VMs were removed after validation.

## Patched end-to-end validation

Commit `3098506` was rebuilt as an amd64 binary with SHA-256 `fc220b8776515a26a31aefd8208752c589d6b9353b0810487dd12b9ddbd145f9` and run inside a fresh disposable vmctl VM against a nested KVM/libvirt domain. The mock used `/usr/bin/virsh` 12.0.0 directly.

- [x] Redfish insertion, live replacement, and ejection succeeded against real libvirt. Redfish state, live XML, persistent XML, and guest-observed media remained aligned.
- [x] The CirrOS guest mounted each inserted ISO and read the expected Alpine payload. Distinct whole-device SHA-256 values verified live replacement.
- [x] Media remained readable and state remained aligned across `ForceRestart` and `PowerCycle`; the guest boot ID changed for each operation.
- [x] With a foreign SCSI disk at `sdc`, insertion returned HTTP 500, Redfish state rolled back to `Inserted: false` and `Image: null`, and the foreign disk remained intact.
- [x] The DPU endpoint exposed exactly one virtual-media member: `ConfigCd`.
- [x] No downstream `vm-bmc-virsh` adapter was used.

All nested libvirt resources and the disposable outer VM were removed after validation.

## Review follow-up validation

Commit `8773436` addresses the review findings around active-domain provisioning, bounded `virsh` execution, asynchronous reconciliation, concurrent rollback ordering, callback contracts, and diagnostics.

Run from the repository root:

```console
CARGO_TARGET_DIR=/tmp/bmc-pr5874-ai-target cargo test --offline --locked -p bmc-mock -- --skip real_ipmitool_resets_chassis
CARGO_TARGET_DIR=/tmp/bmc-pr5874-ai-target cargo clippy --offline --locked -p bmc-mock --all-targets -- -D warnings
```

- [x] 99 library tests and 9 binary tests passed (108 total); the external real-`ipmitool` test was explicitly filtered because `ipmitool` is unavailable on the development host.
- [x] Clippy passed for all `bmc-mock` targets with warnings denied.
- [x] Focused regressions cover provisioning a missing CD-ROM into both live and persistent active-domain XML, terminating a hung `virsh`, keeping the current-thread Tokio executor responsive during backend refresh, and preventing a failed concurrent update from rolling back a later successful update.

The real nested-KVM/libvirt acceptance results above were collected from commit `3098506`. The review follow-up in `8773436` was validated with unit and fake-`virsh` coverage; it does not claim a second real-libvirt run.
