### PR TITLE
fix(site-explorer): prevent span leak into hyper connections

### DIFF
--- a/crates/redfish/src/nv_redfish/mod.rs
+++ b/crates/redfish/src/nv_redfish/mod.rs
@@ -36,7 +36,11 @@ use nv_redfish::{Error as NvError, ServiceRoot as NvServiceRoot};
 use reqwest::header::HeaderMap;
 use url::Url;
 
-pub type RedfishBmc = HttpBmc<RedfishReqwestClient>;
+mod span_isolated_http_client;
+
+use span_isolated_http_client::SpanIsolatedHttpClient;
+
+pub type RedfishBmc = HttpBmc<SpanIsolatedHttpClient>;
 pub type ServiceRoot = NvServiceRoot<RedfishBmc>;
 pub type Error = NvError<RedfishBmc>;
 
@@ -524,7 +528,7 @@ impl NvRedfishClientPool {
             }
         };
         Ok(Arc::new(RedfishBmc::with_custom_headers(
-            client,
+            SpanIsolatedHttpClient::new(client),
             bmc_url,
             credentials,
             CacheSettings::with_capacity(10),

--- a/crates/redfish/src/nv_redfish/span_isolated_http_client.rs
+++ b/crates/redfish/src/nv_redfish/span_isolated_http_client.rs
@@ -1,0 +1,169 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+use http::HeaderMap;
+use nv_redfish::bmc_http::reqwest::{BmcError, Client};
+use nv_redfish::bmc_http::{BmcCredentials, HttpClient, MultipartUpdateRequest};
+use nv_redfish::core::{
+    BoxTryStream, ModificationResponse, ODataETag, SessionCreateResponse, UploadReader,
+};
+use serde::Serialize;
+use serde::de::DeserializeOwned;
+use tracing::Instrument;
+use url::Url;
+
+/// An nv-redfish Reqwest client whose transport work is detached from application spans.
+#[derive(Clone)]
+pub struct SpanIsolatedHttpClient {
+    inner: Client,
+}
+
+impl SpanIsolatedHttpClient {
+    pub(super) fn new(inner: Client) -> Self {
+        Self { inner }
+    }
+
+    fn span() -> tracing::Span {
+        // hyper-util's TokioExecutor instruments connection driver tasks with
+        // the current span. A pooled connection can outlive the request, so it
+        // must retain only this detached span rather than the caller's span.
+        tracing::info_span!(
+            parent: None,
+            "nv_redfish_http",
+            logfmt.suppress = true,
+        )
+    }
+}
+
+impl HttpClient for SpanIsolatedHttpClient {
+    type Error = BmcError;
+
+    async fn get<T>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        etag: Option<ODataETag>,
+        custom_headers: &HeaderMap,
+    ) -> Result<T, Self::Error>
+    where
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner
+            .get(url, credentials, etag, custom_headers)
+            .instrument(Self::span())
+            .await
+    }
+
+    async fn post<B, T>(
+        &self,
+        url: Url,
+        body: &B,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner
+            .post(url, body, credentials, custom_headers)
+            .instrument(Self::span())
+            .await
+    }
+
+    async fn post_session<B, T>(
+        &self,
+        url: Url,
+        body: &B,
+        custom_headers: &HeaderMap,
+    ) -> Result<SessionCreateResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner
+            .post_session(url, body, custom_headers)
+            .instrument(Self::span())
+            .await
+    }
+
+    async fn post_multipart_update<U, V, T>(
+        &self,
+        url: Url,
+        request: MultipartUpdateRequest<'_, U, V>,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        U: UploadReader,
+        T: DeserializeOwned + Send + Sync,
+        V: Serialize + Send + Sync,
+    {
+        self.inner
+            .post_multipart_update(url, request, credentials, custom_headers)
+            .instrument(Self::span())
+            .await
+    }
+
+    async fn patch<B, T>(
+        &self,
+        url: Url,
+        etag: ODataETag,
+        body: &B,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        B: Serialize + Send + Sync,
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner
+            .patch(url, etag, body, credentials, custom_headers)
+            .instrument(Self::span())
+            .await
+    }
+
+    async fn delete<T>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<ModificationResponse<T>, Self::Error>
+    where
+        T: DeserializeOwned + Send + Sync,
+    {
+        self.inner
+            .delete(url, credentials, custom_headers)
+            .instrument(Self::span())
+            .await
+    }
+
+    async fn sse<T>(
+        &self,
+        url: Url,
+        credentials: &BmcCredentials,
+        custom_headers: &HeaderMap,
+    ) -> Result<BoxTryStream<T, Self::Error>, Self::Error>
+    where
+        T: Sized + for<'de> serde::Deserialize<'de> + Send,
+    {
+        self.inner
+            .sse(url, credentials, custom_headers)
+            .instrument(Self::span())
+            .await
+    }
+}


### PR DESCRIPTION
In some circumstances, a tracing span can leak into Hyper’s connection pool, causing the span to close only when the underlying connection closes. This produces misleading, unexpectedly long-lived span records.

This PR prevents spans created by `nv-redfish` operations from leaking into Hyper’s connection pool.

## Related issues

N/A

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
