### PR TITLE
Fix Vault KV v2 metadata list capability for password import

### DIFF
--- a/helm-prereqs/templates/vault-config-job.yaml
+++ b/helm-prereqs/templates/vault-config-job.yaml
@@ -241,6 +241,9 @@ spec:
               path "{{ .Values.vault.kvMount }}/data/*" {
                 capabilities = ["read", "list"]
               }
+              path "{{ .Values.vault.kvMount }}/metadata/*" {
+                capabilities = ["list"]
+              }
               path "{{ .Values.vault.kvMount }}/data/machines*" {
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
@@ -248,7 +251,7 @@ spec:
                 capabilities = ["create", "read", "patch", "list", "update", "delete"]
               }
               path "{{ .Values.vault.kvMount }}/metadata/machines/*" {
-                capabilities = ["delete"]
+                capabilities = ["list", "delete"]
               }
               path "{{ .Values.vault.kvMount }}/destroy/machines/*" {
                 capabilities = ["delete"]


### PR DESCRIPTION
Backport of #5893 to `release/v2.2`.

Vault KV v2's `LIST` operation is served off the `metadata/` endpoint, not
`data/`. `nico-vault-policy` only granted `list` on `data/*`, which has no
effect on Vault's ACL check for `LIST` requests. This broke the
Vault-to-Postgres password import (`import_vault_secrets_once` in
`crates/api/src/resources.rs`), which recursively enumerates secrets via
`kv2::list` (`crates/secrets/src/forge_vault.rs`) starting from the KV
mount root — every `LIST secrets/metadata/...` call was denied, and since
the import uses `EnumerationMode::Strict`, it aborted outright rather than
silently skipping.

This adds a `list` grant on `{{ kvMount }}/metadata/*` so the general
recursive enumeration succeeds. It also adds `list` to the existing
`metadata/machines/*` rule specifically: Vault ACLs resolve each request
against the single most-specific matching path glob rather than unioning
capabilities across all matching rules, so the narrower `machines/*` rule
(previously `delete`-only) would otherwise continue to shadow the new
`metadata/*` grant for the machines subtree, which the import always
walks into.

Clean cherry-pick of the merged commit onto `release/v2.2`, no conflicts.

## Related issues
Backport of #5893

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Same fix as #5893, cherry-picked unmodified. See that PR for the
verification performed (call-chain tracing and Vault ACL reasoning); it
has not been exercised against a live Vault instance.

## Additional Notes

Cherry-picked from `main` commit cedb4b13a onto `release/v2.2` with no
conflicts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)