### PR TITLE
fix(nmxc-browser): sync nmxc-broser endpoint field name at form submit

### DIFF
--- a/crates/api-core/src/handlers/nmxc_browse.rs
+++ b/crates/api-core/src/handlers/nmxc_browse.rs
@@ -177,14 +177,7 @@ pub(crate) async fn nmxc_browse(
         .await?;
 
         let Some(url) = endpoint_url else {
-            let endpoint_id = rack_id
-                .map(|r| r.to_string())
-                .unwrap_or_else(|| chassis_serial.to_string());
-            return Err(CarbideError::NotFoundError {
-                kind: "nvlink_nmxc_endpoint",
-                id: endpoint_id,
-            }
-            .into());
+            return Err(endpoint_not_found_error(group_type, chassis_serial, rack_id).into());
         };
 
         let mut nmxc = api
@@ -274,10 +267,33 @@ fn resolve_group_type(
     }
 }
 
+/// Builds the "no NMX-C endpoint" error for a failed [`resolve_nmx_c_endpoint_url`] lookup.
+///
+/// The chassis and rack paths consult disjoint data (the `nvlink_nmxc_endpoints` table vs.
+/// ready, NMX-C-configured switches in the rack), so `kind` names which lookup came up empty
+/// instead of a single generic label that can't distinguish a missing config row from a rack
+/// with no ready switch.
+fn endpoint_not_found_error(
+    group_type: ManagedHostGroupType,
+    chassis_serial: &str,
+    rack_id: Option<&carbide_uuid::rack::RackId>,
+) -> CarbideError {
+    match group_type {
+        ManagedHostGroupType::Chassis => CarbideError::NotFoundError {
+            kind: "nvlink_nmxc_endpoints",
+            id: chassis_serial.to_string(),
+        },
+        ManagedHostGroupType::Rack => CarbideError::NotFoundError {
+            kind: "nvlink_ready_switch",
+            id: rack_id.map(|r| r.to_string()).unwrap_or_default(),
+        },
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use carbide_test_support::Outcome::{FailsWith, Yields};
-    use carbide_test_support::scenarios;
+    use carbide_test_support::{scenarios, value_scenarios};
     use carbide_uuid::rack::RackId;
 
     use super::*;
@@ -314,6 +330,35 @@ mod tests {
             "neither provided" {
                 ("", None) => FailsWith(SelectionError::Neither),
                 ("   ", None) => FailsWith(SelectionError::Neither),
+            }
+        );
+    }
+
+    #[test]
+    fn endpoint_not_found_error_names_the_path_specific_lookup() {
+        value_scenarios!(run = |(group_type, chassis_serial, rack_id_str): (
+            ManagedHostGroupType,
+            &str,
+            Option<&str>,
+        )| {
+            let rack_id = rack_id_str.map(RackId::new);
+            match endpoint_not_found_error(group_type, chassis_serial, rack_id.as_ref()) {
+                CarbideError::NotFoundError { kind, id } => (kind, id),
+                other => panic!("expected NotFoundError, got {other:?}"),
+            }
+        };
+            "chassis path names the config table, keyed by chassis_serial" {
+                (ManagedHostGroupType::Chassis, "SN-123", None) => (
+                    "nvlink_nmxc_endpoints",
+                    "SN-123".to_string(),
+                ),
+            }
+
+            "rack path names the switch lookup, keyed by rack_id" {
+                (ManagedHostGroupType::Rack, "", Some("a12")) => (
+                    "nvlink_ready_switch",
+                    "a12".to_string(),
+                ),
             }
         );
     }

--- a/crates/api-core/src/handlers/nmxc_browse.rs
+++ b/crates/api-core/src/handlers/nmxc_browse.rs
@@ -18,7 +18,9 @@
 use std::collections::HashMap;
 
 use ::rpc::forge as rpc;
-use carbide_nvlink_manager::nmx_c_endpoint::{ManagedHostGroupType, resolve_nmx_c_endpoint_url};
+use carbide_nvlink_manager::nmx_c_endpoint::{
+    ManagedHostGroupType, NmxCEndpointResolution, resolve_nmx_c_endpoint_url,
+};
 use libnmxc::nmxc_model::{
     GetComputeNodeInfoListRequest, GetGpuInfoListRequest, GetPartitionInfoListRequest,
     GetSwitchNodeInfoListRequest, GpuAttr,
@@ -163,7 +165,7 @@ pub(crate) async fn nmxc_browse(
         && nvlink_config.enabled
     {
         let mut db = api.db_reader();
-        let endpoint_url = resolve_nmx_c_endpoint_url(
+        let resolution = resolve_nmx_c_endpoint_url(
             &mut db,
             group_type,
             rack_id,
@@ -176,8 +178,14 @@ pub(crate) async fn nmxc_browse(
         )
         .await?;
 
-        let Some(url) = endpoint_url else {
-            return Err(endpoint_not_found_error(group_type, chassis_serial, rack_id).into());
+        let url = match resolution {
+            NmxCEndpointResolution::Resolved(url) => url,
+            NmxCEndpointResolution::NotFound => {
+                return Err(endpoint_not_found_error(group_type, chassis_serial, rack_id).into());
+            }
+            NmxCEndpointResolution::SwitchMissingNvosIp => {
+                return Err(switch_missing_nvos_ip_error(rack_id).into());
+            }
         };
 
         let mut nmxc = api
@@ -267,12 +275,13 @@ fn resolve_group_type(
     }
 }
 
-/// Builds the "no NMX-C endpoint" error for a failed [`resolve_nmx_c_endpoint_url`] lookup.
+/// Builds the "no NMX-C endpoint" error for a [`NmxCEndpointResolution::NotFound`] lookup.
 ///
 /// The chassis and rack paths consult disjoint data (the `nvlink_nmxc_endpoints` table vs.
 /// ready, NMX-C-configured switches in the rack), so `kind` names which lookup came up empty
 /// instead of a single generic label that can't distinguish a missing config row from a rack
-/// with no ready switch.
+/// with no ready switch. See [`switch_missing_nvos_ip_error`] for the separate case where a
+/// ready switch was found but its NVOS IP has not been resolved yet — that is not "not found".
 fn endpoint_not_found_error(
     group_type: ManagedHostGroupType,
     chassis_serial: &str,
@@ -287,6 +296,19 @@ fn endpoint_not_found_error(
             kind: "nvlink_ready_switch",
             id: rack_id.map(|r| r.to_string()).unwrap_or_default(),
         },
+    }
+}
+
+/// Builds the error for a [`NmxCEndpointResolution::SwitchMissingNvosIp`] lookup: a ready,
+/// control-plane-configured switch exists in the rack, but its NVOS IP has not been resolved.
+///
+/// This is deliberately a distinct `kind` from [`endpoint_not_found_error`]'s rack case: the
+/// switch itself was found, so reporting it as "switch not found" would misdirect an operator
+/// into investigating a nonexistent switch instead of the missing NVOS interface/IP data.
+fn switch_missing_nvos_ip_error(rack_id: Option<&carbide_uuid::rack::RackId>) -> CarbideError {
+    CarbideError::NotFoundError {
+        kind: "nvlink_switch_nvos_ip",
+        id: rack_id.map(|r| r.to_string()).unwrap_or_default(),
     }
 }
 
@@ -360,6 +382,38 @@ mod tests {
                     "a12".to_string(),
                 ),
             }
+        );
+    }
+
+    #[test]
+    fn switch_missing_nvos_ip_error_is_distinct_from_not_found() {
+        value_scenarios!(run = |rack_id_str: Option<&str>| {
+            let rack_id = rack_id_str.map(RackId::new);
+            match switch_missing_nvos_ip_error(rack_id.as_ref()) {
+                CarbideError::NotFoundError { kind, id } => (kind, id),
+                other => panic!("expected NotFoundError, got {other:?}"),
+            }
+        };
+            "names the NVOS IP gap, not the switch, keyed by rack_id" {
+                Some("a12") => ("nvlink_switch_nvos_ip", "a12".to_string()),
+            }
+        );
+
+        // The kind must not collide with the "no ready switch found" case, since the two
+        // failures point an operator at different data.
+        assert_ne!(
+            match switch_missing_nvos_ip_error(Some(&RackId::new("a12"))) {
+                CarbideError::NotFoundError { kind, .. } => kind,
+                other => panic!("expected NotFoundError, got {other:?}"),
+            },
+            match endpoint_not_found_error(
+                ManagedHostGroupType::Rack,
+                "",
+                Some(&RackId::new("a12"))
+            ) {
+                CarbideError::NotFoundError { kind, .. } => kind,
+                other => panic!("expected NotFoundError, got {other:?}"),
+            },
         );
     }
 }

--- a/crates/api-web/templates/nmxc_browser.html
+++ b/crates/api-web/templates/nmxc_browser.html
@@ -10,7 +10,7 @@ Choose an operation and an endpoint — either a chassis serial or a rack ID.
 See the <a href="https://docs.nvidia.com/networking/display/nmxcv11/grpc+api+documentation">NMX-C gRPC API documentation</a> for details.
 </p>
 
-<form id="nmxc_console" method="GET" action="/admin/nmxc-browser">
+<form id="nmxc_console" method="GET" action="/admin/nmxc-browser" onsubmit="nmxcSyncEndpointName()">
 	<div>
 		<label for="endpoint_value_input">Endpoint:</label>
 		<div style="display: flex; gap: 0.5rem; align-items: center;">
@@ -103,6 +103,14 @@ function nmxcUpdateEndpoint(select) {
 		? 'e.g. ipp6-b03-gb-nvl-124-mini2'
 		: 'e.g. 1234567890';
 	input.focus();
+}
+
+// Derive the submitted field name from the select's current
+// value at submit time, rather than trusting that onchange already synced it.
+function nmxcSyncEndpointName() {
+	var select = document.getElementById('endpoint_type_select');
+	var input = document.getElementById('endpoint_value_input');
+	input.name = select.value;
 }
 </script>
 {% endblock %}

--- a/crates/api-web/templates/nmxc_browser.html
+++ b/crates/api-web/templates/nmxc_browser.html
@@ -94,7 +94,6 @@ See the <a href="https://docs.nvidia.com/networking/display/nmxcv11/grpc+api+doc
 {% endblock %}
 
 {% block script %}
-<script>
 function nmxcUpdateEndpoint(select) {
 	var input = document.getElementById('endpoint_value_input');
 	input.name = select.value;
@@ -112,5 +111,4 @@ function nmxcSyncEndpointName() {
 	var input = document.getElementById('endpoint_value_input');
 	input.name = select.value;
 }
-</script>
 {% endblock %}

--- a/crates/nvlink-manager/src/nmx_c_endpoint.rs
+++ b/crates/nvlink-manager/src/nmx_c_endpoint.rs
@@ -75,6 +75,33 @@ pub fn nmx_c_endpoint_url_from_nvos_ip(
     )
 }
 
+/// Outcome of resolving an NMX-C gRPC endpoint for a chassis- or rack-scoped machine group.
+///
+/// The `Rack` path can fail in two distinct ways that callers should not conflate: no
+/// qualifying switch exists at all, versus a qualifying switch exists but its NVOS IP has not
+/// been resolved yet. Collapsing both into a bare `None` misdiagnoses the latter as "switch not
+/// found" when a switch was in fact found.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum NmxCEndpointResolution {
+    /// The endpoint URL was resolved.
+    Resolved(String),
+    /// No config row (`Chassis`) or no ready, control-plane-configured switch (`Rack`) exists.
+    NotFound,
+    /// `Rack` only: a ready, control-plane-configured switch exists in the rack, but its NVOS
+    /// IP has not been resolved (`find_switch_endpoints_by_ids` returned a null `nvos_ip`).
+    SwitchMissingNvosIp,
+}
+
+impl NmxCEndpointResolution {
+    /// Discards the distinction between failure modes, for callers that only need the URL.
+    pub fn into_url(self) -> Option<String> {
+        match self {
+            Self::Resolved(url) => Some(url),
+            Self::NotFound | Self::SwitchMissingNvosIp => None,
+        }
+    }
+}
+
 /// Resolves the NMX-C gRPC endpoint URL for a chassis- or rack-scoped machine group.
 ///
 /// - [`ManagedHostGroupType::Chassis`]: looks up `nvlink_nmxc_endpoints` by `chassis_serial`.
