### PR TITLE
Document the admin CLI page-size default and receive limit

### DIFF
--- a/dev/mac-local-dev/README.md
+++ b/dev/mac-local-dev/README.md
@@ -3,17 +3,20 @@
 ## Summary
 
 For local development on macOS, this setup runs the full stack (core+rest) on macOS:
+
 - core: dependencies in docker but `nico-api` runs natively on macOS
 - rest: everything runs in docker
 
 **Usage:**
+
 - start NICo API (core) with `dev/mac-local-dev/run-nico-api.sh`<br>
-  You can access `nico-api` admin at https://localhost:1079/admin
+  You can access `nico-api` admin at [https://localhost:1079/admin](https://localhost:1079/admin)
 - start NICo REST API (rest) with `cd rest-api && make kind-reset LOCAL_CORE=true`<br>
   `make` will display all relevant URLs and credentials for the REST API, Temporal, and Keycloak.
 - you can test the full-stack integration (REST API client -> REST API -> NICo API) by running `dev/mac-local-dev/check-rest-core-integration.sh`.
 
 > **Limitations**
+>
 > - TPM / attestation features require Linux and a physical TPM — they are disabled in this setup.
 > - `machine-a-tron` relies on Linux-specific features and is unusable on macOS (can build).
 
@@ -40,11 +43,11 @@ Run from **any directory** — the script resolves the repo root automatically:
 ./dev/mac-local-dev/run-nico-api.sh
 ```
 
-The script is fully self-contained and idempotent.  On each run it:
+The script is fully self-contained and idempotent. On each run it:
 
 1. Checks prerequisites (`docker`, `cargo`, `jq`, `curl`).
 2. Starts a **Vault** container (`nico-vault`) on port **8201** and initialises it
-   (KV secrets + PKI) if not already running.  The root token is cached at
+   (KV secrets + PKI) if not already running. The root token is cached at
    `/tmp/nico-localdev-vault-root-token`.
 3. Regenerates **TLS certificates** under `dev/certs/localhost/` if they are
    missing or stale (`gen-certs.sh` is idempotent).
@@ -156,6 +159,7 @@ In a **second terminal**, use the wrapper script to talk to the running API:
 ```
 
 The script:
+
 - Builds `nico-admin-cli` automatically if `target/debug/nico-admin-cli`
   does not exist.
 - Wires up TLS using the locally-generated certs from `dev/certs/localhost/`
@@ -173,7 +177,13 @@ The script:
 | `--extended` | | Include internal UUIDs and extra fields |
 | `--sort-by <field>` | | `primary-id` (default) or `state` |
 | `--debug` | `-d` | Increase log verbosity (repeat for trace) |
-| `--internal-page-size N` | `-p` | Paging size for list calls (default 100) |
+| `--internal-page-size N` | `-p` | Paging size for list calls, 1-100 (default 25) |
+
+Smaller pages help keep each gRPC reply under the client's 4 MiB receive limit. If a
+reply still exceeds it, raise the limit by setting `TONIC_MAX_DECODING_MESSAGE_SIZE`
+to a positive whole number of bytes (for example `33554432` for 32 MiB) before
+running the CLI. A value that does not parse as a whole number is ignored and the
+4 MiB default stays in effect; `0` is not ignored and rejects every non-empty reply.
 
 ### Common subcommands
 
@@ -223,7 +233,7 @@ Then restart `run-nico-api.sh` (the API must load the new server cert).
 
 > **Note:** `dev/certs/server_identity.pem` and
 > `dev/certs/nico_developer_local_only_root_cert_pem` are checked-in certs
-> that expired in 2023/2024.  Do **not** use them — the scripts default to the
+> that expired in 2023/2024. Do **not** use them — the scripts default to the
 > locally-generated `localhost/` certs instead.
 
 ---
@@ -250,11 +260,11 @@ echo "VAULT_TOKEN=$(cat /tmp/nico-localdev-vault-root-token)"
 
 Cargo run parameters:
 
-```
+```text
 run --package nico-api --no-default-features -- run
 --config-path <absolute-path-to-repo>/dev/mac-local-dev/nico-api-config.toml
 ```
 
-> The config file uses CWD-relative TLS paths.  Set the IDE run configuration's
+> The config file uses CWD-relative TLS paths. Set the IDE run configuration's
 > **Working Directory** to the repository root, or use the absolute-path temp
 > config that `run-nico-api.sh` writes to `/tmp/nico-api-config-<PID>.toml`.


### PR DESCRIPTION
The macOS local-development guide's flag table still quoted `--internal-page-size` as defaulting to 100. #5867 lowered the default to 25 so a page of machines stays under tonic's 4 MiB receive limit, which left this table describing behavior the CLI no longer has.

This updates the row to the new default and its 1-100 range, and adds a short note on raising the receive limit itself with `TONIC_MAX_DECODING_MESSAGE_SIZE`: it is a byte count, a value that does not parse is ignored so the 4 MiB default stays in effect, and `0` rejects every non-empty reply. That variable was previously documented nowhere outside the CLI's own `--help`.

It also applies the repository's Markdown lint fixes to the file, which otherwise fails `rumdl check` with ten pre-existing findings. These documentation changes were kept out of #5867 so that PR stayed code-only.

## Related issues
None.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`nico-admin-cli --help` built at this revision renders `[default: 25]` and the 1-100 range for `--internal-page-size`, matching the updated table.

## Additional Notes
Follow-up to #5867.
