### PR TITLE
fix(flow): reject unlinked rack operation targets

### DIFF
--- a/rest-api/flow/internal/db/model/task.go
+++ b/rest-api/flow/internal/db/model/task.go
@@ -48,8 +48,8 @@ type Task struct {
 	StartedAt     *time.Time                `bun:"started_at"`
 	FinishedAt    *time.Time                `bun:"finished_at"`
 
-	// QueueExpiresAt is set only for waiting tasks. After this time, the
-	// Promoter will discard the task instead of promoting it.
+	// QueueExpiresAt is set for pre-execution waits. After this time, the
+	// Promoter or task manager terminates the task instead of executing it.
 	QueueExpiresAt *time.Time `bun:"queue_expires_at"`
 
 	IdempotencyKey string     `bun:"idempotency_key,nullzero"`
@@ -133,14 +133,16 @@ func (t *Task) UpdateScheduledTask(
 	return err
 }
 
-// UpdateTaskStatus updates the status of the task.
-// report, when non-nil, replaces the stored report column.
+// UpdateTaskStatus updates the status of the task. Non-nil report and
+// queueExpiresAt values replace their corresponding stored columns. Finished
+// statuses clear queueExpiresAt because the deadline applies only while waiting.
 func (t *Task) UpdateTaskStatus(
 	ctx context.Context,
 	idb bun.IDB,
 	status taskcommon.TaskStatus,
 	message string,
 	report json.RawMessage,
+	queueExpiresAt *time.Time,
 ) error {
 	t.Status = status
 	t.Message = message
@@ -151,15 +153,20 @@ func (t *Task) UpdateTaskStatus(
 		t.Report = report
 		columns = append(columns, "report")
 	}
-
 	if status == taskcommon.TaskStatusRunning && t.StartedAt == nil {
 		t.StartedAt = &t.UpdatedAt
 		columns = append(columns, "started_at")
 	}
 	if status.IsFinished() {
 		t.FinishedAt = &t.UpdatedAt
+		t.QueueExpiresAt = nil
+		columns = append(columns, "queue_expires_at")
 	} else {
 		t.FinishedAt = nil
+		if queueExpiresAt != nil {
+			t.QueueExpiresAt = queueExpiresAt
+			columns = append(columns, "queue_expires_at")
+		}
 	}
 
 	_, err := idb.NewUpdate().

--- a/rest-api/flow/internal/db/model/task_test.go
+++ b/rest-api/flow/internal/db/model/task_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/DATA-DOG/go-sqlmock"
 	"github.com/google/uuid"
@@ -52,6 +53,65 @@ func TestListTasks_DefaultOrderBeforePagination(t *testing.T) {
 	assert.Empty(t, tasks)
 	assert.Equal(t, int32(1), total)
 	require.NoError(t, mock.ExpectationsWereMet())
+}
+
+func TestTask_UpdateTaskStatus(t *testing.T) {
+	t.Run("persists a queue deadline", func(t *testing.T) {
+		sqlDB, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer sqlDB.Close()
+
+		db := bun.NewDB(sqlDB, pgdialect.New())
+		defer db.Close()
+
+		deadline := time.Date(2030, time.January, 2, 3, 4, 5, 0, time.UTC)
+		mock.ExpectExec(
+			`UPDATE "task" AS "t" SET .*"queue_expires_at" = '2030-01-02 03:04:05\+00:00'.* WHERE \(id =`,
+		).WillReturnResult(sqlmock.NewResult(0, 1))
+		task := &Task{ID: uuid.New()}
+
+		err = task.UpdateTaskStatus(
+			t.Context(),
+			db,
+			taskcommon.TaskStatusWaiting,
+			"Waiting for target linkage",
+			nil,
+			&deadline,
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, taskcommon.TaskStatusWaiting, task.Status)
+		require.Equal(t, deadline, *task.QueueExpiresAt)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
+
+	t.Run("clears the queue deadline when finished", func(t *testing.T) {
+		sqlDB, mock, err := sqlmock.New()
+		require.NoError(t, err)
+		defer sqlDB.Close()
+
+		db := bun.NewDB(sqlDB, pgdialect.New())
+		defer db.Close()
+
+		mock.ExpectExec(`UPDATE "task" AS "t" SET .*"queue_expires_at" = NULL.* WHERE \(id =`).
+			WillReturnResult(sqlmock.NewResult(0, 1))
+		deadline := time.Now().Add(time.Hour).UTC()
+		task := &Task{ID: uuid.New(), QueueExpiresAt: &deadline}
+
+		err = task.UpdateTaskStatus(
+			t.Context(),
+			db,
+			taskcommon.TaskStatusTerminated,
+			"Expired",
+			nil,
+			nil,
+		)
+
+		require.NoError(t, err)
+		require.Nil(t, task.QueueExpiresAt)
+		require.NotNil(t, task.FinishedAt)
+		require.NoError(t, mock.ExpectationsWereMet())
+	})
 }
 
 // All tests below set TaskType: TaskTypeUnknown explicitly, matching the

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
@@ -249,11 +249,10 @@ func successfulInventoryEntry(
 }
 
 // bmcFirmwareVersion resolves BMC firmware for compute, switch, and power-shelf
-// inventory. Precedence is Core's canonical "bmc" version, then the exact raw
-// inventory ID "BMC", then the legacy "BMC image" description. Retaining the
-// description match as a fallback lets an exact ID later in the report win
-// regardless of inventory ordering. Within each raw fallback tier, the first
-// nonblank match wins.
+// inventory. Precedence is Core's canonical "bmc" version, then a known host
+// BMC inventory ID, then the legacy "BMC image" description. Retaining the
+// description match as a fallback lets a host BMC ID later in the report win
+// over accelerator BMC entries regardless of inventory ordering.
 func bmcFirmwareVersion(report *corev1.EndpointExplorationReport) string {
 	if report == nil {
 		return ""
@@ -269,7 +268,8 @@ func bmcFirmwareVersion(report *corev1.EndpointExplorationReport) string {
 			if version == "" {
 				continue
 			}
-			if inv.GetId() == "BMC" {
+			switch inv.GetId() {
+			case "BMC", "FW_BMC_0", "HostBMC_0":
 				return version
 			}
 			if descriptionFallback == "" && inv.GetDescription() == "BMC image" {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
@@ -4,7 +4,6 @@
 package inventorysync
 
 import (
-	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -188,6 +187,11 @@ func TestPlanDpuBMCReconciliation(t *testing.T) {
 }
 
 func TestReconcileDpuBMCs(t *testing.T) {
+	t.Run("reconciles BMCs by MAC", testReconcileDpuBMCsByMAC)
+	t.Run("invalid snapshot preserves rows", testReconcileDpuBMCsInvalidSnapshotPreservesRows)
+}
+
+func testReconcileDpuBMCsByMAC(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 	dpuType := devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU)
 
@@ -241,7 +245,7 @@ func TestReconcileDpuBMCs(t *testing.T) {
 	assert.Equal(t, componentB.ID, moved.ComponentID)
 }
 
-func TestReconcileDpuBMCsInvalidSnapshotPreservesRows(t *testing.T) {
+func testReconcileDpuBMCsInvalidSnapshotPreservesRows(t *testing.T) {
 	ctx, pool := mirrorTestPool(t)
 	component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute), ComponentID: strPtr("host-1")}
 	require.NoError(t, component.Create(ctx, pool.DB))
@@ -262,127 +266,4 @@ func TestReconcileDpuBMCsInvalidSnapshotPreservesRows(t *testing.T) {
 	require.NoError(t, pool.DB.NewSelect().Model(&got).Scan(ctx))
 	require.Len(t, got, 1)
 	assert.Equal(t, existing.MacAddress, got[0].MacAddress)
-}
-
-func TestSyncMachinesLinksHostAndReconcilesAssociatedDPUInOneCycle(t *testing.T) {
-	ctx, pool := mirrorTestPool(t)
-	const hostMAC = "aa:bb:cc:dd:ee:10"
-	const dpuMAC = "aa:bb:cc:dd:ee:11"
-
-	component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)}
-	require.NoError(t, component.Create(ctx, pool.DB))
-	createTestBMC(ctx, t, pool, component.ID, hostMAC)
-
-	client := nicoapi.NewMockClient()
-	client.AddMachine(nicoapi.MachineDetail{
-		MachineID:               "host-1",
-		MachineType:             corev1.MachineType_HOST.String(),
-		BmcMac:                  hostMAC,
-		AssociatedDpuMachineIDs: []string{"dpu-1"},
-	})
-	client.AddMachine(nicoapi.MachineDetail{
-		MachineID:   "dpu-1",
-		MachineType: corev1.MachineType_DPU.String(),
-		BmcMac:      dpuMAC,
-		BmcIP:       "10.0.0.11",
-	})
-
-	_, drifts, ok := syncMachines(ctx, pool, client)
-
-	require.True(t, ok)
-	assert.Empty(t, drifts)
-	var persistedComponent model.Component
-	require.NoError(t, pool.DB.NewSelect().Model(&persistedComponent).Where("id = ?", component.ID).Scan(ctx))
-	require.NotNil(t, persistedComponent.ComponentID)
-	assert.Equal(t, "host-1", *persistedComponent.ComponentID)
-	var dpu model.BMC
-	require.NoError(t, pool.DB.NewSelect().Model(&dpu).Where("mac_address = ?", dpuMAC).Scan(ctx))
-	assert.Equal(t, devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU), dpu.Type)
-	assert.Equal(t, component.ID, dpu.ComponentID)
-	assert.Equal(t, "10.0.0.11", *dpu.IPAddress)
-}
-
-func TestSyncMachinesGetMachinesFailurePreservesDPUInventory(t *testing.T) {
-	ctx, pool := mirrorTestPool(t)
-	component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)}
-	require.NoError(t, component.Create(ctx, pool.DB))
-	existing := model.BMC{
-		MacAddress:  "aa:bb:cc:dd:ee:11",
-		Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU),
-		ComponentID: component.ID,
-	}
-	_, err := pool.DB.NewInsert().Model(&existing).Exec(ctx)
-	require.NoError(t, err)
-
-	_, _, ok := syncMachines(ctx, pool, &failGetMachinesClient{Client: nicoapi.NewMockClient()})
-
-	assert.False(t, ok)
-	var got []model.BMC
-	require.NoError(t, pool.DB.NewSelect().Model(&got).Scan(ctx))
-	require.Len(t, got, 1)
-	assert.Equal(t, existing.MacAddress, got[0].MacAddress)
-}
-
-func TestSyncMachinesDpuFailureDoesNotBlockHostConvergence(t *testing.T) {
-	ctx, pool := mirrorTestPool(t)
-	component := model.Component{
-		Type:        devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
-		ComponentID: strPtr("host-1"),
-	}
-	require.NoError(t, component.Create(ctx, pool.DB))
-	createTestBMC(ctx, t, pool, component.ID, "aa:bb:cc:dd:ee:10")
-
-	client := nicoapi.NewMockClient()
-	client.AddMachine(nicoapi.MachineDetail{
-		MachineID:               "host-1",
-		MachineType:             corev1.MachineType_HOST.String(),
-		BmcMac:                  "aa:bb:cc:dd:ee:10",
-		AssociatedDpuMachineIDs: []string{"missing-dpu"},
-	})
-	client.AddPowerState("host-1", nicoapi.PowerStateOn)
-
-	_, _, ok := syncMachines(ctx, pool, client)
-
-	assert.False(t, ok, "the cycle remains degraded when DPU reconciliation fails")
-	var persisted model.Component
-	require.NoError(t, pool.DB.NewSelect().Model(&persisted).Where("id = ?", component.ID).Scan(ctx))
-	require.NotNil(t, persisted.PowerState)
-	assert.Equal(t, nicoapi.PowerStateOn, *persisted.PowerState)
-}
-
-func TestSyncMachinesPositionFailureDoesNotBlockDPUReconciliation(t *testing.T) {
-	ctx, pool := mirrorTestPool(t)
-	const hostMAC = "aa:bb:cc:dd:ee:20"
-	const dpuMAC = "aa:bb:cc:dd:ee:21"
-	component := model.Component{
-		Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
-	}
-	require.NoError(t, component.Create(ctx, pool.DB))
-	createTestBMC(ctx, t, pool, component.ID, hostMAC)
-
-	client := &actualInventoryTestClient{
-		Client: nicoapi.NewMockClient(),
-		machines: []nicoapi.MachineDetail{
-			{
-				MachineID:               "host-1",
-				MachineType:             corev1.MachineType_HOST.String(),
-				BmcMac:                  hostMAC,
-				AssociatedDpuMachineIDs: []string{"dpu-1"},
-			},
-			{
-				MachineID:   "dpu-1",
-				MachineType: corev1.MachineType_DPU.String(),
-				BmcMac:      dpuMAC,
-			},
-		},
-		machinePositionErr: errors.New("positions unavailable"),
-	}
-
-	_, _, ok := syncMachines(ctx, pool, client)
-
-	assert.False(t, ok)
-	var dpu model.BMC
-	require.NoError(t, pool.DB.NewSelect().Model(&dpu).Where("mac_address = ?", dpuMAC).Scan(ctx))
-	assert.Equal(t, devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU), dpu.Type)
-	assert.Equal(t, component.ID, dpu.ComponentID)
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
@@ -201,6 +201,129 @@ func TestSyncMachines(t *testing.T) {
 			}
 		})
 	}
+
+	t.Run("links host and reconciles associated DPU in one cycle", func(t *testing.T) {
+		ctx, pool := mirrorTestPool(t)
+		const hostMAC = "aa:bb:cc:dd:ee:10"
+		const dpuMAC = "aa:bb:cc:dd:ee:11"
+
+		component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)}
+		require.NoError(t, component.Create(ctx, pool.DB))
+		createTestBMC(ctx, t, pool, component.ID, hostMAC)
+
+		client := nicoapi.NewMockClient()
+		client.AddMachine(nicoapi.MachineDetail{
+			MachineID:               "host-1",
+			MachineType:             corev1.MachineType_HOST.String(),
+			BmcMac:                  hostMAC,
+			AssociatedDpuMachineIDs: []string{"dpu-1"},
+		})
+		client.AddMachine(nicoapi.MachineDetail{
+			MachineID:   "dpu-1",
+			MachineType: corev1.MachineType_DPU.String(),
+			BmcMac:      dpuMAC,
+			BmcIP:       "10.0.0.11",
+		})
+
+		_, drifts, ok := syncMachines(ctx, pool, client)
+
+		require.True(t, ok)
+		assert.Empty(t, drifts)
+		var persistedComponent model.Component
+		require.NoError(t, pool.DB.NewSelect().Model(&persistedComponent).Where("id = ?", component.ID).Scan(ctx))
+		require.NotNil(t, persistedComponent.ComponentID)
+		assert.Equal(t, "host-1", *persistedComponent.ComponentID)
+		var dpu model.BMC
+		require.NoError(t, pool.DB.NewSelect().Model(&dpu).Where("mac_address = ?", dpuMAC).Scan(ctx))
+		assert.Equal(t, devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU), dpu.Type)
+		assert.Equal(t, component.ID, dpu.ComponentID)
+		assert.Equal(t, "10.0.0.11", *dpu.IPAddress)
+	})
+
+	t.Run("GetMachines failure preserves DPU inventory", func(t *testing.T) {
+		ctx, pool := mirrorTestPool(t)
+		component := model.Component{Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)}
+		require.NoError(t, component.Create(ctx, pool.DB))
+		existing := model.BMC{
+			MacAddress:  "aa:bb:cc:dd:ee:11",
+			Type:        devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU),
+			ComponentID: component.ID,
+		}
+		_, err := pool.DB.NewInsert().Model(&existing).Exec(ctx)
+		require.NoError(t, err)
+
+		_, _, ok := syncMachines(ctx, pool, &failGetMachinesClient{Client: nicoapi.NewMockClient()})
+
+		assert.False(t, ok)
+		var got []model.BMC
+		require.NoError(t, pool.DB.NewSelect().Model(&got).Scan(ctx))
+		require.Len(t, got, 1)
+		assert.Equal(t, existing.MacAddress, got[0].MacAddress)
+	})
+
+	t.Run("DPU failure does not block host convergence", func(t *testing.T) {
+		ctx, pool := mirrorTestPool(t)
+		component := model.Component{
+			Type:        devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
+			ComponentID: strPtr("host-1"),
+		}
+		require.NoError(t, component.Create(ctx, pool.DB))
+		createTestBMC(ctx, t, pool, component.ID, "aa:bb:cc:dd:ee:10")
+
+		client := nicoapi.NewMockClient()
+		client.AddMachine(nicoapi.MachineDetail{
+			MachineID:               "host-1",
+			MachineType:             corev1.MachineType_HOST.String(),
+			BmcMac:                  "aa:bb:cc:dd:ee:10",
+			AssociatedDpuMachineIDs: []string{"missing-dpu"},
+		})
+		client.AddPowerState("host-1", nicoapi.PowerStateOn)
+
+		_, _, ok := syncMachines(ctx, pool, client)
+
+		assert.False(t, ok, "the cycle remains degraded when DPU reconciliation fails")
+		var persisted model.Component
+		require.NoError(t, pool.DB.NewSelect().Model(&persisted).Where("id = ?", component.ID).Scan(ctx))
+		require.NotNil(t, persisted.PowerState)
+		assert.Equal(t, nicoapi.PowerStateOn, *persisted.PowerState)
+	})
+
+	t.Run("position failure does not block DPU reconciliation", func(t *testing.T) {
+		ctx, pool := mirrorTestPool(t)
+		const hostMAC = "aa:bb:cc:dd:ee:20"
+		const dpuMAC = "aa:bb:cc:dd:ee:21"
+		component := model.Component{
+			Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
+		}
+		require.NoError(t, component.Create(ctx, pool.DB))
+		createTestBMC(ctx, t, pool, component.ID, hostMAC)
+
+		client := &actualInventoryTestClient{
+			Client: nicoapi.NewMockClient(),
+			machines: []nicoapi.MachineDetail{
+				{
+					MachineID:               "host-1",
+					MachineType:             corev1.MachineType_HOST.String(),
+					BmcMac:                  hostMAC,
+					AssociatedDpuMachineIDs: []string{"dpu-1"},
+				},
+				{
+					MachineID:   "dpu-1",
+					MachineType: corev1.MachineType_DPU.String(),
+					BmcMac:      dpuMAC,
+				},
+			},
+			machinePositionErr: errors.New("positions unavailable"),
+		}
+
+		_, _, ok := syncMachines(ctx, pool, client)
+
+		assert.False(t, ok)
+		var dpu model.BMC
+		require.NoError(t, pool.DB.NewSelect().Model(&dpu).Where("mac_address = ?", dpuMAC).Scan(ctx))
+		assert.Equal(t, devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU), dpu.Type)
+		assert.Equal(t, component.ID, dpu.ComponentID)
+	})
 }
 
 func TestRunInventoryOne(t *testing.T) {
@@ -396,7 +519,17 @@ func assertInventoryDrifts(t *testing.T, ctx context.Context, pool *cdb.Session,
 	}
 }
 