@@ -86,24 +113,30 @@ pub async fn resolve_nmx_c_endpoint_url<DB>(
     rack_id: Option<&RackId>,
     chassis_serial: Option<&str>,
     nvlink_config: &NvLinkConfig,
-) -> DatabaseResult<Option<String>>
+) -> DatabaseResult<NmxCEndpointResolution>
 where
     for<'db> &'db mut DB: DbReader<'db>,
 {
     match group_type {
         ManagedHostGroupType::Chassis => {
             let Some(chassis_serial) = chassis_serial else {
-                return Ok(None);
+                return Ok(NmxCEndpointResolution::NotFound);
             };
             Ok(
-                db::nvlink_nmxc_endpoints::find_by_chassis_serial(&mut *db, chassis_serial.trim())
-                    .await?
-                    .map(|row| row.endpoint),
+                match db::nvlink_nmxc_endpoints::find_by_chassis_serial(
+                    &mut *db,
+                    chassis_serial.trim(),
+                )
+                .await?
+                {
+                    Some(row) => NmxCEndpointResolution::Resolved(row.endpoint),
+                    None => NmxCEndpointResolution::NotFound,
+                },
             )
         }
         ManagedHostGroupType::Rack => {
             let Some(rack_id) = rack_id else {
-                return Ok(None);
+                return Ok(NmxCEndpointResolution::NotFound);
             };
 
             let switch_ids = db::switch::find_ready_control_plane_configured_switch_ids_in_rack(
@@ -112,16 +145,20 @@ where
             .await?;
 
             let Some(switch_id) = switch_ids.first() else {
-                return Ok(None);
+                return Ok(NmxCEndpointResolution::NotFound);
             };
 
             let endpoint_rows =
                 db::switch::find_switch_endpoints_by_ids(&mut *db, &[*switch_id]).await?;
 
-            Ok(endpoint_rows
-                .first()
-                .and_then(|row| row.nvos_ip.as_ref())
-                .map(|nvos_ip| nmx_c_endpoint_url_from_nvos_ip(nvos_ip, None, nvlink_config)))
+            Ok(
+                match endpoint_rows.first().and_then(|row| row.nvos_ip.as_ref()) {
+                    Some(nvos_ip) => NmxCEndpointResolution::Resolved(
+                        nmx_c_endpoint_url_from_nvos_ip(nvos_ip, None, nvlink_config),
+                    ),
+                    None => NmxCEndpointResolution::SwitchMissingNvosIp,
+                },
+            )
         }
     }
 }
@@ -192,7 +229,10 @@ mod tests {
             &config,
         )
         .await?;
-        assert_eq!(resolved.as_deref(), Some(mapped_endpoint));
+        assert_eq!(
+            resolved,
+            NmxCEndpointResolution::Resolved(mapped_endpoint.to_string())
+        );
         txn.rollback().await?;
         Ok(())
     }
