### PR TITLE
fix(dpf): allow predicted hosts in service sync

### DIFF
--- a/crates/admin-cli/src/dpf/service_sync/args.rs
+++ b/crates/admin-cli/src/dpf/service_sync/args.rs
@@ -16,7 +16,7 @@
  */
 
 use carbide_uuid::instance::InstanceId;
-use carbide_uuid::machine::StableHostMachineId;
+use carbide_uuid::machine::HostMachineId;
 use clap::{ArgGroup, Parser};
 use rpc::forge::ReleaseDpuServiceSyncHoldRequest;
 use rpc::forge::release_dpu_service_sync_hold_request::Target;
@@ -62,7 +62,7 @@ pub(crate) struct List {
         visible_alias = "id",
         help = "Show this host's recorded history instead of the outstanding worklist"
     )]
-    pub(super) machine_id: Option<StableHostMachineId>,
+    pub(super) machine_id: Option<HostMachineId>,
 }
 
 #[derive(Parser, Debug)]
@@ -100,7 +100,7 @@ pub(crate) struct Release {
         group = "target",
         help = "One or more host machine IDs to release"
     )]
-    pub(super) machine_ids: Vec<StableHostMachineId>,
+    pub(super) machine_ids: Vec<HostMachineId>,
 
     /// Releases the hosts currently running these instances even though they
     /// are assigned. Naming an instance is the acknowledgement that its tenant
