### PR TITLE
fix: Pass MAC addresses in lower case to the Weave server

### DIFF
--- a/crates/agent/src/astra_weave.rs
+++ b/crates/agent/src/astra_weave.rs
@@ -549,7 +549,8 @@ async fn create_update_weave_ew_vpc_astra_attachments(
                     .spec
                     .as_ref()
                     .is_some_and(|spec| {
-                        spec.nic_id.as_str() == astra_attachment_status.mac_address.as_str()
+                        spec.nic_id
+                            .eq_ignore_ascii_case(astra_attachment_status.mac_address.as_str())
                     })
             })
             .collect::<Vec<_>>();
@@ -856,7 +857,8 @@ fn weave_ew_vpc_attachment_exists_in_astra_config(
                 .spec
                 .as_ref()
                 .is_some_and(|spec| {
-                    spec.nic_id == astra_attachment_status.mac_address.as_str()
+                    spec.nic_id
+                        .eq_ignore_ascii_case(astra_attachment_status.mac_address.as_str())
                         && spec.vnet_id
                             == astra_weave_ew_vpc_virtual_network_id(astra_attachment_status.vni)
                 })

--- a/crates/agent/src/astra_weave.rs
+++ b/crates/agent/src/astra_weave.rs
@@ -1309,7 +1309,8 @@ fn sync_astra_config_status_from_weave_ew_vpc_attachments(
                         .spec
                         .as_ref()
                         .is_some_and(|spec| {
-                            spec.nic_id == astra_attachment.mac_address.as_str()
+                            spec.nic_id
+                                .eq_ignore_ascii_case(astra_attachment.mac_address.as_str())
                                 && spec.vnet_id
                                     == astra_weave_ew_vpc_virtual_network_id(
                                         astra_attachment.vni as i32,

--- a/crates/api-core/src/handlers/astra.rs
+++ b/crates/api-core/src/handlers/astra.rs
@@ -156,7 +156,7 @@ pub(super) async fn get_astra_config(
 
             // Now we can create the Astra attachment and add it to the Astra config.
             let astra_attachment = AstraAttachment {
-                mac_address: dpa_interface.mac_address.to_string(),
+                mac_address: dpa_interface.mac_address.to_string().to_lowercase(),
                 vni: dpa_vni as u32,
                 subnet_ipv4: subnet_ip.to_string(),
                 subnet_mask,
@@ -169,7 +169,7 @@ pub(super) async fn get_astra_config(
             astra_attachments.push(astra_attachment);
         } else {
             let astra_attachment = AstraAttachment {
-                mac_address: dpa_interface.mac_address.to_string(),
+                mac_address: dpa_interface.mac_address.to_string().to_lowercase(),
                 vni: 0,
                 subnet_ipv4: subnet_ip.to_string(),
                 subnet_mask,


### PR DESCRIPTION
The Weave server currently needs MAC addresses to be in lower case.

## Related issues

Closes https://github.com/dsx-ai-factory/infra-controller/issues/6235

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [X] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes
Will be tested in VR minipod

