### PR TITLE
Fix/instance release paged fetch retry

### DIFF
--- a/crates/admin-cli/src/admission_retry.rs
+++ b/crates/admin-cli/src/admission_retry.rs
@@ -105,6 +105,11 @@ where
     F: FnMut() -> Fut,
     Fut: Future<Output = CarbideCliResult<T>>,
 {
+    // Never let a caller-supplied 0 reach the loop below: `1..=0` is empty, which would fall
+    // through to the `unreachable!` -- a real panic path for a network-retry helper, not just
+    // a formality, since this is `pub(crate)` and every current call site's `8` is a caller
+    // choice, not an enforced invariant.
+    let max_attempts = max_attempts.max(1);
     let mut total_backoff = Duration::ZERO;
     for attempt_number in 1..=max_attempts {
         match attempt().await {

--- a/crates/admin-cli/src/admission_retry.rs
+++ b/crates/admin-cli/src/admission_retry.rs
@@ -21,11 +21,11 @@
 //! lookups, and `get_all_instances`'s internal paged fetches) should go
 //! through [`retry_on_admission_exhaustion`] rather than reimplementing the
 //! loop, so a fix like honoring a negative pushback as a stop-retrying
-//! signal only has to happen in one place. (`release_with_retry` in
+//! signal only has to happen in one place. (`release_batch_with_retry` in
 //! `instance/release/cmd.rs` is the one exception -- it retries a call
-//! returning `Result<(), tonic::Status>` rather than `CarbideCliResult<T>`,
-//! so it still parses pushback via [`resolve_backoff_delay`] directly but
-//! keeps its own loop.)
+//! returning `Result<BatchInstanceReleaseResponse, tonic::Status>` rather
+//! than `CarbideCliResult<T>`, so it still parses pushback via
+//! [`resolve_backoff_delay`] directly but keeps its own loop.)
 
 use std::future::Future;
 use std::time::Duration;

--- a/crates/admin-cli/src/admission_retry.rs
+++ b/crates/admin-cli/src/admission_retry.rs
@@ -1,0 +1,278 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Shared helpers for retrying gRPC calls that get rejected with
+//! `RESOURCE_EXHAUSTED` admission-control errors. Every retry loop in this
+//! crate that reacts to `grpc-retry-pushback-ms` (release's preflight
+//! lookups, and `get_all_instances`'s internal paged fetches) should go
+//! through [`retry_on_admission_exhaustion`] rather than reimplementing the
+//! loop, so a fix like honoring a negative pushback as a stop-retrying
+//! signal only has to happen in one place. (`release_with_retry` in
+//! `instance/release/cmd.rs` is the one exception -- it retries a call
+//! returning `Result<(), tonic::Status>` rather than `CarbideCliResult<T>`,
+//! so it still parses pushback via [`resolve_backoff_delay`] directly but
+//! keeps its own loop.)
+
+use std::future::Future;
+use std::time::Duration;
+
+use crate::errors::{CarbideCliError, CarbideCliResult};
+
+/// gRPC metadata key the API attaches to a `RESOURCE_EXHAUSTED` admission
+/// rejection, carrying the advertised backoff in whole milliseconds. Must
+/// match `GRPC_RETRY_PUSHBACK_HEADER` in `api-core/src/admission/mod.rs`.
+pub(crate) const ADMISSION_RETRY_PUSHBACK_HEADER: &str = "grpc-retry-pushback-ms";
+/// Backoff used when the server omits an (unexpected) parseable pushback value.
+pub(crate) const DEFAULT_ADMISSION_BACKOFF: Duration = Duration::from_secs(5);
+/// Bounds mirroring the server's own advertised range in `admission/retry.rs`.
+pub(crate) const MIN_ADMISSION_BACKOFF: Duration = Duration::from_secs(1);
+pub(crate) const MAX_ADMISSION_BACKOFF: Duration = Duration::from_secs(30);
+
+/// Outcome of parsing the server-advertised `grpc-retry-pushback-ms` header.
+pub(crate) enum PushbackAdvice {
+    /// No header present -- the caller should fall back to its own default.
+    Absent,
+    /// A valid non-negative delay was advertised.
+    Delay(Duration),
+    /// The header was present but negative or otherwise unparseable. Per the
+    /// gRPC retry-pushback spec, this is an explicit "do not retry" signal
+    /// from the server, distinct from simply omitting the header -- treating
+    /// it the same as `Absent` (and retrying anyway with a default delay)
+    /// would ignore the server's request to stop.
+    StopRetrying,
+}
+
+/// Parses the server-advertised retry delay from a rejection's metadata.
+pub(crate) fn admission_retry_delay(status: &tonic::Status) -> PushbackAdvice {
+    let Some(raw) = status.metadata().get(ADMISSION_RETRY_PUSHBACK_HEADER) else {
+        return PushbackAdvice::Absent;
+    };
+    let Ok(raw) = raw.to_str() else {
+        return PushbackAdvice::StopRetrying;
+    };
+    match raw.parse::<i64>() {
+        Ok(millis) if millis >= 0 => PushbackAdvice::Delay(Duration::from_millis(millis as u64)),
+        // Negative (explicit stop signal) or unparseable -- both mean "stop".
+        _ => PushbackAdvice::StopRetrying,
+    }
+}
+
+/// Resolves the delay to sleep for one retry attempt, given a
+/// `RESOURCE_EXHAUSTED` rejection. Returns `None` if the server signaled to
+/// stop retrying (a negative or malformed pushback value), in which case the
+/// caller should surface the error immediately rather than retry.
+pub(crate) fn resolve_backoff_delay(status: &tonic::Status) -> Option<Duration> {
+    match admission_retry_delay(status) {
+        PushbackAdvice::Absent => Some(DEFAULT_ADMISSION_BACKOFF),
+        PushbackAdvice::Delay(delay) => {
+            Some(delay.clamp(MIN_ADMISSION_BACKOFF, MAX_ADMISSION_BACKOFF))
+        }
+        PushbackAdvice::StopRetrying => None,
+    }
+}
+
+/// Retries a fallible call on `RESOURCE_EXHAUSTED` admission rejections,
+/// honoring the server's advertised `grpc-retry-pushback-ms` backoff (or
+/// stopping immediately if the server signals not to retry -- see
+/// [`resolve_backoff_delay`]). Bounded by `max_attempts` and
+/// `max_total_backoff`; any other error surfaces immediately so real
+/// failures are not masked.
+///
+/// Each call site picks its own `max_attempts`/`max_total_backoff` since the
+/// right bound depends on what's being retried (a single lightweight lookup
+/// vs. one page of a large paged fetch), but the parsing and stop-signal
+/// handling stays in one place.
+pub(crate) async fn retry_on_admission_exhaustion<T, F, Fut>(
+    max_attempts: usize,
+    max_total_backoff: Duration,
+    mut attempt: F,
+) -> CarbideCliResult<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = CarbideCliResult<T>>,
+{
+    let mut total_backoff = Duration::ZERO;
+    for attempt_number in 1..=max_attempts {
+        match attempt().await {
+            Ok(value) => return Ok(value),
+            Err(CarbideCliError::ApiInvocationError(status))
+                if status.code() == tonic::Code::ResourceExhausted =>
+            {
+                if attempt_number == max_attempts {
+                    return Err(CarbideCliError::ApiInvocationError(status));
+                }
+                let Some(delay) = resolve_backoff_delay(&status) else {
+                    return Err(CarbideCliError::ApiInvocationError(status));
+                };
+                if total_backoff.saturating_add(delay) > max_total_backoff {
+                    return Err(CarbideCliError::ApiInvocationError(status));
+                }
+                total_backoff = total_backoff.saturating_add(delay);
+                tokio::time::sleep(delay).await;
+            }
+            Err(other) => return Err(other),
+        }
+    }
+    unreachable!("loop returns on the final attempt")
+}
+
+#[cfg(test)]
+mod tests {
+    use tonic::metadata::MetadataValue;
+
+    use super::*;
+
+    fn exhausted(pushback_millis: u64) -> tonic::Status {
+        let mut status = tonic::Status::resource_exhausted("API admission capacity exhausted");
+        status.metadata_mut().insert(
+            ADMISSION_RETRY_PUSHBACK_HEADER,
+            MetadataValue::try_from(pushback_millis.to_string().as_str()).unwrap(),
+        );
+        status
+    }
+
+    fn pushback_status(raw: &str) -> tonic::Status {
+        let mut status = tonic::Status::resource_exhausted("API admission capacity exhausted");
+        status.metadata_mut().insert(
+            ADMISSION_RETRY_PUSHBACK_HEADER,
+            MetadataValue::try_from(raw).unwrap(),
+        );
+        status
+    }
+
+    #[test]
+    fn parses_advertised_pushback_delay() {
+        assert!(matches!(
+            admission_retry_delay(&exhausted(7_000)),
+            PushbackAdvice::Delay(d) if d == Duration::from_secs(7)
+        ));
+        assert!(matches!(
+            admission_retry_delay(&tonic::Status::resource_exhausted("no header")),
+            PushbackAdvice::Absent
+        ));
+    }
+
+    #[test]
+    fn negative_pushback_is_a_stop_retrying_signal() {
+        assert!(matches!(
+            admission_retry_delay(&pushback_status("-1")),
+            PushbackAdvice::StopRetrying
+        ));
+    }
+
+    #[test]
+    fn malformed_pushback_is_a_stop_retrying_signal() {
+        assert!(matches!(
+            admission_retry_delay(&pushback_status("not-a-number")),
+            PushbackAdvice::StopRetrying
+        ));
+    }
+
+    #[test]
+    fn resolve_backoff_delay_clamps_and_defaults() {
+        assert_eq!(
+            resolve_backoff_delay(&tonic::Status::resource_exhausted("no header")),
+            Some(DEFAULT_ADMISSION_BACKOFF)
+        );
+        assert_eq!(
+            resolve_backoff_delay(&exhausted(1)),
+            Some(MIN_ADMISSION_BACKOFF)
+        );
+        assert_eq!(
+            resolve_backoff_delay(&exhausted(60_000)),
+            Some(MAX_ADMISSION_BACKOFF)
+        );
+        assert_eq!(resolve_backoff_delay(&pushback_status("-1")), None);
+    }
+
+    use std::cell::Cell;
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_after_advertised_delay_then_succeeds() {
+        let attempts = Cell::new(0);
+        let start = tokio::time::Instant::now();
+
+        let result = retry_on_admission_exhaustion(8, Duration::from_secs(120), || {
+            let attempt = attempts.get() + 1;
+            attempts.set(attempt);
+            async move {
+                if attempt < 3 {
+                    Err(CarbideCliError::ApiInvocationError(exhausted(7_000)))
+                } else {
+                    Ok(())
+                }
+            }
+        })
+        .await;
+
+        assert!(result.is_ok());
+        assert_eq!(attempts.get(), 3);
+        assert_eq!(start.elapsed(), Duration::from_secs(14));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn retries_are_bounded_by_attempt_cap() {
+        let attempts = Cell::new(0);
+
+        let result = retry_on_admission_exhaustion(8, Duration::from_secs(120), || {
+            attempts.set(attempts.get() + 1);
+            async move { Err::<(), _>(CarbideCliError::ApiInvocationError(exhausted(1_000))) }
+        })
+        .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            CarbideCliError::ApiInvocationError(status) if status.code() == tonic::Code::ResourceExhausted
+        ));
+        assert_eq!(attempts.get(), 8);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn stops_immediately_on_negative_pushback() {
+        let attempts = Cell::new(0);
+
+        let result = retry_on_admission_exhaustion(8, Duration::from_secs(120), || {
+            attempts.set(attempts.get() + 1);
+            async move { Err::<(), _>(CarbideCliError::ApiInvocationError(pushback_status("-1"))) }
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(attempts.get(), 1);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn non_admission_errors_surface_without_retry() {
+        let attempts = Cell::new(0);
+
+        let result = retry_on_admission_exhaustion(8, Duration::from_secs(120), || {
+            attempts.set(attempts.get() + 1);
+            async move {
+                Err::<(), _>(CarbideCliError::ApiInvocationError(
+                    tonic::Status::not_found("gone"),
+                ))
+            }
+        })
+        .await;
+
+        assert!(matches!(
+            result.unwrap_err(),
+            CarbideCliError::ApiInvocationError(status) if status.code() == tonic::Code::NotFound
+        ));
+        assert_eq!(attempts.get(), 1);
+    }
+}

--- a/crates/admin-cli/src/instance/release/cmd.rs
+++ b/crates/admin-cli/src/instance/release/cmd.rs
@@ -22,14 +22,11 @@ use ::rpc::forge::{BatchInstanceReleaseResponse, InstanceReleaseRequest};
 use carbide_uuid::instance::InstanceId;
 
 use super::args::Args;
+use crate::admission_retry::{resolve_backoff_delay, retry_on_admission_exhaustion};
 use crate::cfg::runtime::RuntimeContext;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::rpc::ApiClient;
 
-/// gRPC metadata key the API attaches to a `RESOURCE_EXHAUSTED` admission
-/// rejection, carrying the advertised backoff in whole milliseconds. Must match
-/// `GRPC_RETRY_PUSHBACK_HEADER` in `api-core/src/admission/mod.rs`.
-const ADMISSION_RETRY_PUSHBACK_HEADER: &str = "grpc-retry-pushback-ms";
 /// Attempt cap for the single batch RPC call, bounding how many times a
 /// completed `RESOURCE_EXHAUSTED` rejection is retried. This does NOT bound
 /// how long any single in-flight attempt can take: neither this loop nor the
@@ -40,111 +37,24 @@ const MAX_BATCH_ATTEMPTS: usize = 8;
 /// Cumulative backoff cap across retries of the one batch call; give up past
 /// this rather than retrying indefinitely.
 const MAX_TOTAL_BACKOFF: Duration = Duration::from_secs(120);
-/// Backoff used when the server omits an (unexpected) parseable pushback value.
-const DEFAULT_ADMISSION_BACKOFF: Duration = Duration::from_secs(5);
-/// Bounds mirroring the server's own advertised range in `admission/retry.rs`.
-const MIN_ADMISSION_BACKOFF: Duration = Duration::from_secs(1);
-const MAX_ADMISSION_BACKOFF: Duration = Duration::from_secs(30);
 /// Attempt cap for the one-off preflight lookup that resolves `--label-key`/
 /// `--machine` into a concrete instance list, mirroring [`MAX_BATCH_ATTEMPTS`].
 const MAX_PREFLIGHT_LOOKUP_ATTEMPTS: usize = 8;
 
-/// Outcome of parsing the server-advertised `grpc-retry-pushback-ms` header.
-enum PushbackAdvice {
-    /// No header present -- the caller should fall back to its own default.
-    Absent,
-    /// A valid non-negative delay was advertised.
-    Delay(Duration),
-    /// The header was present but negative or otherwise unparseable. Per the
-    /// gRPC retry-pushback spec, this is an explicit "do not retry" signal
-    /// from the server, distinct from simply omitting the header -- treating
-    /// it the same as `Absent` (and retrying anyway with a default delay)
-    /// would ignore the server's request to stop.
-    StopRetrying,
-}
-
-/// Parses the server-advertised retry delay from a rejection's metadata.
-fn admission_retry_delay(status: &tonic::Status) -> PushbackAdvice {
-    let Some(raw) = status.metadata().get(ADMISSION_RETRY_PUSHBACK_HEADER) else {
-        return PushbackAdvice::Absent;
-    };
-    let Ok(raw) = raw.to_str() else {
-        return PushbackAdvice::StopRetrying;
-    };
-    match raw.parse::<i64>() {
-        Ok(millis) if millis >= 0 => PushbackAdvice::Delay(Duration::from_millis(millis as u64)),
-        // Negative (explicit stop signal) or unparseable -- both mean "stop".
-        _ => PushbackAdvice::StopRetrying,
-    }
-}
-
-/// Resolves the delay to sleep for one retry attempt, given a
-/// `RESOURCE_EXHAUSTED` rejection. Returns `None` if the server signaled to
-/// stop retrying (a negative or malformed pushback value), in which case the
-/// caller should surface the error immediately rather than retry.
-fn resolve_backoff_delay(status: &tonic::Status) -> Option<Duration> {
-    match admission_retry_delay(status) {
-        PushbackAdvice::Absent => Some(DEFAULT_ADMISSION_BACKOFF),
-        PushbackAdvice::Delay(delay) => {
-            Some(delay.clamp(MIN_ADMISSION_BACKOFF, MAX_ADMISSION_BACKOFF))
-        }
-        PushbackAdvice::StopRetrying => None,
-    }
-}
-
-/// Retries a fallible preflight lookup call on `RESOURCE_EXHAUSTED` admission
-/// rejections, honoring the server's advertised `grpc-retry-pushback-ms`
-/// backoff exactly like [`release_batch_with_retry`] does for the batch
-/// release call itself. Any other error surfaces immediately so real failures
-/// are not masked.
-///
-/// Motivation: resolving `--machine` into a concrete instance via the single
-/// `find_instance_by_machine_id` lookup happens *before* the batch release
-/// call. Without this, a `RESOURCE_EXHAUSTED` rejection on that single
-/// preflight call aborted the whole release command with zero instances
-/// attempted, even though the batch call itself was already retry-safe --
-/// observed live at ~4,500-instance scale, where under sustained admission
-/// pressure some release invocations failed instantly with no progress purely
-/// because this one lookup call happened to land in a saturated window.
-///
-/// The `--label-key` path deliberately does *not* use this wrapper:
-/// `get_all_instances` retries each of its own internal paged calls, so
-/// wrapping it again would discard already-fetched chunks on a late failure.
-async fn retry_lookup_on_admission_exhaustion<T, F, Fut>(mut attempt: F) -> CarbideCliResult<T>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = CarbideCliResult<T>>,
-{
-    let mut total_backoff = Duration::ZERO;
-    for attempt_number in 1..=MAX_PREFLIGHT_LOOKUP_ATTEMPTS {
-        match attempt().await {
-            Ok(value) => return Ok(value),
-            Err(CarbideCliError::ApiInvocationError(status))
-                if status.code() == tonic::Code::ResourceExhausted =>
-            {
-                if attempt_number == MAX_PREFLIGHT_LOOKUP_ATTEMPTS {
-                    return Err(CarbideCliError::ApiInvocationError(status));
-                }
-                let Some(delay) = resolve_backoff_delay(&status) else {
-                    return Err(CarbideCliError::ApiInvocationError(status));
-                };
-                if total_backoff.saturating_add(delay) > MAX_TOTAL_BACKOFF {
-                    return Err(CarbideCliError::ApiInvocationError(status));
-                }
-                total_backoff = total_backoff.saturating_add(delay);
-                tokio::time::sleep(delay).await;
-            }
-            Err(other) => return Err(other),
-        }
-    }
-    unreachable!("loop returns on the final attempt")
-}
-
 /// Runs the single batch-release call, retrying only `RESOURCE_EXHAUSTED`
 /// admission rejections of the call itself by honoring the server's advertised
-/// `grpc-retry-pushback-ms` backoff. Retries are bounded by attempt count and
-/// cumulative backoff; any other error surfaces immediately so real failures
-/// are not masked.
+/// `grpc-retry-pushback-ms` backoff (parsed via
+/// [`crate::admission_retry::resolve_backoff_delay`], the same logic every
+/// other admission-retry loop in this crate uses). Retries are bounded by
+/// attempt count and cumulative backoff; any other error surfaces immediately
+/// so real failures are not masked.
+///
+/// Keeps its own loop rather than delegating to
+/// [`crate::admission_retry::retry_on_admission_exhaustion`]: that helper is
+/// typed around `CarbideCliResult<T>`/`CarbideCliError`, while this call
+/// returns `Result<BatchInstanceReleaseResponse, tonic::Status>` directly
+/// (the raw RPC result, not yet converted) -- see the module doc comment on
+/// `crate::admission_retry` for the full rationale.
 ///
 /// Per-instance retry/backoff no longer lives here: the server-side
 /// `ReleaseInstances` RPC releases the whole batch in one call (best-effort
@@ -200,13 +110,17 @@ pub(super) async fn release(
                 .into(),
         ),
         (_, Some(machine_id), _) => {
-            let instances = retry_lookup_on_admission_exhaustion(|| async move {
-                api_client
-                    .0
-                    .find_instance_by_machine_id(machine_id)
-                    .await
-                    .map_err(CarbideCliError::from)
-            })
+            let instances = retry_on_admission_exhaustion(
+                MAX_PREFLIGHT_LOOKUP_ATTEMPTS,
+                MAX_TOTAL_BACKOFF,
+                || async move {
+                    api_client
+                        .0
+                        .find_instance_by_machine_id(machine_id)
+                        .await
+                        .map_err(CarbideCliError::from)
+                },
+            )
             .await?
             .instances;
             let Some(instance_id) = instances.into_iter().next().and_then(|i| i.id) else {
@@ -335,6 +249,7 @@ mod tests {
     use tonic::metadata::MetadataValue;
 
     use super::*;
+    use crate::admission_retry::ADMISSION_RETRY_PUSHBACK_HEADER;
 
     fn exhausted(pushback_millis: u64) -> tonic::Status {
         let mut status = tonic::Status::resource_exhausted("API admission capacity exhausted");
@@ -414,33 +329,9 @@ mod tests {
         assert!(summarize_release_response(ids.len(), response).is_err());
     }
 
-    #[test]
-    fn parses_advertised_pushback_delay() {
-        assert!(matches!(
-            admission_retry_delay(&exhausted(7_000)),
-            PushbackAdvice::Delay(d) if d == Duration::from_secs(7)
-        ));
-        assert!(matches!(
-            admission_retry_delay(&tonic::Status::resource_exhausted("no header")),
-            PushbackAdvice::Absent
-        ));
-    }
-
-    #[test]
-    fn negative_pushback_is_a_stop_retrying_signal() {
-        assert!(matches!(
-            admission_retry_delay(&pushback_status("-1")),
-            PushbackAdvice::StopRetrying
-        ));
-    }
-
-    #[test]
-    fn malformed_pushback_is_a_stop_retrying_signal() {
-        assert!(matches!(
-            admission_retry_delay(&pushback_status("not-a-number")),
-            PushbackAdvice::StopRetrying
-        ));
-    }
+    // Pushback-parsing (`PushbackAdvice`/`admission_retry_delay`/`resolve_backoff_delay`) is
+    // covered by `crate::admission_retry`'s own tests now that this module delegates to it --
+    // no need to duplicate that coverage here.
 
     #[tokio::test(start_paused = true)]
     async fn retries_after_advertised_delay_then_succeeds() {

--- a/crates/admin-cli/src/instance/release/cmd.rs
+++ b/crates/admin-cli/src/instance/release/cmd.rs
@@ -98,15 +98,18 @@ fn resolve_backoff_delay(status: &tonic::Status) -> Option<Duration> {
 /// release call itself. Any other error surfaces immediately so real failures
 /// are not masked.
 ///
-/// Motivation: resolving `--label-key`/`--machine` into a concrete instance
-/// list (`get_all_instances` / `find_instance_by_machine_id`) happens *before*
-/// the batch release call. Without this, a `RESOURCE_EXHAUSTED` rejection on
-/// that single preflight call aborted the whole release command with zero
-/// instances attempted, even though the batch call itself was already
-/// retry-safe -- observed live at ~4,500-instance scale, where under
-/// sustained admission pressure some release invocations failed instantly
-/// with no progress purely because this one lookup call happened to land in a
-/// saturated window.
+/// Motivation: resolving `--machine` into a concrete instance via the single
+/// `find_instance_by_machine_id` lookup happens *before* the batch release
+/// call. Without this, a `RESOURCE_EXHAUSTED` rejection on that single
+/// preflight call aborted the whole release command with zero instances
+/// attempted, even though the batch call itself was already retry-safe --
+/// observed live at ~4,500-instance scale, where under sustained admission
+/// pressure some release invocations failed instantly with no progress purely
+/// because this one lookup call happened to land in a saturated window.
+///
+/// The `--label-key` path deliberately does *not* use this wrapper:
+/// `get_all_instances` retries each of its own internal paged calls, so
+/// wrapping it again would discard already-fetched chunks on a late failure.
 async fn retry_lookup_on_admission_exhaustion<T, F, Fut>(mut attempt: F) -> CarbideCliResult<T>
 where
     F: FnMut() -> Fut,
@@ -214,8 +217,15 @@ pub(super) async fn release(
             instance_ids.push(instance_id);
         }
         (_, _, Some(key)) => {
-            let instances = retry_lookup_on_admission_exhaustion(|| {
-                api_client.get_all_instances(
+            // No outer retry wrap here: `get_all_instances` retries each of its
+            // own internal calls (the id listing and every id-chunk fetch)
+            // individually on `RESOURCE_EXHAUSTED`, so it is already retry-safe
+            // end-to-end. Wrapping the whole call again would re-run it from
+            // scratch on a late failure, discarding every chunk already fetched
+            // and burning a second retry budget -- the exact waste the internal
+            // per-call retry was added to avoid.
+            let instances = api_client
+                .get_all_instances(
                     None,
                     None,
                     Some(key.clone()),
@@ -223,8 +233,7 @@ pub(super) async fn release(
                     None,
                     ctx.config.page_size,
                 )
-            })
-            .await?;
+                .await?;
             if instances.instances.is_empty() {
                 return Err(CarbideCliError::GenericError(
                     "No instances with the passed label.key exist".to_string(),

--- a/crates/admin-cli/src/main.rs
+++ b/crates/admin-cli/src/main.rs
@@ -43,6 +43,7 @@ use crate::cfg::runtime::{RuntimeConfig, RuntimeContext};
 use crate::errors::CarbideCliError;
 use crate::rpc::ApiClient;
 
+mod admission_retry;
 mod async_write;
 mod attestation;
 mod bmc_machine;

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -215,13 +215,17 @@ impl ApiClient {
     /// source `version` already exposes. A zero/unset cap means the server
     /// enforces no limit, so we fall back to `page_size` -- `chunks(0)` panics.
     pub(crate) async fn effective_chunk_size(&self, page_size: usize) -> CarbideCliResult<usize> {
-        let cap = self
-            .0
-            .version(true)
-            .await?
-            .runtime_config
-            .unwrap_or_default()
-            .max_find_by_ids as usize;
+        // Every `*_by_ids` paged fetch calls this first to size its chunks, so a
+        // `RESOURCE_EXHAUSTED` rejection here needs the same retry protection as the
+        // paged fetches themselves -- otherwise it's a single unretried call sitting
+        // in front of code that's supposed to be retry-safe end-to-end.
+        let version = retry_on_admission_exhaustion(
+            MAX_PAGED_FETCH_ATTEMPTS,
+            MAX_PAGED_FETCH_BACKOFF,
+            || async { self.0.version(true).await.map_err(CarbideCliError::from) },
+        )
+        .await?;
+        let cap = version.runtime_config.unwrap_or_default().max_find_by_ids as usize;
         Ok(cap_chunk_size(page_size, cap))
     }
 

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::HashMap;
+use std::time::Duration;
 
 use ::rpc::forge::instance_interface_config::NetworkDetails;
 use ::rpc::forge::{
@@ -50,6 +51,7 @@ use futures::{StreamExt, TryStreamExt, stream};
 use mac_address::MacAddress;
 
 use crate::IntoOnlyOne;
+use crate::admission_retry::retry_on_admission_exhaustion;
 use crate::errors::{CarbideCliError, CarbideCliResult};
 use crate::expected_machines::common::{ExpectedMachineJson, HostDpuPolicy};
 use crate::instance::AllocateInstance;
@@ -188,6 +190,14 @@ fn legacy_bmc_patch_fields(
 
 // Benchmarks showed 4 had better overall performance while still overlapping page fetch latency.
 const PAGED_LIST_FETCH_CONCURRENCY: usize = 4;
+
+/// Attempt cap for retrying a single `RESOURCE_EXHAUSTED`-rejected call inside
+/// [`ApiClient::get_all_instances`]'s paged fetch (the id listing and each id
+/// chunk fetch individually), mirroring the per-instance/preflight caps used
+/// elsewhere in this crate.
+const MAX_PAGED_FETCH_ATTEMPTS: usize = 8;
+/// Cumulative backoff cap for one such retried call.
+const MAX_PAGED_FETCH_BACKOFF: Duration = Duration::from_secs(120);
 
 // Note: You do *not* need to add every gRPC method to this wrapper. Callers can use `.0` to get
 // access to the underlying ForgeApiClient, if they want to simply call the gRPC methods themselves.
@@ -368,6 +378,17 @@ impl ApiClient {
             ))
     }
 
+    /// Resolves the full instance list matching a filter, via one id-listing
+    /// RPC followed by concurrently-chunked `find_instances_by_ids` fetches.
+    ///
+    /// Each of those calls is retried individually on `RESOURCE_EXHAUSTED`
+    /// (see [`retry_on_admission_exhaustion`]), rather than the whole method
+    /// being wrapped by a caller-side retry. A rejection while fetching, say,
+    /// the last of 20 chunks would otherwise burn the whole outer retry
+    /// budget re-fetching all 20 chunks from scratch, discarding the 19 that
+    /// already succeeded -- found via PR review at large-batch (`--label-key`)
+    /// scale, where a late chunk landing in a saturated admission window was
+    /// common.
     pub(crate) async fn get_all_instances(
         &self,
         tenant_org_id: Option<String>,
@@ -395,7 +416,22 @@ impl ApiClient {
                 .instance_ids
                 .chunks(self.effective_chunk_size(page_size).await?),
         )
-        .map(|ids| self.0.find_instances_by_ids(ids.to_vec()))
+        .map(|ids| {
+            let ids = ids.to_vec();
+            retry_on_admission_exhaustion(
+                MAX_PAGED_FETCH_ATTEMPTS,
+                MAX_PAGED_FETCH_BACKOFF,
+                move || {
+                    let ids = ids.clone();
+                    async move {
+                        self.0
+                            .find_instances_by_ids(ids)
+                            .await
+                            .map_err(CarbideCliError::from)
+                    }
+                },
+            )
+        })
         .buffered(PAGED_LIST_FETCH_CONCURRENCY)
         .try_for_each(|list| {
             all_list.instances.extend(list.instances);
@@ -436,7 +472,16 @@ impl ApiClient {
                 })
             },
         };
-        Ok(self.0.find_instance_ids(request).await?)
+        retry_on_admission_exhaustion(MAX_PAGED_FETCH_ATTEMPTS, MAX_PAGED_FETCH_BACKOFF, || {
+            let request = request.clone();
+            async move {
+                self.0
+                    .find_instance_ids(request)
+                    .await
+                    .map_err(CarbideCliError::from)
+            }
+        })
+        .await
     }
 
     pub(crate) async fn get_all_racks(&self, page_size: usize) -> CarbideCliResult<rpc::RackList> {


### PR DESCRIPTION
## Problem

`instance release --label-key` resolves the label into instance IDs via `get_all_instances`,
which for more than one page issues `find_instance_ids` then N chunked `find_instances_by_ids`
calls. The existing retry wrap treated the whole multi-call operation as one unit — a
`RESOURCE_EXHAUSTED` rejection on a late chunk discarded every page already fetched and burned
one of the whole-lookup's limited retry attempts. Flagged on #5735 review
([r3927074124](https://github.com/NVIDIA/infra-controller/pull/5735#discussion_r3927074124)).

Separately, `instance/release/cmd.rs` carried its own local copy of the pushback-parsing/retry
logic (`PushbackAdvice`, `admission_retry_delay`, `resolve_backoff_delay`,
`retry_lookup_on_admission_exhaustion`), duplicating a shared `crate::admission_retry` module
built on this same branch — a deliberately deferred cleanup once all the original
instance-lifecycle branches merged.

## Fix

- `get_all_instances` (`rpc.rs`): each individual RPC call (the id listing, and every id-chunk
  fetch) now retries independently on `RESOURCE_EXHAUSTED` via the shared
  `admission_retry::retry_on_admission_exhaustion`, so a late failure only re-does the one
  failed call, not everything before it.
- `instance/release/cmd.rs`: switched to the shared module — the preflight `--machine` lookup
  now calls `admission_retry::retry_on_admission_exhaustion` directly;
  `release_batch_with_retry` keeps its own loop (it retries a raw `Result<..., tonic::Status>`,
  not `CarbideCliResult<T>`) but delegates parsing to the shared `resolve_backoff_delay`. Net
  -109 lines of duplicated code.

## Testing

- `cargo check` / `test` / `clippy` — clean, 262/262 `nico-admin-cli` tests pass.
- Live end-to-end at 1,000-host scale (dev7, image `v2.4-paged-retry-cleanup`), exercising both
  the paged `--label-key` release and the batch release call:

  | Phase | This branch | 2026-09-04 baseline |
  |---|---|---|
  | Allocate call | 1m19s | 1m20s |
  | Instance-ready wait | 3m03s | 3m16s |
  | Release call | 21s | 23s |
  | Decommission wait | 13m30s | 16m06s |
  | **Total run time** | **19m53s** | **22m39s** |
  | **Result** | **1,000/1,000 READY, 0 failures** | 1,000/1,000 READY, 0 failures |

  No regression — every phase matches or is faster than baseline (decommission-wait delta is
  normal run-to-run variance, not attributable to this change).

## Review

Rebased onto post-#5861 `main` (the gRPC-timeout fix) with no conflicts — this branch doesn't
touch `crates/rpc`, no interaction with that change.
