### PR TITLE
fix(flow): isolate drift persistence by component type

### DIFF
--- a/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.down.sql
@@ -1,1 +1,4 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 ALTER TABLE component_drift DROP COLUMN component_type;

--- a/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE component_drift DROP COLUMN component_type;

--- a/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.up.sql
@@ -1,0 +1,8 @@
+-- Scope derived drift rows so each actual-inventory source can refresh independently.
+-- NULL remains accepted while predecessor Flow instances may still write the table.
+ALTER TABLE component_drift ADD COLUMN component_type VARCHAR(32);
+
+UPDATE component_drift AS drift
+SET component_type = component.type
+FROM component
+WHERE drift.component_id = component.id;

--- a/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260909120000_component_drift_component_type.up.sql
@@ -1,3 +1,6 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
 -- Scope derived drift rows so each actual-inventory source can refresh independently.
 -- NULL remains accepted while predecessor Flow instances may still write the table.
 ALTER TABLE component_drift ADD COLUMN component_type VARCHAR(32);

--- a/rest-api/flow/internal/db/migrations/component_drift_component_type_test.go
+++ b/rest-api/flow/internal/db/migrations/component_drift_component_type_test.go
@@ -5,6 +5,7 @@ package migrations_test
 
 import (
 	"context"
+	"database/sql"
 	_ "embed"
 	"testing"
 
@@ -49,17 +50,24 @@ func TestComponentDriftComponentTypeMigration(t *testing.T) {
 	_, err = session.DB.ExecContext(ctx, componentDriftComponentTypeUp)
 	require.NoError(t, err)
 
-	var componentTypes []*string
+	var linkedComponentType sql.NullString
 	err = session.DB.NewSelect().
 		Table("component_drift").
 		Column("component_type").
-		OrderExpr("component_id NULLS LAST").
-		Scan(ctx, &componentTypes)
+		Where("component_id = ?", componentID).
+		Scan(ctx, &linkedComponentType)
 	require.NoError(t, err)
-	require.Len(t, componentTypes, 2)
-	require.NotNil(t, componentTypes[0])
-	require.Equal(t, "Compute", *componentTypes[0])
-	require.Nil(t, componentTypes[1], "an unlinked predecessor row must not be assigned a guessed type")
+	require.True(t, linkedComponentType.Valid)
+	require.Equal(t, "Compute", linkedComponentType.String)
+
+	var unlinkedComponentType sql.NullString
+	err = session.DB.NewSelect().
+		Table("component_drift").
+		Column("component_type").
+		Where("component_id IS NULL").
+		Scan(ctx, &unlinkedComponentType)
+	require.NoError(t, err)
+	require.False(t, unlinkedComponentType.Valid, "an unlinked predecessor row must not be assigned a guessed type")
 
 	_, err = session.DB.ExecContext(
 		ctx,

--- a/rest-api/flow/internal/db/migrations/component_drift_component_type_test.go
+++ b/rest-api/flow/internal/db/migrations/component_drift_component_type_test.go
@@ -1,0 +1,70 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations_test
+
+import (
+	"context"
+	_ "embed"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/storetest"
+)
+
+//go:embed 20260909120000_component_drift_component_type.up.sql
+var componentDriftComponentTypeUp string
+
+//go:embed 20260909120000_component_drift_component_type.down.sql
+var componentDriftComponentTypeDown string
+
+func TestComponentDriftComponentTypeMigration(t *testing.T) {
+	ctx := context.Background()
+	session := storetest.NewPostgresTestSession(t)
+
+	_, err := session.DB.ExecContext(ctx, componentDriftComponentTypeDown)
+	require.NoError(t, err)
+
+	componentID := uuid.New()
+	_, err = session.DB.ExecContext(
+		ctx,
+		`INSERT INTO component (id, type, manufacturer, serial_number, rack_id)
+		 VALUES (?, 'Compute', 'test', 'compute-1', ?)`,
+		componentID,
+		uuid.New(),
+	)
+	require.NoError(t, err)
+
+	_, err = session.DB.ExecContext(
+		ctx,
+		`INSERT INTO component_drift (component_id, drift_type, diffs)
+		 VALUES (?, 'missing_in_actual', '[]'),
+		        (NULL, 'missing_in_expected', '[]')`,
+		componentID,
+	)
+	require.NoError(t, err)
+
+	_, err = session.DB.ExecContext(ctx, componentDriftComponentTypeUp)
+	require.NoError(t, err)
+
+	var componentTypes []*string
+	err = session.DB.NewSelect().
+		Table("component_drift").
+		Column("component_type").
+		Order("component_id NULLS LAST").
+		Scan(ctx, &componentTypes)
+	require.NoError(t, err)
+	require.Len(t, componentTypes, 2)
+	require.NotNil(t, componentTypes[0])
+	require.Equal(t, "Compute", *componentTypes[0])
+	require.Nil(t, componentTypes[1], "an unlinked predecessor row must not be assigned a guessed type")
+
+	_, err = session.DB.ExecContext(
+		ctx,
+		`INSERT INTO component_drift (external_id, drift_type, diffs)
+		 VALUES ('predecessor-write', 'missing_in_expected', '[]')`,
+	)
+	require.NoError(t, err, "the additive column must remain optional for a predecessor writer")
+}

--- a/rest-api/flow/internal/db/migrations/component_drift_component_type_test.go
+++ b/rest-api/flow/internal/db/migrations/component_drift_component_type_test.go
@@ -53,7 +53,7 @@ func TestComponentDriftComponentTypeMigration(t *testing.T) {
 	err = session.DB.NewSelect().
 		Table("component_drift").
 		Column("component_type").
-		Order("component_id NULLS LAST").
+		OrderExpr("component_id NULLS LAST").
 		Scan(ctx, &componentTypes)
 	require.NoError(t, err)
 	require.Len(t, componentTypes, 2)

--- a/rest-api/flow/internal/db/model/component_drift.go
+++ b/rest-api/flow/internal/db/model/component_drift.go
@@ -41,30 +41,58 @@ type FieldDiff struct {
 type ComponentDrift struct {
 	bun.BaseModel `bun:"table:component_drift,alias:cd"`
 
-	ID          uuid.UUID   `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
-	ComponentID *uuid.UUID  `bun:"component_id,type:uuid"` // NULL for missing_in_expected
-	ExternalID  *string     `bun:"external_id"`            // Component ID from the component manager service; NULL for missing_in_actual
-	DriftType   DriftType   `bun:"drift_type,type:varchar(32),notnull"`
-	Diffs       []FieldDiff `bun:"diffs,type:jsonb,notnull,default:'[]'"`
-	CheckedAt   time.Time   `bun:"checked_at,notnull,default:current_timestamp"`
+	ID            uuid.UUID   `bun:"id,pk,type:uuid,default:gen_random_uuid()"`
+	ComponentID   *uuid.UUID  `bun:"component_id,type:uuid"` // NULL for missing_in_expected
+	ExternalID    *string     `bun:"external_id"`            // Component ID from the component manager service; NULL for missing_in_actual
+	ComponentType *string     `bun:"component_type"`         // Internal replacement boundary; NULL only for rows written by a predecessor
+	DriftType     DriftType   `bun:"drift_type,type:varchar(32),notnull"`
+	Diffs         []FieldDiff `bun:"diffs,type:jsonb,notnull,default:'[]'"`
+	CheckedAt     time.Time   `bun:"checked_at,notnull,default:current_timestamp"`
 }
 
-// ReplaceAllDrifts replaces all component_drift rows with the given set.
-// This is called once per inventory loop cycle to overwrite stale data.
-func ReplaceAllDrifts(ctx context.Context, idb bun.IDB, drifts []ComponentDrift) error {
-	// Delete all existing drift records
-	if _, err := idb.NewDelete().Model((*ComponentDrift)(nil)).Where("TRUE").Exec(ctx); err != nil {
+// ReplaceDriftsByComponentType atomically replaces one component type's drift
+// rows. Legacy linked rows can be classified through component.type and are
+// removed with that type. Unlinked legacy rows cannot be classified safely and
+// remain until a complete successful inventory cycle removes them.
+func ReplaceDriftsByComponentType(
+	ctx context.Context,
+	idb bun.IDB,
+	componentType string,
+	drifts []ComponentDrift,
+) error {
+	if _, err := idb.NewDelete().
+		Model((*ComponentDrift)(nil)).
+		Where("component_type = ?", componentType).
+		WhereOr(
+			"component_type IS NULL AND component_id IN (SELECT id FROM component WHERE type = ?)",
+			componentType,
+		).
+		Exec(ctx); err != nil {
 		return err
 	}
 
-	// Insert new drift records (if any)
 	if len(drifts) > 0 {
+		for i := range drifts {
+			drifts[i].ComponentType = &componentType
+		}
 		if _, err := idb.NewInsert().Model(&drifts).Exec(ctx); err != nil {
 			return err
 		}
 	}
 
 	return nil
+}
+
+// DeleteLegacyUnscopedDrifts removes rows written without a component type.
+// Callers may invoke this only after every supported type was synchronized and
+// persisted successfully, because unlinked rows cannot otherwise be assigned
+// to a safe replacement boundary.
+func DeleteLegacyUnscopedDrifts(ctx context.Context, idb bun.IDB) error {
+	_, err := idb.NewDelete().
+		Model((*ComponentDrift)(nil)).
+		Where("component_type IS NULL").
+		Exec(ctx)
+	return err
 }
 
 // GetDriftsByComponentIDs retrieves drift records for the given component UUIDs.

--- a/rest-api/flow/internal/db/model/component_drift_test.go
+++ b/rest-api/flow/internal/db/model/component_drift_test.go
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package model_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/storetest"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+)
+
+func TestReplaceDriftsByComponentType(t *testing.T) {
+	ctx := context.Background()
+	session := storetest.NewPostgresTestSession(t)
+
+	computeType := devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute)
+	switchType := devicetypes.ComponentTypeToString(devicetypes.ComponentTypeNVSwitch)
+	compute := createDriftTestComponent(t, ctx, session.DB, computeType)
+	switchComponent := createDriftTestComponent(t, ctx, session.DB, switchType)
+	legacyOrphanID := "legacy-orphan"
+	drifts := []model.ComponentDrift{
+		{ComponentID: &compute.ID, DriftType: model.DriftTypeMissingInActual, Diffs: []model.FieldDiff{}, CheckedAt: time.Now()},
+		{ComponentID: &switchComponent.ID, DriftType: model.DriftTypeMissingInActual, Diffs: []model.FieldDiff{}, CheckedAt: time.Now()},
+		{ExternalID: &legacyOrphanID, DriftType: model.DriftTypeMissingInExpected, Diffs: []model.FieldDiff{}, CheckedAt: time.Now()},
+		{ComponentType: &computeType, DriftType: model.DriftTypeMissingInActual, Diffs: []model.FieldDiff{}, CheckedAt: time.Now()},
+		{ComponentType: &switchType, DriftType: model.DriftTypeMissingInActual, Diffs: []model.FieldDiff{}, CheckedAt: time.Now()},
+	}
+	_, err := session.DB.NewInsert().Model(&drifts).Exec(ctx)
+	require.NoError(t, err)
+
+	newComputeID := "new-compute"
+	err = session.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return model.ReplaceDriftsByComponentType(ctx, tx, computeType, []model.ComponentDrift{{
+			ExternalID: &newComputeID,
+			DriftType:  model.DriftTypeMissingInExpected,
+			Diffs:      []model.FieldDiff{},
+			CheckedAt:  time.Now(),
+		}})
+	})
+	require.NoError(t, err)
+
+	got, err := model.GetAllDrifts(ctx, session.DB)
+	require.NoError(t, err)
+	assertDriftExternalIDsByType(t, got, map[string][]string{
+		"":          {legacyOrphanID, ""},
+		computeType: {newComputeID},
+		switchType:  {""},
+	})
+
+	err = session.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		return model.ReplaceDriftsByComponentType(ctx, tx, switchType, nil)
+	})
+	require.NoError(t, err)
+	got, err = model.GetAllDrifts(ctx, session.DB)
+	require.NoError(t, err)
+	assertDriftExternalIDsByType(t, got, map[string][]string{
+		"":          {legacyOrphanID},
+		computeType: {newComputeID},
+	})
+
+	require.NoError(t, model.DeleteLegacyUnscopedDrifts(ctx, session.DB))
+	got, err = model.GetAllDrifts(ctx, session.DB)
+	require.NoError(t, err)
+	assertDriftExternalIDsByType(t, got, map[string][]string{computeType: {newComputeID}})
+}
+
+func createDriftTestComponent(t *testing.T, ctx context.Context, db bun.IDB, componentType string) model.Component {
+	t.Helper()
+	component := model.Component{
+		Type:         componentType,
+		Manufacturer: "test",
+		SerialNumber: uuid.NewString(),
+		RackID:       uuid.New(),
+	}
+	require.NoError(t, component.Create(ctx, db))
+	return component
+}
+
+func assertDriftExternalIDsByType(t *testing.T, drifts []model.ComponentDrift, expected map[string][]string) {
+	t.Helper()
+	actual := make(map[string][]string)
+	for _, drift := range drifts {
+		componentType := ""
+		if drift.ComponentType != nil {
+			componentType = *drift.ComponentType
+		}
+		externalID := ""
+		if drift.ExternalID != nil {
+			externalID = *drift.ExternalID
+		}
+		actual[componentType] = append(actual[componentType], externalID)
+	}
+	require.Len(t, actual, len(expected))
+	for componentType, externalIDs := range expected {
+		assert.ElementsMatch(t, externalIDs, actual[componentType], componentType)
+	}
+}

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
@@ -13,46 +13,54 @@ import (
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
 
-// runActualSync runs every per-type actual-vs-expected drift detector, projects
-// observed NVLink domain topology, concatenates the component drifts, and logs
-// a per-type inventory summary. Each type-specific function handles its own
-// errors internally and falls back to nil drifts; one type's snapshot or
-// reconciliation failure doesn't suppress the others.
-//
-// allSyncOK is true only when every type obtained a complete drift-affecting
-// snapshot and safely reconciled the identity state needed to interpret it. The
-// drift table is a full-table replace with no per-type discriminator, so the
-// caller must not overwrite it from a partial view: if any type failed, the
-// previously persisted drifts are kept rather than being wiped. The
-// observed-domain projection is best effort and does not affect allSyncOK
-// because it does not contribute component drifts. The returned drifts are not
-// yet persisted — runInventoryOne owns the table-replacement transaction.
+type actualSyncResult struct {
+	componentType devicetypes.ComponentType
+	drifts        []model.ComponentDrift
+	syncOK        bool
+}
+
+// runActualSync runs every per-type actual-vs-expected drift detector and
+// returns each type's result independently. A type's result is authoritative
+// only when syncOK is true. The observed-domain projection remains best effort
+// because it does not contribute component drifts.
 func runActualSync(
 	ctx context.Context,
 	pool *cdb.Session,
 	nicoClient nicoapi.Client,
-) (drifts []model.ComponentDrift, allSyncOK bool) {
-	allSyncOK = true
+) []actualSyncResult {
+	results := make([]actualSyncResult, 0, 3)
 
 	computeReceived, machineDrifts, machineOK := syncMachines(ctx, pool, nicoClient)
-	drifts = append(drifts, machineDrifts...)
-	allSyncOK = allSyncOK && machineOK
+	results = append(results, actualSyncResult{
+		componentType: devicetypes.ComponentTypeCompute,
+		drifts:        machineDrifts,
+		syncOK:        machineOK,
+	})
 
 	switchesReceived, nvSwitchDrifts, switchOK := syncNVSwitchesNICo(ctx, pool, nicoClient)
-	drifts = append(drifts, nvSwitchDrifts...)
-	allSyncOK = allSyncOK && switchOK
+	results = append(results, actualSyncResult{
+		componentType: devicetypes.ComponentTypeNVSwitch,
+		drifts:        nvSwitchDrifts,
+		syncOK:        switchOK,
+	})
 
 	// Domain membership is observed topology rather than expected inventory.
 	// Project it after switch sync so this cycle's switch links are available.
 	syncObservedNVLinkDomainTopology(ctx, pool, nicoClient)
 
 	powershelvesReceived, powershelfDrifts, powershelfOK := syncPowershelvesNICo(ctx, pool, nicoClient)
-	drifts = append(drifts, powershelfDrifts...)
-	allSyncOK = allSyncOK && powershelfOK
+	results = append(results, actualSyncResult{
+		componentType: devicetypes.ComponentTypePowerShelf,
+		drifts:        powershelfDrifts,
+		syncOK:        powershelfOK,
+	})
+
+	allSyncOK := machineOK && switchOK && powershelfOK
 
 	log.Info().
 		Int("compute", computeReceived).
@@ -66,7 +74,7 @@ func runActualSync(
 		Msgf("Inventory received from Core: compute=%d nvswitches=%d powershelves=%d",
 			computeReceived, switchesReceived, powershelvesReceived)
 
-	return drifts, allSyncOK
+	return results
 }
 
 // mapKeys returns the keys of a string-keyed component map in arbitrary

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_dpu_test.go
@@ -4,6 +4,7 @@
 package inventorysync
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/google/uuid"
@@ -347,4 +348,41 @@ func TestSyncMachinesDpuFailureDoesNotBlockHostConvergence(t *testing.T) {
 	require.NoError(t, pool.DB.NewSelect().Model(&persisted).Where("id = ?", component.ID).Scan(ctx))
 	require.NotNil(t, persisted.PowerState)
 	assert.Equal(t, nicoapi.PowerStateOn, *persisted.PowerState)
+}
+
+func TestSyncMachinesPositionFailureDoesNotBlockDPUReconciliation(t *testing.T) {
+	ctx, pool := mirrorTestPool(t)
+	const hostMAC = "aa:bb:cc:dd:ee:20"
+	const dpuMAC = "aa:bb:cc:dd:ee:21"
+	component := model.Component{
+		Type: devicetypes.ComponentTypeToString(devicetypes.ComponentTypeCompute),
+	}
+	require.NoError(t, component.Create(ctx, pool.DB))
+	createTestBMC(ctx, t, pool, component.ID, hostMAC)
+
+	client := &actualInventoryTestClient{
+		Client: nicoapi.NewMockClient(),
+		machines: []nicoapi.MachineDetail{
+			{
+				MachineID:               "host-1",
+				MachineType:             corev1.MachineType_HOST.String(),
+				BmcMac:                  hostMAC,
+				AssociatedDpuMachineIDs: []string{"dpu-1"},
+			},
+			{
+				MachineID:   "dpu-1",
+				MachineType: corev1.MachineType_DPU.String(),
+				BmcMac:      dpuMAC,
+			},
+		},
+		machinePositionErr: errors.New("positions unavailable"),
+	}
+
+	_, _, ok := syncMachines(ctx, pool, client)
+
+	assert.False(t, ok)
+	var dpu model.BMC
+	require.NoError(t, pool.DB.NewSelect().Model(&dpu).Where("mac_address = ?", dpuMAC).Scan(ctx))
+	assert.Equal(t, devicetypes.BMCTypeToString(devicetypes.BMCTypeDPU), dpu.Type)
+	assert.Equal(t, component.ID, dpu.ComponentID)
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
@@ -31,6 +32,36 @@ type failGetMachinesClient struct {
 // while its embedded mock client continues to serve the other sync RPCs.
 func (c *failGetMachinesClient) GetMachines(_ context.Context) ([]nicoapi.MachineDetail, error) {
 	return nil, errors.New("boom")
+}
+
+type actualInventoryTestClient struct {
+	nicoapi.Client
+	machines           []nicoapi.MachineDetail
+	switches           []nicoapi.ObservedControllerDevice
+	powerShelves       []nicoapi.ObservedControllerDevice
+	machineErr         error
+	switchErr          error
+	powerShelfErr      error
+	machinePositionErr error
+}
+
+func (c *actualInventoryTestClient) GetMachines(_ context.Context) ([]nicoapi.MachineDetail, error) {
+	return c.machines, c.machineErr
+}
+
+func (c *actualInventoryTestClient) GetSwitches(_ context.Context) ([]nicoapi.ObservedControllerDevice, error) {
+	return c.switches, c.switchErr
+}
+
+func (c *actualInventoryTestClient) GetPowerShelves(_ context.Context) ([]nicoapi.ObservedControllerDevice, error) {
+	return c.powerShelves, c.powerShelfErr
+}
+
+func (c *actualInventoryTestClient) GetMachinePositionInfo(
+	_ context.Context,
+	_ []string,
+) ([]nicoapi.MachinePosition, error) {
+	return nil, c.machinePositionErr
 }
 
 func TestFilterHostMachineDetails(t *testing.T) {
@@ -235,6 +266,134 @@ func TestRunInventoryOne(t *testing.T) {
 		require.NotNil(t, drifts[0].ExternalID)
 		assert.Equal(t, externalID, *drifts[0].ExternalID)
 	})
+
+	for _, failedType := range []devicetypes.ComponentType{
+		devicetypes.ComponentTypeCompute,
+		devicetypes.ComponentTypeNVSwitch,
+		devicetypes.ComponentTypePowerShelf,
+	} {
+		failedType := failedType
+		t.Run("type failure preserves only "+devicetypes.ComponentTypeToString(failedType), func(t *testing.T) {
+			ctx, pool := mirrorTestPool(t)
+			seedInventoryDrifts(t, ctx, pool, "old")
+
+			client := newActualInventoryTestClient("first")
+			switch failedType {
+			case devicetypes.ComponentTypeCompute:
+				client.machineErr = errors.New("compute unavailable")
+			case devicetypes.ComponentTypeNVSwitch:
+				client.switchErr = errors.New("switch unavailable")
+			case devicetypes.ComponentTypePowerShelf:
+				client.powerShelfErr = errors.New("power shelf unavailable")
+			}
+
+			runInventoryOne(ctx, pool, client, false)
+
+			expected := map[string]string{
+				"Compute":    "compute-first",
+				"NVSwitch":   "switch-first",
+				"PowerShelf": "powershelf-first",
+			}
+			expected[devicetypes.ComponentTypeToString(failedType)] = "old-" + devicetypes.ComponentTypeToString(failedType)
+			assertInventoryDrifts(t, ctx, pool, expected)
+
+			client = newActualInventoryTestClient("recovery")
+			runInventoryOne(ctx, pool, client, false)
+			assertInventoryDrifts(t, ctx, pool, map[string]string{
+				"Compute":    "compute-recovery",
+				"NVSwitch":   "switch-recovery",
+				"PowerShelf": "powershelf-recovery",
+			})
+		})
+	}
+
+	t.Run("persistence failure does not block later component types", func(t *testing.T) {
+		ctx, pool := mirrorTestPool(t)
+		seedInventoryDrifts(t, ctx, pool, "old")
+		_, err := pool.DB.ExecContext(ctx, `
+			CREATE FUNCTION fail_nvswitch_drift_delete() RETURNS trigger AS $$
+			BEGIN
+				RAISE EXCEPTION 'injected NVSwitch persistence failure';
+			END;
+			$$ LANGUAGE plpgsql;
+			CREATE TRIGGER fail_nvswitch_drift_delete
+			BEFORE DELETE ON component_drift
+			FOR EACH ROW WHEN (OLD.component_type = 'NVSwitch')
+			EXECUTE FUNCTION fail_nvswitch_drift_delete();
+		`)
+		require.NoError(t, err)
+
+		runInventoryOne(ctx, pool, newActualInventoryTestClient("first"), false)
+		assertInventoryDrifts(t, ctx, pool, map[string]string{
+			"Compute":    "compute-first",
+			"NVSwitch":   "old-NVSwitch",
+			"PowerShelf": "powershelf-first",
+		})
+
+		_, err = pool.DB.ExecContext(ctx, `
+			DROP TRIGGER fail_nvswitch_drift_delete ON component_drift;
+			DROP FUNCTION fail_nvswitch_drift_delete();
+		`)
+		require.NoError(t, err)
+		runInventoryOne(ctx, pool, newActualInventoryTestClient("recovery"), false)
+		assertInventoryDrifts(t, ctx, pool, map[string]string{
+			"Compute":    "compute-recovery",
+			"NVSwitch":   "switch-recovery",
+			"PowerShelf": "powershelf-recovery",
+		})
+	})
+}
+
+func newActualInventoryTestClient(suffix string) *actualInventoryTestClient {
+	return &actualInventoryTestClient{
+		Client: nicoapi.NewMockClient(),
+		machines: []nicoapi.MachineDetail{{
+			MachineID:   "compute-" + suffix,
+			MachineType: corev1.MachineType_HOST.String(),
+		}},
+		switches: []nicoapi.ObservedControllerDevice{{
+			ID:     "switch-" + suffix,
+			BmcMac: "aa:bb:cc:dd:ee:01",
+		}},
+		powerShelves: []nicoapi.ObservedControllerDevice{{
+			ID:     "powershelf-" + suffix,
+			BmcMac: "aa:bb:cc:dd:ee:02",
+		}},
+	}
+}
+
+func seedInventoryDrifts(t *testing.T, ctx context.Context, pool *cdb.Session, suffix string) {
+	t.Helper()
+	drifts := make([]model.ComponentDrift, 0, 3)
+	for _, componentType := range []devicetypes.ComponentType{
+		devicetypes.ComponentTypeCompute,
+		devicetypes.ComponentTypeNVSwitch,
+		devicetypes.ComponentTypePowerShelf,
+	} {
+		typeName := devicetypes.ComponentTypeToString(componentType)
+		externalID := suffix + "-" + typeName
+		drifts = append(drifts, model.ComponentDrift{
+			ExternalID:    &externalID,
+			ComponentType: &typeName,
+			DriftType:     model.DriftTypeMissingInExpected,
+			Diffs:         []model.FieldDiff{},
+			CheckedAt:     time.Now(),
+		})
+	}
+	_, err := pool.DB.NewInsert().Model(&drifts).Exec(ctx)
+	require.NoError(t, err)
+}
+
+func assertInventoryDrifts(t *testing.T, ctx context.Context, pool *cdb.Session, expected map[string]string) {
+	t.Helper()
+	drifts, err := model.GetAllDrifts(ctx, pool.DB)
+	require.NoError(t, err)
+	require.Len(t, drifts, len(expected))
+	for _, drift := range drifts {
+		require.NotNil(t, drift.ComponentType)
+		require.NotNil(t, drift.ExternalID)
+		assert.Equal(t, expected[*drift.ComponentType], *drift.ExternalID)
+	}
 }
 
 func TestCompareMachineFieldsForDrift_NoMismatch(t *testing.T) {

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory.go
@@ -14,7 +14,8 @@
 // transactional batch reconcile, resurrection of soft-deleted rows,
 // column-whitelist updates, tombstone GC, and a drift-table replace. Follow-up:
 // add those as transactional batch methods on the store (e.g.
-// ReconcileExpectedRacks / ReconcileExpectedComponents / ReplaceAllDrifts) and
+// ReconcileExpectedRacks / ReconcileExpectedComponents /
+// ReplaceDriftsByComponentType) and
 // route both halves of this job through the manager so there's a single
 // writer. Tracked separately from the correctness fixes.
 package inventorysync
@@ -28,6 +29,7 @@ import (
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 )
 
 // runInventoryOne is a single iteration of the inventory sync job. Order:
@@ -38,15 +40,11 @@ import (
 //     step is skipped entirely and Flow's existing ingestion path is the
 //     sole writer to rack / component.
 //  2. runActualSync reconciles actual component state, projects valid NVLink
-//     domain observations, and returns one combined drift set (the "actual"
-//     half — see actual_sync*.go).
-//  3. The drift set replaces the whole component_drift table atomically so
-//     stale rows from previous runs can't linger. The replace is skipped
-//     when any actual-sync snapshot or reconciliation failed:
-//     component_drift is a full-table replace with no per-type discriminator,
-//     so writing a partial view would wipe the drifts of the failed types. The
-//     existing table is left intact until a fully successful cycle refreshes
-//     it.
+//     domain observations, and returns an independent result for Compute,
+//     NVSwitch, and PowerShelf (the "actual" half — see actual_sync*.go).
+//  3. Each successful type atomically replaces only its own drift rows. A
+//     failed type preserves its previous rows, and one persistence failure does
+//     not prevent later types from being attempted.
 //
 // Errors are handled inside each step: any per-type RPC failure is logged
 // and that type's drifts are skipped, but the rest of the cycle continues.
@@ -64,18 +62,34 @@ func runInventoryOne(
 		log.Debug().Msgf("Expected-inventory mirror: skipped this cycle (gate %s is off)", envExpectedSyncEnabled)
 	}
 
-	drifts, allSyncOK := runActualSync(ctx, pool, nicoClient)
-	if !allSyncOK {
-		log.Warn().Int("drifts_this_cycle", len(drifts)).
-			Msg("Drift detection: one or more actual-sync snapshots or reconciliations failed; preserving existing component_drift table this cycle instead of overwriting it with a partial view")
-		return
+	results := runActualSync(ctx, pool, nicoClient)
+	allPersisted := true
+	for _, result := range results {
+		componentType := devicetypes.ComponentTypeToString(result.componentType)
+		if !result.syncOK {
+			allPersisted = false
+			log.Warn().Str("component_type", componentType).
+				Msg("Drift detection failed; preserving this component type's previous drift records")
+			continue
+		}
+
+		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+			return model.ReplaceDriftsByComponentType(ctx, tx, componentType, result.drifts)
+		}); err != nil {
+			allPersisted = false
+			log.Error().Err(err).Str("component_type", componentType).
+				Msg("Unable to persist drift records")
+			continue
+		}
+		log.Info().Str("component_type", componentType).
+			Msg("Drift snapshot persisted")
 	}
 
-	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
-		return model.ReplaceAllDrifts(ctx, tx, drifts)
-	}); err != nil {
-		log.Error().Msgf("Unable to persist drift records: %v", err)
-	} else {
-		log.Info().Msgf("Drift detection complete: %d drift(s) detected", len(drifts))
+	if allPersisted {
+		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+			return model.DeleteLegacyUnscopedDrifts(ctx, tx)
+		}); err != nil {
+			log.Error().Err(err).Msg("Unable to remove legacy unscoped drift records")
+		}
 	}
 }


### PR DESCRIPTION
Flow currently treats Compute, NVSwitch, and PowerShelf drift persistence as one failure domain. If one actual-inventory source fails, successful sources continue reconciling direct inventory fields but cannot publish their drift snapshots because the only safe operation is a full-table replacement. This change gives each source an explicit persisted ownership boundary so successful sources can refresh independently without deleting failed-source drift.

## Related issues

- Fixes #5932

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

The additive nullable `component_type` column remains writable by predecessor Flow instances. The migration backfills only linked rows whose type is proven by `component.id`; unlinked legacy rows are not guessed and are removed only after every supported source synchronizes and persists successfully. The public drift API shape is unchanged.

Verification:

- `make test-flow`
- `make lint-go`
- `make fmt-go`
- `make rest-api/generate-sdk`
- `make rest-api/core-proto`