### PR TITLE
revert(machine-controller): stop waiting for instance restart verification

### DIFF
--- a/crates/api-core/src/tests/client_resolution.rs
+++ b/crates/api-core/src/tests/client_resolution.rs
@@ -33,8 +33,7 @@ use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfig
 use crate::test_support::network_segment::{FIXTURE_TENANT_ORG_ID, create_default_flat_vpc};
 use crate::tests::common;
 use crate::tests::common::api_fixtures::instance::{
-    advance_created_instance_into_ready_state, default_os_config, default_tenant_config,
-    single_interface_network_config,
+    default_os_config, default_tenant_config, single_interface_network_config,
 };
 use crate::tests::common::api_fixtures::network_segment::{
     FIXTURE_ADMIN_NETWORK_SEGMENT_GATEWAY, FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY,
@@ -483,7 +482,6 @@ async fn test_zero_dpu_cloud_init_prefers_instance_when_ip_matches_host_interfac
 
     // When the instance is ready, we should get tenant cloud-init instructions
     for instance_state in [InstanceState::WaitingForRebootToReady, InstanceState::Ready] {
-        let reboot_pending = instance_state == InstanceState::WaitingForRebootToReady;
         env.run_machine_state_controller_iteration_until_state_matches(
             &mh.host().id,
             10,
@@ -531,11 +529,6 @@ async fn test_zero_dpu_cloud_init_prefers_instance_when_ip_matches_host_interfac
                 .instance_id,
             instance_id.to_string()
         );
-
-        if reboot_pending {
-            env.run_machine_state_controller_iteration().await;
-            mh.host().reboot_completed().await;
-        }
     }
 }
 
@@ -616,7 +609,14 @@ async fn test_cloud_init_local_hostname_set_from_instance_name(pool: sqlx::PgPoo
     let instance_id = instance.id.expect("allocated instance should have an ID");
 
     // Advance to Assigned/Ready so the Instance path is taken
-    advance_created_instance_into_ready_state(&env, &mh).await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        10,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+    )
+    .await;
 
     let cloud_init = env
         .api
@@ -722,7 +722,14 @@ async fn test_cloud_init_local_hostname_omitted_when_instance_name_is_not_a_vali
     let instance_id = instance.id.expect("allocated instance should have an ID");
 
     // Advance to Assigned/Ready so the Instance path is taken
-    advance_created_instance_into_ready_state(&env, &mh).await;
+    env.run_machine_state_controller_iteration_until_state_matches(
+        &mh.host().id,
+        10,
+        ManagedHostState::Assigned {
+            instance_state: InstanceState::Ready,
+        },
+    )
+    .await;
 
     let cloud_init = env
         .api

--- a/crates/api-core/src/tests/common/api_fixtures/instance.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/instance.rs
@@ -421,17 +421,6 @@ pub(in crate::tests) async fn advance_created_instance_into_state(
     )
     .await;
 
-    env.run_machine_state_controller_iteration_until_state_matches(
-        &mh.host().id,
-        20,
-        ManagedHostState::Assigned {
-            instance_state: model::machine::InstanceState::WaitingForRebootToReady,
-        },
-    )
-    .await;
-    env.run_machine_state_controller_iteration().await;
-    mh.host().reboot_completed().await;
-
     // State controller continues to run till target state
     env.run_machine_state_controller_iteration_until_state_condition(
         &mh.host().id,

--- a/crates/api-core/src/tests/instance.rs
+++ b/crates/api-core/src/tests/instance.rs
@@ -1364,8 +1364,6 @@ async fn test_instance_deletion_before_provisioning_finishes(
         },
     )
     .await;
-    env.run_machine_state_controller_iteration().await;
-    mh.host().reboot_completed().await;
 
     // Now go through regular deletion
     mh.delete_instance(&env, instance_id).await;
