### PR TITLE
Fix Vault KV v2 metadata list capability for password import

### DIFF
--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -241,6 +241,9 @@ spec:
               path "{{ .Values.vault.kvMount }}/data/*" {
                 capabilities = ["read", "list"]
               }
+              path "{{ .Values.vault.kvMount }}/metadata/*" {
+                capabilities = ["list"]
+              }
               path "{{ .Values.vault.kvMount }}/data/machines*" {
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
@@ -248,7 +251,7 @@ spec:
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
               path "{{ .Values.vault.kvMount }}/metadata/machines/*" {
-                capabilities = ["delete"]
+                capabilities = ["list", "delete"]
               }
               path "{{ .Values.vault.kvMount }}/destroy/machines/*" {
                 capabilities = ["delete"]


### PR DESCRIPTION
Vault KV v2's `LIST` operation is served off the `metadata/` endpoint, not
`data/`. `nico-vault-policy` only granted `list` on `data/*`, which has no
effect on Vault's ACL check for `LIST` requests. This broke the
Vault-to-Postgres password import (`import_vault_secrets_once` in
`crates/api/src/resources.rs`), which recursively enumerates secrets via
`kv2::list` (`crates/secrets/src/forge_vault.rs`) starting from the KV
mount root — every `LIST secrets/metadata/...` call was denied, and since
the import uses `EnumerationMode::Strict`, it aborted outright rather than
silently skipping.

This adds a `list` grant on `{{ kvMount }}/metadata/*` so the general
recursive enumeration succeeds. It also adds `list` to the existing
`metadata/machines/*` rule specifically: Vault ACLs resolve each request
against the single most-specific matching path glob rather than unioning
capabilities across all matching rules, so the narrower `machines/*` rule
(previously `delete`-only) would otherwise continue to shadow the new
`metadata/*` grant for the machines subtree, which the import always
walks into.

The other existing narrower `metadata/*` rules (`firmware_artifacts/+/access-token`,
`racks/+/maintenance/access-token`) use single-segment (`+`) wildcards tied to
an exact leaf suffix, so they don't intercept the directory-level `LIST`
calls the import issues and don't need changes.

## Related issues

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Verified by tracing the exact `kv2::list` call chain used by the import
(`crates/secrets/src/forge_vault.rs`) against the `vaultrs` crate's request
builder to confirm it issues `LIST {mount}/metadata/{path}`, and by
reasoning through Vault's most-specific-path ACL resolution for every
existing policy rule in this block. This is a Helm-templated policy
manifest with no unit-testable Rust surface; it has not yet been exercised
against a live Vault instance. Recommend a reviewer or deploy owner
validate against a real Vault (or the `helm-prereqs` dev cluster) that the
import now succeeds end-to-end.

## Additional Notes

Manual verification command for a live Vault instance (rewrites the whole
named policy, since `vault policy write` is a full replace, not a patch):

```bash
vault policy write nico-vault-policy - <<'POLICY'
# ... (see helm-prereqs/templates/vault-config-job.yaml for full contents)
POLICY
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)