### PR TITLE
fix(dhcp): ignore SIGPIPE in the Kea hook so a closed API socket is not fatal

### DIFF
--- a/crates/dhcp/src/kea/loader.cc
+++ b/crates/dhcp/src/kea/loader.cc
@@ -15,6 +15,8 @@
  * limitations under the License.
  */
 
+#include <csignal>
+
 #include <asiolink/io_address.h>
 #include <asiolink/io_error.h>
 #include <hooks/hooks.h>
@@ -191,6 +193,11 @@ int shim_load(void *handle_ptr) {
   LibraryHandle *handle = static_cast<LibraryHandle *>(handle_ptr);
 
   LOG_INFO(loader_logger, isc::log::LOG_CARBIDE_INITIALIZATION);
+
+  // Rust installs SIG_IGN for SIGPIPE in lang_start, which runs only for Rust
+  // binaries. This hook is a cdylib loaded into Kea, so the disposition stays
+  // SIG_DFL and a write to a closed Carbide API socket terminates the server.
+  signal(SIGPIPE, SIG_IGN);
 
   auto family = configured_family();
   // Family-specific validation must happen before common metrics startup,


### PR DESCRIPTION
fix(dhcp): ignore SIGPIPE in the Kea hook so a closed API socket is not fatal

crates/dhcp is a cdylib loaded into kea-dhcp4, so Rust's runtime entry point never runs and the SIG_IGN for SIGPIPE that std installs for every Rust binary is never applied. The disposition stays SIG_DFL, which turns any write to a closed carbide-api socket into process termination with exit 141 rather than an EPIPE return; tokio, hyper and tonic all issue plain socket writes and assume that ignore is in place. Setting it in shim_load, before any callout is registered, restores the environment the async client stack is written against and lets the failure surface through the existing error path instead of pre-empting it.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
This is already standard behavior for _all_ Rust Unix binaries (it's done in lang_start in the Rust runtime); we just didn't inherit it because we're a cdylib.  Every async library already expects this signal to be handled like this, and this bug has therefore existed for quite some time; recent changes to main have just exposed it.