@@ -1571,8 +1569,6 @@ async fn test_instance_waits_for_primary_dpu_bgp_before_pxe_reboot(
 
     // Clearing the last PXE blocking Merge report lets provisioning reach Ready.
     remove_health_report_entry(&env, &dpu_id, "test-pxe-bgp-merge".to_string()).await;
-    env.run_machine_state_controller_iteration().await;
-    mh.host().reboot_completed().await;
     env.run_machine_state_controller_iteration_until_state_matches(
         &mh.host().id,
         1,

--- a/crates/api-core/src/tests/instance_ipxe_behaviors.rs
+++ b/crates/api-core/src/tests/instance_ipxe_behaviors.rs
@@ -106,17 +106,6 @@ async fn test_instance_uses_custom_ipxe_only_once(pool: sqlx::PgPool) {
         matches!(
             machine.current_state(),
             model::machine::ManagedHostState::Assigned {
-                instance_state: model::machine::InstanceState::WaitingForRebootToReady
-            }
-        )
-    })
-    .await;
-    env.run_machine_state_controller_iteration().await;
-    mh.host().reboot_completed().await;
-    env.run_machine_state_controller_iteration_until_state_condition(&mh.id, 5, |machine| {
-        matches!(
-            machine.current_state(),
-            model::machine::ManagedHostState::Assigned {
                 instance_state: model::machine::InstanceState::Ready
             }
         )

--- a/crates/api-core/src/tests/machine_states.rs
+++ b/crates/api-core/src/tests/machine_states.rs
@@ -21,9 +21,7 @@ use std::sync::atomic::AtomicBool;
 
 use ::rpc::measured_boot::FromGrpc;
 use base64::prelude::*;
-use carbide_machine_controller::context::MachineStateHandlerContextObjects;
-use carbide_machine_controller::handler::{MachineStateHandlerBuilder, handler_host_power_control};
-use carbide_machine_controller::metrics::MachineMetrics;
+use carbide_machine_controller::handler::MachineStateHandlerBuilder;
 use carbide_redfish::libredfish::test_support::{RedfishSimAction, RedfishSimPlatformAction};
 use carbide_site_explorer::MachineCreator;
 use carbide_site_explorer::config::SiteExplorerConfig;
@@ -82,8 +80,6 @@ use rpc::forge::{
 use rpc::forge_agent_control_response::{Action, LegacyAction};
 use rpc::machine_discovery::AttestKeyInfo;
 use rpc::{DiscoveryData, DiscoveryInfo};
-use state_controller::db_write_batch::DbWriteBatch;
-use state_controller::state_handler::StateHandlerContext;
 use tonic::{Code, Request};
 
 use crate::cfg::file::DpuConfig as InitialDpuConfig;
@@ -100,7 +96,7 @@ use crate::tests::common::api_fixtures::instance::{
 };
 use crate::tests::common::api_fixtures::{
     TestEnvOverrides, create_managed_host_with_ek, discovery_completed, forge_agent_control,
-    on_demand_machine_validation, reboot_completed, update_time_params,
+    on_demand_machine_validation, update_time_params,
 };
 use crate::tests::common::attestation::spdm_attestation_run_to_failed_then_to_success;
 use crate::tests::instance_ipxe_behaviors::create_instance;
@@ -6356,235 +6352,6 @@ async fn load_host_state(env: &TestEnv, host_id: &HostMachineId) -> ManagedHostS
 }
 
 #[crate::sqlx_test]
-async fn test_waiting_for_reboot_requires_completion_when_phone_home_disabled(pool: sqlx::PgPool) {
-    let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.id;
-    let mut txn = env.db_txn().await;
-    let snapshot = mh.snapshot(&mut txn).await;
-    assert!(!snapshot.instance.unwrap().config.os.phone_home_enabled);
-    txn.commit().await.unwrap();
-
-    set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
-    env.run_machine_state_controller_iteration().await;
-
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::WaitingForRebootToReady,
-        }
-    );
-
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart = host.status.last_reboot_requested.unwrap();
-    assert_eq!(restart.restart_verified, Some(false));
-    assert_eq!(restart.verification_attempts, Some(0));
-    txn.commit().await.unwrap();
-
-    reboot_completed(&env, host_id).await;
-    env.run_machine_state_controller_iteration().await;
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::Ready,
-        }
-    );
-}
-
-#[crate::sqlx_test]
-async fn test_waiting_for_reboot_restarts_after_power_on_substitution(pool: sqlx::PgPool) {
-    let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.id;
-
-    let mut txn = env.db_txn().await;
-    let snapshot = mh.snapshot(&mut txn).await;
-    let mut write_batch = DbWriteBatch::new();
-    let mut services = env.machine_state_handler_services();
-    let mut metrics = MachineMetrics::default();
-    let mut ctx = StateHandlerContext::<MachineStateHandlerContextObjects> {
-        services: &mut services,
-        metrics: &mut metrics,
-        pending_db_writes: &mut write_batch,
-    };
-    handler_host_power_control(
-        &snapshot,
-        &mut ctx,
-        libredfish::SystemPowerControl::ForceOff,
-    )
-    .await
-    .unwrap();
-    write_batch.apply_all(&mut txn).await.unwrap();
-    txn.commit().await.unwrap();
-
-    set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
-    env.run_machine_state_controller_iteration().await;
-
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let power_on = host.status.last_reboot_requested.unwrap();
-    assert_eq!(power_on.mode, MachineLastRebootRequestedMode::PowerOn);
-    assert_eq!(power_on.restart_verified, None);
-    txn.commit().await.unwrap();
-
-    let checkpoint = env.redfish_sim.timepoint();
-    env.run_machine_state_controller_iteration().await;
-
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::WaitingForRebootToReady,
-        }
-    );
-    let actions = env.redfish_sim.actions_since(&checkpoint).all_hosts();
-    assert!(
-        actions.contains(&RedfishSimAction::Power(
-            libredfish::SystemPowerControl::ForceRestart,
-        )),
-        "the power-on substitution must be followed by the intended restart, got: {actions:?}"
-    );
-
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart = host.status.last_reboot_requested.unwrap();
-    assert_eq!(restart.mode, MachineLastRebootRequestedMode::Reboot);
-    assert_eq!(restart.restart_verified, Some(false));
-    assert_eq!(restart.verification_attempts, Some(0));
-    txn.commit().await.unwrap();
-}
-
-#[crate::sqlx_test]
-async fn test_waiting_for_reboot_keeps_transient_bmc_error_retryable(pool: sqlx::PgPool) {
-    let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.id;
-    env.redfish_sim.set_bmc_event_log_supported(true);
-    set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
-    env.run_machine_state_controller_iteration().await;
-
-    let checkpoint = env.redfish_sim.timepoint();
-    env.redfish_sim.fail_next_bmc_event_log_read();
-    env.run_machine_state_controller_iteration().await;
-
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::WaitingForRebootToReady,
-        }
-    );
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart = host.status.last_reboot_requested.unwrap();
-    assert_eq!(restart.restart_verified, Some(false));
-    assert_eq!(restart.verification_attempts, Some(0));
-    txn.commit().await.unwrap();
-
-    env.run_machine_state_controller_iteration().await;
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart = host.status.last_reboot_requested.unwrap();
-    assert_eq!(restart.restart_verified, Some(false));
-    assert_eq!(restart.verification_attempts, Some(1));
-    txn.commit().await.unwrap();
-
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::WaitingForRebootToReady,
-        }
-    );
-
-    let actions = env.redfish_sim.actions_since(&checkpoint).all_hosts();
-    assert!(
-        actions
-            .iter()
-            .all(|action| !matches!(action, RedfishSimAction::Power(_))),
-        "transient BMC errors must not repeat a power action, got: {actions:?}"
-    );
-}
-
-#[crate::sqlx_test]
-async fn test_waiting_for_reboot_exhausted_verification_is_non_destructive(pool: sqlx::PgPool) {
-    let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.id;
-    env.redfish_sim.set_bmc_event_log_supported(true);
-    set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
-    env.run_machine_state_controller_iteration().await;
-
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart_time = host.status.last_reboot_requested.unwrap().time;
-    txn.commit().await.unwrap();
-    update_time_params(
-        &env.pool,
-        &host,
-        5,
-        Some(restart_time - Duration::minutes(2)),
-    )
-    .await;
-
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart = host.status.last_reboot_requested.unwrap();
-    db::machine::update_restart_verification_status(
-        &host_id,
-        restart,
-        Some(false),
-        2,
-        txn.as_mut(),
-    )
-    .await
-    .unwrap();
-    txn.commit().await.unwrap();
-
-    let checkpoint = env.redfish_sim.timepoint();
-    env.run_machine_state_controller_iteration().await;
-
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::WaitingForRebootToReady,
-        }
-    );
-    let actions = env.redfish_sim.actions_since(&checkpoint).all_hosts();
-    assert!(
-        actions
-            .iter()
-            .all(|action| !matches!(action, RedfishSimAction::Power(_))),
-        "exhausted verification must not repeat a power action, got: {actions:?}"
-    );
-
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart = host.status.last_reboot_requested.unwrap();
-    assert_eq!(restart.restart_verified, None);
-    assert_eq!(restart.verification_attempts, Some(0));
-    txn.commit().await.unwrap();
-}
-
-#[crate::sqlx_test]
-async fn test_waiting_for_reboot_accepts_bmc_verification(pool: sqlx::PgPool) {
-    let (env, mh) = zero_dpu_host_with_instance(pool).await;
-    let host_id = mh.id;
-    set_assigned_state(&env, &host_id, InstanceState::WaitingForRebootToReady).await;
-    env.run_machine_state_controller_iteration().await;
-
-    let mut txn = env.db_txn().await;
-    let host = mh.host().db_machine(&mut txn).await;
-    let restart = host.status.last_reboot_requested.unwrap();
-    db::machine::update_restart_verification_status(&host_id, restart, Some(true), 0, txn.as_mut())
-        .await
-        .unwrap();
-    txn.commit().await.unwrap();
-
-    env.run_machine_state_controller_iteration().await;
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::Ready,
-        }
-    );
-}
-
-#[crate::sqlx_test]
 async fn test_waiting_for_reboot_checks_health_for_zero_dpu(pool: sqlx::PgPool) {
     let (env, mh) = zero_dpu_host_with_instance(pool).await;
     let host_id = mh.id;
@@ -6631,15 +6398,6 @@ async fn test_waiting_for_reboot_checks_health_for_zero_dpu(pool: sqlx::PgPool) 
         HealthReport::empty(health_source.to_string()),
     )
     .await;