@@ -121,7 +121,7 @@ impl From<Release> for ReleaseDpuServiceSyncHoldRequest {
         // so a non-empty instance list is the only way to reach the instance
         // target.
         let target = if args.instance_ids.is_empty() {
-            Target::MachineIds(::rpc::common::StableHostMachineIdList {
+            Target::MachineIds(::rpc::common::HostMachineIdList {
                 machine_ids: args.machine_ids,
             })
         } else {

--- a/crates/admin-cli/src/rpc.rs
+++ b/crates/admin-cli/src/rpc.rs
@@ -3022,7 +3022,7 @@ impl ApiClient {
     /// needs no paging.
     pub(crate) async fn list_dpu_service_sync_history(
         &self,
-        machine_id: carbide_uuid::machine::StableHostMachineId,
+        machine_id: carbide_uuid::machine::HostMachineId,
     ) -> CarbideCliResult<Vec<PendingDpuServiceSync>> {
         let response = self
             .0

--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -3405,7 +3405,7 @@ impl Forge for Api {
     async fn find_pending_dpu_service_sync_ids(
         &self,
         request: Request<rpc::FindPendingDpuServiceSyncIdsRequest>,
-    ) -> Result<Response<::rpc::common::StableHostMachineIdList>, Status> {
+    ) -> Result<Response<::rpc::common::HostMachineIdList>, Status> {
         crate::handlers::dpu_service_sync::find_pending_dpu_service_sync_ids(self, request).await
     }
 

--- a/crates/api-core/src/handlers/dpu_service_sync.rs
+++ b/crates/api-core/src/handlers/dpu_service_sync.rs
@@ -61,7 +61,7 @@ const MAX_RELEASE_BATCH: usize = 256;
 pub(crate) async fn find_pending_dpu_service_sync_ids(
     api: &Api,
     request: Request<rpc::FindPendingDpuServiceSyncIdsRequest>,
-) -> Result<Response<::rpc::common::StableHostMachineIdList>, Status> {
+) -> Result<Response<::rpc::common::HostMachineIdList>, Status> {
     log_request_data(&request);
 
     let machine_ids =
@@ -73,7 +73,7 @@ pub(crate) async fn find_pending_dpu_service_sync_ids(
         .map(TryInto::try_into)
         .collect::<Result<Vec<_>, _>>()
         .map_err(CarbideError::from)?;
-    Ok(Response::new(::rpc::common::StableHostMachineIdList {
+    Ok(Response::new(::rpc::common::HostMachineIdList {
         machine_ids,
     }))
 }
@@ -121,7 +121,7 @@ pub(crate) async fn list_dpu_service_sync_history(
     request: Request<rpc::ListDpuServiceSyncHistoryRequest>,
 ) -> Result<Response<rpc::ListPendingDpuServiceSyncsResponse>, Status> {
     log_request_data(&request);
-    let machine_id: StableHostMachineId =
+    let machine_id: HostMachineId =
         convert_and_log_machine_id(request.get_ref().machine_id.as_ref())?;
 
     let mut txn = api.txn_begin().await?;
@@ -155,7 +155,7 @@ async fn project(
     actions
         .into_iter()
         .map(|action| {
-            let host_machine_id = StableHostMachineId::try_from(action.machine_id)?;
+            let host_machine_id = HostMachineId::try_from(action.machine_id)?;
             Ok::<_, CarbideError>(rpc::PendingDpuServiceSync {
                 machine_id: Some(host_machine_id),
                 requested_at: Some(action.requested_at.into()),
@@ -198,7 +198,7 @@ pub(crate) async fn release_dpu_service_sync_hold(
     // Each entry carries its own tenant policy: naming an instance consents to
     // disrupting that instance's tenant and nobody else's.
     let targets = resolve_target(api, request.get_ref()).await?;
-    let machine_ids: Vec<StableHostMachineId> = targets.iter().map(|(id, _)| *id).collect();
+    let machine_ids: Vec<HostMachineId> = targets.iter().map(|(id, _)| *id).collect();
     validate(api, &machine_ids).await?;
 
     // One machine at a time, each committed as it goes. Nothing spans the batch:
@@ -225,7 +225,7 @@ pub(crate) async fn release_dpu_service_sync_hold(
 async fn resolve_target(
     api: &Api,
     request: &rpc::ReleaseDpuServiceSyncHoldRequest,
-) -> Result<Vec<(StableHostMachineId, TenantPolicy)>, Status> {
+) -> Result<Vec<(HostMachineId, TenantPolicy)>, Status> {
     use rpc::release_dpu_service_sync_hold_request::Target;
 
     match request.target.as_ref() {
@@ -249,12 +249,12 @@ async fn resolve_target(
                         kind: "instance",
                         id: instance_id.to_string(),
                     })?;
-                // TODO: Instances should store StableHostMachineId in the first place so that we
-                // don't need to handle this.
+                // Only machines with stable IDs can be assigned to instances.
                 let instance_machine_id = StableHostMachineId::try_from(instance.machine_id)
                     .map_err(|e| {
                         CarbideError::internal(format!("bug: invalid machine ID in instance: {e}"))
-                    })?;
+                    })?
+                    .into();
                 // Consent is for this instance, not for its host: if the host
                 // has been reallocated since, the new tenant agreed to nothing.
                 targets.push((
@@ -288,33 +288,20 @@ fn check_batch_size(len: usize) -> Result<(), Status> {
 /// must not release half of itself first. It also keeps `FAILED` meaning
 /// "retry": a mistyped machine id is not retryable and would be actively
 /// misleading reported that way.
-async fn validate(api: &Api, machine_ids: &[StableHostMachineId]) -> Result<(), Status> {
+async fn validate(api: &Api, machine_ids: &[HostMachineId]) -> Result<(), Status> {
     if machine_ids.is_empty() {
         return Err(CarbideError::InvalidArgument("no machines were named".to_string()).into());
     }
     check_batch_size(machine_ids.len())?;
 
-    // A DPU id is refused rather than resolved to its host: the hold is per
-    // node, so honouring it would quietly widen the request from one DPU to
-    // every DPU on that host.
-    let dpu_ids: Vec<String> = machine_ids
-        .iter()
-        .filter(|machine_id| machine_id.machine_type().is_dpu())
-        .map(ToString::to_string)
-        .collect();
-    if !dpu_ids.is_empty() {
-        return Err(CarbideError::InvalidArgument(format!(
-            "only host ids are expected, got DPU ids: {}",
-            dpu_ids.join(", ")
-        ))
-        .into());
-    }
-
     let mut txn = api.txn_begin().await?;
     let found = db::machine::find(
         &mut txn,
         db::ObjectFilter::List(machine_ids),
-        MachineSearchConfig::default(),
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..MachineSearchConfig::default()
+        },
     )
     .await?
     .into_iter()
@@ -343,7 +330,7 @@ async fn validate(api: &Api, machine_ids: &[StableHostMachineId]) -> Result<(), 
 async fn release_one(
     api: &Api,
     dpf_sdk: &dyn carbide_machine_controller::dpf::DpfOperations,
-    machine_id: StableHostMachineId,
+    machine_id: HostMachineId,
     tenant_policy: &TenantPolicy,
 ) -> rpc::DpuServiceSyncReleaseResult {
     use rpc::DpuServiceSyncReleaseStatus as ProtoStatus;
@@ -378,7 +365,7 @@ async fn release_one(
 async fn release_one_inner(
     api: &Api,
     dpf_sdk: &dyn carbide_machine_controller::dpf::DpfOperations,
-    machine_id: StableHostMachineId,
+    machine_id: HostMachineId,
     tenant_policy: &TenantPolicy,
 ) -> Result<Option<ReleaseOutcome>, String> {
     // A pooled connection rather than a transaction, matching the automatic path.
@@ -451,7 +438,10 @@ where
     let machines = db::machine::find(
         txn,
         db::ObjectFilter::List(machine_ids),
-        MachineSearchConfig::default(),
+        MachineSearchConfig {
+            include_predicted_host: true,
+            ..MachineSearchConfig::default()
+        },
     )
     .await?;
     Ok(machines

--- a/crates/api-core/src/tests/dpf/dpu_service_sync_release.rs
+++ b/crates/api-core/src/tests/dpf/dpu_service_sync_release.rs
@@ -27,7 +27,10 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 
 use ::rpc::forge as rpc;
-use carbide_uuid::machine::{MachineId, StableHostMachineId};
+use carbide_uuid::machine::{
+    HostMachineId, HostMachineIdSubtypeTrait, MachineId, PredictedHostMachineId,
+    StableHostMachineId,
+};
 use rpc::DpuServiceSyncReleaseStatus as ReleaseStatus;
 use rpc::forge_server::Forge;
 use tonic::Request;
@@ -37,12 +40,14 @@ use super::dpu_service_sync::{
     reset_host_to_waiting_for_ready,
 };
 
-fn by_machine_ids(ids: &[StableHostMachineId]) -> rpc::ReleaseDpuServiceSyncHoldRequest {
+fn by_machine_ids<ID: HostMachineIdSubtypeTrait>(
+    ids: &[ID],
+) -> rpc::ReleaseDpuServiceSyncHoldRequest {
     rpc::ReleaseDpuServiceSyncHoldRequest {
         target: Some(
             rpc::release_dpu_service_sync_hold_request::Target::MachineIds(
-                ::rpc::common::StableHostMachineIdList {
-                    machine_ids: ids.to_vec(),
+                ::rpc::common::HostMachineIdList {
+                    machine_ids: ids.iter().map(|id| id.to_host_machine_id()).collect(),
                 },
             ),
         ),
@@ -52,7 +57,7 @@ fn by_machine_ids(ids: &[StableHostMachineId]) -> rpc::ReleaseDpuServiceSyncHold
 async fn release(
     fixture: &Fixture,
     request: rpc::ReleaseDpuServiceSyncHoldRequest,
-) -> Vec<(StableHostMachineId, ReleaseStatus, String)> {
+) -> Vec<(HostMachineId, ReleaseStatus, String)> {
     fixture
         .env
         .api
@@ -73,7 +78,7 @@ async fn release(
 }
 
 /// The worklist as an operator reads it: ids first, detail fetched per page.
-async fn worklist_ids(fixture: &Fixture) -> Vec<StableHostMachineId> {
+async fn worklist_ids(fixture: &Fixture) -> Vec<HostMachineId> {
     fixture
         .env
         .api
@@ -122,6 +127,59 @@ async fn a_site_with_sync_disabled_can_still_be_released_by_hand(pool: sqlx::PgP
     assert_eq!(results.len(), 1);
     assert_eq!(results[0].1, ReleaseStatus::Released);
     assert!(!is_outstanding(&fixture.pool, &fixture.mh.id).await);
+    assert_eq!(fixture.calls.hold_releases.load(Ordering::SeqCst), 1);
+}
+
+/// A predicted host is a real host row whose stable hardware identity is not
+/// known yet, so an operator must still be able to release its DPF hold.
+#[crate::sqlx_test]
+async fn a_predicted_host_can_be_released_by_hand(pool: sqlx::PgPool) {
+    let (outdated, release_fails) = unsynced();
+    let fixture = provisioned_with_sync(pool, outdated, release_fails, false).await;
+    let predicted_id: PredictedHostMachineId = MachineId::new(
+        carbide_uuid::machine::MachineIdSource::ProductBoardChassisSerial,
+        [0xAC; 32],
+        carbide_uuid::machine::MachineType::PredictedHost,
+    )
+    .try_into()
+    .unwrap();
+    let renamed = sqlx::query("UPDATE machines SET id = $1 WHERE id = $2")
+        .bind(predicted_id)
+        .bind(fixture.mh.id)
+        .execute(&fixture.pool)
+        .await
+        .unwrap();
+    assert_eq!(renamed.rows_affected(), 1);
+    request_sync(&fixture.pool, predicted_id.as_host_machine_id()).await;
+
+    let worklist = worklist_ids(&fixture).await;
+    assert_eq!(worklist, vec![predicted_id.to_host_machine_id()]);
+    let detail = fixture
+        .env
+        .api
+        .find_pending_dpu_service_syncs_by_ids(Request::new(
+            rpc::FindPendingDpuServiceSyncsByIdsRequest {
+                machine_ids: worklist,
+            },
+        ))
+        .await
+        .expect("predicted host worklist detail")
+        .into_inner()
+        .pending;
+    assert_eq!(
+        detail[0].machine_id,
+        Some(predicted_id.to_host_machine_id())
+    );
+
+    let results = release(&fixture, by_machine_ids(&[predicted_id])).await;
+
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].0, predicted_id.to_host_machine_id());
+    assert_eq!(results[0].1, ReleaseStatus::Released);
+    assert!(
+        !is_outstanding(&fixture.pool, predicted_id.as_host_machine_id()).await,
+        "a successful release must complete the predicted host's pending action"
+    );
     assert_eq!(fixture.calls.hold_releases.load(Ordering::SeqCst), 1);
 }
 
@@ -219,7 +277,7 @@ async fn a_mixed_batch_reports_one_result_per_machine_in_request_order(pool: sql
     let results = release(&fixture, by_machine_ids(&[fixture.mh.id, fixture.mh.id])).await;
 
     assert_eq!(results.len(), 2, "one result per named machine");
-    assert_eq!(results[0].0, fixture.mh.id);
+    assert_eq!(results[0].0, fixture.mh.id.to_host_machine_id());
     assert_eq!(results[0].1, ReleaseStatus::Released);
     assert_eq!(results[1].1, ReleaseStatus::NotPending);
 }
@@ -272,7 +330,7 @@ async fn an_assigned_host_named_by_instance_id_is_released(pool: sqlx::PgPool) {
     .await;
 
     assert_eq!(results.len(), 1, "the instance resolves to its one host");
-    assert_eq!(results[0].0, fixture.mh.id);
+    assert_eq!(results[0].0, fixture.mh.id.to_host_machine_id());
     assert_eq!(results[0].1, ReleaseStatus::Released);
     assert!(!is_outstanding(&fixture.pool, &fixture.mh.id).await);
 }
@@ -317,7 +375,7 @@ async fn the_worklist_empties_on_release_and_the_history_records_the_operator(po
     request_sync(&fixture.pool, &fixture.mh.id).await;
 
     let worklist = worklist_ids(&fixture).await;
-    assert_eq!(worklist, vec![fixture.mh.id]);
+    assert_eq!(worklist, vec![fixture.mh.id.to_host_machine_id()]);
 
     let detail = fixture
         .env
@@ -350,7 +408,7 @@ async fn the_worklist_empties_on_release_and_the_history_records_the_operator(po
         .env
         .api
         .list_dpu_service_sync_history(Request::new(rpc::ListDpuServiceSyncHistoryRequest {
-            machine_id: Some(fixture.mh.id),
+            machine_id: Some(fixture.mh.id.to_host_machine_id()),
         }))
         .await
         .expect("history")

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1056,7 +1056,8 @@ service Forge {
   // Helm/docker versions for the carbide DPF mandatory services, from both
   // the carbide config and the live DPUServiceTemplate CRs.
   rpc GetDPFServiceVersions(GetDPFServiceVersionsRequest) returns (DPFServiceVersionsResponse);
-  // Machines DPF is waiting on before a changed DPUService can roll out.
+  // Predicted or stable host machines DPF is waiting on before a changed
+  // DPUService can roll out.
   //
   // Required rather than convenient: the release RPC has no fleet-wide form, so
   // this is the only way to discover which machines to name. Split ids-then-
@@ -9815,15 +9816,16 @@ message DPFServiceVersionsResponse {
 // services under every tenant at once.
 message ReleaseDPUServiceSyncHoldRequest {
   oneof target {
-    // Host machines to release. DPU machine ids are rejected: the hold is per
-    // node, so accepting one would silently widen the request from a single DPU
-    // to every DPU on its host. Assigned hosts are declined -- name the instance
-    // instead.
+    // Predicted or stable host machines to release. DPU machine ids are
+    // rejected: the hold is per node, so accepting one would silently widen the
+    // request from a single DPU to every DPU on its host. Assigned hosts are
+    // declined -- name the instance instead.
     common.MachineIdList machine_ids = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineIdList"];
     // Release the hosts currently holding these instances, even though they are
     // assigned. Naming an instance is the acknowledgement that its tenant will
     // be disrupted, and each consent covers only the instance named: if a host
-    // has since been reallocated, that release is declined.
+    // has since been reallocated, that release is declined. Instances resolve
+    // only to stable host machines.
     InstanceIdList instance_ids = 2;
   }
 }
@@ -9851,6 +9853,7 @@ enum DPUServiceSyncReleaseStatus {
 }
 
 message DPUServiceSyncReleaseResult {
+  // The predicted or stable host acted on.
   common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
   DPUServiceSyncReleaseStatus status = 2;
   // Names the DPU or instance responsible on the deferred statuses, and the
@@ -9868,17 +9871,20 @@ message FindPendingDPUServiceSyncIdsRequest {
 }
 
 message FindPendingDPUServiceSyncsByIdsRequest {
-  // Bounded by the server's `max_find_by_ids`, like every other by-ids call.
+  // Predicted and stable host IDs are accepted. Bounded by the server's
+  // `max_find_by_ids`, like every other by-ids call.
   repeated common.MachineId machine_ids = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
 }
 
 message ListDPUServiceSyncHistoryRequest {
+  // The predicted or stable host whose history to return.
   common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
 }
 
 // One recorded DPU service sync. Completed entries appear only in the history
 // form.
 message PendingDPUServiceSync {
+  // The predicted or stable host waiting for service sync.
   common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
   // First time DPF was seen waiting on this machine. Survives repeat requests,
   // so it measures the whole wait rather than the last observation.

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -1063,7 +1063,7 @@ service Forge {
   // details because a fleet-wide rollout can leave every host waiting at once,
   // and the worklist must not become one unbounded response.
   rpc FindPendingDPUServiceSyncIds(FindPendingDPUServiceSyncIdsRequest) returns (common.MachineIdList) {
-    option (carbide.codegen.v1.method_rust_output_type) = ".common.StableHostMachineIdList";
+    option (carbide.codegen.v1.method_rust_output_type) = ".common.HostMachineIdList";
   }
   rpc FindPendingDPUServiceSyncsByIds(FindPendingDPUServiceSyncsByIdsRequest) returns (ListPendingDPUServiceSyncsResponse);
   // One machine's recorded sync history, newest first. Needs no paging: the
@@ -9819,7 +9819,7 @@ message ReleaseDPUServiceSyncHoldRequest {
     // node, so accepting one would silently widen the request from a single DPU
     // to every DPU on its host. Assigned hosts are declined -- name the instance
     // instead.
-    common.MachineIdList machine_ids = 1 [(carbide.codegen.v1.field_rust_type) = ".common.StableHostMachineIdList"];
+    common.MachineIdList machine_ids = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineIdList"];
     // Release the hosts currently holding these instances, even though they are
     // assigned. Naming an instance is the acknowledgement that its tenant will
     // be disrupted, and each consent covers only the instance named: if a host
@@ -9851,7 +9851,7 @@ enum DPUServiceSyncReleaseStatus {
 }
 
 message DPUServiceSyncReleaseResult {
-  common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.StableHostMachineId"];
+  common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
   DPUServiceSyncReleaseStatus status = 2;
   // Names the DPU or instance responsible on the deferred statuses, and the
   // error on FAILED. Empty otherwise.
@@ -9869,17 +9869,17 @@ message FindPendingDPUServiceSyncIdsRequest {
 
 message FindPendingDPUServiceSyncsByIdsRequest {
   // Bounded by the server's `max_find_by_ids`, like every other by-ids call.
-  repeated common.MachineId machine_ids = 1 [(carbide.codegen.v1.field_rust_type) = ".common.StableHostMachineId"];
+  repeated common.MachineId machine_ids = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
 }
 
 message ListDPUServiceSyncHistoryRequest {
-  common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.StableHostMachineId"];
+  common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
 }
 
 // One recorded DPU service sync. Completed entries appear only in the history
 // form.
 message PendingDPUServiceSync {
-  common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.StableHostMachineId"];
+  common.MachineId machine_id = 1 [(carbide.codegen.v1.field_rust_type) = ".common.HostMachineId"];
   // First time DPF was seen waiting on this machine. Survives repeat requests,
   // so it measures the whole wait rather than the last observation.
   google.protobuf.Timestamp requested_at = 2;

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -58708,10 +58708,10 @@ type isReleaseDPUServiceSyncHoldRequest_Target interface {
 }
 
 type ReleaseDPUServiceSyncHoldRequest_MachineIds struct {
-	// Host machines to release. DPU machine ids are rejected: the hold is per
-	// node, so accepting one would silently widen the request from a single DPU
-	// to every DPU on its host. Assigned hosts are declined -- name the instance
-	// instead.
+	// Predicted or stable host machines to release. DPU machine ids are
+	// rejected: the hold is per node, so accepting one would silently widen the
+	// request from a single DPU to every DPU on its host. Assigned hosts are
+	// declined -- name the instance instead.
 	MachineIds *MachineIdList `protobuf:"bytes,1,opt,name=machine_ids,json=machineIds,proto3,oneof"`
 }
 
@@ -58719,7 +58719,8 @@ type ReleaseDPUServiceSyncHoldRequest_InstanceIds struct {
 	// Release the hosts currently holding these instances, even though they are
 	// assigned. Naming an instance is the acknowledgement that its tenant will
 	// be disrupted, and each consent covers only the instance named: if a host
-	// has since been reallocated, that release is declined.
+	// has since been reallocated, that release is declined. Instances resolve
+	// only to stable host machines.
 	InstanceIds *InstanceIdList `protobuf:"bytes,2,opt,name=instance_ids,json=instanceIds,proto3,oneof"`
 }
 
@@ -58728,7 +58729,8 @@ func (*ReleaseDPUServiceSyncHoldRequest_MachineIds) isReleaseDPUServiceSyncHoldR
 func (*ReleaseDPUServiceSyncHoldRequest_InstanceIds) isReleaseDPUServiceSyncHoldRequest_Target() {}
 
 type DPUServiceSyncReleaseResult struct {
-	state     protoimpl.MessageState      `protogen:"open.v1"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The predicted or stable host acted on.
 	MachineId *MachineId                  `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
 	Status    DPUServiceSyncReleaseStatus `protobuf:"varint,2,opt,name=status,proto3,enum=forge.DPUServiceSyncReleaseStatus" json:"status,omitempty"`
 	// Names the DPU or instance responsible on the deferred statuses, and the
@@ -58873,7 +58875,8 @@ func (*FindPendingDPUServiceSyncIdsRequest) Descriptor() ([]byte, []int) {
 
 type FindPendingDPUServiceSyncsByIdsRequest struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
-	// Bounded by the server's `max_find_by_ids`, like every other by-ids call.
+	// Predicted and stable host IDs are accepted. Bounded by the server's
+	// `max_find_by_ids`, like every other by-ids call.
 	MachineIds    []*MachineId `protobuf:"bytes,1,rep,name=machine_ids,json=machineIds,proto3" json:"machine_ids,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
@@ -58917,8 +58920,9 @@ func (x *FindPendingDPUServiceSyncsByIdsRequest) GetMachineIds() []*MachineId {
 }
 
 type ListDPUServiceSyncHistoryRequest struct {
-	state         protoimpl.MessageState `protogen:"open.v1"`
-	MachineId     *MachineId             `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The predicted or stable host whose history to return.
+	MachineId     *MachineId `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -58963,8 +58967,9 @@ func (x *ListDPUServiceSyncHistoryRequest) GetMachineId() *MachineId {
 // One recorded DPU service sync. Completed entries appear only in the history
 // form.
 type PendingDPUServiceSync struct {
-	state     protoimpl.MessageState `protogen:"open.v1"`
-	MachineId *MachineId             `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// The predicted or stable host waiting for service sync.
+	MachineId *MachineId `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
 	// First time DPF was seen waiting on this machine. Survives repeat requests,
 	// so it measures the whole wait rather than the last observation.
 	RequestedAt *timestamppb.Timestamp `protobuf:"bytes,2,opt,name=requested_at,json=requestedAt,proto3" json:"requested_at,omitempty"`

--- a/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
@@ -1369,7 +1369,8 @@ type ForgeClient interface {
 	// Helm/docker versions for the nico DPF mandatory services, from both
 	// the nico config and the live DPUServiceTemplate CRs.
 	GetDPFServiceVersions(ctx context.Context, in *GetDPFServiceVersionsRequest, opts ...grpc.CallOption) (*DPFServiceVersionsResponse, error)
-	// Machines DPF is waiting on before a changed DPUService can roll out.
+	// Predicted or stable host machines DPF is waiting on before a changed
+	// DPUService can roll out.
 	//
 	// Required rather than convenient: the release RPC has no fleet-wide form, so
 	// this is the only way to discover which machines to name. Split ids-then-
@@ -7184,7 +7185,8 @@ type ForgeServer interface {
 	// Helm/docker versions for the nico DPF mandatory services, from both
 	// the nico config and the live DPUServiceTemplate CRs.
 	GetDPFServiceVersions(context.Context, *GetDPFServiceVersionsRequest) (*DPFServiceVersionsResponse, error)
-	// Machines DPF is waiting on before a changed DPUService can roll out.
+	// Predicted or stable host machines DPF is waiting on before a changed
+	// DPUService can roll out.
 	//
 	// Required rather than convenient: the release RPC has no fleet-wide form, so
 	// this is the only way to discover which machines to name. Split ids-then-

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -1044,7 +1044,8 @@ service Forge {
   // Helm/docker versions for the nico DPF mandatory services, from both
   // the nico config and the live DPUServiceTemplate CRs.
   rpc GetDPFServiceVersions(GetDPFServiceVersionsRequest) returns (DPFServiceVersionsResponse);
-  // Machines DPF is waiting on before a changed DPUService can roll out.
+  // Predicted or stable host machines DPF is waiting on before a changed
+  // DPUService can roll out.
   //
   // Required rather than convenient: the release RPC has no fleet-wide form, so
   // this is the only way to discover which machines to name. Split ids-then-
@@ -9424,15 +9425,16 @@ message DPFServiceVersionsResponse {
 // services under every tenant at once.
 message ReleaseDPUServiceSyncHoldRequest {
   oneof target {
-    // Host machines to release. DPU machine ids are rejected: the hold is per
-    // node, so accepting one would silently widen the request from a single DPU
-    // to every DPU on its host. Assigned hosts are declined -- name the instance
-    // instead.
+    // Predicted or stable host machines to release. DPU machine ids are
+    // rejected: the hold is per node, so accepting one would silently widen the
+    // request from a single DPU to every DPU on its host. Assigned hosts are
+    // declined -- name the instance instead.
     common.MachineIdList machine_ids = 1;
     // Release the hosts currently holding these instances, even though they are
     // assigned. Naming an instance is the acknowledgement that its tenant will
     // be disrupted, and each consent covers only the instance named: if a host
-    // has since been reallocated, that release is declined.
+    // has since been reallocated, that release is declined. Instances resolve
+    // only to stable host machines.
     InstanceIdList instance_ids = 2;
   }
 }
@@ -9460,6 +9462,7 @@ enum DPUServiceSyncReleaseStatus {
 }
 
 message DPUServiceSyncReleaseResult {
+  // The predicted or stable host acted on.
   common.MachineId machine_id = 1;
   DPUServiceSyncReleaseStatus status = 2;
   // Names the DPU or instance responsible on the deferred statuses, and the
@@ -9477,17 +9480,20 @@ message FindPendingDPUServiceSyncIdsRequest {
 }
 
 message FindPendingDPUServiceSyncsByIdsRequest {
-  // Bounded by the server's `max_find_by_ids`, like every other by-ids call.
+  // Predicted and stable host IDs are accepted. Bounded by the server's
+  // `max_find_by_ids`, like every other by-ids call.
   repeated common.MachineId machine_ids = 1;
 }
 
 message ListDPUServiceSyncHistoryRequest {
+  // The predicted or stable host whose history to return.
   common.MachineId machine_id = 1;
 }
 
 // One recorded DPU service sync. Completed entries appear only in the history
 // form.
 message PendingDPUServiceSync {
+  // The predicted or stable host waiting for service sync.
   common.MachineId machine_id = 1;
   // First time DPF was seen waiting on this machine. Survives repeat requests,
   // so it measures the whole wait rather than the last observation.


### PR DESCRIPTION
Predicted host IDs (`fm100p`) could not be used to inspect or release pending DPU service-sync work. This change allows service-sync commands to accept both predicted and stable host IDs while keeping instance-targeted releases stable-only.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

None.