### PR TITLE
fix(flow): include DPUs in Core inventory

### DIFF
--- a/rest-api/flow/internal/nicoapi/grpc.go
+++ b/rest-api/flow/internal/nicoapi/grpc.go
@@ -225,7 +225,7 @@ func NewClient(grpcTimeout time.Duration) (Client, error) {
 // (FindMachineIds + FindMachinesByIds).
 func (c *grpcClient) GetMachines(ctx context.Context) ([]MachineDetail, error) {
 	idsCtx, idsCancel := context.WithTimeout(ctx, c.grpcTimeout)
-	machineIDs, err := c.gclient.FindMachineIds(idsCtx, &corev1.MachineSearchConfig{})
+	machineIDs, err := c.gclient.FindMachineIds(idsCtx, &corev1.MachineSearchConfig{IncludeDpus: true})
 	idsCancel()
 	if err != nil {
 		return nil, err

--- a/rest-api/flow/internal/nicoapi/grpc_batch_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_batch_test.go
@@ -34,6 +34,7 @@ type recordingForgeClient struct {
 	shelfIDDelay      time.Duration
 	shelfDelay        time.Duration
 	versionRequests   []*corev1.VersionRequest
+	machineSearches   []*corev1.MachineSearchConfig
 	machineIDs        []string
 	switchIDs         []string
 	shelfIDs          []string
@@ -76,12 +77,16 @@ func (c *recordingForgeClient) Version(
 
 func (c *recordingForgeClient) FindMachineIds(
 	ctx context.Context,
-	_ *corev1.MachineSearchConfig,
+	request *corev1.MachineSearchConfig,
 	_ ...grpc.CallOption,
 ) (*corev1.MachineIdList, error) {
-	if c.machineIDDelay > 0 {
+	c.mu.Lock()
+	c.machineSearches = append(c.machineSearches, request)
+	delay := c.machineIDDelay
+	c.mu.Unlock()
+	if delay > 0 {
 		select {
-		case <-time.After(c.machineIDDelay):
+		case <-time.After(delay):
 		case <-ctx.Done():
 			return nil, ctx.Err()
 		}
@@ -251,6 +256,16 @@ func stringsToPowerShelfIds(ids []string) []*corev1.PowerShelfId {
 		result = append(result, &corev1.PowerShelfId{Id: id})
 	}
 	return result
+}
+
+func TestGrpcClient_GetMachines(t *testing.T) {
+	fake := &recordingForgeClient{}
+
+	_, err := newRecordingGRPCClient(fake).GetMachines(context.Background())
+
+	require.NoError(t, err)
+	require.Len(t, fake.machineSearches, 1)
+	assert.True(t, fake.machineSearches[0].GetIncludeDpus())
 }
 
 func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {

--- a/rest-api/flow/internal/nicoapi/grpc_batch_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_batch_test.go
@@ -259,13 +259,61 @@ func stringsToPowerShelfIds(ids []string) []*corev1.PowerShelfId {
 }
 
 func TestGrpcClient_GetMachines(t *testing.T) {
-	fake := &recordingForgeClient{}
+	ids := []string{"a", "b", "c", "d"}
+	tests := []struct {
+		name        string
+		fake        *recordingForgeClient
+		grpcTimeout time.Duration
+		check       func(*testing.T, *recordingForgeClient, []MachineDetail, error)
+	}{
+		{
+			name: "includes DPUs in ID search",
+			fake: &recordingForgeClient{},
+			check: func(t *testing.T, fake *recordingForgeClient, _ []MachineDetail, err error) {
+				require.NoError(t, err)
+				require.Len(t, fake.machineSearches, 1)
+				assert.True(t, fake.machineSearches[0].GetIncludeDpus())
+			},
+		},
+		{
+			name: "gives ID and detail RPCs independent timeouts",
+			fake: &recordingForgeClient{
+				machineIDs:     []string{"machine-1"},
+				machineIDDelay: 120 * time.Millisecond,
+				machineDelay:   120 * time.Millisecond,
+			},
+			grpcTimeout: 200 * time.Millisecond,
+			check: func(t *testing.T, _ *recordingForgeClient, machines []MachineDetail, err error) {
+				require.NoError(t, err)
+				assert.Len(t, machines, 1)
+			},
+		},
+		{
+			name: "rejects a partial projected snapshot",
+			fake: &recordingForgeClient{
+				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 2},
+				machineIDs:    ids,
+				failCall:      2,
+			},
+			check: func(t *testing.T, _ *recordingForgeClient, machines []MachineDetail, err error) {
+				require.Error(t, err)
+				assert.Nil(t, machines)
+			},
+		},
+	}
 
-	_, err := newRecordingGRPCClient(fake).GetMachines(context.Background())
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := newRecordingGRPCClient(test.fake)
+			if test.grpcTimeout != 0 {
+				client.grpcTimeout = test.grpcTimeout
+			}
 
-	require.NoError(t, err)
-	require.Len(t, fake.machineSearches, 1)
-	assert.True(t, fake.machineSearches[0].GetIncludeDpus())
+			machines, err := client.GetMachines(context.Background())
+
+			test.check(t, test.fake, machines, err)
+		})
+	}
 }
 
 func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {
@@ -274,18 +322,6 @@ func TestGrpcClient_ActualInventoryRPCsHaveIndependentTimeouts(t *testing.T) {
 		fake   *recordingForgeClient
 		invoke func(context.Context, *grpcClient) (int, error)
 	}{
-		{
-			name: "machines",
-			fake: &recordingForgeClient{
-				machineIDs:     []string{"machine-1"},
-				machineIDDelay: 120 * time.Millisecond,
-				machineDelay:   120 * time.Millisecond,
-			},
-			invoke: func(ctx context.Context, client *grpcClient) (int, error) {
-				machines, err := client.GetMachines(ctx)
-				return len(machines), err
-			},
-		},
 		{
 			name: "switches",
 			fake: &recordingForgeClient{
@@ -788,17 +824,6 @@ func TestGrpcClient_ActualInventoryRejectsPartialProjectedSnapshots(t *testing.T
 		fake   *recordingForgeClient
 		invoke func(context.Context, *grpcClient) (any, error)
 	}{
-		{
-			name: "machines",
-			fake: &recordingForgeClient{
-				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 2},
-				machineIDs:    ids,
-				failCall:      2,
-			},
-			invoke: func(ctx context.Context, client *grpcClient) (any, error) {
-				return client.GetMachines(ctx)
-			},
-		},
 		{
 			name: "switches",
 			fake: &recordingForgeClient{

--- a/rest-api/flow/internal/nicoapi/grpc_batch_test.go
+++ b/rest-api/flow/internal/nicoapi/grpc_batch_test.go
@@ -300,6 +300,18 @@ func TestGrpcClient_GetMachines(t *testing.T) {
 				assert.Nil(t, machines)
 			},
 		},
+		{
+			name: "honors the Core batch limit",
+			fake: &recordingForgeClient{
+				runtimeConfig: &corev1.RuntimeConfig{MaxFindByIds: 2},
+				machineIDs:    []string{"a", "b", "c", "d", "e"},
+			},
+			check: func(t *testing.T, fake *recordingForgeClient, machines []MachineDetail, err error) {
+				require.NoError(t, err)
+				assert.Len(t, machines, 5)
+				assert.Equal(t, [][]string{{"a", "b"}, {"c", "d"}, {"e"}}, fake.machineBatches)
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -406,14 +418,6 @@ func TestGrpcClient_ByIDLookupsHonorCoreBatchLimit(t *testing.T) {
 		invoke     func(context.Context, *grpcClient, []string) (int, error)
 		batchCalls func(*recordingForgeClient) [][]string
 	}{
-		{
-			name: "listed machines",
-			invoke: func(ctx context.Context, client *grpcClient, _ []string) (int, error) {
-				machines, err := client.GetMachines(ctx)
-				return len(machines), err
-			},
-			batchCalls: func(fake *recordingForgeClient) [][]string { return fake.machineBatches },
-		},
 		{
 			name: "machines by IDs",
 			invoke: func(ctx context.Context, client *grpcClient, ids []string) (int, error) {


### PR DESCRIPTION
PR #5198 added DPU BMC reconciliation from a complete Core machine snapshot, but Flow's `GetMachines` still called `FindMachineIds` with `include_dpus` at its default `false` value. Host association references therefore could not resolve their DPU `MachineDetail` records, so reconciliation rejected the incomplete snapshot instead of creating or refreshing DPU BMC rows.

This enables DPU inclusion for the inventory ID query. Existing downstream host filtering remains unchanged, while DPU reconciliation receives both the HOST records and their referenced DPU details. The gRPC client test now records the search request and protects this production wiring.

## Related issues

Follow-up to #5198.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.) 