-    env.run_machine_state_controller_iteration().await;
-    assert_eq!(
-        load_host_state(&env, &host_id).await,
-        ManagedHostState::Assigned {
-            instance_state: InstanceState::WaitingForRebootToReady,
-        }
-    );
-
-    reboot_completed(&env, host_id).await;
     env.run_machine_state_controller_iteration().await;
     assert_eq!(
         load_host_state(&env, &host_id).await,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -2720,22 +2720,6 @@ async fn handle_restart_verification(
     if let Some(last_reboot) = &mh_snapshot.host_snapshot.status.last_reboot_requested
         && last_reboot.restart_verified == Some(false)
     {
-        if mh_snapshot
-            .host_snapshot
-            .status
-            .last_reboot_time
-            .is_some_and(|completed| completed > last_reboot.time)
-        {
-            ctx.pending_db_writes
-                .push(MachineWriteOp::UpdateRestartVerificationStatus {
-                    machine_id: mh_snapshot.host_snapshot.id.into(),
-                    current_reboot: *last_reboot,
-                    verified: Some(true),
-                    attempts: 0,
-                });
-            return Ok(None);
-        }
-
         let verification_attempts = last_reboot.verification_attempts.unwrap_or(0);
 
         let host_redfish_client = match ctx
@@ -2750,7 +2734,14 @@ async fn handle_restart_verification(
                     error = %err,
                     "Failed to create Redfish client for host during force-restart verification",
                 );
-                return Ok(None);
+                ctx.pending_db_writes
+                    .push(MachineWriteOp::UpdateRestartVerificationStatus {
+                        machine_id: mh_snapshot.host_snapshot.id.into(),
+                        current_reboot: *last_reboot,
+                        verified: None,
+                        attempts: 0,
+                    });
+                return Ok(None); // Skip verification, continue with state transition
             }
         };
 
@@ -2763,7 +2754,14 @@ async fn handle_restart_verification(
                         error = %err,
                         "Failed to fetch BMC logs for host during force-restart verification",
                     );
-                    return Ok(None);
+                    ctx.pending_db_writes
+                        .push(MachineWriteOp::UpdateRestartVerificationStatus {
+                            machine_id: mh_snapshot.host_snapshot.id.into(),
+                            current_reboot: *last_reboot,
+                            verified: None,
+                            attempts: 0,
+                        });
+                    return Ok(None); // Skip verification, continue with state transition
                 }
             };
 
