### PR TITLE
feat(health): support config-defined gNMI subscriptions

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -502,6 +502,62 @@ platform_general_enabled = true
 # Enable only on NVOS releases that support this path. Default: false.
 leak_sensors_enabled = false
 
+# Additional subscriptions are optional and default to an empty list. Each
+# entry opens an independent gNMI STREAM RPC for every switch host eligible for
+# NVUE gNMI and can bundle multiple paths. A rejected path affects its bundled
+# subscription; connection and stream failures retry only that subscription.
+# Configuration changes require a service restart.
+#
+# [[collectors.nvue.gnmi.additional_subscriptions]]
+# Required unique lower_snake_case name. The name is emitted as the
+# `subscription` metric label and in stream diagnostics.
+# name = "external_platform"
+# Optional gNMI prefix fields. target defaults to "nvos"; origin and prefix
+# default to empty. Path arrays contain unkeyed element names.
+# target = "nvos"
+# origin = "openconfig-platform"
+# prefix = ["components"]
+# Optional response encoding. Default: "json". Accepted values: "json",
+# "ascii", and "json_ietf". These encodings provide scalar values that the
+# extended metric outputs can project.
+# encoding = "json_ietf"
+# Optional. Default: false. When true, the target omits its initial snapshot.
+# updates_only = false
+# mode defaults to "target_defined" and also accepts "on_change" or "sample".
+# sample_interval is required only for "sample". heartbeat_interval is supported
+# for "sample" and "on_change". Both intervals must be greater than zero.
+# suppress_redundant defaults to false and is supported only for "sample".
+# mode = "sample"
+# sample_interval = "30s"
+# suppress_redundant = true
+# heartbeat_interval = "5m"
+#
+# At least one request path is required. Each path is relative to prefix.
+# paths = [["component"]]
+#
+# Each metric maps one exact response path below prefix. Multiple metrics can
+# map descendant leaves from one request path. Optional labels copy named keys
+# from response path elements; an update without every configured key is
+# ignored. Each selected element must occur exactly once in prefix plus the
+# metric path. Label names cannot use `subscription`, `state`, or the endpoint
+# and hardware metadata labels added by the service. Each distinct key
+# combination creates a metric series. At least one metric is required.
+# [[collectors.nvue.gnmi.additional_subscriptions.metrics]]
+# path = ["component", "state", "reading"]
+# metric_type = "component_reading"
+# labels = [{ name = "component_name", element = "component", key = "name" }]
+# output = { kind = "gauge", unit = "count" }
+#
+# The output can instead use a finite state_set or info domain. Values outside
+# the declared domain, malformed values, and unsupported value encodings do
+# not produce metrics. Delete notifications are ignored; emitted metrics remain
+# until the collector is removed.
+# A state_set output uses the reserved `state` label and emits one series per
+# declared state: 1 for the current state and 0 for the others. An info output
+# emits one constant-1 series with the matched value in its configured label.
+# output = { kind = "state_set", states = ["normal", "attention"] }
+# output = { kind = "info", label = "mode", values = ["active", "standby"] }
+
 # ==============================================================================
 # Processors
 # ==============================================================================

--- a/crates/health/src/collectors/nvue/gnmi/client.rs
+++ b/crates/health/src/collectors/nvue/gnmi/client.rs
@@ -30,7 +30,10 @@ use super::proto::{
     SubscriptionMode,
 };
 use crate::HealthError;
-use crate::config::{MtlsProfileConfig, NvueGnmiPaths};
+use crate::config::{
+    MtlsProfileConfig, NvueGnmiEncoding, NvueGnmiPaths, NvueGnmiSubscriptionConfig,
+    NvueGnmiSubscriptionMode,
+};
 
 pub(super) fn nvue_subscribe_paths(paths_config: &NvueGnmiPaths) -> Vec<Path> {
     let mut paths = Vec::with_capacity(5);
@@ -277,20 +280,8 @@ impl GnmiClient {
         paths: &[Path],
         sample_interval_nanos: u64,
     ) -> Result<tonic::Streaming<proto::SubscribeResponse>, HealthError> {
-        let mut client = self.connect().await?;
-
         let subscribe_request = build_sample_subscribe_request(paths, sample_interval_nanos);
-
-        let auth = build_auth_metadata(&self.username, &self.password)?;
-
-        let stream = tokio_stream::once(subscribe_request).chain(tokio_stream::pending());
-
-        let request = Request::from_parts(auth, Extensions::default(), stream);
-
-        let response = client
-            .subscribe(request)
-            .await
-            .map_err(HealthError::GnmiStatus)?;
+        let response = self.subscribe_request(subscribe_request).await?;
 
         tracing::debug!(
             switch_id = %self.switch_id,
@@ -299,7 +290,7 @@ impl GnmiClient {
             "gNMI SAMPLE stream opened"
         );
 
-        Ok(response.into_inner())
+        Ok(response)
     }
 
     /// open a gNMI ON_CHANGE streaming subscription
@@ -308,26 +299,31 @@ impl GnmiClient {
         prefix: &Path,
         paths: &[Path],
     ) -> Result<tonic::Streaming<proto::SubscribeResponse>, HealthError> {
-        let mut client = self.connect().await?;
-
         let subscribe_request = build_on_change_subscribe_request(prefix, paths);
-
-        let auth = build_auth_metadata(&self.username, &self.password)?;
-
-        let stream = tokio_stream::once(subscribe_request).chain(tokio_stream::pending());
-
-        let request = Request::from_parts(auth, Extensions::default(), stream);
-
-        let response = client
-            .subscribe(request)
-            .await
-            .map_err(HealthError::GnmiStatus)?;
+        let response = self.subscribe_request(subscribe_request).await?;
 
         tracing::debug!(
             switch_id = %self.switch_id,
             rack_id = self.rack_id.as_ref().map(tracing::field::display),
             "gNMI ON_CHANGE stream opened"
         );
+
+        Ok(response)
+    }
+
+    pub(super) async fn subscribe_request(
+        &self,
+        subscribe_request: SubscribeRequest,
+    ) -> Result<tonic::Streaming<proto::SubscribeResponse>, HealthError> {
+        let mut client = self.connect().await?;
+        let auth = build_auth_metadata(&self.username, &self.password)?;
+        let stream = tokio_stream::once(subscribe_request).chain(tokio_stream::pending());
+        let request = Request::from_parts(auth, Extensions::default(), stream);
+
+        let response = client
+            .subscribe(request)
+            .await
+            .map_err(HealthError::GnmiStatus)?;
 
         Ok(response.into_inner())
     }
@@ -401,6 +397,93 @@ fn build_sample_subscribe_request(paths: &[Path], sample_interval_nanos: u64) ->
         )),
         extension: vec![],
     }
+}
+
+/// Builds a fixed-STREAM request from one validated additional subscription.
+pub(super) fn build_extended_subscribe_request(
+    config: &NvueGnmiSubscriptionConfig,
+) -> Result<SubscribeRequest, HealthError> {
+    let prefix = Path {
+        origin: config.origin.clone(),
+        elem: path_elements(&config.prefix),
+        target: config.target.clone(),
+        ..Default::default()
+    };
+
+    let subscription = config
+        .paths
+        .iter()
+        .map(|path| {
+            Ok(Subscription {
+                path: Some(Path {
+                    elem: path_elements(path),
+                    ..Default::default()
+                }),
+                mode: match config.mode {
+                    NvueGnmiSubscriptionMode::TargetDefined => SubscriptionMode::TargetDefined,
+                    NvueGnmiSubscriptionMode::OnChange => SubscriptionMode::OnChange,
+                    NvueGnmiSubscriptionMode::Sample => SubscriptionMode::Sample,
+                }
+                .into(),
+                sample_interval: duration_nanos(
+                    config.sample_interval,
+                    "sample_interval",
+                    &config.name,
+                )?,
+                suppress_redundant: config.suppress_redundant,
+                heartbeat_interval: duration_nanos(
+                    config.heartbeat_interval,
+                    "heartbeat_interval",
+                    &config.name,
+                )?,
+            })
+        })
+        .collect::<Result<Vec<_>, HealthError>>()?;
+
+    Ok(SubscribeRequest {
+        request: Some(proto::subscribe_request::Request::Subscribe(
+            SubscriptionList {
+                prefix: Some(prefix),
+                subscription,
+                mode: SubscriptionListMode::Stream.into(),
+                encoding: match config.encoding {
+                    NvueGnmiEncoding::Json => Encoding::Json,
+                    NvueGnmiEncoding::Ascii => Encoding::Ascii,
+                    NvueGnmiEncoding::JsonIetf => Encoding::JsonIetf,
+                }
+                .into(),
+                updates_only: config.updates_only,
+                ..Default::default()
+            },
+        )),
+        extension: Vec::new(),
+    })
+}
+
+fn path_elements(elements: &[String]) -> Vec<PathElem> {
+    elements
+        .iter()
+        .map(|name| PathElem {
+            name: name.clone(),
+            key: Default::default(),
+        })
+        .collect()
+}
+
+fn duration_nanos(
+    duration: Option<Duration>,
+    field: &str,
+    subscription_name: &str,
+) -> Result<u64, HealthError> {
+    let Some(duration) = duration else {
+        return Ok(0);
+    };
+
+    u64::try_from(duration.as_nanos()).map_err(|_| {
+        HealthError::GnmiError(format!(
+            "extended gNMI subscription {subscription_name:?} {field} does not fit in u64 nanoseconds"
+        ))
+    })
 }
 
 fn build_auth_metadata(
@@ -941,5 +1024,61 @@ mod tests {
                 .is_some_and(|path| path.elem.is_empty()),
             "empty path subscribes to all events under prefix"
         );
+    }
+
+    #[test]
+    fn extended_subscribe_request_preserves_subscription_contract() {
+        let config = NvueGnmiSubscriptionConfig {
+            name: "external_metrics".to_string(),
+            target: "switch".to_string(),
+            origin: "openconfig".to_string(),
+            prefix: vec!["interfaces".to_string()],
+            encoding: NvueGnmiEncoding::JsonIetf,
+            updates_only: true,
+            mode: NvueGnmiSubscriptionMode::Sample,
+            sample_interval: Some(Duration::from_secs(10)),
+            suppress_redundant: true,
+            heartbeat_interval: Some(Duration::from_secs(60)),
+            paths: vec![
+                vec!["interface".to_string(), "state".to_string()],
+                vec!["interface".to_string(), "counter".to_string()],
+            ],
+            metrics: Vec::new(),
+        };
+
+        let request = build_extended_subscribe_request(&config)
+            .expect("validated extended request should build");
+
+        let Some(proto::subscribe_request::Request::Subscribe(list)) = request.request else {
+            panic!("extended request should contain a subscription list");
+        };
+
+        assert_eq!(list.mode, i32::from(SubscriptionListMode::Stream));
+        assert_eq!(list.encoding, i32::from(Encoding::JsonIetf));
+        assert!(list.updates_only);
+
+        let prefix = list
+            .prefix
+            .expect("extended request should contain a prefix");
+
+        assert_eq!(prefix.target, "switch");
+        assert_eq!(prefix.origin, "openconfig");
+        assert_eq!(prefix.elem[0].name, "interfaces");
+
+        assert_eq!(list.subscription.len(), 2);
+
+        for subscription in &list.subscription {
+            assert_eq!(subscription.mode, i32::from(SubscriptionMode::Sample));
+            assert_eq!(subscription.sample_interval, 10_000_000_000);
+            assert!(subscription.suppress_redundant);
+            assert_eq!(subscription.heartbeat_interval, 60_000_000_000);
+        }
+
+        assert!(list.subscription.iter().all(|subscription| {
+            subscription
+                .path
+                .as_ref()
+                .is_some_and(|path| path.elem.iter().all(|element| element.key.is_empty()))
+        }));
     }
 }