@@ -268,7 +308,97 @@ mod tests {
             &config,
         )
         .await?;
-        assert_eq!(resolved.as_deref(), Some(expected_url.as_str()));
+        assert_eq!(resolved, NmxCEndpointResolution::Resolved(expected_url));
+        txn.rollback().await?;
+        Ok(())
+    }
+
+    #[sqlx_test]
+    async fn resolve_rack_reports_switch_missing_nvos_ip_distinctly_from_not_found(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let rack_id: RackId = "rack-nmxc-no-nvos-ip".parse()?;
+        let config = NvLinkConfig::default();
+
+        let mut txn = pool.begin().await?;
+        db::rack::create(
+            txn.as_mut(),
+            &rack_id,
+            Some(&RackProfileId::new("NVL72")),
+            &RackConfig::default(),
+            None,
+        )
+        .await?;
+        txn.commit().await?;
+
+        let mut txn = pool.begin().await?;
+        let switch =
+            db::test_support::switch::create_seeded_discovered(txn.as_mut(), 2, "Switch2").await?;
+        txn.commit().await?;
+
+        let mut txn = pool.begin().await?;
+        sqlx::query("UPDATE switches SET rack_id = $1 WHERE id = $2")
+            .bind(&rack_id)
+            .bind(switch.id)
+            .execute(txn.as_mut())
+            .await?;
+
+        // Simulate a switch whose NVOS management interface has never been discovered:
+        // ready and control-plane-configured, but with no NVOS MAC/IP to resolve.
+        sqlx::query(
+            "UPDATE expected_switches SET nvos_mac_addresses = NULL WHERE bmc_mac_address = $1",
+        )
+        .bind(
+            switch
+                .bmc_mac_address
+                .expect("seeded switch should have a BMC MAC"),
+        )
+        .execute(txn.as_mut())
+        .await?;
+
+        let switch = db::switch::find_by_id(txn.as_mut(), &switch.id)
+            .await?
+            .expect("switch should exist");
+        assert!(
+            db::switch::try_update_controller_state(
+                txn.as_mut(),
+                switch.id,
+                switch.controller_state.version,
+                switch.controller_state.version.increment(),
+                &SwitchControllerState::Ready,
+            )
+            .await?
+        );
+        db::switch::update_fabric_manager_status(
+            txn.as_mut(),
+            switch.id,
+            Some(&FabricManagerStatus {
+                fabric_manager_state: FabricManagerState::Ok,
+                addition_info: Some(CONTROL_PLANE_STATE_CONFIGURED.to_string()),
+                reason: None,
+                error_message: None,
+            }),
+        )
+        .await?;
+
+        let endpoint_row = db::switch::find_switch_endpoints_by_ids(txn.as_mut(), &[switch.id])
+            .await?
+            .pop()
+            .expect("switch endpoint row should still be returned");
+        assert!(
+            endpoint_row.nvos_ip.is_none(),
+            "test setup should leave nvos_ip unresolved"
+        );
+
+        let resolved = resolve_nmx_c_endpoint_url(
+            txn.as_mut(),
+            ManagedHostGroupType::Rack,
+            Some(&rack_id),
+            None,
+            &config,
+        )
+        .await?;
+        assert_eq!(resolved, NmxCEndpointResolution::SwitchMissingNvosIp);
         txn.rollback().await?;
         Ok(())
     }
@@ -302,7 +432,7 @@ mod tests {
             &config,
         )
         .await?;
-        assert_eq!(rack_resolved, None);
+        assert_eq!(rack_resolved, NmxCEndpointResolution::NotFound);
 
         let chassis_resolved = resolve_nmx_c_endpoint_url(
             txn.as_mut(),
@@ -312,7 +442,10 @@ mod tests {
             &config,
         )
         .await?;
-        assert_eq!(chassis_resolved.as_deref(), Some(mapped_endpoint));
+        assert_eq!(
+            chassis_resolved,
+            NmxCEndpointResolution::Resolved(mapped_endpoint.to_string())
+        );
         txn.rollback().await?;
         Ok(())
     }


### PR DESCRIPTION
The parmeter value for selector (chassis_serial vs rack_id) in /admin/nmxc-browser is not getting set correctly when rack_id is chosen and a wrong url is getting generated resulting in an input rack id getting treated as chassis_serial. Ensure that the selector type is synced at form submit. Improve error message to include selctor type.


## Related issues
(https://github.com/dsx-ai-factory/infra-controller/issues/5943)

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ X] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