@@ -2780,25 +2778,6 @@ async fn handle_restart_verification(
         }
 
         if verification_attempts >= MAX_VERIFICATION_ATTEMPTS {
-            if matches!(
-                &mh_snapshot.managed_state,
-                ManagedHostState::Assigned {
-                    instance_state: InstanceState::WaitingForRebootToReady,
-                }
-            ) {
-                ctx.pending_db_writes
-                    .push(MachineWriteOp::UpdateRestartVerificationStatus {
-                        machine_id: mh_snapshot.host_snapshot.id.into(),
-                        current_reboot: *last_reboot,
-                        verified: None,
-                        attempts: 0,
-                    });
-                return Ok(Some(StateHandlerOutcome::wait(
-                    "Waiting for host restart completion after BMC verification attempts were exhausted."
-                        .to_string(),
-                )));
-            }
-
             host_redfish_client
                 .power(SystemPowerControl::ForceRestart)
                 .await
@@ -8644,38 +8623,17 @@ impl StateHandler for InstanceStateHandler {
                             });
                     }
 
-                    let host = &mh_snapshot.host_snapshot;
-                    if let Some(restart) =
-                        host.status
-                            .last_reboot_requested
-                            .as_ref()
-                            .filter(|restart| {
-                                restart.mode == MachineLastRebootRequestedMode::Reboot
-                                    && restart.time > host.state.version.timestamp()
-                            })
-                    {
-                        let restart_completed = host
-                            .status
-                            .last_reboot_time
-                            .is_some_and(|completed| completed > restart.time);
-                        if restart_completed || restart.restart_verified == Some(true) {
-                            return Ok(StateHandlerOutcome::transition(
-                                ManagedHostState::Assigned {
-                                    instance_state: InstanceState::Ready,
-                                },
-                            ));
-                        }
-
-                        return Ok(StateHandlerOutcome::wait(
-                            "Waiting for host restart completion or verification.".to_string(),
-                        ));
-                    }
-
+                    // Reboot host
                     handler_host_power_control(mh_snapshot, ctx, SystemPowerControl::ForceRestart)
                         .await?;