--- a/crates/health/src/collectors/nvue/gnmi/extended_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/extended_processor.rs
@@ -1,0 +1,650 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Metric projection for extended gNMI subscriptions.
+
+use std::borrow::Cow;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use std::time::Instant;
+
+use super::client::{typed_value_to_f64, typed_value_to_string};
+use super::proto::{self, PathElem};
+use super::sample_processor::now_unix_secs;
+use super::subscriber::GnmiStreamMetrics;
+use crate::config::{NvueGnmiMetricConfig, NvueGnmiMetricOutput, NvueGnmiSubscriptionConfig};
+use crate::metrics::MetricLabel;
+use crate::sink::{CollectorEvent, DataSink, EventContext, MetricSample};
+
+pub(super) const EXTENDED_GNMI_STREAM_ID: &str = "nvue_gnmi_extended";
+
+/// Projects one named subscription without interpreting its data-tree schema.
+pub(super) struct ExtendedGnmiProcessor {
+    data_sink: Option<Arc<dyn DataSink>>,
+    event_context: EventContext,
+    pub(super) subscription_name: String,
+    pub(super) switch_id: String,
+    mappings: HashMap<Vec<String>, NvueGnmiMetricConfig>,
+}
+
+impl ExtendedGnmiProcessor {
+    pub(super) fn new(
+        config: &NvueGnmiSubscriptionConfig,
+        data_sink: Option<Arc<dyn DataSink>>,
+        event_context: EventContext,
+        switch_id: String,
+    ) -> Self {
+        let mappings = config
+            .metrics
+            .iter()
+            .map(|metric| {
+                let combined_path = config.prefix.iter().chain(&metric.path).cloned().collect();
+
+                (combined_path, metric.clone())
+            })
+            .collect();
+
+        Self {
+            data_sink,
+            event_context,
+            subscription_name: config.name.clone(),
+            switch_id,
+            mappings,
+        }
+    }
+
+    /// Processes one response and reports whether it established a usable stream.
+    ///
+    /// An in-band gNMI error is returned as a status so the subscriber can
+    /// refresh credentials when required and reconnect.
+    pub(super) fn process_subscribe_response(
+        &mut self,
+        response: &proto::SubscribeResponse,
+        stream_metrics: &GnmiStreamMetrics,
+    ) -> Result<bool, tonic::Status> {
+        let Some(response) = response.response.as_ref() else {
+            return Ok(false);
+        };
+
+        let notification = match response {
+            proto::subscribe_response::Response::Update(notification) => notification,
+            proto::subscribe_response::Response::SyncResponse(_) => return Ok(true),
+            #[allow(deprecated, reason = "accept the legacy in-band gNMI error response")]
+            proto::subscribe_response::Response::Error(error) => {
+                stream_metrics.stream_errors_total.inc();
+
+                tracing::warn!(
+                    grpc_status_code = error.code,
+                    error = %error.message,
+                    switch_id = %self.switch_id,
+                    subscription = %self.subscription_name,
+                    rack_id = self.event_context.rack_id().map(tracing::field::display),
+                    "extended gNMI stream reported an error"
+                );
+
+                let Ok(code) = i32::try_from(error.code) else {
+                    return Err(tonic::Status::unknown(error.message.clone()));
+                };
+
+                return Err(tonic::Status::new(
+                    tonic::Code::from_i32(code),
+                    error.message.clone(),
+                ));
+            }
+        };
+
+        stream_metrics.notifications_received_total.inc();
+        stream_metrics
+            .last_notification_timestamp
+            .set(now_unix_secs());
+
+        let start = Instant::now();
+        let emitted = self.process_notification(notification);
+
+        stream_metrics
+            .notification_processing_seconds
+            .observe(start.elapsed().as_secs_f64());
+
+        stream_metrics.monitored_entities.set(emitted as f64);
+
+        Ok(true)
+    }
+
+    fn process_notification(&mut self, notification: &proto::Notification) -> usize {
+        let prefix = notification
+            .prefix
+            .as_ref()
+            .map(|path| path.elem.as_slice())
+            .unwrap_or_default();
+
+        let mut entities = HashSet::new();
+
+        for update in &notification.update {
+            let Some(value) = update.val.as_ref() else {
+                continue;
+            };
+
+            let update_path = update
+                .path
+                .as_ref()
+                .map(|path| path.elem.as_slice())
+                .unwrap_or_default();
+
+            let combined = prefix.iter().chain(update_path).collect::<Vec<_>>();
+
+            let names = combined
+                .iter()
+                .map(|element| element.name.clone())
+                .collect::<Vec<_>>();
+
+            let Some(mapping) = self.mappings.get(names.as_slice()) else {
+                continue;
+            };
+
+            if let Some(entity) = self.emit_metric(mapping, &combined, value) {
+                entities.insert(entity);
+            }
+        }
+
+        entities.len()
+    }
+
+    fn emit_metric(
+        &self,
+        mapping: &NvueGnmiMetricConfig,
+        path: &[&PathElem],
+        value: &proto::TypedValue,
+    ) -> Option<String> {
+        let mut labels = response_key_labels(mapping, path)?;
+
+        let mut entity = String::new();
+        push_key_component(&mut entity, &self.subscription_name);
+
+        for (name, value) in &labels {
+            push_key_component(&mut entity, name.as_ref());
+            push_key_component(&mut entity, value);
+        }
+
+        let mut key = String::new();
+        push_key_component(&mut key, &self.subscription_name);
+        push_key_component(&mut key, &mapping.metric_type);
+
+        for (name, value) in &labels {
+            push_key_component(&mut key, name.as_ref());
+            push_key_component(&mut key, value);
+        }
+
+        labels.insert(
+            0,
+            (
+                Cow::Borrowed("subscription"),
+                self.subscription_name.clone(),
+            ),
+        );
+
+        match &mapping.output {
+            NvueGnmiMetricOutput::Gauge { unit } => {
+                let value = extended_value_to_f64(value)?;
+                let sample = metric_sample(key, &mapping.metric_type, unit, value, labels);
+
+                self.emit_sample(sample);
+            }
+            NvueGnmiMetricOutput::StateSet { states } => {
+                let current = categorical_value(value)?;
+
+                if !states.iter().any(|state| state == &current) {
+                    return None;
+                }
+
+                for state in states {
+                    let mut state_key = key.clone();
+                    push_key_component(&mut state_key, state);
+
+                    let mut state_labels = labels.clone();
+                    state_labels.push((Cow::Borrowed("state"), state.clone()));
+
+                    let sample = metric_sample(
+                        state_key,
+                        &mapping.metric_type,
+                        "state",
+                        if state == &current { 1.0 } else { 0.0 },
+                        state_labels,
+                    );
+
+                    self.emit_sample(sample);
+                }
+            }
+            NvueGnmiMetricOutput::Info {
+                label,
+                values: allowed_values,
+            } => {
+                let value = categorical_value(value)?;
+
+                if !allowed_values.iter().any(|allowed| allowed == &value) {
+                    return None;
+                }
+
+                labels.push((Cow::Owned(label.clone()), value));
+
+                let sample = metric_sample(key, &mapping.metric_type, "info", 1.0, labels);
+                self.emit_sample(sample);
+            }
+        }
+
+        Some(entity)
+    }
+
+    fn emit_sample(&self, sample: MetricSample) {
+        if let Some(sink) = &self.data_sink {
+            sink.handle_event(
+                &self.event_context,
+                &CollectorEvent::Metric(Box::new(sample)),
+            );
+        }
+    }
+}
+
+fn categorical_value(value: &proto::TypedValue) -> Option<String> {
+    use proto::typed_value::Value;
+
+    match &value.value {
+        Some(Value::JsonVal(bytes)) | Some(Value::JsonIetfVal(bytes)) => {
+            match serde_json::from_slice(bytes).ok()? {
+                serde_json::Value::String(value) => Some(value),
+                serde_json::Value::Number(value) => Some(value.to_string()),
+                serde_json::Value::Bool(value) => Some(value.to_string()),
+                _ => None,
+            }
+        }
+        _ => typed_value_to_string(value),
+    }
+}
+
+/// Adds ASCII numeric support and rejects non-finite results.
+fn extended_value_to_f64(value: &proto::TypedValue) -> Option<f64> {
+    use proto::typed_value::Value;
+
+    let value = match &value.value {
+        Some(Value::AsciiVal(value)) => value.parse().ok(),
+        _ => typed_value_to_f64(value),
+    }?;
+
+    value.is_finite().then_some(value)
+}
+
+fn response_key_labels(
+    mapping: &NvueGnmiMetricConfig,
+    path: &[&PathElem],
+) -> Option<Vec<MetricLabel>> {
+    mapping
+        .labels
+        .iter()
+        .map(|label| {
+            let element = path.iter().find(|element| element.name == label.element)?;
+
+            let value = element
+                .key
+                .get(&label.key)
+                .filter(|value| !value.is_empty())?;
+
+            Some((Cow::Owned(label.name.clone()), value.clone()))
+        })
+        .collect()
+}
+
+fn metric_sample(
+    key: String,
+    metric_type: &str,
+    unit: &str,
+    value: f64,
+    labels: Vec<MetricLabel>,
+) -> MetricSample {
+    MetricSample {
+        key,
+        name: EXTENDED_GNMI_STREAM_ID.to_string(),
+        metric_type: metric_type.to_string(),
+        unit: unit.to_string(),
+        value,
+        labels,
+        context: None,
+    }
+}
+
+/// Uses length prefixes so extended names and response keys cannot alias.
+fn push_key_component(key: &mut String, component: &str) {
+    key.push_str(&component.len().to_string());
+    key.push(':');
+    key.push_str(component);
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+    use std::sync::Mutex;
+
+    use mac_address::MacAddress;
+
+    use super::*;
+    use crate::config::NvueGnmiResponseKeyLabel;
+    use crate::endpoint::BmcAddr;
+
+    #[derive(Default)]
+    struct CapturingSink {
+        events: Mutex<Vec<CollectorEvent>>,
+    }
+
+    impl DataSink for CapturingSink {
+        fn sink_type(&self) -> &'static str {
+            "capturing_sink"
+        }
+
+        fn try_handle_event(
+            &self,
+            _context: &EventContext,
+            event: &CollectorEvent,
+        ) -> Result<(), crate::HealthError> {
+            self.events
+                .lock()
+                .expect("event capture mutex should not be poisoned")
+                .push(event.clone());
+
+            Ok(())
+        }
+    }
+
+    fn event_context() -> EventContext {
+        EventContext {
+            endpoint_key: "aa:bb:cc:dd:ee:ff".to_string(),
+            addr: BmcAddr {
+                ip: "10.0.0.1".parse().expect("test address should parse"),
+                port: None,
+                mac: MacAddress::from_str("AA:BB:CC:DD:EE:FF").expect("test MAC should parse"),
+            },
+            collector_type: EXTENDED_GNMI_STREAM_ID,
+            metadata: None,
+            rack_id: None,
+            labels: Default::default(),
+        }
+    }
+
+    fn subscription(output: NvueGnmiMetricOutput) -> NvueGnmiSubscriptionConfig {
+        NvueGnmiSubscriptionConfig {
+            name: "external_metrics".to_string(),
+            prefix: vec!["interfaces".to_string()],
+            paths: vec![vec!["interface".to_string()]],
+            metrics: vec![NvueGnmiMetricConfig {
+                path: vec![
+                    "interface".to_string(),
+                    "state".to_string(),
+                    "reading".to_string(),
+                ],
+                metric_type: "interface_reading".to_string(),
+                labels: vec![NvueGnmiResponseKeyLabel {
+                    name: "interface_name".to_string(),
+                    element: "interface".to_string(),
+                    key: "name".to_string(),
+                }],
+                output,
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn processor(output: NvueGnmiMetricOutput) -> (ExtendedGnmiProcessor, Arc<CapturingSink>) {
+        let sink = Arc::new(CapturingSink::default());
+
+        let processor = ExtendedGnmiProcessor::new(
+            &subscription(output),
+            Some(sink.clone()),
+            event_context(),
+            "switch-1".to_string(),
+        );
+
+        (processor, sink)
+    }
+
+    fn path_element(name: &str, keys: &[(&str, &str)]) -> PathElem {
+        PathElem {
+            name: name.to_string(),
+            key: keys
+                .iter()
+                .map(|(key, value)| (key.to_string(), value.to_string()))
+                .collect(),
+        }
+    }
+
+    fn notification(value: Option<proto::TypedValue>, keyed: bool) -> proto::Notification {
+        proto::Notification {
+            prefix: Some(proto::Path {
+                elem: vec![path_element("interfaces", &[])],
+                ..Default::default()
+            }),
+            update: vec![proto::Update {
+                path: Some(proto::Path {
+                    elem: vec![
+                        path_element("interface", if keyed { &[("name", "port-1")] } else { &[] }),
+                        path_element("state", &[]),
+                        path_element("reading", &[]),
+                    ],
+                    ..Default::default()
+                }),
+                val: value,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }
+    }
+
+    fn captured_metrics(sink: &CapturingSink) -> Vec<MetricSample> {
+        sink.events
+            .lock()
+            .expect("event capture mutex should not be poisoned")
+            .iter()
+            .map(|event| {
+                let CollectorEvent::Metric(sample) = event else {
+                    panic!("extended processor should emit only metrics");
+                };
+
+                sample.as_ref().clone()
+            })
+            .collect()
+    }
+
+    fn stream_metrics() -> GnmiStreamMetrics {
+        super::super::subscriber::test_gnmi_stream_metrics()
+    }
+
+    #[test]
+    fn extended_gauge_maps_response_path_key() {
+        let (mut processor, sink) = processor(NvueGnmiMetricOutput::Gauge {
+            unit: "count".to_string(),
+        });
+
+        let value = proto::TypedValue {
+            value: Some(proto::typed_value::Value::DoubleVal(42.5)),
+        };
+
+        let mut sample_notification = notification(Some(value), true);
+        sample_notification
+            .update
+            .push(sample_notification.update[0].clone());
+
+        assert_eq!(processor.process_notification(&sample_notification), 1);
+
+        let samples = captured_metrics(&sink);
+
+        assert_eq!(samples.len(), 2);
+        assert_eq!(samples[0].name, EXTENDED_GNMI_STREAM_ID);
+        assert_eq!(samples[0].metric_type, "interface_reading");
+        assert_eq!(samples[0].unit, "count");
+        assert_eq!(samples[0].value, 42.5);
+
+        assert_eq!(
+            samples[0].labels,
+            [
+                (
+                    Cow::Borrowed("subscription"),
+                    "external_metrics".to_string()
+                ),
+                (Cow::Borrowed("interface_name"), "port-1".to_string()),
+            ]
+        );
+
+        let ascii = proto::TypedValue {
+            value: Some(proto::typed_value::Value::AsciiVal("1.25".to_string())),
+        };
+
+        assert_eq!(
+            processor.process_notification(&notification(Some(ascii), true)),
+            1
+        );
+
+        assert_eq!(captured_metrics(&sink).last().unwrap().value, 1.25);
+    }
+
+    #[test]
+    fn extended_categorical_outputs_use_finite_domains() {
+        let (mut state_processor, state_sink) = processor(NvueGnmiMetricOutput::StateSet {
+            states: vec!["normal".to_string(), "attention".to_string()],
+        });
+
+        let attention = proto::TypedValue {
+            value: Some(proto::typed_value::Value::StringVal(
+                "attention".to_string(),
+            )),
+        };
+
+        assert_eq!(
+            state_processor.process_notification(&notification(Some(attention), true)),
+            1
+        );
+
+        let state_samples = captured_metrics(&state_sink);
+
+        assert_eq!(state_samples.len(), 2);
+        assert_eq!(state_samples[0].value, 0.0);
+        assert_eq!(state_samples[1].value, 1.0);
+
+        let (mut info_processor, info_sink) = processor(NvueGnmiMetricOutput::Info {
+            label: "mode".to_string(),
+            values: vec!["active".to_string(), "standby".to_string()],
+        });
+
+        let active = proto::TypedValue {
+            value: Some(proto::typed_value::Value::JsonIetfVal(
+                br#""active""#.to_vec(),
+            )),
+        };
+
+        assert_eq!(
+            info_processor.process_notification(&notification(Some(active), true)),
+            1
+        );
+
+        let info_samples = captured_metrics(&info_sink);
+
+        assert_eq!(info_samples.len(), 1);
+        assert_eq!(info_samples[0].unit, "info");
+
+        assert!(
+            info_samples[0]
+                .labels
+                .contains(&(Cow::Owned("mode".to_string()), "active".to_string()))
+        );
+    }
+
+    #[test]
+    fn extended_metrics_ignore_unusable_updates() {
+        let (mut processor, sink) = processor(NvueGnmiMetricOutput::StateSet {
+            states: vec!["normal".to_string(), "attention".to_string()],
+        });
+
+        let unknown = proto::TypedValue {
+            value: Some(proto::typed_value::Value::StringVal("other".to_string())),
+        };
+
+        let malformed_json = proto::TypedValue {
+            value: Some(proto::typed_value::Value::JsonVal(b"attention".to_vec())),
+        };
+
+        assert_eq!(
+            processor.process_notification(&notification(Some(unknown), true)),
+            0
+        );
+
+        assert_eq!(
+            processor.process_notification(&notification(Some(malformed_json), true)),
+            0
+        );
+
+        assert_eq!(processor.process_notification(&notification(None, true)), 0);
+
+        assert_eq!(
+            processor.process_notification(&notification(
+                Some(proto::TypedValue {
+                    value: Some(proto::typed_value::Value::StringVal("normal".to_string(),)),
+                }),
+                false,
+            )),
+            0
+        );
+
+        assert!(captured_metrics(&sink).is_empty());
+    }
+
+    #[test]
+    #[allow(deprecated, reason = "exercise legacy in-band gNMI error handling")]
+    fn extended_stream_response_types_are_isolated() {
+        let (mut processor, sink) = processor(NvueGnmiMetricOutput::Gauge {
+            unit: "count".to_string(),
+        });
+
+        let metrics = stream_metrics();
+
+        assert!(
+            processor
+                .process_subscribe_response(
+                    &proto::SubscribeResponse {
+                        response: Some(proto::subscribe_response::Response::SyncResponse(true)),
+                        ..Default::default()
+                    },
+                    &metrics,
+                )
+                .is_ok_and(|usable| usable)
+        );
+
+        let error = processor
+            .process_subscribe_response(
+                &proto::SubscribeResponse {
+                    response: Some(proto::subscribe_response::Response::Error(proto::Error {
+                        code: tonic::Code::Unauthenticated as u32,
+                        message: "test error".to_string(),
+                        ..Default::default()
+                    })),
+                    ..Default::default()
+                },
+                &metrics,
+            )
+            .expect_err("in-band gNMI error should request reconnection");
+
+        assert_eq!(error.code(), tonic::Code::Unauthenticated);
+
+        assert_eq!(metrics.notifications_received_total.get(), 0.0);
+        assert_eq!(metrics.stream_errors_total.get(), 1.0);
+        assert!(captured_metrics(&sink).is_empty());
+    }
+}

--- a/crates/health/src/collectors/nvue/gnmi/mod.rs
+++ b/crates/health/src/collectors/nvue/gnmi/mod.rs
@@ -16,6 +16,7 @@
  */
 
 mod client;
+mod extended_processor;
 mod on_change_processor;
 mod sample_processor;
 pub(in crate::collectors) mod subscriber;

--- a/crates/health/src/collectors/nvue/gnmi/subscriber.rs
+++ b/crates/health/src/collectors/nvue/gnmi/subscriber.rs
@@ -26,9 +26,10 @@ use tokio::sync::OnceCell;
 use tokio_util::sync::CancellationToken;
 
 use super::client::{
-    GnmiClient, GnmiClientConfig, nvue_subscribe_paths, system_events_prefix,
-    system_events_subscribe_path,
+    GnmiClient, GnmiClientConfig, build_extended_subscribe_request, nvue_subscribe_paths,
+    system_events_prefix, system_events_subscribe_path,
 };
+use super::extended_processor::{EXTENDED_GNMI_STREAM_ID, ExtendedGnmiProcessor};
 use super::on_change_processor::{
     GnmiOnChangeProcessor, ON_CHANGE_STREAM_ID_SYSTEM_EVENTS, OnChangeStreamMetrics,
 };
@@ -179,10 +180,34 @@ impl GnmiStreamMetrics {
     }
 }
 
+#[cfg(test)]
+pub(super) fn test_gnmi_stream_metrics() -> GnmiStreamMetrics {
+    GnmiStreamMetrics::new(
+        &prometheus::Registry::new(),
+        "test",
+        "_extended",
+        HashMap::new(),
+    )
+    .unwrap()
+}
+
 struct GnmiStreamConfig {
     client_provider: GnmiClientProvider,
     paths: Vec<proto::Path>,
     sample_interval_nanos: u64,
+}
+
+struct ExtendedGnmiStreamState {
+    client_provider: GnmiClientProvider,
+    request: proto::SubscribeRequest,
+    stream_metrics: GnmiStreamMetrics,
+    processor: ExtendedGnmiProcessor,
+}
+
+#[derive(Clone, Copy, Eq, PartialEq)]
+enum ExtendedStreamExit {
+    Cancelled,
+    Reconnect,
 }
 
 #[derive(Clone)]
@@ -331,6 +356,30 @@ async fn subscribe_on_change_with_cached_credentials(
             error,
             credential_generation: Some(credential_generation),
         })?;
+    Ok((stream, credential_generation))
+}
+
+async fn subscribe_extended_with_cached_credentials(
+    client_provider: &GnmiClientProvider,
+    request: proto::SubscribeRequest,
+) -> Result<(tonic::Streaming<proto::SubscribeResponse>, u64), GnmiStreamOpenError> {
+    let (client, credential_generation) =
+        client_provider
+            .new_client()
+            .await
+            .map_err(|error| GnmiStreamOpenError {
+                error,
+                credential_generation: None,
+            })?;
+
+    let stream = client
+        .subscribe_request(request)
+        .await
+        .map_err(|error| GnmiStreamOpenError {
+            error,
+            credential_generation: Some(credential_generation),
+        })?;
+
     Ok((stream, credential_generation))
 }
 
@@ -490,6 +539,10 @@ pub(crate) fn spawn_gnmi_collector(
     let prefix = collector_registry.prefix().clone();
     let collector_removed_sample_context = sample_event_context.clone();
     let mut collector_removed_on_change_context = None;
+    let extended_event_context = EventContext::from_endpoint(endpoint, EXTENDED_GNMI_STREAM_ID);
+
+    let collector_removed_extended_context =
+        (!gnmi_config.additional_subscriptions.is_empty()).then(|| extended_event_context.clone());
 
     let sample_const_labels = collector_metric_labels(
         NVUE_GNMI_SAMPLE_STREAM_ID,
@@ -505,11 +558,39 @@ pub(crate) fn spawn_gnmi_collector(
         sample_interval_nanos: gnmi_config.sample_interval.as_nanos() as u64,
     };
 
+    let sample_enabled = !sample_config.paths.is_empty();
+
     let sample_processor = GnmiSampleProcessor {
         data_sink: data_sink.clone(),
         event_context: sample_event_context,
         switch_id: switch_id.clone(),
     };
+
+    let mut extended_states = Vec::with_capacity(gnmi_config.additional_subscriptions.len());
+
+    for subscription in &gnmi_config.additional_subscriptions {
+        let mut const_labels = collector_metric_labels(
+            EXTENDED_GNMI_STREAM_ID,
+            endpoint.hash_key().into_owned(),
+            endpoint,
+        );
+
+        const_labels.insert("subscription".to_string(), subscription.name.clone());
+
+        let stream_metrics = GnmiStreamMetrics::new(registry, &prefix, "_extended", const_labels)?;
+
+        extended_states.push(ExtendedGnmiStreamState {
+            client_provider: client_provider.clone(),
+            request: build_extended_subscribe_request(subscription)?,
+            stream_metrics,
+            processor: ExtendedGnmiProcessor::new(
+                subscription,
+                data_sink.clone(),
+                extended_event_context.clone(),
+                switch_id.clone(),
+            ),
+        });
+    }
 
     let on_change_state = if gnmi_config.system_events_enabled {
         let on_change_const_labels = collector_metric_labels(
@@ -548,42 +629,223 @@ pub(crate) fn spawn_gnmi_collector(
     let collector_removed_data_sink = data_sink;
 
     Ok(Collector::spawn_task(move |cancel_token| async move {
-        // Keep the subregistry registered until both gNMI stream tasks finish.
+        // Keep the subregistry registered until all gNMI stream tasks finish.
         let _collector_registry = collector_registry;
 
-        let sample_handle = tokio::spawn(gnmi_sample_task(
-            cancel_token.clone(),
-            sample_config,
-            sample_stream_metrics,
-            sample_processor,
-        ));
+        let sample_handle = sample_enabled.then(|| {
+            tokio::spawn(gnmi_sample_task(
+                cancel_token.clone(),
+                sample_config,
+                sample_stream_metrics,
+                sample_processor,
+            ))
+        });
 
         let on_change_handle =
             on_change_state.map(|(client_provider, stream_metrics, on_change_processor)| {
                 tokio::spawn(gnmi_on_change_task(
-                    cancel_token,
+                    cancel_token.clone(),
                     client_provider,
                     stream_metrics,
                     on_change_processor,
                 ))
             });
 
-        let _ = sample_handle.await;
+        let extended_handles = extended_states
+            .into_iter()
+            .map(|state| tokio::spawn(gnmi_extended_task(cancel_token.clone(), state)))
+            .collect::<Vec<_>>();
+
+        if let Some(handle) = sample_handle {
+            let _ = handle.await;
+        }
+
         if let Some(handle) = on_change_handle {
             let _ = handle.await;
         }
 
+        for handle in extended_handles {
+            let _ = handle.await;
+        }
+
         if let Some(data_sink) = collector_removed_data_sink.as_deref() {
-            data_sink.handle_event(
-                &collector_removed_sample_context,
-                &CollectorEvent::CollectorRemoved,
-            );
+            if sample_enabled {
+                data_sink.handle_event(
+                    &collector_removed_sample_context,
+                    &CollectorEvent::CollectorRemoved,
+                );
+            }
 
             if let Some(event_context) = &collector_removed_on_change_context {
                 data_sink.handle_event(event_context, &CollectorEvent::CollectorRemoved);
             }
+
+            if let Some(event_context) = &collector_removed_extended_context {
+                data_sink.handle_event(event_context, &CollectorEvent::CollectorRemoved);
+            }
         }
     }))
+}
+
+async fn gnmi_extended_task(cancel_token: CancellationToken, mut state: ExtendedGnmiStreamState) {
+    let mut backoff = ExponentialBackoff::new(&BackoffConfig {
+        initial: Duration::from_secs(2),
+        max: Duration::from_secs(60),
+    });
+
+    loop {
+        state.stream_metrics.connection_state.set(CONNECTING);
+
+        let Some(stream) = cancel_token
+            .run_until_cancelled(subscribe_extended_with_cached_credentials(
+                &state.client_provider,
+                state.request.clone(),
+            ))
+            .await
+        else {
+            state.stream_metrics.connection_state.set(SHUTDOWN);
+            return;
+        };
+
+        match stream {
+            Err(error) => {
+                state.stream_metrics.connection_state.set(TRANSIENT_FAILURE);
+                state.stream_metrics.reconnections_total.inc();
+
+                if let Some(credential_generation) = error.credential_generation {
+                    state
+                        .client_provider
+                        .refresh_auth_if_needed(&error.error, credential_generation)
+                        .await;
+                }
+
+                tracing::warn!(
+                    error = ?error.error,
+                    switch_id = %state.processor.switch_id,
+                    subscription = %state.processor.subscription_name,
+                    rack_id = state.client_provider.rack_id.as_ref().map(tracing::field::display),
+                    "extended gNMI stream connection failed; backing off"
+                );
+            }
+            Ok((mut stream, credential_generation)) => {
+                state.stream_metrics.connection_state.set(READY);
+                state
+                    .stream_metrics
+                    .connection_established_timestamp
+                    .set(now_unix_secs());
+
+                let _connection_guard =
+                    StreamingConnectionGuard::inc(state.stream_metrics.connected.clone());
+
+                tracing::info!(
+                    switch_id = %state.processor.switch_id,
+                    subscription = %state.processor.subscription_name,
+                    rack_id = state.client_provider.rack_id.as_ref().map(tracing::field::display),
+                    "extended gNMI stream connected"
+                );
+
+                if consume_extended_stream(
+                    &cancel_token,
+                    &mut state,
+                    &mut stream,
+                    credential_generation,
+                    &mut backoff,
+                )
+                .await
+                    == ExtendedStreamExit::Cancelled
+                {
+                    return;
+                }
+            }
+        }
+
+        if cancel_token
+            .run_until_cancelled(tokio::time::sleep(backoff.next_delay()))
+            .await
+            .is_none()
+        {
+            state.stream_metrics.connection_state.set(SHUTDOWN);
+            return;
+        }
+    }
+}
+
+async fn consume_extended_stream(
+    cancel_token: &CancellationToken,
+    state: &mut ExtendedGnmiStreamState,
+    stream: &mut tonic::Streaming<proto::SubscribeResponse>,
+    credential_generation: u64,
+    backoff: &mut ExponentialBackoff,
+) -> ExtendedStreamExit {
+    loop {
+        let Some(message) = cancel_token.run_until_cancelled(stream.message()).await else {
+            state.stream_metrics.connection_state.set(SHUTDOWN);
+
+            tracing::info!(
+                switch_id = %state.processor.switch_id,
+                subscription = %state.processor.subscription_name,
+                rack_id = state.client_provider.rack_id.as_ref().map(tracing::field::display),
+                "extended gNMI stream cancelled"
+            );
+
+            return ExtendedStreamExit::Cancelled;
+        };
+
+        match message {
+            Ok(Some(response)) => {
+                match state
+                    .processor
+                    .process_subscribe_response(&response, &state.stream_metrics)
+                {
+                    Ok(true) => backoff.reset(),
+                    Ok(false) => {}
+                    Err(error) => {
+                        state
+                            .client_provider
+                            .refresh_status_auth_if_needed(&error, credential_generation)
+                            .await;
+
+                        state.stream_metrics.connection_state.set(TRANSIENT_FAILURE);
+
+                        state.stream_metrics.reconnections_total.inc();
+                        return ExtendedStreamExit::Reconnect;
+                    }
+                }
+            }
+            Ok(None) => {
+                state.stream_metrics.connection_state.set(IDLE);
+                state.stream_metrics.server_initiated_closures_total.inc();
+
+                tracing::info!(
+                    switch_id = %state.processor.switch_id,
+                    subscription = %state.processor.subscription_name,
+                    rack_id = state.client_provider.rack_id.as_ref().map(tracing::field::display),
+                    "extended gNMI stream closed by server; reconnecting"
+                );
+
+                return ExtendedStreamExit::Reconnect;
+            }
+            Err(error) => {
+                state.stream_metrics.connection_state.set(TRANSIENT_FAILURE);
+                state.stream_metrics.stream_errors_total.inc();
+                state.stream_metrics.reconnections_total.inc();
+                state
+                    .client_provider
+                    .refresh_status_auth_if_needed(&error, credential_generation)
+                    .await;
+
+                tracing::warn!(
+                    error = ?error,
+                    switch_id = %state.processor.switch_id,
+                    subscription = %state.processor.subscription_name,
+                    rack_id = state.client_provider.rack_id.as_ref().map(tracing::field::display),
+                    "extended gNMI stream error; reconnecting"
+                );
+
+                return ExtendedStreamExit::Reconnect;
+            }
+        }
+    }
 }
 
 async fn gnmi_sample_task(
@@ -880,6 +1142,30 @@ mod tests {
             };
             Box::pin(async move { response })
         }
+    }
+
+    #[test]
+    fn extended_stream_metrics_share_families_by_subscription_label() {
+        let registry = prometheus::Registry::new();
+
+        for subscription in ["first", "second"] {
+            GnmiStreamMetrics::new(
+                &registry,
+                "test",
+                "_extended",
+                HashMap::from([("subscription".to_string(), subscription.to_string())]),
+            )
+            .expect("distinct subscription labels should share metric families");
+        }
+
+        let families = registry.gather();
+
+        let connection = families
+            .iter()
+            .find(|family| family.name() == "test_nvue_gnmi_extended_connection_state")
+            .expect("extended connection metric should be registered");
+
+        assert_eq!(connection.get_metric().len(), 2);
     }
 
     fn test_addr() -> BmcAddr {

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -37,6 +37,23 @@ const DEFAULT_BMC_REQUEST_CONCURRENCY: NonZeroUsize = NonZeroUsize::MIN.saturati
 const ENDPOINT_SOURCES_CONFIG_KEY: &str = "endpoint_sources";
 const NICO_API_CONFIG_KEY: &str = "nico_api";
 const CARBIDE_API_CONFIG_ALIAS: &str = "carbide_api";
+const RESERVED_ENDPOINT_LABELS: &[&str] = &[
+    "collector_type",
+    "endpoint_ip",
+    "endpoint_key",
+    "endpoint_mac",
+    "machine_id",
+    "machine_slot_number",
+    "machine_tray_index",
+    "nvlink_domain_uuid",
+    "power_shelf_id",
+    "rack_id",
+    "serial_number",
+    "switch_id",
+    "switch_slot_number",
+    "switch_tray_index",
+    "system_uuid",
+];
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(default)]
@@ -370,24 +387,6 @@ impl StaticBmcEndpoint {
             ));
         }
 
-        const RESERVED_LABELS: &[&str] = &[
-            "collector_type",
-            "endpoint_ip",
-            "endpoint_key",
-            "endpoint_mac",
-            "machine_id",
-            "machine_slot_number",
-            "machine_tray_index",
-            "nvlink_domain_uuid",
-            "power_shelf_id",
-            "rack_id",
-            "serial_number",
-            "switch_id",
-            "switch_slot_number",
-            "switch_tray_index",
-            "system_uuid",
-        ];
-
         if self.labels.len() > 32 {
             return Err(format!(
                 "{config_path}[{index}].labels supports at most 32 labels"
@@ -405,7 +404,7 @@ impl StaticBmcEndpoint {
                     "{config_path}[{index}].labels key {name:?} must match [a-zA-Z_][a-zA-Z0-9_]*"
                 ));
             }
-            if RESERVED_LABELS.contains(&name.as_str()) {
+            if RESERVED_ENDPOINT_LABELS.contains(&name.as_str()) {
                 return Err(format!(
                     "{config_path}[{index}].labels key {name:?} is reserved"
                 ));
@@ -1862,6 +1861,12 @@ pub struct NvueGnmiConfig {
 
     /// gNMI SAMPLE subscription paths.
     pub paths: NvueGnmiPaths,
+
+    /// Additional independent gNMI STREAM subscriptions.
+    ///
+    /// Each entry defines its request paths and metric projections. The list is
+    /// loaded at startup; omission leaves only the built-in subscriptions.
+    pub additional_subscriptions: Vec<NvueGnmiSubscriptionConfig>,
 }
 
 impl Default for NvueGnmiConfig {
@@ -1873,8 +1878,446 @@ impl Default for NvueGnmiConfig {
             dangerously_skip_tls_verification: false,
             system_events_enabled: true,
             paths: NvueGnmiPaths::default(),
+            additional_subscriptions: Vec::new(),
         }
     }
+}
+
+impl NvueGnmiConfig {
+    fn validate(&self) -> Result<(), String> {
+        let mut names = HashSet::new();
+        let mut exported_metrics = HashMap::new();
+
+        for (index, subscription) in self.additional_subscriptions.iter().enumerate() {
+            if !names.insert(subscription.name.as_str()) {
+                return Err(format!(
+                    "collectors.nvue.gnmi.additional_subscriptions[{index}].name duplicates {:?}",
+                    subscription.name
+                ));
+            }
+
+            subscription.validate(index)?;
+
+            for (metric_index, metric) in subscription.metrics.iter().enumerate() {
+                let metric_type = metric.metric_type.as_str();
+                let unit = metric.output.unit();
+                let exported_name = format!("{metric_type}_{unit}");
+
+                if let Some((previous_type, previous_unit)) =
+                    exported_metrics.insert(exported_name.clone(), (metric_type, unit))
+                    && (previous_type, previous_unit) != (metric_type, unit)
+                {
+                    return Err(format!(
+                        "collectors.nvue.gnmi.additional_subscriptions[{index}].metrics[{metric_index}] renders the same metric name {exported_name:?} as another extended metric"
+                    ));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// One configuration-defined gNMI STREAM subscription.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NvueGnmiSubscriptionConfig {
+    /// Stable name used to identify the subscription in telemetry and logs.
+    pub name: String,
+
+    /// gNMI target placed on the subscription prefix.
+    pub target: String,
+
+    /// Optional gNMI origin placed on the subscription prefix.
+    pub origin: String,
+
+    /// Unkeyed element names prepended to every subscription path.
+    pub prefix: Vec<String>,
+
+    /// Encoding requested from the gNMI target.
+    pub encoding: NvueGnmiEncoding,
+
+    /// Whether the target should omit the initial data snapshot.
+    pub updates_only: bool,
+
+    /// Delivery mode requested for every path in this subscription.
+    pub mode: NvueGnmiSubscriptionMode,
+
+    /// SAMPLE interval. Required only when `mode` is `sample`.
+    #[serde(with = "humantime_serde::option")]
+    pub sample_interval: Option<Duration>,
+
+    /// Suppress unchanged SAMPLE values between heartbeat updates.
+    pub suppress_redundant: bool,
+
+    /// Optional forced update interval for SAMPLE or ON_CHANGE mode.
+    #[serde(with = "humantime_serde::option")]
+    pub heartbeat_interval: Option<Duration>,
+
+    /// Request paths bundled into this subscription.
+    pub paths: Vec<Vec<String>>,
+
+    /// Exact response paths projected into metrics.
+    pub metrics: Vec<NvueGnmiMetricConfig>,
+}
+
+impl Default for NvueGnmiSubscriptionConfig {
+    fn default() -> Self {
+        Self {
+            name: String::new(),
+            target: "nvos".to_string(),
+            origin: String::new(),
+            prefix: Vec::new(),
+            encoding: NvueGnmiEncoding::default(),
+            updates_only: false,
+            mode: NvueGnmiSubscriptionMode::default(),
+            sample_interval: None,
+            suppress_redundant: false,
+            heartbeat_interval: None,
+            paths: Vec::new(),
+            metrics: Vec::new(),
+        }
+    }
+}
+
+impl NvueGnmiSubscriptionConfig {
+    fn validate(&self, index: usize) -> Result<(), String> {
+        let config_path = format!("collectors.nvue.gnmi.additional_subscriptions[{index}]");
+
+        if !is_gnmi_identifier(&self.name) {
+            return Err(format!(
+                "{config_path}.name must use lower_snake_case and start with a letter"
+            ));
+        }
+
+        if self.prefix.iter().any(|element| element.is_empty()) {
+            return Err(format!(
+                "{config_path} ({:?}).prefix elements must not be empty",
+                self.name
+            ));
+        }
+
+        if self.paths.is_empty()
+            || self
+                .paths
+                .iter()
+                .any(|path| path.is_empty() || path.iter().any(String::is_empty))
+        {
+            return Err(format!(
+                "{config_path} ({:?}).paths must contain non-empty paths and elements",
+                self.name
+            ));
+        }
+
+        if self.metrics.is_empty() {
+            return Err(format!(
+                "{config_path} ({:?}).metrics must not be empty",
+                self.name
+            ));
+        }
+
+        match self.mode {
+            NvueGnmiSubscriptionMode::TargetDefined => {
+                if self.sample_interval.is_some()
+                    || self.suppress_redundant
+                    || self.heartbeat_interval.is_some()
+                {
+                    return Err(format!(
+                        "{config_path} ({:?}) cannot set sample_interval, suppress_redundant, or heartbeat_interval in target_defined mode",
+                        self.name
+                    ));
+                }
+            }
+            NvueGnmiSubscriptionMode::OnChange => {
+                if self.sample_interval.is_some() || self.suppress_redundant {
+                    return Err(format!(
+                        "{config_path} ({:?}) cannot set sample_interval or suppress_redundant in on_change mode",
+                        self.name
+                    ));
+                }
+            }
+            NvueGnmiSubscriptionMode::Sample => {
+                if self.sample_interval.is_none() {
+                    return Err(format!(
+                        "{config_path} ({:?}).sample_interval is required in sample mode",
+                        self.name
+                    ));
+                }
+            }
+        }
+
+        for (field, interval) in [
+            ("sample_interval", self.sample_interval),
+            ("heartbeat_interval", self.heartbeat_interval),
+        ] {
+            if let Some(interval) = interval {
+                if interval.is_zero() {
+                    return Err(format!(
+                        "{config_path} ({:?}).{field} must be greater than 0",
+                        self.name
+                    ));
+                }
+
+                if interval.as_nanos() > u64::MAX as u128 {
+                    return Err(format!(
+                        "{config_path} ({:?}).{field} must fit in gNMI's u64 nanosecond field",
+                        self.name
+                    ));
+                }
+            }
+        }
+
+        let mut metric_paths = HashSet::new();
+
+        for (metric_index, metric) in self.metrics.iter().enumerate() {
+            if !metric_paths.insert(metric.path.as_slice()) {
+                return Err(format!(
+                    "{config_path} ({:?}).metrics[{metric_index}].path is duplicated",
+                    self.name
+                ));
+            }
+
+            metric.validate(&config_path, &self.name, metric_index, &self.prefix)?;
+
+            if !self
+                .paths
+                .iter()
+                .any(|request_path| metric.path.starts_with(request_path))
+            {
+                return Err(format!(
+                    "{config_path} ({:?}).metrics[{metric_index}].path must descend from one of the configured request paths",
+                    self.name
+                ));
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// Encoding requested for one configuration-defined subscription.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NvueGnmiEncoding {
+    /// JSON encoding.
+    #[default]
+    Json,
+
+    /// ASCII encoding.
+    Ascii,
+
+    /// RFC 7951 JSON encoding.
+    JsonIetf,
+}
+
+/// Delivery mode for a configuration-defined STREAM subscription.
+#[derive(Debug, Clone, Copy, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NvueGnmiSubscriptionMode {
+    /// Let the target select SAMPLE or ON_CHANGE behavior.
+    #[default]
+    TargetDefined,
+
+    /// Emit an update when the target observes a value change.
+    OnChange,
+
+    /// Emit values at the configured sample interval.
+    Sample,
+}
+
+/// Metric projection for one exact response path.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NvueGnmiMetricConfig {
+    /// Exact response path relative to the subscription prefix.
+    pub path: Vec<String>,
+
+    /// Lower-snake-case metric type appended to the extended collector name.
+    pub metric_type: String,
+
+    /// Response path keys copied into explicit metric labels.
+    pub labels: Vec<NvueGnmiResponseKeyLabel>,
+
+    /// Value projection applied to matching updates.
+    pub output: NvueGnmiMetricOutput,
+}
+
+impl NvueGnmiMetricConfig {
+    fn validate(
+        &self,
+        subscription_path: &str,
+        subscription_name: &str,
+        index: usize,
+        prefix: &[String],
+    ) -> Result<(), String> {
+        let config_path = format!("{subscription_path}.metrics[{index}]");
+        let context = format!("{config_path} ({subscription_name:?})");
+
+        if self.path.is_empty() || self.path.iter().any(|element| element.is_empty()) {
+            return Err(format!("{context}.path must contain non-empty elements"));
+        }
+
+        if !is_gnmi_identifier(&self.metric_type) {
+            return Err(format!(
+                "{context}.metric_type must use lower_snake_case and start with a letter"
+            ));
+        }
+
+        let mut label_names = HashSet::new();
+
+        for (index, label) in self.labels.iter().enumerate() {
+            if !is_gnmi_identifier(&label.name) {
+                return Err(format!(
+                    "{context}.labels[{index}].name must use lower_snake_case and start with a letter"
+                ));
+            }
+
+            if is_reserved_extended_metric_label(&label.name)
+                || !label_names.insert(label.name.as_str())
+            {
+                return Err(format!(
+                    "{context}.labels[{index}].name {:?} is reserved or duplicated",
+                    label.name
+                ));
+            }
+
+            if label.element.is_empty() || label.key.is_empty() {
+                return Err(format!(
+                    "{context}.labels[{index}].element and key must not be empty"
+                ));
+            }
+
+            let occurrences = prefix
+                .iter()
+                .chain(&self.path)
+                .filter(|element| element.as_str() == label.element)
+                .count();
+
+            if occurrences != 1 {
+                return Err(format!(
+                    "{context}.labels[{index}].element {:?} must occur exactly once in the combined prefix and metric path",
+                    label.element
+                ));
+            }
+        }
+
+        match &self.output {
+            NvueGnmiMetricOutput::Gauge { unit } => {
+                if !is_gnmi_identifier(unit) {
+                    return Err(format!(
+                        "{context}.output.unit must use lower_snake_case and start with a letter"
+                    ));
+                }
+            }
+            NvueGnmiMetricOutput::StateSet { states } => {
+                validate_finite_values(&context, "states", states)?;
+            }
+            NvueGnmiMetricOutput::Info { label, values } => {
+                if !is_gnmi_identifier(label)
+                    || is_reserved_extended_metric_label(label)
+                    || label_names.contains(label.as_str())
+                {
+                    return Err(format!(
+                        "{context}.output.label must be a unique lower_snake_case label"
+                    ));
+                }
+
+                validate_finite_values(&context, "values", values)?;
+            }
+        }
+
+        Ok(())
+    }
+}
+
+/// A metric label read from a named key on one response path element.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct NvueGnmiResponseKeyLabel {
+    /// Metric label name.
+    pub name: String,
+
+    /// Response path element containing the key.
+    pub element: String,
+
+    /// Key name read from the response path element.
+    pub key: String,
+}
+
+/// Supported output form for an extended gNMI metric.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case", deny_unknown_fields)]
+pub enum NvueGnmiMetricOutput {
+    /// Numeric gauge with an operator-defined unit.
+    Gauge {
+        /// Unit appended to the exported metric name.
+        unit: String,
+    },
+
+    /// One 0 or 1 series for each declared state.
+    StateSet {
+        /// Complete finite state domain.
+        states: Vec<String>,
+    },
+
+    /// Constant 1 gauge carrying one finite information label.
+    Info {
+        /// Label that carries the matched extended value.
+        label: String,
+
+        /// Complete finite set of accepted values.
+        values: Vec<String>,
+    },
+}
+
+impl Default for NvueGnmiMetricOutput {
+    fn default() -> Self {
+        Self::Gauge {
+            unit: String::new(),
+        }
+    }
+}
+
+impl NvueGnmiMetricOutput {
+    fn unit(&self) -> &str {
+        match self {
+            Self::Gauge { unit } => unit,
+            Self::StateSet { .. } => "state",
+            Self::Info { .. } => "info",
+        }
+    }
+}
+
+fn validate_finite_values(config_path: &str, field: &str, values: &[String]) -> Result<(), String> {
+    if values.is_empty() {
+        return Err(format!("{config_path}.output.{field} must not be empty"));
+    }
+
+    let mut unique = HashSet::new();
+
+    if values
+        .iter()
+        .any(|value| value.is_empty() || !unique.insert(value.as_str()))
+    {
+        return Err(format!(
+            "{config_path}.output.{field} must contain unique non-empty values"
+        ));
+    }
+
+    Ok(())
+}
+
+fn is_gnmi_identifier(value: &str) -> bool {
+    let mut chars = value.chars();
+
+    chars.next().is_some_and(|first| first.is_ascii_lowercase())
+        && chars.all(|character| {
+            character.is_ascii_lowercase() || character.is_ascii_digit() || character == '_'
+        })
+}
+
+fn is_reserved_extended_metric_label(value: &str) -> bool {
+    RESERVED_ENDPOINT_LABELS.contains(&value) || matches!(value, "state" | "subscription")
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -2217,6 +2660,12 @@ impl Config {
 
         if let Configurable::Enabled(logs) = &self.collectors.logs {
             logs.validate()?;
+        }
+
+        if let Configurable::Enabled(nvue) = &self.collectors.nvue
+            && let Configurable::Enabled(gnmi) = &nvue.gnmi
+        {
+            gnmi.validate()?;
         }
 
         if let Some(tls_config) = &self.tls.switch {
@@ -4241,6 +4690,7 @@ platform_environment_leakage_enabled = false
                 interfaces_enabled: bool,
                 platform_general_enabled: bool,
                 leak_sensors_enabled: bool,
+                additional_subscriptions: usize,
             },
         }
 
@@ -4269,6 +4719,7 @@ platform_environment_leakage_enabled = false
                         interfaces_enabled: true,
                         platform_general_enabled: true,
                         leak_sensors_enabled: false,
+                        additional_subscriptions: 0,
                     },
                 },
                 Check {
@@ -4297,6 +4748,7 @@ leak_sensors_enabled = true
                         interfaces_enabled: true,
                         platform_general_enabled: false,
                         leak_sensors_enabled: true,
+                        additional_subscriptions: 0,
                     },
                 },
                 Check {
@@ -4315,6 +4767,7 @@ system_events_subscription_enabled = false
                         interfaces_enabled: true,
                         platform_general_enabled: true,
                         leak_sensors_enabled: false,
+                        additional_subscriptions: 0,
                     },
                 },
                 Check {
@@ -4333,6 +4786,7 @@ events_enabled = false
                         interfaces_enabled: true,
                         platform_general_enabled: true,
                         leak_sensors_enabled: false,
+                        additional_subscriptions: 0,
                     },
                 },
             ],
@@ -4359,9 +4813,277 @@ events_enabled = false
                     interfaces_enabled: gnmi.paths.interfaces_enabled,
                     platform_general_enabled: gnmi.paths.platform_general_enabled,
                     leak_sensors_enabled: gnmi.paths.leak_sensors_enabled,
+                    additional_subscriptions: gnmi.additional_subscriptions.len(),
                 }
             },
         );
+    }
+
+    #[test]
+    fn nvue_gnmi_additional_subscription_parses_complete_contract() {
+        let config: Config = Figment::new()
+            .merge(Serialized::defaults(Config::default()))
+            .merge(Toml::string(
+                r#"
+[collectors.nvue.gnmi]
+
+[[collectors.nvue.gnmi.additional_subscriptions]]
+name = "external_metrics"
+target = "switch"
+origin = "openconfig"
+prefix = ["interfaces"]
+encoding = "json_ietf"
+updates_only = true
+mode = "sample"
+sample_interval = "10s"
+suppress_redundant = true
+heartbeat_interval = "1m"
+paths = [["interface"]]
+metrics = [
+  { path = ["interface", "state", "health"], metric_type = "interface_health", labels = [{ name = "interface_name", element = "interface", key = "name" }], output = { kind = "state_set", states = ["healthy", "attention"] } },
+  { path = ["interface", "state", "counter"], metric_type = "interface_counter", labels = [{ name = "interface_name", element = "interface", key = "name" }], output = { kind = "gauge", unit = "count" } },
+]
+"#,
+            ))
+            .extract()
+            .expect("complete additional gNMI subscription should parse");
+
+        config
+            .validate()
+            .expect("complete additional gNMI subscription should validate");
+
+        let Configurable::Enabled(nvue) = &config.collectors.nvue else {
+            panic!("NVUE collector should be enabled");
+        };
+
+        let Configurable::Enabled(gnmi) = &nvue.gnmi else {
+            panic!("NVUE gNMI collector should be enabled");
+        };
+
+        let subscription = gnmi
+            .additional_subscriptions
+            .first()
+            .expect("one additional subscription should be configured");
+
+        assert_eq!(subscription.name, "external_metrics");
+        assert_eq!(subscription.target, "switch");
+        assert_eq!(subscription.origin, "openconfig");
+        assert_eq!(subscription.prefix, ["interfaces"]);
+        assert_eq!(subscription.encoding, NvueGnmiEncoding::JsonIetf);
+        assert!(subscription.updates_only);
+        assert_eq!(subscription.paths.len(), 1);
+        assert_eq!(subscription.metrics.len(), 2);
+
+        assert_eq!(subscription.mode, NvueGnmiSubscriptionMode::Sample);
+        assert_eq!(subscription.sample_interval, Some(Duration::from_secs(10)));
+        assert!(subscription.suppress_redundant);
+
+        assert_eq!(
+            subscription.heartbeat_interval,
+            Some(Duration::from_secs(60))
+        );
+    }
+
+    #[test]
+    fn nvue_gnmi_additional_subscription_validation_cases() {
+        #[derive(Clone, Copy)]
+        enum InvalidCase {
+            DuplicateName,
+            EmptyPath,
+            EmptyMetricPath,
+            SampleWithoutInterval,
+            OnChangeWithSampleInterval,
+            ZeroHeartbeat,
+            DuplicateMetricPath,
+            MissingResponseKeyElement,
+            MetricNameCollision,
+            ReservedMetricLabel,
+            UnboundedInfoValues,
+            MetricOutsideRequestPaths,
+        }
+
+        struct Case {
+            scenario: &'static str,
+            invalid: InvalidCase,
+            expected: &'static str,
+        }
+
+        let cases = [
+            Case {
+                scenario: "duplicate subscription name",
+                invalid: InvalidCase::DuplicateName,
+                expected: ".name duplicates",
+            },
+            Case {
+                scenario: "empty path",
+                invalid: InvalidCase::EmptyPath,
+                expected: ".paths must contain non-empty paths and elements",
+            },
+            Case {
+                scenario: "empty metric path",
+                invalid: InvalidCase::EmptyMetricPath,
+                expected: ".path must contain non-empty elements",
+            },
+            Case {
+                scenario: "sample interval required",
+                invalid: InvalidCase::SampleWithoutInterval,
+                expected: ".sample_interval is required in sample mode",
+            },
+            Case {
+                scenario: "sample interval rejected for on change",
+                invalid: InvalidCase::OnChangeWithSampleInterval,
+                expected: "cannot set sample_interval or suppress_redundant",
+            },
+            Case {
+                scenario: "zero heartbeat",
+                invalid: InvalidCase::ZeroHeartbeat,
+                expected: ".heartbeat_interval must be greater than 0",
+            },
+            Case {
+                scenario: "duplicate metric path",
+                invalid: InvalidCase::DuplicateMetricPath,
+                expected: ".path is duplicated",
+            },
+            Case {
+                scenario: "response key element absent from path",
+                invalid: InvalidCase::MissingResponseKeyElement,
+                expected: "must occur exactly once",
+            },
+            Case {
+                scenario: "different metric fields render the same exported name",
+                invalid: InvalidCase::MetricNameCollision,
+                expected: "renders the same metric name",
+            },
+            Case {
+                scenario: "metric label conflicts with endpoint metadata",
+                invalid: InvalidCase::ReservedMetricLabel,
+                expected: "is reserved or duplicated",
+            },
+            Case {
+                scenario: "info values must be finite",
+                invalid: InvalidCase::UnboundedInfoValues,
+                expected: ".output.values must not be empty",
+            },
+            Case {
+                scenario: "metric path outside requested subtrees",
+                invalid: InvalidCase::MetricOutsideRequestPaths,
+                expected: ".path must descend from one of the configured request paths",
+            },
+        ];
+
+        for case in cases {
+            let metric = NvueGnmiMetricConfig {
+                path: vec![
+                    "interface".to_string(),
+                    "state".to_string(),
+                    "value".to_string(),
+                ],
+                metric_type: "configured_value".to_string(),
+                labels: vec![NvueGnmiResponseKeyLabel {
+                    name: "interface_name".to_string(),
+                    element: "interface".to_string(),
+                    key: "name".to_string(),
+                }],
+                output: NvueGnmiMetricOutput::Gauge {
+                    unit: "count".to_string(),
+                },
+            };
+
+            let subscription = NvueGnmiSubscriptionConfig {
+                name: "external_metrics".to_string(),
+                prefix: vec!["interfaces".to_string()],
+                mode: NvueGnmiSubscriptionMode::OnChange,
+                heartbeat_interval: Some(Duration::from_secs(30)),
+                paths: vec![vec!["interface".to_string()]],
+                metrics: vec![metric],
+                ..Default::default()
+            };
+
+            let mut gnmi = NvueGnmiConfig {
+                additional_subscriptions: vec![subscription],
+                ..Default::default()
+            };
+
+            match case.invalid {
+                InvalidCase::DuplicateName => {
+                    gnmi.additional_subscriptions
+                        .push(gnmi.additional_subscriptions[0].clone());
+                }
+                InvalidCase::EmptyPath => {
+                    gnmi.additional_subscriptions[0].paths[0].clear();
+                }
+                InvalidCase::EmptyMetricPath => {
+                    gnmi.additional_subscriptions[0].metrics[0].path.clear();
+                }
+                InvalidCase::SampleWithoutInterval => {
+                    gnmi.additional_subscriptions[0].mode = NvueGnmiSubscriptionMode::Sample;
+                    gnmi.additional_subscriptions[0].heartbeat_interval = None;
+                }
+                InvalidCase::OnChangeWithSampleInterval => {
+                    gnmi.additional_subscriptions[0].sample_interval =
+                        Some(Duration::from_secs(10));
+                }
+                InvalidCase::ZeroHeartbeat => {
+                    gnmi.additional_subscriptions[0].heartbeat_interval = Some(Duration::ZERO);
+                }
+                InvalidCase::DuplicateMetricPath => {
+                    let metric = gnmi.additional_subscriptions[0].metrics[0].clone();
+                    gnmi.additional_subscriptions[0].metrics.push(metric);
+                }
+                InvalidCase::MissingResponseKeyElement => {
+                    gnmi.additional_subscriptions[0].metrics[0].labels[0].element =
+                        "component".to_string();
+                }
+                InvalidCase::MetricNameCollision => {
+                    let mut metric = gnmi.additional_subscriptions[0].metrics[0].clone();
+
+                    metric.path.push("other".to_string());
+
+                    metric.metric_type = "configured".to_string();
+
+                    metric.output = NvueGnmiMetricOutput::Gauge {
+                        unit: "value_count".to_string(),
+                    };
+
+                    gnmi.additional_subscriptions[0].metrics.push(metric);
+                }
+                InvalidCase::ReservedMetricLabel => {
+                    gnmi.additional_subscriptions[0].metrics[0].labels[0].name =
+                        "endpoint_key".to_string();
+                }
+                InvalidCase::UnboundedInfoValues => {
+                    gnmi.additional_subscriptions[0].metrics[0].output =
+                        NvueGnmiMetricOutput::Info {
+                            label: "status".to_string(),
+                            values: Vec::new(),
+                        };
+                }
+                InvalidCase::MetricOutsideRequestPaths => {
+                    gnmi.additional_subscriptions[0].paths[0][0] = "component".to_string();
+                }
+            }
+
+            let error = gnmi
+                .validate()
+                .expect_err("invalid additional gNMI subscription should fail validation");
+
+            assert!(
+                error.contains(case.expected),
+                "{}: expected {error:?} to contain {:?}",
+                case.scenario,
+                case.expected
+            );
+
+            assert!(
+                error.contains(if matches!(case.invalid, InvalidCase::DuplicateName) {
+                    "additional_subscriptions[1]"
+                } else {
+                    "additional_subscriptions[0]"
+                }),
+                "{}: {error}",
+                case.scenario
+            );
+        }
     }
 
     #[test]

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1901,11 +1901,12 @@ impl NvueGnmiConfig {
             for (metric_index, metric) in subscription.metrics.iter().enumerate() {
                 let metric_type = metric.metric_type.as_str();
                 let unit = metric.output.unit();
+                let output_kind = metric.output.kind();
                 let exported_name = format!("{metric_type}_{unit}");
 
-                if let Some((previous_type, previous_unit)) =
-                    exported_metrics.insert(exported_name.clone(), (metric_type, unit))
-                    && (previous_type, previous_unit) != (metric_type, unit)
+                if let Some(previous) =
+                    exported_metrics.insert(exported_name.clone(), (metric_type, unit, output_kind))
+                    && previous != (metric_type, unit, output_kind)
                 {
                     return Err(format!(
                         "collectors.nvue.gnmi.additional_subscriptions[{index}].metrics[{metric_index}] renders the same metric name {exported_name:?} as another extended metric"
@@ -2279,6 +2280,10 @@ impl Default for NvueGnmiMetricOutput {
 }
 
 impl NvueGnmiMetricOutput {
+    fn kind(&self) -> std::mem::Discriminant<Self> {
+        std::mem::discriminant(self)
+    }
+
     fn unit(&self) -> &str {
         match self {
             Self::Gauge { unit } => unit,
@@ -4897,6 +4902,7 @@ metrics = [
             DuplicateMetricPath,
             MissingResponseKeyElement,
             MetricNameCollision,
+            OutputKindCollision,
             ReservedMetricLabel,
             UnboundedInfoValues,
             MetricOutsideRequestPaths,
@@ -4952,6 +4958,11 @@ metrics = [
             Case {
                 scenario: "different metric fields render the same exported name",
                 invalid: InvalidCase::MetricNameCollision,
+                expected: "renders the same metric name",
+            },
+            Case {
+                scenario: "different output kinds render the same exported name",
+                invalid: InvalidCase::OutputKindCollision,
                 expected: "renders the same metric name",
             },
             Case {
@@ -5043,6 +5054,22 @@ metrics = [
 
                     metric.output = NvueGnmiMetricOutput::Gauge {
                         unit: "value_count".to_string(),
+                    };
+
+                    gnmi.additional_subscriptions[0].metrics.push(metric);
+                }
+                InvalidCase::OutputKindCollision => {
+                    gnmi.additional_subscriptions[0].metrics[0].output =
+                        NvueGnmiMetricOutput::Gauge {
+                            unit: "state".to_string(),
+                        };
+
+                    let mut metric = gnmi.additional_subscriptions[0].metrics[0].clone();
+
+                    metric.path.push("other".to_string());
+
+                    metric.output = NvueGnmiMetricOutput::StateSet {
+                        states: vec!["healthy".to_string()],
                     };
 
                     gnmi.additional_subscriptions[0].metrics.push(metric);


### PR DESCRIPTION
Add optional `collectors.nvue.gnmi.additional_subscriptions` entries for collecting and projecting gNMI data. Each entry runs as an independent STREAM RPC, bundles one or more request paths, and maps response paths to gauge, state-set, or info metrics.

Subscriptions support configurable prefixes, encodings, delivery modes, intervals, and path-key labels. Configuration is validated at startup, categorical values are bounded by declared domains, and stream failures remain isolated to the affected additional subscription. Additional subscriptions default to an empty list, and configuration changes require a service restart.

## Related Issues

Resolves #5880

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)