### PR TITLE
fix(helm): render OTEL_EXPORTER_OTLP_TRACES_ENDPOINT in nico-api deployment

### DIFF
--- a/helm/charts/nico-api/templates/deployment.yaml
+++ b/helm/charts/nico-api/templates/deployment.yaml
@@ -225,6 +225,10 @@ spec:
               value: {{ .Values.env.RUST_BACKTRACE | quote }}
             - name: RUST_LIB_BACKTRACE
               value: {{ .Values.env.RUST_LIB_BACKTRACE | quote }}
+            {{- with .Values.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT }}
+            - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
+              value: {{ . | quote }}
+            {{- end }}
             {{- with .Values.dsxExchangeEventBusConfig }}
             - name: CARBIDE_API_DSX_EXCHANGE_EVENT_BUS
               value: {{ . | quote }}


### PR DESCRIPTION
Add `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` to the env vars rendered from `.Values.env`.
This enables configuring the OTLP traces endpoint for OpenTelemetry integration.

## Related issues
- Closes #5886 

## Type of Change
- [x] **Fix** - Bug fixes

## Testing
- [x] Manual testing performed

```bash
helm template test helm/charts/nico-api \
  --set env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT="http://otel-collector:4317" \
  | grep -A1 OTEL_EXPORTER
# - name: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
#   value: "http://otel-collector:4317"
```