### PR TITLE
fix(site-explorer): skip switch and power shelf SecureBoot warnings

### DIFF
--- a/crates/bmc-explorer/src/lib.rs
+++ b/crates/bmc-explorer/src/lib.rs
@@ -279,10 +279,17 @@ pub async fn nv_generate_exploration_report<B: Bmc>(
         .transpose()?
         .and_then(identity);
 
-    let secure_boot_status = explored_system
-        .secure_boot_status()
-        .inspect_err(|error| tracing::warn!(%error, "Failed to fetch forge secure boot status."))
-        .ok();
+    let secure_boot_status = match hw_type {
+        Some(hw::HwType::LiteonPowerShelf | hw::HwType::DeltaPowerShelf | hw::HwType::NvSwitch) => {
+            None
+        }
+        _ => explored_system
+            .secure_boot_status()
+            .inspect_err(
+                |error| tracing::warn!(%error, "Failed to fetch forge secure boot status."),
+            )
+            .ok(),
+    };
 
     let machine_setup_status = hw_type
         .map(|hw_type| {


### PR DESCRIPTION
Power shelves and switches do not have any secure boot but site-explorer generate warning on each exploration.

This PR suppress these warning messages.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