-                    Ok(StateHandlerOutcome::wait(
-                        "Waiting for host restart completion or verification.".to_string(),
-                    ))
+
+                    // Instance is ready.
+                    // We can not determine if machine is rebooted successfully or not. Just leave
+                    // it like this and declare Instance Ready.
+                    let next_state = ManagedHostState::Assigned {
+                        instance_state: InstanceState::Ready,
+                    };
+                    Ok(StateHandlerOutcome::transition(next_state))
                 }
                 InstanceState::Ready => {
                     // Machine is up after reboot. Hurray. Instance is up.

--- a/crates/redfish/src/libredfish/test_support.rs
+++ b/crates/redfish/src/libredfish/test_support.rs
@@ -106,10 +106,6 @@ struct RedfishSimState {
     /// (`503`), so callers' error-propagation paths can be exercised distinctly
     /// from an unauthorized rejection.
     get_accounts_error: bool,
-    /// When set, BMC event-log reads succeed with an empty log.
-    bmc_event_log_supported: bool,
-    /// When set, the next BMC event-log read fails with a transient error.
-    bmc_event_log_error_once: bool,
     /// Opt-in password-reuse policy. When on, a password *change* whose new
     /// value equals the account's current password is rejected (`400`), modeling
     /// the real BMCs that refuse a same-value change -- the exact behavior BMC
@@ -459,16 +455,6 @@ impl RedfishSim {
     /// transport error (`503`), to exercise a caller's error-propagation path.
     pub fn set_get_accounts_error(&self, error: bool) {
         self.state.lock().unwrap().get_accounts_error = error;
-    }
-
-    /// Control whether BMC event-log reads succeed with an empty log.
-    pub fn set_bmc_event_log_supported(&self, supported: bool) {
-        self.state.lock().unwrap().bmc_event_log_supported = supported;
-    }
-
-    /// Fail the next BMC event-log read with a transient simulated error.
-    pub fn fail_next_bmc_event_log_read(&self) {
-        self.state.lock().unwrap().bmc_event_log_error_once = true;
     }
 
     /// Enable the opt-in password-reuse policy (see
@@ -1738,15 +1724,6 @@ impl Redfish for RedfishSimClient {
     ) -> libredfish::RedfishFuture<'a, Result<Vec<libredfish::model::sel::LogEntry>, RedfishError>>
     {
         Box::pin(async move {
-            let mut state = self.state.lock().unwrap();
-            if std::mem::take(&mut state.bmc_event_log_error_once) {
-                return Err(RedfishError::GenericError {
-                    error: "transient BMC event-log failure".to_string(),
-                });
-            }
-            if state.bmc_event_log_supported {
-                return Ok(Vec::new());
-            }
             Err(RedfishError::NotSupported(
                 "BMC Event Log not supported for tests".to_string(),
             ))


### PR DESCRIPTION
**Summary**

Revert the restart-verification behavior introduced by [#5283](https://github.com/dsx-ai-factory/infra-controller/pull/5283) for `Assigned/WaitingForRebootToReady`.

The verification gate can leave instance creation, custom-iPXE boots, and instance termination stuck indefinitely on platforms where BMC event-log verification is unavailable or unreliable.

**Problem**

[#5283](https://github.com/dsx-ai-factory/infra-controller/pull/5283) relies on Scout or vendor-specific BMC logs to verify the restart. However, Scout is no longer available after the host restarts into the tenant OS in `Assigned/WaitingForRebootToReady` and BMC verification is not universally supported (Vera Rubin, Dell, etc).

While the machine remains in `WaitingForRebootToReady`, its PXE request receives:
`Could not continue boot due to invalid state`

<img width="1653" height="952" alt="image" src="https://github.com/user-attachments/assets/3e48a3c7-a375-4b65-b2d7-0561e07eb092" />

Consequently, neither the tenant OS nor a requested custom-iPXE script can boot successfully, and the state cannot advance. The same problem affects termination when a deleted instance reaches this state before completing provisioning.

**Change**

Revert #5283’s restart-verification gate and restore the immediate transition from `WaitingForRebootToReady` to `Ready` after requesting the restart.

## Related issues
https://github.com/dsx-ai-factory/infra-controller/issues/5951

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

## Additional Notes