-func TestCompareMachineFieldsForDrift_NoMismatch(t *testing.T) {
+func TestCompareMachineFieldsForDrift(t *testing.T) {
+	t.Run("no mismatch", testCompareMachineFieldsForDriftNoMismatch)
+	t.Run("all positional fields mismatch", testCompareMachineFieldsForDriftAllPositionalFieldsMismatch)
+	t.Run("nil position fields skipped", testCompareMachineFieldsForDriftNilPositionFieldsSkipped)
+	t.Run("serial never compared", testCompareMachineFieldsForDriftSerialNeverCompared)
+	t.Run("partial mismatch", testCompareMachineFieldsForDriftPartialMismatch)
+	t.Run("missing position reports drift", testCompareMachineFieldsForDriftMissingPositionReportsDrift)
+	t.Run("missing position with zero expected does not drift", testCompareMachineFieldsForDriftMissingPositionZeroExpectedNoDrift)
+}
+
+func testCompareMachineFieldsForDriftNoMismatch(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber:    "SN001",
 		FirmwareVersion: "1.0.0",
@@ -414,7 +547,7 @@ func TestCompareMachineFieldsForDrift_NoMismatch(t *testing.T) {
 	assert.Empty(t, diffs)
 }
 
-func TestCompareMachineFieldsForDrift_AllPositionalFieldsMismatch(t *testing.T) {
+func testCompareMachineFieldsForDriftAllPositionalFieldsMismatch(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber:    "SN001",
 		FirmwareVersion: "1.0.0",
@@ -450,7 +583,7 @@ func TestCompareMachineFieldsForDrift_AllPositionalFieldsMismatch(t *testing.T) 
 	assert.NotContains(t, diffByField, "firmware_version")
 }
 
-func TestCompareMachineFieldsForDrift_NilPositionFieldsSkipped(t *testing.T) {
+func testCompareMachineFieldsForDriftNilPositionFieldsSkipped(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber:    "SN001",
 		FirmwareVersion: "1.0.0",
@@ -465,7 +598,7 @@ func TestCompareMachineFieldsForDrift_NilPositionFieldsSkipped(t *testing.T) {
 	assert.Empty(t, diffs)
 }
 
-func TestCompareMachineFieldsForDrift_SerialNeverCompared(t *testing.T) {
+func testCompareMachineFieldsForDriftSerialNeverCompared(t *testing.T) {
 	// Even when serial numbers differ, no drift is produced: serial is not a
 	// correlation/drift signal anymore.
 	expected := &model.Component{
@@ -477,7 +610,7 @@ func TestCompareMachineFieldsForDrift_SerialNeverCompared(t *testing.T) {
 	assert.Empty(t, diffs)
 }
 
-func TestCompareMachineFieldsForDrift_PartialMismatch(t *testing.T) {
+func testCompareMachineFieldsForDriftPartialMismatch(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber:    "SN001",
 		FirmwareVersion: "1.0.0",
@@ -506,7 +639,7 @@ func TestCompareMachineFieldsForDrift_PartialMismatch(t *testing.T) {
 	assert.NotContains(t, diffByField, "serial_number")
 }
 
-func TestCompareMachineFieldsForDrift_MissingPositionReportsDrift(t *testing.T) {
+func testCompareMachineFieldsForDriftMissingPositionReportsDrift(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber:    "SN001",
 		FirmwareVersion: "1.0.0",
@@ -534,7 +667,7 @@ func TestCompareMachineFieldsForDrift_MissingPositionReportsDrift(t *testing.T) 
 	assert.Equal(t, "<missing>", diffByField["host_id"].ActualValue)
 }
 
-func TestCompareMachineFieldsForDrift_MissingPositionZeroExpectedNoDrift(t *testing.T) {
+func testCompareMachineFieldsForDriftMissingPositionZeroExpectedNoDrift(t *testing.T) {
 	expected := &model.Component{
 		SerialNumber: "SN001",
 		SlotID:       0,

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
@@ -320,6 +320,40 @@ func TestBMCFirmwareVersionExactIDWinsOverEarlierDescription(t *testing.T) {
 	assert.Equal(t, exactIDVersion, bmcFirmwareVersion(report))
 }
 
+func TestBMCFirmwareVersionHostIDWinsOverAcceleratorBMCs(t *testing.T) {
+	description := "BMC image"
+	hostVersion := "25.06-2_NV_WW_02"
+	hgxVersion := "GB200Nvl-25.06-A"
+	mgxVersion := "MGX-25.06-A"
+	host := &corev1.Inventory{Id: "FW_BMC_0", Description: &description, Version: &hostVersion}
+	hgx := &corev1.Inventory{Id: "HGX_FW_BMC_0", Description: &description, Version: &hgxVersion}
+	mgx := &corev1.Inventory{Id: "MGX_FW_BMC_0", Description: &description, Version: &mgxVersion}
+
+	testCases := []struct {
+		name        string
+		inventories []*corev1.Inventory
+	}{
+		{
+			name:        "host BMC follows accelerator BMCs",
+			inventories: []*corev1.Inventory{hgx, mgx, host},
+		},
+		{
+			name:        "host BMC precedes accelerator BMCs",
+			inventories: []*corev1.Inventory{host, hgx, mgx},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			report := &corev1.EndpointExplorationReport{
+				Service: []*corev1.Service{{Inventories: tc.inventories}},
+			}
+
+			assert.Equal(t, hostVersion, bmcFirmwareVersion(report))
+		})
+	}
+}
+
 // TestApplyInventoryToComponentsPreservesConcurrentFields verifies that the
 // shared switch and power-shelf projection updates only its owned columns.
 func TestApplyInventoryToComponentsPreservesConcurrentFields(t *testing.T) {

--- a/rest-api/flow/internal/task/common/common.go
+++ b/rest-api/flow/internal/task/common/common.go
@@ -71,8 +71,8 @@ const (
 	TaskStatusCompleted  TaskStatus = "completed"
 	TaskStatusFailed     TaskStatus = "failed"
 	TaskStatusTerminated TaskStatus = "terminated"
-	// TaskStatusWaiting means the task was queued due to a conflict and is
-	// waiting for the rack to become available. It is NOT a finished state.
+	// TaskStatusWaiting means the task is waiting for a pre-execution condition,
+	// such as rack availability or target linkage. It is NOT a finished state.
 	TaskStatusWaiting TaskStatus = "waiting"
 )
 

--- a/rest-api/flow/internal/task/manager/manager.go
+++ b/rest-api/flow/internal/task/manager/manager.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
+	"strings"
 	"sync"
 	"time"
 
@@ -206,6 +208,24 @@ func (m *ManagerImpl) SubmitTask(
 		return nil, err
 	}
 
+	// A caller may retry after task submission succeeded but persisting the
+	// returned task ID failed. Once the task is scheduled, its idempotency key
+	// owns the outcome; mutable inventory and rule state must not turn that
+	// retry into a failure.
+	if req.HasIdempotencyKey() {
+		existing, err := m.taskStore.GetTaskByIdempotencyKey(ctx, req.IdempotencyKey)
+		if err != nil {
+			return nil, fmt.Errorf("look up idempotent task: %w", err)
+		}
+		if err := validateIdempotentTaskRack(req, existing); err != nil {
+			return nil, err
+		}
+		if existing != nil && (existing.IsScheduled() ||
+			existing.Status == taskcommon.TaskStatusWaiting) {
+			return []uuid.UUID{existing.ID}, nil
+		}
+	}
+
 	// Fail-fast: verify the requested rule exists before creating any tasks.
 	// The resolver will check again at execution time (defense-in-depth for
 	// queued tasks whose rule may be deleted while waiting).
@@ -248,6 +268,11 @@ func (m *ManagerImpl) SubmitTask(
 		}
 	}
 
+	err = m.validateSubmissionRackTargets(ctx, req.Operation, rackMap)
+	if err != nil {
+		return nil, err
+	}
+
 	// Create and execute task for each rack.
 	var taskIDs []uuid.UUID
 	for _, targetRack := range rackMap {
@@ -274,6 +299,134 @@ func (m *ManagerImpl) SubmitTask(
 	}
 
 	return taskIDs, nil
+}
+
+// validateSubmissionRackTargets resolves the effective ingest rule for each
+// rack before deciding whether unlinked expected components are safe targets.
+func (m *ManagerImpl) validateSubmissionRackTargets(
+	ctx context.Context,
+	op operation.Wrapper,
+	rackMap map[uuid.UUID]*rack.Rack,
+) error {
+	if op.Type != taskcommon.TaskTypeBringUp || op.Code != taskcommon.OpCodeIngest {
+		if err := validateResolvedRackTargets(op, nil, rackMap); err != nil {
+			return fmt.Errorf("operation cannot be submitted: %w", err)
+		}
+		return nil
+	}
+
+	rackIDs := make([]uuid.UUID, 0, len(rackMap))
+	for rackID := range rackMap {
+		rackIDs = append(rackIDs, rackID)
+	}
+	slices.SortFunc(rackIDs, func(a, b uuid.UUID) int {
+		return strings.Compare(a.String(), b.String())
+	})
+
+	for _, rackID := range rackIDs {
+		rule, err := m.resolveOperationRule(ctx, op, rackID)
+		if err != nil {
+			return err
+		}
+		if err := validateResolvedRackTargets(
+			op,
+			&rule.RuleDefinition,
+			map[uuid.UUID]*rack.Rack{rackID: rackMap[rackID]},
+		); err != nil {
+			return fmt.Errorf("operation cannot be submitted: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// validateResolvedRackTargets enforces the boundary between expected
+// inventory and actionable actual devices. Expectation-only operations are
+// the exception: they intentionally operate on expected components that may
+// not have an external ID yet.
+func validateResolvedRackTargets(
+	op operation.Wrapper,
+	ruleDef *operationrules.RuleDefinition,
+	rackMap map[uuid.UUID]*rack.Rack,
+) error {
+	var emptyRacks []string
+	var unlinkedComponents []string
+	expectationOnly := (op.Type == taskcommon.TaskTypeInjectExpectation &&
+		op.Code == taskcommon.OpCodeInjectExpectation) ||
+		(op.Type == taskcommon.TaskTypeBringUp &&
+			op.Code == taskcommon.OpCodeIngest &&
+			ruleUsesOnlyExpectedInventory(ruleDef))
+
+	for rackID, resolvedRack := range rackMap {
+		if resolvedRack == nil || len(resolvedRack.Components) == 0 {
+			emptyRacks = append(emptyRacks, rackID.String())
+			continue
+		}
+		if expectationOnly {
+			continue
+		}
+		for _, comp := range resolvedRack.Components {
+			if comp.ComponentID == "" {
+				unlinkedComponents = append(
+					unlinkedComponents,
+					fmt.Sprintf(
+						"rack %s %s/%s",
+						rackID,
+						devicetypes.ComponentTypeToString(comp.Type),
+						comp.Info.ID,
+					),
+				)
+			}
+		}
+	}
+
+	if len(emptyRacks) > 0 {
+		slices.Sort(emptyRacks)
+		return fmt.Errorf(
+			"racks have no selected components: %s",
+			strings.Join(emptyRacks, ", "),
+		)
+	}
+	if len(unlinkedComponents) > 0 {
+		slices.Sort(unlinkedComponents)
+		return &unlinkedTargetsError{components: unlinkedComponents}
+	}
+
+	return nil
+}
+
+type unlinkedTargetsError struct {
+	components []string
+}
+
+func (e *unlinkedTargetsError) Error() string {
+	return fmt.Sprintf(
+		"selected components not linked to actual inventory (%d): %s",
+		len(e.components),
+		strings.Join(e.components, ", "),
+	)
+}
+
+func ruleUsesOnlyExpectedInventory(ruleDef *operationrules.RuleDefinition) bool {
+	if ruleDef == nil {
+		return false
+	}
+
+	foundInjectExpectation := false
+	for _, step := range ruleDef.Steps {
+		for _, action := range step.OrderedActions() {
+			switch action.Name {
+			case operationrules.ActionInjectExpectation:
+				foundInjectExpectation = true
+			case operationrules.ActionSleep:
+				// Sleep has no inventory target side effect.
+			default:
+				return false
+			}
+		}
+	}
+
+	return foundInjectExpectation
 }
 
 // createAndExecuteTask creates a task for a single rack and executes it.
@@ -344,17 +497,12 @@ func (m *ManagerImpl) createAndExecuteIdempotentTask(
 			}
 
 			if persistedTask != nil {
+				if err := validateIdempotentTaskRack(req, persistedTask); err != nil {
+					return err
+				}
 				// There are existing tasks with this idempotency key, reuse it.
 				task = *persistedTask
 
-				if task.IsScheduled() {
-					// The task is already scheduled, so we can return it.
-					log.Info().
-						Str("task_id", task.ID.String()).
-						Str("idempotency_key", task.IdempotencyKey).
-						Msg("idempotent duplicate: returning existing scheduled task")
-					return nil
-				}
 			} else {
 				// No existing tasks with this idempotency key, create a new one.
 				task = newTaskForRack(req, targetRack)
@@ -367,8 +515,14 @@ func (m *ManagerImpl) createAndExecuteIdempotentTask(
 				}
 			}
 
+			if task.IsScheduled() {
+				log.Info().
+					Str("task_id", task.ID.String()).
+					Str("idempotency_key", task.IdempotencyKey).
+					Msg("idempotent duplicate: returning existing scheduled task")
+				return nil
+			}
 			if task.Status == taskcommon.TaskStatusWaiting {
-				// The task has conflict and is waiting, so we can return it.
 				log.Info().
 					Str("task_id", task.ID.String()).
 					Str("rack_id", targetRack.Info.ID.String()).
@@ -376,16 +530,29 @@ func (m *ManagerImpl) createAndExecuteIdempotentTask(
 				return nil
 			}
 
-			// Resolve and execute the task.
-			return m.resolveAndExecuteTask(txCtx, &task, targetRack)
+			// Keep the idempotency lock until the execution ID or deferred
+			// status is persisted so a concurrent retry cannot execute the
+			// same pending task.
+			return m.resolveAndExecuteTaskInTransaction(txCtx, &task, targetRack)
 		},
 	)
 
 	if txErr != nil {
 		return uuid.Nil, txErr
 	}
-
 	return task.ID, nil
+}
+
+func validateIdempotentTaskRack(req *operation.Request, existing *taskdef.Task) error {
+	if existing == nil || existing.RackID == req.RequiredRackID {
+		return nil
+	}
+	return fmt.Errorf(
+		"idempotency key %q belongs to rack %s, not requested rack %s",
+		req.IdempotencyKey,
+		existing.RackID,
+		req.RequiredRackID,
+	)
 }
 
 func newTaskForRack(req *operation.Request, targetRack *rack.Rack) taskdef.Task {
@@ -496,11 +663,24 @@ func (m *ManagerImpl) resolveAndExecuteTask(
 	task *taskdef.Task,
 	targetRack *rack.Rack,
 ) error {
-	ruleID := operations.ExtractRuleID(task.Operation.Info)
+	return m.resolveAndExecuteTaskWithTransaction(ctx, task, targetRack, false)
+}
 
-	rule, err := m.ruleResolver.ResolveRule(
-		ctx, task.Operation.Type, task.Operation.Code, task.RackID, ruleID,
-	)
+func (m *ManagerImpl) resolveAndExecuteTaskInTransaction(
+	ctx context.Context,
+	task *taskdef.Task,
+	targetRack *rack.Rack,
+) error {
+	return m.resolveAndExecuteTaskWithTransaction(ctx, task, targetRack, true)
+}
+
+func (m *ManagerImpl) resolveAndExecuteTaskWithTransaction(
+	ctx context.Context,
+	task *taskdef.Task,
+	targetRack *rack.Rack,
+	transactionActive bool,
+) error {
+	rule, err := m.resolveOperationRule(ctx, task.Operation, task.RackID)
 	if err != nil {
 		return fmt.Errorf("failed to resolve operation rule: %w", err)
 	}
@@ -528,6 +708,10 @@ func (m *ManagerImpl) resolveAndExecuteTask(
 
 	resp, err := m.executeTask(ctx, task, targetRack, &rule.RuleDefinition)
 	if err != nil {
+		deferred, deferErr := m.deferUnlinkedTask(ctx, task, err, transactionActive)
+		if deferred {
+			return deferErr
+		}
 		if uerr := m.taskStore.UpdateTaskStatus(ctx, &taskdef.TaskStatusUpdate{
 			ID:      task.ID,
 			Status:  taskcommon.TaskStatusFailed,
@@ -546,6 +730,106 @@ func (m *ManagerImpl) resolveAndExecuteTask(
 			Msgf("failed to update scheduled task %s", task.ID)
 	}
 	return nil
+}
+
+func (m *ManagerImpl) deferUnlinkedTask(
+	ctx context.Context,
+	task *taskdef.Task,
+	executionErr error,
+	transactionActive bool,
+) (bool, error) {
+	var unlinkedErr *unlinkedTargetsError
+	if !errors.As(executionErr, &unlinkedErr) {
+		return false, nil
+	}
+
+	deadline := task.QueueExpiresAt
+	if deadline == nil {
+		timeout := m.defaultQueueTimeout
+		if timeout <= 0 {
+			timeout = defaultQueueTimeout
+		}
+		fallback := time.Now().Add(timeout)
+		deadline = &fallback
+	}
+
+	status := taskcommon.TaskStatusWaiting
+	statusMessage := fmt.Sprintf("Waiting for target linkage: %v", unlinkedErr)
+	if !time.Now().Before(*deadline) {
+		status = taskcommon.TaskStatusTerminated
+		statusMessage = fmt.Sprintf(
+			"Expired: target linkage unavailable before queue timeout: %v",
+			unlinkedErr,
+		)
+		if err := m.taskStore.UpdateTaskStatus(ctx, &taskdef.TaskStatusUpdate{
+			ID:      task.ID,
+			Status:  status,
+			Message: statusMessage,
+		}); err != nil {
+			return true, fmt.Errorf("expire task awaiting target linkage: %w", err)
+		}
+	} else {
+		limit := m.maxWaitingPerRack
+		if limit <= 0 {
+			limit = defaultMaxWaitingPerRack
+		}
+		persistWaiting := func(txCtx context.Context) error {
+			if err := m.taskStore.LockRack(txCtx, task.RackID); err != nil {
+				return err
+			}
+			count, err := m.taskStore.CountWaitingTasksForRack(txCtx, task.RackID)
+			if err != nil {
+				return err
+			}
+			if count >= limit {
+				status = taskcommon.TaskStatusTerminated
+				statusMessage = fmt.Sprintf(
+					"Terminated: rack waiting queue is full while target linkage is unavailable (%d/%d tasks): %v",
+					count,
+					limit,
+					unlinkedErr,
+				)
+			}
+
+			update := &taskdef.TaskStatusUpdate{
+				ID:      task.ID,
+				Status:  status,
+				Message: statusMessage,
+			}
+			if status == taskcommon.TaskStatusWaiting {
+				update.QueueExpiresAt = deadline
+			}
+			return m.taskStore.UpdateTaskStatus(txCtx, update)
+		}
+
+		var err error
+		if transactionActive {
+			err = persistWaiting(ctx)
+		} else {
+			err = m.taskStore.RunInTransaction(ctx, persistWaiting)
+		}
+		if err != nil {
+			return true, fmt.Errorf("defer task awaiting target linkage: %w", err)
+		}
+	}
+
+	task.Status = status
+	task.Message = statusMessage
+	if status == taskcommon.TaskStatusWaiting {
+		task.QueueExpiresAt = deadline
+	} else {
+		task.QueueExpiresAt = nil
+	}
+	return true, nil
+}
+
+func (m *ManagerImpl) resolveOperationRule(
+	ctx context.Context,
+	op operation.Wrapper,
+	rackID uuid.UUID,
+) (*operationrules.OperationRule, error) {
+	ruleID := operations.ExtractRuleID(op.Info)
+	return m.ruleResolver.ResolveRule(ctx, op.Type, op.Code, rackID, ruleID)
 }
 
 // CancelTask cancels a task by its ID.
@@ -648,6 +932,15 @@ func (m *ManagerImpl) executeTask(
 ) (*taskdef.ExecutionResponse, error) {
 	if task == nil {
 		return nil, fmt.Errorf("task is nil")
+	}
+
+	err := validateResolvedRackTargets(
+		task.Operation,
+		ruleDef,
+		map[uuid.UUID]*rack.Rack{task.RackID: targetRack},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("operation cannot be executed: %w", err)
 	}
 
 	req := taskdef.ExecutionRequest{

--- a/rest-api/flow/internal/task/manager/manager_test.go
+++ b/rest-api/flow/internal/task/manager/manager_test.go
@@ -6,56 +6,748 @@ package manager
 import (
 	"context"
 	"fmt"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 
 	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
+	inventorystore "github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/store"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/operation"
 	taskcommon "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/common"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/conflict"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operationrules"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/operations"
 	taskdef "github.com/NVIDIA/infra-controller/rest-api/flow/internal/task/task"
+	identifier "github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/Identifier"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/inventoryobjects/rack"
 )
 
-func TestCreateAndExecuteTaskReturnsExistingIdempotentTaskBeforeRackConflict(t *testing.T) {
-	ctx := context.Background()
-	rackID := uuid.New()
-	componentID := uuid.New()
-	taskID := uuid.New()
-	idempotencyKey := "operation-run-target:" + uuid.NewString()
-	op := testPowerControlOperation(t)
-	targetRack := newTestRack(rackID, "rack-1")
-	targetRack.AddComponent(newTestComponent(
-		componentID,
-		rackID,
-		devicetypes.ComponentTypeCompute,
-		"compute-1",
-	))
-	existingTask := &taskdef.Task{
-		ID:             taskID,
-		Operation:      op,
-		RackID:         rackID,
-		Status:         taskcommon.TaskStatusPending,
-		ExecutionID:    `{"workflow_id":"workflow","run_id":"run"}`,
-		IdempotencyKey: idempotencyKey,
-		Attributes: taskcommon.TaskAttributes{
-			ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
-				devicetypes.ComponentTypeCompute: {componentID},
+type submitTaskInventory struct {
+	inventorystore.Store
+	rack         *rack.Rack
+	getRackCalls int
+}
+
+func (s *submitTaskInventory) GetRackByIdentifier(
+	_ context.Context,
+	_ identifier.Identifier,
+	_ bool,
+) (*rack.Rack, error) {
+	s.getRackCalls++
+	return s.rack, nil
+}
+
+func TestManagerImpl_SubmitTask(t *testing.T) {
+	t.Run("rejects an unlinked operation target", func(t *testing.T) {
+		rackID := uuid.New()
+		resolvedRack := newTestRack(rackID, "rack-1")
+		unlinkedID := uuid.New()
+		unlinked := newTestComponent(
+			unlinkedID,
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		unlinked.ComponentID = ""
+		resolvedRack.AddComponent(unlinked)
+
+		store := &managerTaskStore{}
+		manager := &ManagerImpl{
+			inventoryStore: &submitTaskInventory{rack: resolvedRack},
+			taskStore:      store,
+		}
+
+		_, err := manager.SubmitTask(context.Background(), &operation.Request{
+			Operation: testPowerControlOperation(t),
+			TargetSpec: operation.TargetSpec{
+				Racks: []operation.RackTarget{{
+					Identifier: identifier.Identifier{ID: rackID},
+				}},
 			},
+		})
+
+		require.ErrorContains(t, err, "selected components not linked to actual inventory (1)")
+		require.ErrorContains(t, err, unlinkedID.String())
+		require.Zero(t, store.createTaskCalls)
+	})
+
+	t.Run("returns a scheduled idempotent task before inventory validation", func(t *testing.T) {
+		rackID := uuid.New()
+		taskID := uuid.New()
+		idempotencyKey := "operation-run-target:" + uuid.NewString()
+		store := &managerTaskStore{
+			taskByIdempotencyKey: map[string]*taskdef.Task{
+				idempotencyKey: {
+					ID:             taskID,
+					RackID:         rackID,
+					ExecutionID:    `{"workflow_id":"workflow","run_id":"run"}`,
+					IdempotencyKey: idempotencyKey,
+				},
+			},
+		}
+		inventory := &submitTaskInventory{}
+		manager := &ManagerImpl{inventoryStore: inventory, taskStore: store}
+
+		taskIDs, err := manager.SubmitTask(context.Background(), &operation.Request{
+			Operation:      testPowerControlOperation(t),
+			RequiredRackID: rackID,
+			IdempotencyKey: idempotencyKey,
+			TargetSpec: operation.TargetSpec{
+				Racks: []operation.RackTarget{{
+					Identifier: identifier.Identifier{ID: rackID},
+				}},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, []uuid.UUID{taskID}, taskIDs)
+		require.Zero(t, inventory.getRackCalls)
+		require.Zero(t, store.createTaskCalls)
+	})
+
+	t.Run("returns a waiting idempotent task before inventory validation", func(t *testing.T) {
+		rackID := uuid.New()
+		taskID := uuid.New()
+		idempotencyKey := "operation-run-target:" + uuid.NewString()
+		deadline := time.Now().Add(time.Hour)
+		store := &managerTaskStore{
+			taskByIdempotencyKey: map[string]*taskdef.Task{
+				idempotencyKey: {
+					ID:             taskID,
+					RackID:         rackID,
+					Status:         taskcommon.TaskStatusWaiting,
+					QueueExpiresAt: &deadline,
+					IdempotencyKey: idempotencyKey,
+				},
+			},
+		}
+		inventory := &submitTaskInventory{}
+		manager := &ManagerImpl{inventoryStore: inventory, taskStore: store}
+
+		taskIDs, err := manager.SubmitTask(context.Background(), &operation.Request{
+			Operation:      testPowerControlOperation(t),
+			RequiredRackID: rackID,
+			IdempotencyKey: idempotencyKey,
+			TargetSpec: operation.TargetSpec{
+				Racks: []operation.RackTarget{{
+					Identifier: identifier.Identifier{ID: rackID},
+				}},
+			},
+		})
+
+		require.NoError(t, err)
+		require.Equal(t, []uuid.UUID{taskID}, taskIDs)
+		require.Zero(t, inventory.getRackCalls)
+		require.Zero(t, store.createTaskCalls)
+	})
+
+	t.Run("rejects an idempotency key belonging to another rack", func(t *testing.T) {
+		requestedRackID := uuid.New()
+		existingRackID := uuid.New()
+		idempotencyKey := "operation-run-target:" + uuid.NewString()
+		store := &managerTaskStore{
+			taskByIdempotencyKey: map[string]*taskdef.Task{
+				idempotencyKey: {
+					ID:             uuid.New(),
+					RackID:         existingRackID,
+					ExecutionID:    `{"workflow_id":"workflow","run_id":"run"}`,
+					IdempotencyKey: idempotencyKey,
+				},
+			},
+		}
+		inventory := &submitTaskInventory{}
+		manager := &ManagerImpl{inventoryStore: inventory, taskStore: store}
+
+		taskIDs, err := manager.SubmitTask(context.Background(), &operation.Request{
+			Operation:      testPowerControlOperation(t),
+			RequiredRackID: requestedRackID,
+			IdempotencyKey: idempotencyKey,
+			TargetSpec: operation.TargetSpec{
+				Racks: []operation.RackTarget{{
+					Identifier: identifier.Identifier{ID: requestedRackID},
+				}},
+			},
+		})
+
+		require.Nil(t, taskIDs)
+		require.ErrorContains(t, err, "idempotency key")
+		require.ErrorContains(t, err, existingRackID.String())
+		require.ErrorContains(t, err, requestedRackID.String())
+		require.Zero(t, inventory.getRackCalls)
+		require.Zero(t, store.createTaskCalls)
+	})
+
+	t.Run("rejects unlinked ingest with an actual inventory rule", func(t *testing.T) {
+		rackID := uuid.New()
+		ruleID := uuid.New()
+		resolvedRack := newTestRack(rackID, "rack-1")
+		unlinked := newTestComponent(
+			uuid.New(),
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		unlinked.ComponentID = ""
+		resolvedRack.AddComponent(unlinked)
+
+		rule := &operationrules.OperationRule{
+			ID:            ruleID,
+			OperationType: taskcommon.TaskTypeBringUp,
+			OperationCode: taskcommon.OpCodeIngest,
+			RuleDefinition: operationrules.RuleDefinition{Steps: []operationrules.SequenceStep{{
+				ComponentType: devicetypes.ComponentTypeCompute,
+				Stage:         1,
+				MainOperation: operationrules.ActionConfig{Name: operationrules.ActionPowerControl},
+			}}},
+		}
+		store := &managerTaskStore{rulesByID: map[uuid.UUID]*operationrules.OperationRule{ruleID: rule}}
+		manager := &ManagerImpl{
+			inventoryStore: &submitTaskInventory{rack: resolvedRack},
+			taskStore:      store,
+			ruleResolver:   operationrules.NewResolver(store),
+		}
+
+		_, err := manager.SubmitTask(context.Background(), &operation.Request{
+			Operation: testIngestOperation(t, &ruleID),
+			RuleID:    &ruleID,
+			TargetSpec: operation.TargetSpec{
+				Racks: []operation.RackTarget{{
+					Identifier: identifier.Identifier{ID: rackID},
+				}},
+			},
+		})
+
+		require.ErrorContains(t, err, "selected components not linked to actual inventory (1)")
+		require.Zero(t, store.createTaskCalls)
+	})
+}
+
+func TestManagerImpl_ExecuteTask(t *testing.T) {
+	t.Run("rejects an unlinked operation target", func(t *testing.T) {
+		rackID := uuid.New()
+		resolvedRack := newTestRack(rackID, "rack-1")
+		unlinked := newTestComponent(
+			uuid.New(),
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		unlinked.ComponentID = ""
+		resolvedRack.AddComponent(unlinked)
+
+		manager := &ManagerImpl{}
+		resp, err := manager.executeTask(
+			context.Background(),
+			&taskdef.Task{
+				ID:        uuid.New(),
+				RackID:    rackID,
+				Operation: testPowerControlOperation(t),
+			},
+			resolvedRack,
+			&operationrules.RuleDefinition{},
+		)
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "operation cannot be executed")
+		require.ErrorContains(t, err, "selected components not linked to actual inventory (1)")
+	})
+
+	t.Run("rejects unlinked ingest with an actual inventory rule", func(t *testing.T) {
+		rackID := uuid.New()
+		resolvedRack := newTestRack(rackID, "rack-1")
+		unlinked := newTestComponent(
+			uuid.New(),
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		unlinked.ComponentID = ""
+		resolvedRack.AddComponent(unlinked)
+		ruleDef := &operationrules.RuleDefinition{Steps: []operationrules.SequenceStep{{
+			MainOperation: operationrules.ActionConfig{Name: operationrules.ActionPowerControl},
+		}}}
+
+		resp, err := (&ManagerImpl{}).executeTask(
+			context.Background(),
+			&taskdef.Task{
+				ID:        uuid.New(),
+				RackID:    rackID,
+				Operation: testIngestOperation(t, nil),
+			},
+			resolvedRack,
+			ruleDef,
+		)
+
+		require.Nil(t, resp)
+		require.ErrorContains(t, err, "operation cannot be executed")
+		require.ErrorContains(t, err, "selected components not linked to actual inventory (1)")
+	})
+}
+
+func TestManagerImpl_ResolveAndExecuteTask(t *testing.T) {
+	t.Run("retries unlinked targets until the deadline", func(t *testing.T) {
+		rackID := uuid.New()
+		componentID := uuid.New()
+		deadline := time.Now().Add(time.Hour)
+		resolvedRack := newTestRack(rackID, "rack-1")
+		component := newTestComponent(
+			componentID,
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		component.ComponentID = ""
+		resolvedRack.AddComponent(component)
+		task := &taskdef.Task{
+			ID:             uuid.New(),
+			RackID:         rackID,
+			Operation:      testPowerControlOperation(t),
+			Status:         taskcommon.TaskStatusPending,
+			QueueExpiresAt: &deadline,
+		}
+		store := &managerTaskStore{}
+		executor := &managerExecutor{executionID: `{"workflow_id":"workflow","run_id":"run"}`}
+		manager := &ManagerImpl{
+			taskStore:    store,
+			executor:     executor,
+			ruleResolver: operationrules.NewResolver(store),
+		}
+
+		err := manager.resolveAndExecuteTask(context.Background(), task, resolvedRack)
+
+		require.NoError(t, err)
+		require.Equal(t, taskcommon.TaskStatusWaiting, task.Status)
+		require.Len(t, store.statusUpdates, 1)
+		require.Equal(t, taskcommon.TaskStatusWaiting, store.statusUpdates[0].Status)
+		require.Equal(t, deadline, *store.statusUpdates[0].QueueExpiresAt)
+		require.Equal(t, 1, store.runTransactionCalls)
+		require.Equal(t, 1, store.lockRackCalls)
+		require.Equal(t, 1, store.countWaitingCalls)
+		require.Zero(t, executor.executeCalls)
+
+		// A later promotion reloads the same task after inventory linkage recovers.
+		task.Status = taskcommon.TaskStatusPending
+		resolvedRack.Components[0].ComponentID = "machine-1"
+		err = manager.resolveAndExecuteTask(context.Background(), task, resolvedRack)
+
+		require.NoError(t, err)
+		require.Equal(t, 1, executor.executeCalls)
+		require.Equal(t, 1, store.updateScheduledCalls)
+		require.Equal(t, executor.executionID, store.updatedScheduledTask.ExecutionID)
+	})
+
+	t.Run("terminates unlinked targets at the deadline", func(t *testing.T) {
+		rackID := uuid.New()
+		deadline := time.Now().Add(-time.Minute)
+		resolvedRack := newTestRack(rackID, "rack-1")
+		unlinked := newTestComponent(
+			uuid.New(),
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		unlinked.ComponentID = ""
+		resolvedRack.AddComponent(unlinked)
+		task := &taskdef.Task{
+			ID:             uuid.New(),
+			RackID:         rackID,
+			Operation:      testPowerControlOperation(t),
+			Status:         taskcommon.TaskStatusPending,
+			QueueExpiresAt: &deadline,
+		}
+		store := &managerTaskStore{}
+		manager := &ManagerImpl{
+			taskStore:    store,
+			executor:     &managerExecutor{},
+			ruleResolver: operationrules.NewResolver(store),
+		}
+
+		err := manager.resolveAndExecuteTask(context.Background(), task, resolvedRack)
+
+		require.NoError(t, err)
+		require.Equal(t, taskcommon.TaskStatusTerminated, task.Status)
+		require.Len(t, store.statusUpdates, 1)
+		require.Equal(t, taskcommon.TaskStatusTerminated, store.statusUpdates[0].Status)
+		require.Nil(t, store.statusUpdates[0].QueueExpiresAt)
+		require.Nil(t, task.QueueExpiresAt)
+		require.Zero(t, store.runTransactionCalls)
+	})
+
+	t.Run("terminates when the waiting queue is full", func(t *testing.T) {
+		rackID := uuid.New()
+		deadline := time.Now().Add(time.Hour)
+		resolvedRack := newTestRack(rackID, "rack-1")
+		unlinked := newTestComponent(
+			uuid.New(),
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		unlinked.ComponentID = ""
+		resolvedRack.AddComponent(unlinked)
+		task := &taskdef.Task{
+			ID:             uuid.New(),
+			RackID:         rackID,
+			Operation:      testPowerControlOperation(t),
+			Status:         taskcommon.TaskStatusPending,
+			QueueExpiresAt: &deadline,
+		}
+		store := &managerTaskStore{waitingCount: 1}
+		manager := &ManagerImpl{
+			taskStore:         store,
+			executor:          &managerExecutor{},
+			ruleResolver:      operationrules.NewResolver(store),
+			maxWaitingPerRack: 1,
+		}
+
+		err := manager.resolveAndExecuteTask(context.Background(), task, resolvedRack)
+
+		require.NoError(t, err)
+		require.Equal(t, taskcommon.TaskStatusTerminated, task.Status)
+		require.Nil(t, task.QueueExpiresAt)
+		require.Len(t, store.statusUpdates, 1)
+		require.Equal(t, taskcommon.TaskStatusTerminated, store.statusUpdates[0].Status)
+		require.Nil(t, store.statusUpdates[0].QueueExpiresAt)
+		require.Contains(t, task.Message, "waiting queue is full while target linkage is unavailable (1/1 tasks)")
+		require.Equal(t, 1, store.runTransactionCalls)
+		require.Equal(t, 1, store.lockRackCalls)
+		require.Equal(t, 1, store.countWaitingCalls)
+	})
+}
+
+func TestManagerImpl_CreateAndExecuteTask(t *testing.T) {
+	t.Run("waits when a target unlinks after admission", func(t *testing.T) {
+		rackID := uuid.New()
+		resolvedRack := newTestRack(rackID, "rack-1")
+		unlinked := newTestComponent(
+			uuid.New(),
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		)
+		unlinked.ComponentID = ""
+		resolvedRack.AddComponent(unlinked)
+		store := &managerTaskStore{}
+		executor := &managerExecutor{}
+		manager := &ManagerImpl{
+			taskStore:           store,
+			executor:            executor,
+			ruleResolver:        operationrules.NewResolver(store),
+			conflictResolver:    conflict.NewResolver(store),
+			defaultQueueTimeout: 30 * time.Minute,
+		}
+		startedAt := time.Now()
+
+		taskID, err := manager.createAndExecuteTask(context.Background(), &operation.Request{
+			Operation:        testPowerControlOperation(t),
+			ConflictStrategy: operation.ConflictStrategyReject,
+		}, resolvedRack)
+
+		require.NoError(t, err)
+		require.NotEqual(t, uuid.Nil, taskID)
+		require.Equal(t, 1, store.createTaskCalls)
+		require.Len(t, store.statusUpdates, 1)
+		update := store.statusUpdates[0]
+		require.Equal(t, taskID, update.ID)
+		require.Equal(t, taskcommon.TaskStatusWaiting, update.Status)
+		require.NotNil(t, update.QueueExpiresAt)
+		require.WithinDuration(
+			t,
+			startedAt.Add(manager.defaultQueueTimeout),
+			*update.QueueExpiresAt,
+			time.Second,
+		)
+		require.Zero(t, executor.executeCalls)
+	})
+}
+
+func TestValidateResolvedRackTargets(t *testing.T) {
+	tests := []struct {
+		name         string
+		op           operation.Wrapper
+		ruleDef      *operationrules.RuleDefinition
+		componentIDs []string
+		wantError    string
+	}{
+		{
+			name: "linked components allow a disruptive operation",
+			op: operation.Wrapper{
+				Type: taskcommon.TaskTypePowerControl,
+				Code: taskcommon.OpCodePowerControlPowerOff,
+			},
+			componentIDs: []string{"machine-1", "machine-2"},
+		},
+		{
+			name: "unlinked component rejects a disruptive operation",
+			op: operation.Wrapper{
+				Type: taskcommon.TaskTypeFirmwareControl,
+				Code: taskcommon.OpCodeFirmwareControlUpgrade,
+			},
+			componentIDs: []string{"machine-1", ""},
+			wantError:    "selected components not linked to actual inventory (1)",
+		},
+		{
+			name: "ingestion allows an unlinked expected component",
+			op: operation.Wrapper{
+				Type: taskcommon.TaskTypeBringUp,
+				Code: taskcommon.OpCodeIngest,
+			},
+			ruleDef: &operationrules.RuleDefinition{Steps: []operationrules.SequenceStep{{
+				MainOperation: operationrules.ActionConfig{Name: operationrules.ActionInjectExpectation},
+			}}},
+			componentIDs: []string{""},
+		},
+		{
+			name: "ingestion with an actual inventory action rejects an unlinked component",
+			op: operation.Wrapper{
+				Type: taskcommon.TaskTypeBringUp,
+				Code: taskcommon.OpCodeIngest,
+			},
+			ruleDef: &operationrules.RuleDefinition{Steps: []operationrules.SequenceStep{{
+				MainOperation: operationrules.ActionConfig{Name: operationrules.ActionPowerControl},
+			}}},
+			componentIDs: []string{""},
+			wantError:    "selected components not linked to actual inventory (1)",
+		},
+		{
+			name: "inject expectation allows an unlinked expected component",
+			op: operation.Wrapper{
+				Type: taskcommon.TaskTypeInjectExpectation,
+				Code: taskcommon.OpCodeInjectExpectation,
+			},
+			componentIDs: []string{""},
+		},
+		{
+			name: "empty selected scope rejects every operation",
+			op: operation.Wrapper{
+				Type: taskcommon.TaskTypeBringUp,
+				Code: taskcommon.OpCodeIngest,
+			},
+			wantError: "racks have no selected components",
 		},
 	}
-	store := &managerTaskStore{
-		activeTasksByRack: map[uuid.UUID][]*taskdef.Task{
-			rackID: {
-				{
-					ID:        uuid.New(),
-					Operation: op,
-					RackID:    rackID,
-					Status:    taskcommon.TaskStatusRunning,
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rackID := uuid.New()
+			resolvedRack := newTestRack(rackID, "rack-1")
+			componentFlowIDs := make([]uuid.UUID, 0, len(test.componentIDs))
+			for i, externalID := range test.componentIDs {
+				flowID := uuid.New()
+				componentFlowIDs = append(componentFlowIDs, flowID)
+				comp := newTestComponent(
+					flowID,
+					rackID,
+					devicetypes.ComponentTypeCompute,
+					fmt.Sprintf("compute-%d", i),
+				)
+				comp.ComponentID = externalID
+				resolvedRack.AddComponent(comp)
+			}
+
+			err := validateResolvedRackTargets(
+				test.op,
+				test.ruleDef,
+				map[uuid.UUID]*rack.Rack{rackID: resolvedRack},
+			)
+			if test.wantError != "" {
+				require.ErrorContains(t, err, test.wantError)
+				for i, externalID := range test.componentIDs {
+					if externalID == "" {
+						require.ErrorContains(t, err, componentFlowIDs[i].String())
+					}
+				}
+				return
+			}
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestManagerImpl_CreateAndExecuteIdempotentTask(t *testing.T) {
+	t.Run("returns an existing scheduled task before rack conflict", func(t *testing.T) {
+		ctx := context.Background()
+		rackID := uuid.New()
+		componentID := uuid.New()
+		taskID := uuid.New()
+		idempotencyKey := "operation-run-target:" + uuid.NewString()
+		op := testPowerControlOperation(t)
+		targetRack := newTestRack(rackID, "rack-1")
+		targetRack.AddComponent(newTestComponent(
+			componentID,
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		))
+		existingTask := &taskdef.Task{
+			ID:             taskID,
+			Operation:      op,
+			RackID:         rackID,
+			Status:         taskcommon.TaskStatusPending,
+			ExecutionID:    `{"workflow_id":"workflow","run_id":"run"}`,
+			IdempotencyKey: idempotencyKey,
+			Attributes: taskcommon.TaskAttributes{
+				ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+					devicetypes.ComponentTypeCompute: {componentID},
+				},
+			},
+		}
+		store := &managerTaskStore{
+			activeTasksByRack: map[uuid.UUID][]*taskdef.Task{
+				rackID: {
+					{
+						ID:        uuid.New(),
+						Operation: op,
+						RackID:    rackID,
+						Status:    taskcommon.TaskStatusRunning,
+						Attributes: taskcommon.TaskAttributes{
+							ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+								devicetypes.ComponentTypeCompute: {componentID},
+							},
+						},
+					},
+				},
+			},
+			taskByIdempotencyKey: map[string]*taskdef.Task{
+				idempotencyKey: existingTask,
+			},
+		}
+		manager := &ManagerImpl{
+			taskStore:           store,
+			conflictResolver:    conflict.NewResolver(store),
+			maxWaitingPerRack:   defaultMaxWaitingPerRack,
+			defaultQueueTimeout: defaultQueueTimeout,
+		}
+
+		gotTaskID, err := manager.createAndExecuteTask(ctx, &operation.Request{
+			Operation:        op,
+			Description:      "retry operation-run target",
+			ConflictStrategy: operation.ConflictStrategyReject,
+			RequiredRackID:   rackID,
+			IdempotencyKey:   idempotencyKey,
+		}, targetRack)
+
+		require.NoError(t, err)
+		require.Equal(t, taskID, gotTaskID)
+		require.Zero(t, store.listActiveCalls)
+		require.Zero(t, store.createTaskCalls)
+	})
+
+	t.Run("schedules an existing pending task without an execution ID", func(t *testing.T) {
+		ctx := context.Background()
+		rackID := uuid.New()
+		componentID := uuid.New()
+		taskID := uuid.New()
+		idempotencyKey := "operation-run-target:" + uuid.NewString()
+		op := testPowerControlOperation(t)
+		targetRack := newTestRack(rackID, "rack-1")
+		targetRack.AddComponent(newTestComponent(
+			componentID,
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		))
+		existingTask := &taskdef.Task{
+			ID:             taskID,
+			Operation:      op,
+			RackID:         rackID,
+			Status:         taskcommon.TaskStatusPending,
+			IdempotencyKey: idempotencyKey,
+			Attributes: taskcommon.TaskAttributes{
+				ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
+					devicetypes.ComponentTypeCompute: {componentID},
+				},
+			},
+		}
+		store := &managerTaskStore{
+			taskByIdempotencyKey: map[string]*taskdef.Task{
+				idempotencyKey: existingTask,
+			},
+		}
+		executor := &managerExecutor{executionID: `{"workflow_id":"workflow","run_id":"run"}`}
+		manager := &ManagerImpl{
+			taskStore:           store,
+			executor:            executor,
+			maxWaitingPerRack:   defaultMaxWaitingPerRack,
+			defaultQueueTimeout: defaultQueueTimeout,
+		}
+
+		gotTaskID, err := manager.createAndExecuteTask(ctx, &operation.Request{
+			Operation:        op,
+			Description:      "retry operation-run target",
+			ConflictStrategy: operation.ConflictStrategyReject,
+			RequiredRackID:   rackID,
+			IdempotencyKey:   idempotencyKey,
+		}, targetRack)
+
+		require.NoError(t, err)
+		require.Equal(t, taskID, gotTaskID)
+		require.Equal(t, 1, executor.executeCalls)
+		require.Equal(t, taskID, executor.lastRequest.Info.TaskID)
+		require.Equal(t, 1, store.updateScheduledCalls)
+		require.Equal(t, executor.executionID, store.updatedScheduledTask.ExecutionID)
+		require.Zero(t, store.listActiveCalls)
+		require.Zero(t, store.createTaskCalls)
+	})
+
+	t.Run("rejects an existing task for a different rack", func(t *testing.T) {
+		requestedRackID := uuid.New()
+		existingRackID := uuid.New()
+		idempotencyKey := "operation-run-target:" + uuid.NewString()
+		targetRack := newTestRack(requestedRackID, "rack-1")
+		store := &managerTaskStore{
+			taskByIdempotencyKey: map[string]*taskdef.Task{
+				idempotencyKey: {
+					ID:             uuid.New(),
+					RackID:         existingRackID,
+					IdempotencyKey: idempotencyKey,
+				},
+			},
+		}
+		manager := &ManagerImpl{taskStore: store}
+
+		taskID, err := manager.createAndExecuteTask(context.Background(), &operation.Request{
+			Operation:      testPowerControlOperation(t),
+			RequiredRackID: requestedRackID,
+			IdempotencyKey: idempotencyKey,
+		}, targetRack)
+
+		require.Equal(t, uuid.Nil, taskID)
+		require.ErrorContains(t, err, "idempotency key")
+		require.ErrorContains(t, err, existingRackID.String())
+		require.ErrorContains(t, err, requestedRackID.String())
+		require.Equal(t, 1, store.lockKeyCalls)
+		require.Zero(t, store.lockRackCalls)
+		require.Zero(t, store.createTaskCalls)
+		require.Zero(t, store.updateScheduledCalls)
+	})
+
+	t.Run("serializes concurrent retries until execution is persisted", func(t *testing.T) {
+		rackID := uuid.New()
+		componentID := uuid.New()
+		taskID := uuid.New()
+		idempotencyKey := "operation-run-target:" + uuid.NewString()
+		op := testPowerControlOperation(t)
+		targetRack := newTestRack(rackID, "rack-1")
+		targetRack.AddComponent(newTestComponent(
+			componentID,
+			rackID,
+			devicetypes.ComponentTypeCompute,
+			"compute-1",
+		))
+		baseStore := &managerTaskStore{
+			taskByIdempotencyKey: map[string]*taskdef.Task{
+				idempotencyKey: {
+					ID:             taskID,
+					Operation:      op,
+					RackID:         rackID,
+					Status:         taskcommon.TaskStatusPending,
+					IdempotencyKey: idempotencyKey,
 					Attributes: taskcommon.TaskAttributes{
 						ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
 							devicetypes.ComponentTypeCompute: {componentID},
@@ -63,87 +755,60 @@ func TestCreateAndExecuteTaskReturnsExistingIdempotentTaskBeforeRackConflict(t *
 					},
 				},
 			},
-		},
-		taskByIdempotencyKey: map[string]*taskdef.Task{
-			idempotencyKey: existingTask,
-		},
-	}
-	manager := &ManagerImpl{
-		taskStore:           store,
-		conflictResolver:    conflict.NewResolver(store),
-		maxWaitingPerRack:   defaultMaxWaitingPerRack,
-		defaultQueueTimeout: defaultQueueTimeout,
-	}
-
-	gotTaskID, err := manager.createAndExecuteTask(ctx, &operation.Request{
-		Operation:        op,
-		Description:      "retry operation-run target",
-		ConflictStrategy: operation.ConflictStrategyReject,
-		RequiredRackID:   rackID,
-		IdempotencyKey:   idempotencyKey,
-	}, targetRack)
-
-	require.NoError(t, err)
-	require.Equal(t, taskID, gotTaskID)
-	require.Zero(t, store.listActiveCalls)
-	require.Zero(t, store.createTaskCalls)
-}
-
-func TestCreateAndExecuteTaskSchedulesExistingIdempotentTaskWithoutExecutionID(t *testing.T) {
-	ctx := context.Background()
-	rackID := uuid.New()
-	componentID := uuid.New()
-	taskID := uuid.New()
-	idempotencyKey := "operation-run-target:" + uuid.NewString()
-	op := testPowerControlOperation(t)
-	targetRack := newTestRack(rackID, "rack-1")
-	targetRack.AddComponent(newTestComponent(
-		componentID,
-		rackID,
-		devicetypes.ComponentTypeCompute,
-		"compute-1",
-	))
-	existingTask := &taskdef.Task{
-		ID:             taskID,
-		Operation:      op,
-		RackID:         rackID,
-		Status:         taskcommon.TaskStatusPending,
-		IdempotencyKey: idempotencyKey,
-		Attributes: taskcommon.TaskAttributes{
-			ComponentsByType: map[devicetypes.ComponentType][]uuid.UUID{
-				devicetypes.ComponentTypeCompute: {componentID},
+		}
+		transactionAttempts := make(chan struct{}, 2)
+		store := &serialManagerTaskStore{
+			managerTaskStore:    baseStore,
+			transactionAttempts: transactionAttempts,
+		}
+		executor := &blockingManagerExecutor{
+			managerExecutor: managerExecutor{
+				executionID: `{"workflow_id":"workflow","run_id":"run"}`,
 			},
-		},
-	}
-	store := &managerTaskStore{
-		taskByIdempotencyKey: map[string]*taskdef.Task{
-			idempotencyKey: existingTask,
-		},
-	}
-	executor := &managerExecutor{executionID: `{"workflow_id":"workflow","run_id":"run"}`}
-	manager := &ManagerImpl{
-		taskStore:           store,
-		executor:            executor,
-		maxWaitingPerRack:   defaultMaxWaitingPerRack,
-		defaultQueueTimeout: defaultQueueTimeout,
-	}
+			started: make(chan struct{}),
+			release: make(chan struct{}),
+		}
+		manager := &ManagerImpl{
+			taskStore: store,
+			executor:  executor,
+		}
+		req := &operation.Request{
+			Operation:        op,
+			ConflictStrategy: operation.ConflictStrategyReject,
+			RequiredRackID:   rackID,
+			IdempotencyKey:   idempotencyKey,
+		}
 
-	gotTaskID, err := manager.createAndExecuteTask(ctx, &operation.Request{
-		Operation:        op,
-		Description:      "retry operation-run target",
-		ConflictStrategy: operation.ConflictStrategyReject,
-		RequiredRackID:   rackID,
-		IdempotencyKey:   idempotencyKey,
-	}, targetRack)
+		results := make(chan uuid.UUID, 2)
+		errs := make(chan error, 2)
+		var submissions sync.WaitGroup
+		submissions.Add(2)
+		submit := func() {
+			defer submissions.Done()
+			gotTaskID, err := manager.createAndExecuteTask(t.Context(), req, targetRack)
+			results <- gotTaskID
+			errs <- err
+		}
 
-	require.NoError(t, err)
-	require.Equal(t, taskID, gotTaskID)
-	require.Equal(t, 1, executor.executeCalls)
-	require.Equal(t, taskID, executor.lastRequest.Info.TaskID)
-	require.Equal(t, 1, store.updateScheduledCalls)
-	require.Equal(t, executor.executionID, store.updatedScheduledTask.ExecutionID)
-	require.Zero(t, store.listActiveCalls)
-	require.Zero(t, store.createTaskCalls)
+		go submit()
+		<-transactionAttempts
+		<-executor.started
+		go submit()
+		<-transactionAttempts
+		close(executor.release)
+		submissions.Wait()
+		close(results)
+		close(errs)
+
+		for err := range errs {
+			require.NoError(t, err)
+		}
+		for gotTaskID := range results {
+			require.Equal(t, taskID, gotTaskID)
+		}
+		require.EqualValues(t, 1, executor.calls.Load())
+		require.Equal(t, 1, baseStore.updateScheduledCalls)
+	})
 }
 
 func testPowerControlOperation(t *testing.T) operation.Wrapper {
@@ -161,6 +826,23 @@ func testPowerControlOperation(t *testing.T) operation.Wrapper {
 	}
 }
 
+func testIngestOperation(t *testing.T, ruleID *uuid.UUID) operation.Wrapper {
+	t.Helper()
+
+	info := &operations.BringUpTaskInfo{OpCode: taskcommon.OpCodeIngest}
+	if ruleID != nil {
+		info.RuleID = ruleID.String()
+	}
+	raw, err := info.Marshal()
+	require.NoError(t, err)
+
+	return operation.Wrapper{
+		Type: taskcommon.TaskTypeBringUp,
+		Code: taskcommon.OpCodeIngest,
+		Info: raw,
+	}
+}
+
 type managerTaskStore struct {
 	activeTasksByRack    map[uuid.UUID][]*taskdef.Task
 	taskByIdempotencyKey map[string]*taskdef.Task
@@ -170,18 +852,59 @@ type managerTaskStore struct {
 	lockRackCalls        int
 	updateScheduledCalls int
 	updatedScheduledTask *taskdef.Task
+	statusUpdates        []*taskdef.TaskStatusUpdate
+	runTransactionCalls  int
+	countWaitingCalls    int
+	waitingCount         int
+	rulesByID            map[uuid.UUID]*operationrules.OperationRule
+}
+
+type serialManagerTaskStore struct {
+	*managerTaskStore
+	idempotencyMu       sync.Mutex
+	transactionAttempts chan<- struct{}
+}
+
+func (s *serialManagerTaskStore) RunInTransaction(
+	ctx context.Context,
+	fn func(context.Context) error,
+) error {
+	s.transactionAttempts <- struct{}{}
+	err := fn(ctx)
+	s.idempotencyMu.Unlock()
+	return err
+}
+
+func (s *serialManagerTaskStore) LockIdempotencyKey(_ context.Context, _ string) error {
+	s.idempotencyMu.Lock()
+	return nil
+}
+
+func (s *serialManagerTaskStore) UpdateScheduledTask(
+	ctx context.Context,
+	task *taskdef.Task,
+) error {
+	err := s.managerTaskStore.UpdateScheduledTask(ctx, task)
+	if err != nil {
+		return err
+	}
+
+	persisted := *task
+	s.taskByIdempotencyKey[task.IdempotencyKey] = &persisted
+	return nil
 }
 
 func (s *managerTaskStore) RunInTransaction(
 	ctx context.Context,
 	fn func(context.Context) error,
 ) error {
+	s.runTransactionCalls++
 	return fn(ctx)
 }
 
 func (s *managerTaskStore) CreateTask(_ context.Context, _ *taskdef.Task) error {
 	s.createTaskCalls++
-	return fmt.Errorf("CreateTask should not be called")
+	return nil
 }
 
 func (s *managerTaskStore) LockRack(_ context.Context, _ uuid.UUID) error {
@@ -232,9 +955,10 @@ func (s *managerTaskStore) UpdateScheduledTask(_ context.Context, task *taskdef.
 
 func (s *managerTaskStore) UpdateTaskStatus(
 	_ context.Context,
-	_ *taskdef.TaskStatusUpdate,
+	update *taskdef.TaskStatusUpdate,
 ) error {
-	panic("managerTaskStore.UpdateTaskStatus: not implemented")
+	s.statusUpdates = append(s.statusUpdates, update)
+	return nil
 }
 
 func (s *managerTaskStore) UpdateTaskReport(
@@ -260,7 +984,8 @@ func (s *managerTaskStore) ListWaitingTasksForRack(
 }
 
 func (s *managerTaskStore) CountWaitingTasksForRack(_ context.Context, _ uuid.UUID) (int, error) {
-	panic("managerTaskStore.CountWaitingTasksForRack: not implemented")
+	s.countWaitingCalls++
+	return s.waitingCount, nil
 }
 
 func (s *managerTaskStore) ListRacksWithWaitingTasks(_ context.Context) ([]uuid.UUID, error) {
@@ -292,9 +1017,9 @@ func (s *managerTaskStore) SetRuleAsDefault(_ context.Context, _ uuid.UUID) erro
 
 func (s *managerTaskStore) GetRule(
 	_ context.Context,
-	_ uuid.UUID,
+	id uuid.UUID,
 ) (*operationrules.OperationRule, error) {
-	panic("managerTaskStore.GetRule: not implemented")
+	return s.rulesByID[id], nil
 }
 
 func (s *managerTaskStore) GetRuleByName(
@@ -318,7 +1043,7 @@ func (s *managerTaskStore) GetRuleByOperationAndRack(
 	_ string,
 	_ *uuid.UUID,
 ) (*operationrules.OperationRule, error) {
-	panic("managerTaskStore.GetRuleByOperationAndRack: not implemented")
+	return nil, nil
 }
 
 func (s *managerTaskStore) ListRules(
@@ -370,6 +1095,24 @@ type managerExecutor struct {
 	executionID  string
 	executeCalls int
 	lastRequest  *taskdef.ExecutionRequest
+}
+
+type blockingManagerExecutor struct {
+	managerExecutor
+	calls   atomic.Int32
+	started chan struct{}
+	release chan struct{}
+}
+
+func (e *blockingManagerExecutor) Execute(
+	_ context.Context,
+	_ *taskdef.ExecutionRequest,
+) (*taskdef.ExecutionResponse, error) {
+	if e.calls.Add(1) == 1 {
+		close(e.started)
+	}
+	<-e.release
+	return &taskdef.ExecutionResponse{ExecutionID: e.executionID}, nil
 }
 
 func (e *managerExecutor) Start(context.Context) error {

--- a/rest-api/flow/internal/task/manager/notifying_store.go
+++ b/rest-api/flow/internal/task/manager/notifying_store.go
@@ -47,7 +47,9 @@ func (s *notifyingTaskStore) UpdateTaskStatus(
 		return nil
 	}
 
-	tasks, err := s.Store.GetTasks(ctx, []uuid.UUID{u.ID})
+	// Delegate explicitly so a future wrapper override cannot change this
+	// post-update lookup's semantics.
+	tasks, err := s.Store.GetTasks(ctx, []uuid.UUID{u.ID}) //nolint:staticcheck // Intentional embedded-field qualification.
 	if err != nil || len(tasks) == 0 {
 		log.Warn().
 			Str("task_id", u.ID.String()).

--- a/rest-api/flow/internal/task/manager/resolver_test.go
+++ b/rest-api/flow/internal/task/manager/resolver_test.go
@@ -171,6 +171,7 @@ func newTestComponent(id uuid.UUID, rackID uuid.UUID, compType devicetypes.Compo
 	)
 
 	comp.RackID = rackID
+	comp.ComponentID = name
 	return comp
 }
 
@@ -709,6 +710,7 @@ func TestResolveRackTarget_MultipleComponentTypeFilters(t *testing.T) {
 	comp1 := newTestComponent(uuid.New(), rackID, devicetypes.ComponentTypeCompute, "comp-1")
 	comp2 := newTestComponent(uuid.New(), rackID, devicetypes.ComponentTypeNVSwitch, "comp-2")
 	comp3 := newTestComponent(uuid.New(), rackID, devicetypes.ComponentTypePowerShelf, "comp-3")
+	comp3.ComponentID = "" // Unlinked but outside the selected component types.
 	testRack.AddComponent(comp1)
 	testRack.AddComponent(comp2)
 	testRack.AddComponent(comp3)

--- a/rest-api/flow/internal/task/store/postgres.go
+++ b/rest-api/flow/internal/task/store/postgres.go
@@ -224,18 +224,23 @@ func (s *PostgresStore) UpdateScheduledTask(
 	return nil
 }
 
-// UpdateTaskStatus persists status, message, and (optionally) the report
-// snapshot. The report carried in arg is treated as authoritative: when
-// non-empty it replaces the stored document, when empty the stored
-// document is left untouched (the underlying model omits the report
-// column from the UPDATE in that case). No read-modify-write is performed,
-// so concurrent transitions cannot lose updates.
+// UpdateTaskStatus persists status and message, plus optional report and queue
+// deadline changes. Finished statuses clear the queue deadline; otherwise nil
+// optional values leave their stored columns untouched. No read-modify-write is
+// performed, so concurrent transitions cannot lose updates.
 func (s *PostgresStore) UpdateTaskStatus(
 	ctx context.Context,
 	arg *taskdef.TaskStatusUpdate,
 ) error {
 	taskDao := &model.Task{ID: arg.ID}
-	err := taskDao.UpdateTaskStatus(ctx, s.idb(ctx), arg.Status, arg.Message, arg.Report)
+	err := taskDao.UpdateTaskStatus(
+		ctx,
+		s.idb(ctx),
+		arg.Status,
+		arg.Message,
+		arg.Report,
+		arg.QueueExpiresAt,
+	)
 	if err != nil {
 		return errors.GRPCErrorInternal(err.Error())
 	}

--- a/rest-api/flow/internal/task/store/store.go
+++ b/rest-api/flow/internal/task/store/store.go
@@ -61,7 +61,7 @@ type Store interface {
 	// UpdateScheduledTask updates task scheduling information (execution ID, executor type).
 	UpdateScheduledTask(ctx context.Context, task *taskdef.Task) error
 
-	// UpdateTaskStatus updates the status and message of a task.
+	// UpdateTaskStatus updates status and message, plus an optional queue deadline.
 	UpdateTaskStatus(ctx context.Context, arg *taskdef.TaskStatusUpdate) error
 
 	// UpdateTaskReport merges a report snapshot without a status change.

--- a/rest-api/flow/internal/task/task/task.go
+++ b/rest-api/flow/internal/task/task/task.go
@@ -46,8 +46,8 @@ type Task struct {
 	StartedAt     *time.Time
 	FinishedAt    *time.Time
 
-	// QueueExpiresAt is the deadline for a waiting task to be promoted.
-	// After this time the Promoter terminates the task automatically.
+	// QueueExpiresAt is the deadline for a pre-execution wait. After this time
+	// the Promoter or task manager terminates the task automatically.
 	// Nil for non-waiting tasks.
 	QueueExpiresAt *time.Time
 
@@ -148,6 +148,10 @@ type TaskStatusUpdate struct {
 	ID      uuid.UUID
 	Status  taskcommon.TaskStatus
 	Message string
+	// QueueExpiresAt, when non-nil, replaces the task's pre-execution wait
+	// deadline. A nil value leaves it unchanged unless Status is finished, in
+	// which case the stored deadline is cleared.
+	QueueExpiresAt *time.Time
 	// Report, when non-empty, replaces the stored report document. An
 	// empty value leaves the stored report untouched.
 	Report json.RawMessage


### PR DESCRIPTION
Rack operations resolve targets from expected inventory. A selected expected component without an external ID is not linked to actionable actual inventory, but the previous flow could still persist and execute the task with an incomplete target set.

This change validates resolved rack targets before task persistence and again immediately before execution. Non-expectation operations now fail the whole rack operation when any selected component is unlinked. Ingest permits unlinked components only when its resolved rule contains exclusively expectation-injection actions and side-effect-free sleeps; custom ingest rules that touch actual inventory are rejected. Direct expectation injection remains allowed. Submission and execution failures identify the lifecycle phase in their operator-facing messages.

Submission-time validation remains fail-fast and creates no task. If an admitted task loses target linkage before reaching the executor, it transitions to waiting instead of terminal failure. Conflict-queued tasks retain their original queue deadline; immediately executing tasks receive the server's default pre-execution deadline. A later promotion retries after linkage recovers, while a task still unlinked at its deadline is terminated. The waiting limit is enforced transactionally per rack so linkage deferrals cannot overfill the queue.

Retries for existing scheduled or waiting idempotent tasks return the persisted task before consulting mutable inventory or rule state. Reusing an idempotency key for a different required rack is rejected both on the fast path and after acquiring the idempotency lock. Pending idempotent tasks are claimed under the same lock before execution so concurrent retries cannot start the same task twice.

The PR also fixes BMC firmware selection during inventory sync. Core reports can contain host, HGX, and MGX entries that all use the legacy `BMC image` description, so choosing the first description match could persist an accelerator BMC version as the machine's BMC firmware. Resolution now prefers Core's canonical `bmc` version, then recognized host BMC inventory IDs (`BMC`, `FW_BMC_0`, and `HostBMC_0`), and uses the legacy description only as a fallback. Tests cover host entries both before and after accelerator entries.

Inventory-sync scenarios for `syncMachines`, `reconcileDpuBMCs`, and `compareMachineFieldsForDrift` are consolidated under one top-level test per production function, retaining the existing scenario coverage while following the repository test organization convention.

## Related issues

Fixes #5902

Follow-up #5904 tracks an explicit `allow_partial_targets` mode.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

No database schema or public API changes.
