### PR TITLE
fix(helm-prereqs): relay DPU and switch DHCP through a simulated underlay segment in scale mode

### DIFF
--- a/dev/deployment/devspace/values.base.yaml
+++ b/dev/deployment/devspace/values.base.yaml
@@ -182,8 +182,8 @@ nico-machine-a-tron:
           hwType: wiwynn_gb200_nvl
           hostCount: 2
           dpuPerHostCount: 2
-          oobDhcpRelayAddress: "192.168.192.1"
-          adminDhcpRelayAddress: "192.168.176.1"
+          bmcDhcpRelayAddress: "192.168.192.1"
+          underlayDhcpRelayAddress: "192.168.176.1"
 nico-dhcp:
   enabled: false
 nico-dns:

--- a/dev/deployment/tilt/values.yaml
+++ b/dev/deployment/tilt/values.yaml
@@ -281,8 +281,8 @@ nico-machine-a-tron:
           hwType: wiwynn_gb200_nvl
           hostCount: 2
           dpuPerHostCount: 2
-          oobDhcpRelayAddress: 10.96.64.1
-          adminDhcpRelayAddress: 192.168.176.1
+          bmcDhcpRelayAddress: 10.96.64.1
+          underlayDhcpRelayAddress: 192.168.176.1
 
 tilt:
   machineATronDhcp:

--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -224,7 +224,7 @@ Copy `helm-prereqs/values/machine-a-tron.yaml` and fill in the site-specific val
 |-------|-------------|
 | `image.tag` | Tag produced by [building the container image](#building-the-container-image) (e.g. `8c35783af-amd64`) |
 | `machines.dell-hosts.oobDhcpRelayAddress` | Gateway of the OOB/underlay network from nico-core site config |
-| `machines.dell-hosts.adminDhcpRelayAddress` | Gateway of the admin network from nico-core site config |
+| `machines.dell-hosts.adminDhcpRelayAddress` | Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP (MAT reads it as `underlay_dhcp_relay_address`) |
 | `machines.dell-hosts.hostCount` | Must not exceed available OOB DHCP addresses (`hostCount + hostCount×dpuPerHostCount`) |
 
 ### SPIFFE URI override

--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -224,7 +224,7 @@ Copy `helm-prereqs/values/machine-a-tron.yaml` and fill in the site-specific val
 |-------|-------------|
 | `image.tag` | Tag produced by [building the container image](#building-the-container-image) (e.g. `8c35783af-amd64`) |
 | `machines.dell-hosts.bmcDhcpRelayAddress` | Gateway of the BMC (OOB) network from nico-core site config; relay for BMC DHCP |
-| `machines.dell-hosts.underlayDhcpRelayAddress` | Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP (`bmcDhcpRelayAddress` and `underlayDhcpRelayAddress` remain accepted as deprecated aliases) |
+| `machines.dell-hosts.underlayDhcpRelayAddress` | Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP (the previous names `oobDhcpRelayAddress` and `adminDhcpRelayAddress` remain accepted as deprecated aliases) |
 | `machines.dell-hosts.hostCount` | Must not exceed available OOB DHCP addresses (`hostCount + hostCount×dpuPerHostCount`) |
 
 ### SPIFFE URI override
@@ -380,7 +380,7 @@ seeds, SPIFFE URI). Multi-pod with controller adds the following requirements:
             hostCount: 100
             dpuPerHostCount: 2
             bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-            underlayDhcpRelayAddress: "192.168.176.1"
+            underlayDhcpRelayAddress: "10.104.0.1"
       mat-1:
         machines:
           compute:
@@ -388,7 +388,7 @@ seeds, SPIFFE URI). Multi-pod with controller adds the following requirements:
             hostCount: 100
             dpuPerHostCount: 2
             bmcDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
-            underlayDhcpRelayAddress: "192.168.176.1"
+            underlayDhcpRelayAddress: "10.104.0.1"
 
     macAddressPool:
       enabled: true

--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -223,8 +223,8 @@ Copy `helm-prereqs/values/machine-a-tron.yaml` and fill in the site-specific val
 | Field | Description |
 |-------|-------------|
 | `image.tag` | Tag produced by [building the container image](#building-the-container-image) (e.g. `8c35783af-amd64`) |
-| `machines.dell-hosts.oobDhcpRelayAddress` | Gateway of the OOB/underlay network from nico-core site config |
-| `machines.dell-hosts.adminDhcpRelayAddress` | Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP (MAT reads it as `underlay_dhcp_relay_address`) |
+| `machines.dell-hosts.bmcDhcpRelayAddress` | Gateway of the BMC (OOB) network from nico-core site config; relay for BMC DHCP |
+| `machines.dell-hosts.underlayDhcpRelayAddress` | Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP (`bmcDhcpRelayAddress` and `underlayDhcpRelayAddress` remain accepted as deprecated aliases) |
 | `machines.dell-hosts.hostCount` | Must not exceed available OOB DHCP addresses (`hostCount + hostCount×dpuPerHostCount`) |
 
 ### SPIFFE URI override
@@ -333,7 +333,7 @@ with ClusterIP = BMC IP assigned by NICo DHCP. NICo dials each BMC IP directly
 Everything single-pod mode needs still applies (namespaces, CA copy, Vault
 seeds, SPIFFE URI). Multi-pod with controller adds the following requirements:
 
-1. **`oobDhcpRelayAddress` must be within Kubernetes ServiceCIDR.** All pods
+1. **`bmcDhcpRelayAddress` must be within Kubernetes ServiceCIDR.** All pods
    can share the same relay address — NICo assigns unique IPs from the network.
    Default ServiceCIDR ranges:
    - `10.96.0.0/12` - vanilla Kubernetes (kubeadm)
@@ -379,16 +379,16 @@ seeds, SPIFFE URI). Multi-pod with controller adds the following requirements:
             hwType: wiwynn_gb200_nvl
             hostCount: 100
             dpuPerHostCount: 2
-            oobDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-            adminDhcpRelayAddress: "192.168.176.1"
+            bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
+            underlayDhcpRelayAddress: "192.168.176.1"
       mat-1:
         machines:
           compute:
             hwType: wiwynn_gb200_nvl
             hostCount: 100
             dpuPerHostCount: 2
-            oobDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
-            adminDhcpRelayAddress: "192.168.176.1"
+            bmcDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
+            underlayDhcpRelayAddress: "192.168.176.1"
 
     macAddressPool:
       enabled: true

--- a/docs/development/machine-a-tron-deployment.md
+++ b/docs/development/machine-a-tron-deployment.md
@@ -223,8 +223,8 @@ Copy `helm-prereqs/values/machine-a-tron.yaml` and fill in the site-specific val
 | Field | Description |
 |-------|-------------|
 | `image.tag` | Tag produced by [building the container image](#building-the-container-image) (e.g. `8c35783af-amd64`) |
-| `machines.dell-hosts.bmcDhcpRelayAddress` | Gateway of the BMC (OOB) network from nico-core site config; relay for BMC DHCP |
-| `machines.dell-hosts.underlayDhcpRelayAddress` | Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP (the previous names `oobDhcpRelayAddress` and `adminDhcpRelayAddress` remain accepted as deprecated aliases) |
+| `machines.dell-hosts.bmcDhcpRelayAddress` | Gateway of the BMC (OOB) network from nico-core site config; relay for BMC DHCP (previously `oobDhcpRelayAddress`, still accepted) |
+| `machines.dell-hosts.underlayDhcpRelayAddress` | Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP (previously `adminDhcpRelayAddress`, still accepted) |
 | `machines.dell-hosts.hostCount` | Must not exceed available OOB DHCP addresses (`hostCount + hostCount×dpuPerHostCount`) |
 
 ### SPIFFE URI override

--- a/docs/development/machine-a-tron-scale-testing.md
+++ b/docs/development/machine-a-tron-scale-testing.md
@@ -33,7 +33,7 @@ The `mat-k8s-controller` dynamically creates one ClusterIP Service per BMC:
 - Services route to correct pod via `nvidia-infra-controller/pod-name` selector
 
 **Requirements:**
-- `oobDhcpRelayAddress` must be within Kubernetes ServiceCIDR
+- `bmcDhcpRelayAddress` must be within Kubernetes ServiceCIDR
 - NICo siteConfig needs `allow_insecure_discovery = true` and a network
   covering the BMC IP range
 - Leave `site_explorer.bmc_proxy` unset — NICo dials each BMC's ClusterIP directly

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -209,7 +209,7 @@ NICO_DB="nico_system_nico"
 #   NICo network covering the BMC IP range. See the chart README "Controller Mode".
 MAT_MODE="${MAT_MODE:-override}"
 # Networks for scale mode. The OOB gateway must match the scale values file
-# (oobDhcpRelayAddress). Both are sized from MEASURED demand, not from the host
+# (bmcDhcpRelayAddress). Both are sized from MEASURED demand, not from the host
 # count: since the mock BMCs became DHCP clients, a 4,500-host fleet needs far
 # more addresses than the obvious "one per host" arithmetic suggests.
 #
@@ -863,7 +863,7 @@ mtu = 9000
 reserve_first = {env["SCALE_RESERVE"]}
 '''
 # DPU OOB + switch NVOS DHCP relay target (MAT underlay_dhcp_relay_address,
-# rendered as adminDhcpRelayAddress). Kept separate from the admin pool: NICo
+# rendered as underlayDhcpRelayAddress). Kept separate from the admin pool: NICo
 # predicts DPU oob interfaces on an underlay-typed segment.
 networks_underlay = f'''
 [networks.simulated-underlay]
@@ -1159,7 +1159,7 @@ if [[ "$MAT_MODE" == "scale" ]]; then
     # no live-config parsing needed.
     OOB_PREFIX="$SCALE_OOB_PREFIX";   OOB_DHCP_RELAY="${OOB_DHCP_RELAY:-$SCALE_OOB_GW}"
     ADMIN_PREFIX="$SCALE_ADMIN_PREFIX"
-    # MAT's adminDhcpRelayAddress is its underlay relay (DPU OOB + switch NVOS
+    # MAT's underlayDhcpRelayAddress is its underlay relay (DPU OOB + switch NVOS
     # DHCP); it must resolve to an underlay-typed segment, not the admin pool.
     UNDERLAY_PREFIX="$SCALE_UNDERLAY_PREFIX"; UNDERLAY_RESERVE="$SCALE_RESERVE"
     ADMIN_DHCP_RELAY="${ADMIN_DHCP_RELAY:-$SCALE_UNDERLAY_GW}"
@@ -1202,7 +1202,7 @@ _usable() { local m="${1##*/}" r="$2"; local u=$(( (1 << (32 - m)) - r - 1 )); (
 #           PLUS one admin IP per host allocated by machine creation (creation
 #           fails with "No IP addresses left in prefix <admin>" without it)
 #   underlay = hostCount*dpuPerHost + switchCount - one DPU OOB IP per DPU plus
-#           one NVOS IP per switch (scale mode; relayed via adminDhcpRelayAddress)
+#           one NVOS IP per switch (scale mode; relayed via underlayDhcpRelayAddress)
 if [[ "${OOB_PREFIX:-}" == */* && "${ADMIN_PREFIX:-}" == */* ]]; then
     OOB_USABLE="$(_usable "$OOB_PREFIX" "$OOB_RESERVE")"; ADMIN_USABLE="$(_usable "$ADMIN_PREFIX" "$ADMIN_RESERVE")"
     # max hosts each pool supports, then take the min
@@ -1255,9 +1255,9 @@ def groups_from_yaml(doc):
             out.append({
                 "hosts": hosts,
                 "dpus": int(grp.get("dpuPerHostCount") or 0),
-                "relay": str(grp.get("oobDhcpRelayAddress") or "").strip(),
+                "relay": str(grp.get("bmcDhcpRelayAddress") or grp.get("oobDhcpRelayAddress") or "").strip(),
                 "hw": str(grp.get("hwType") or "").lower(),
-                "urelay": str(grp.get("adminDhcpRelayAddress") or "").strip(),
+                "urelay": str(grp.get("underlayDhcpRelayAddress") or grp.get("adminDhcpRelayAddress") or "").strip(),
             })
     return out
 
@@ -1297,9 +1297,9 @@ for raw in text.splitlines():
         cur["hw"] = val.strip('"\'').lower()
     elif key == "dpuPerHostCount" and cur is not None:
         cur["dpus"] = int(re.sub(r"\D", "", val) or 0)
-    elif key == "oobDhcpRelayAddress" and cur is not None:
+    elif key in ("bmcDhcpRelayAddress", "oobDhcpRelayAddress") and cur is not None:
         cur["relay"] = val.strip('"\'')
-    elif key == "adminDhcpRelayAddress" and cur is not None:
+    elif key in ("underlayDhcpRelayAddress", "adminDhcpRelayAddress") and cur is not None:
         cur["urelay"] = val.strip('"\'')
 if cur is not None:
     groups.append(cur)
@@ -1347,7 +1347,7 @@ for relay, need in sorted(demand.items()):
         problems.append(f"relay {relay} needs {need} IPs but {cidr} only provides ~{cap}")
 
 # Underlay demand is additive across every group that relays DPU OOB / switch
-# NVOS DHCP to the same adminDhcpRelayAddress: one lease per DPU, one per switch.
+# NVOS DHCP to the same underlayDhcpRelayAddress: one lease per DPU, one per switch.
 underlay = {}
 for g in groups:
     need = g["hosts"] * g["dpus"] + (g["hosts"] if "switch" in g["hw"] else 0)
@@ -1488,8 +1488,8 @@ pods:
       dell-hosts:
         hostCount: ${HOST_COUNT}
         dpuPerHostCount: ${DPU_PER_HOST}
-        oobDhcpRelayAddress: "${OOB_DHCP_RELAY}"
-        adminDhcpRelayAddress: "${ADMIN_DHCP_RELAY}"
+        bmcDhcpRelayAddress: "${OOB_DHCP_RELAY}"
+        underlayDhcpRelayAddress: "${ADMIN_DHCP_RELAY}"
 EOF
 fi
 if [[ "$MAT_MODE" == "scale" ]]; then

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -117,7 +117,9 @@
 #                          Default: NicoSiteRoot1
 #   OOB_DHCP_RELAY         OOB/underlay gateway (BMC DHCP relay). Auto-detected
 #                          from nico-core site config if unset.
-#   ADMIN_DHCP_RELAY       Admin network gateway. Auto-detected if unset.
+#   ADMIN_DHCP_RELAY       Relay MAT uses for DPU OOB and switch NVOS DHCP
+#                          (MAT underlay_dhcp_relay_address). Scale mode:
+#                          simulated-underlay gateway; else auto-detected.
 #   HOST_COUNT             Override machines.dell-hosts.hostCount.
 #   DPU_PER_HOST           Override machines.dell-hosts.dpuPerHostCount.
 #   CHART_DIR              Path to the nico-machine-a-tron chart.
@@ -221,8 +223,13 @@ MAT_MODE="${MAT_MODE:-override}"
 # and must come from the Kubernetes ServiceCIDR, so it must override these.
 SCALE_OOB_PREFIX="${SCALE_OOB_PREFIX:-10.96.64.0/18}";  SCALE_OOB_GW="${SCALE_OOB_GW:-10.96.64.1}"
 SCALE_ADMIN_PREFIX="${SCALE_ADMIN_PREFIX:-10.102.0.0/18}"; SCALE_ADMIN_GW="${SCALE_ADMIN_GW:-10.102.0.1}"
+# DPU OOB and switch NVOS DHCP relay target. NICo predicts DPU oob interfaces
+# on an underlay-typed segment and rejects DHCP relayed from any other type,
+# while host admin links must stay on an admin-typed segment, so the relay
+# MAT uses for DPU/switch DHCP gets its own underlay segment.
+SCALE_UNDERLAY_PREFIX="${SCALE_UNDERLAY_PREFIX:-10.104.0.0/18}"; SCALE_UNDERLAY_GW="${SCALE_UNDERLAY_GW:-10.104.0.1}"
 SCALE_RESERVE=1
-# These four are operator-overridable and are written straight into the site
+# These six are operator-overridable and are written straight into the site
 # config and the DB, so validate them before anything consumes them: an
 # invalid prefix would insert a network segment and only fail on the separate
 # prefix insert, leaving a half-built segment that later runs skip as
@@ -245,6 +252,7 @@ PYCHK
 }
 _valid_cidr_gw "$SCALE_OOB_PREFIX"   "$SCALE_OOB_GW"   "SCALE_OOB"   || die "$(_valid_cidr_gw "$SCALE_OOB_PREFIX" "$SCALE_OOB_GW" "SCALE_OOB" 2>&1)"
 _valid_cidr_gw "$SCALE_ADMIN_PREFIX" "$SCALE_ADMIN_GW" "SCALE_ADMIN" || die "$(_valid_cidr_gw "$SCALE_ADMIN_PREFIX" "$SCALE_ADMIN_GW" "SCALE_ADMIN" 2>&1)"
+_valid_cidr_gw "$SCALE_UNDERLAY_PREFIX" "$SCALE_UNDERLAY_GW" "SCALE_UNDERLAY" || die "$(_valid_cidr_gw "$SCALE_UNDERLAY_PREFIX" "$SCALE_UNDERLAY_GW" "SCALE_UNDERLAY" 2>&1)"
 # site_explorer throughput knobs applied in scale mode (defaults 30/90/4 make
 # 4500-host ingestion take ~9h; these bring it to ~1-2h).
 # Defaults are the values measured best at BOTH scales:
@@ -737,6 +745,7 @@ elif [[ "$MAT_MODE" == "scale" ]]; then
         || die "nico-api-site-config-files configmap not found"
     _PATCH_RESULT="$(SCALE_OOB_PREFIX="$SCALE_OOB_PREFIX" SCALE_OOB_GW="$SCALE_OOB_GW" \
         SCALE_ADMIN_PREFIX="$SCALE_ADMIN_PREFIX" SCALE_ADMIN_GW="$SCALE_ADMIN_GW" \
+        SCALE_UNDERLAY_PREFIX="$SCALE_UNDERLAY_PREFIX" SCALE_UNDERLAY_GW="$SCALE_UNDERLAY_GW" \
         SCALE_RESERVE="$SCALE_RESERVE" \
         BMC_PROXY="${BMC_MOCK_FQDN}:${BMC_MOCK_PORT}" \
         KNOB_CONC="$SCALE_CONCURRENT_EXPLORATIONS" KNOB_EPR="$SCALE_EXPLORATIONS_PER_RUN" \
@@ -819,6 +828,17 @@ gateway = "{env["SCALE_ADMIN_GW"]}"
 mtu = 9000
 reserve_first = {env["SCALE_RESERVE"]}
 '''
+# DPU OOB + switch NVOS DHCP relay target (MAT underlay_dhcp_relay_address,
+# rendered as adminDhcpRelayAddress). Kept separate from the admin pool: NICo
+# predicts DPU oob interfaces on an underlay-typed segment.
+networks_underlay = f'''
+[networks.simulated-underlay]
+type = "underlay"
+prefix = "{env["SCALE_UNDERLAY_PREFIX"]}"
+gateway = "{env["SCALE_UNDERLAY_GW"]}"
+mtu = 9000
+reserve_first = {env["SCALE_RESERVE"]}
+'''
 # Machine creation allocates one loopback IP per machine from pools.lo-ip —
 # site templates ship tiny ranges (often only a few addresses) that exhaust
 # ("Resource pool lo-ip is empty"). Pools DO reconcile at startup (unlike
@@ -871,6 +891,8 @@ for k, v in cm["data"].items():
     new = "\n".join(out) + ("\n" if v_work.endswith("\n") else "")
     if "[networks.simulated-oob]" not in new:
         new = new.rstrip("\n") + "\n" + networks
+    if "[networks.simulated-underlay]" not in new:
+        new = new.rstrip("\n") + "\n" + networks_underlay
     # Sections not present in the file are emitted in the sentinel tail.
     # (A dotted subtable like [machine_state_controller.controller] is valid
     # there even when its parent table exists elsewhere.)
@@ -941,13 +963,17 @@ PY
     }
     _ensure_segment "simulated-oob"   "underlay" "$SCALE_OOB_PREFIX"   "$SCALE_OOB_GW"   "$SCALE_RESERVE"
     _ensure_segment "simulated-admin" "admin"    "$SCALE_ADMIN_PREFIX" "$SCALE_ADMIN_GW" "$SCALE_RESERVE"
+    # Underlay-typed: DPU OOB and switch NVOS DHCP relay through this gateway.
+    # NICo's site explorer predicts DPU oob interfaces with expected type
+    # underlay and rejects DHCP relayed onto a segment of any other type.
+    _ensure_segment "simulated-underlay" "underlay" "$SCALE_UNDERLAY_PREFIX" "$SCALE_UNDERLAY_GW" "$SCALE_RESERVE"
     # Backfill segments created before this script seeded svi_ip (or created
     # by config-driven bootstrap, which leaves it NULL).
     _SVI_FIXED="$(psql_q "WITH fixed AS (
             UPDATE network_prefixes np SET svi_ip = np.gateway
             FROM network_segments ns
             WHERE ns.id = np.segment_id
-              AND ns.name IN ('simulated-oob','simulated-admin')
+              AND ns.name IN ('simulated-oob','simulated-admin','simulated-underlay')
               AND np.svi_ip IS NULL
             RETURNING 1)
         SELECT count(*) FROM fixed;" || echo 0)"
@@ -1065,7 +1091,11 @@ if [[ "$MAT_MODE" == "scale" ]]; then
     # scale mode uses the SIMULATED networks added in Phase 5 — constants,
     # no live-config parsing needed.
     OOB_PREFIX="$SCALE_OOB_PREFIX";   OOB_DHCP_RELAY="${OOB_DHCP_RELAY:-$SCALE_OOB_GW}"
-    ADMIN_PREFIX="$SCALE_ADMIN_PREFIX"; ADMIN_DHCP_RELAY="${ADMIN_DHCP_RELAY:-$SCALE_ADMIN_GW}"
+    ADMIN_PREFIX="$SCALE_ADMIN_PREFIX"
+    # MAT's adminDhcpRelayAddress is its underlay relay (DPU OOB + switch NVOS
+    # DHCP); it must resolve to an underlay-typed segment, not the admin pool.
+    UNDERLAY_PREFIX="$SCALE_UNDERLAY_PREFIX"; UNDERLAY_RESERVE="$SCALE_RESERVE"
+    ADMIN_DHCP_RELAY="${ADMIN_DHCP_RELAY:-$SCALE_UNDERLAY_GW}"
     OOB_RESERVE="$SCALE_RESERVE"; ADMIN_RESERVE="$SCALE_RESERVE"
 else
     SITE_CFG="$(kubectl get cm nico-api-site-config-files -n "$NICO_SYSTEM_NS" \
@@ -1095,20 +1125,29 @@ fi
 [[ -n "$OOB_DHCP_RELAY" && -n "$ADMIN_DHCP_RELAY" ]] \
     || die "could not resolve DHCP relays; set OOB_DHCP_RELAY and ADMIN_DHCP_RELAY"
 ok "OOB:   relay ${OOB_DHCP_RELAY}   prefix ${OOB_PREFIX:-unknown}"
-ok "admin: relay ${ADMIN_DHCP_RELAY}   prefix ${ADMIN_PREFIX:-unknown}"
+ok "admin: pool ${ADMIN_PREFIX:-unknown}   DPU/switch DHCP relay ${ADMIN_DHCP_RELAY} (underlay pool ${UNDERLAY_PREFIX:-n/a})"
 _usable() { local m="${1##*/}" r="$2"; local u=$(( (1 << (32 - m)) - r - 1 )); (( u < 0 )) && u=0; echo "$u"; }
 # Demand per pool (measured live):
 #   OOB   = hostCount*(1 + dpuPerHost)   — one BMC IP per host and per DPU
 #   admin = hostCount*(dpuPerHost + 1)   — one host-PF IP per DPU at DHCP time,
 #           PLUS one admin IP per host allocated by machine creation (creation
 #           fails with "No IP addresses left in prefix <admin>" without it)
+#   underlay = hostCount*dpuPerHost + switchCount - one DPU OOB IP per DPU plus
+#           one NVOS IP per switch (scale mode; relayed via adminDhcpRelayAddress)
 if [[ "${OOB_PREFIX:-}" == */* && "${ADMIN_PREFIX:-}" == */* ]]; then
     OOB_USABLE="$(_usable "$OOB_PREFIX" "$OOB_RESERVE")"; ADMIN_USABLE="$(_usable "$ADMIN_PREFIX" "$ADMIN_RESERVE")"
     # max hosts each pool supports, then take the min
     FIT_OOB=$(( OOB_USABLE / (1 + DPU_PER_HOST) ))
     FIT_ADMIN=$(( ADMIN_USABLE / (DPU_PER_HOST + 1) ))
     FIT=$(( FIT_OOB < FIT_ADMIN ? FIT_OOB : FIT_ADMIN ))
-    info "pool fit: OOB ${OOB_PREFIX} ≈${OOB_USABLE} usable → ≤${FIT_OOB} hosts; admin ${ADMIN_PREFIX} ≈${ADMIN_USABLE} usable → ≤${FIT_ADMIN} hosts"
+    FIT_NOTE=""
+    if [[ "${UNDERLAY_PREFIX:-}" == */* && "${DPU_PER_HOST:-0}" -gt 0 ]]; then
+        UNDERLAY_USABLE="$(_usable "$UNDERLAY_PREFIX" "${UNDERLAY_RESERVE:-$ADMIN_RESERVE}")"
+        FIT_UNDERLAY=$(( UNDERLAY_USABLE / DPU_PER_HOST ))   # switch NVOS demand not counted
+        FIT=$(( FIT < FIT_UNDERLAY ? FIT : FIT_UNDERLAY ))
+        FIT_NOTE="; underlay ${UNDERLAY_PREFIX} ≈${UNDERLAY_USABLE} usable → ≤${FIT_UNDERLAY} hosts"
+    fi
+    info "pool fit: OOB ${OOB_PREFIX} ≈${OOB_USABLE} usable → ≤${FIT_OOB} hosts; admin ${ADMIN_PREFIX} ≈${ADMIN_USABLE} usable → ≤${FIT_ADMIN} hosts${FIT_NOTE}"
     if [[ "${MAT_MULTIPOD:-0}" == "1" ]]; then
         # Multipod: HOST_COUNT/DPU_PER_HOST are only the FIRST pod group, so
         # the single-pool clamp above is meaningless here. Two cases matter:

--- a/helm-prereqs/setup-machine-a-tron.sh
+++ b/helm-prereqs/setup-machine-a-tron.sh
@@ -119,7 +119,12 @@
 #                          from nico-core site config if unset.
 #   ADMIN_DHCP_RELAY       Relay MAT uses for DPU OOB and switch NVOS DHCP
 #                          (MAT underlay_dhcp_relay_address). Scale mode:
-#                          simulated-underlay gateway; else auto-detected.
+#                          simulated-underlay gateway. Override mode: the
+#                          first site gateway, as before; set it when DPU
+#                          OOB must relay through another segment.
+#   SWITCH_COUNT           Override the switch total (NVOS leases) used by
+#                          the pool-fit check. Default: sum of hostCount over
+#                          machine groups whose hwType contains "switch".
 #   HOST_COUNT             Override machines.dell-hosts.hostCount.
 #   DPU_PER_HOST           Override machines.dell-hosts.dpuPerHostCount.
 #   CHART_DIR              Path to the nico-machine-a-tron chart.
@@ -292,7 +297,7 @@ for arg in "$@"; do
         --scale) MAT_MODE="scale" ;;
         --skip-nico-core-config) SKIP_NICO_CORE_CONFIG=true ;;
         --skip-dpf-sim) SKIP_DPF_SIM=true ;;
-        -h|--help) grep '^#' "$0" | sed 's/^# \{0,1\}//' | head -130; exit 0 ;;
+        -h|--help) awk 'NR==1{next} /^# =+$/{r++; if(r==2) exit} /^#/{sub(/^# ?/,""); print}' "$0"; exit 0 ;;
         *) echo "Unknown argument: $arg" >&2; exit 2 ;;
     esac
 done
@@ -383,6 +388,35 @@ DPU_PER_HOST="${DPU_PER_HOST:-$(grep -E '^[[:space:]]*dpuPerHostCount:' "$VALUES
 [[ -n "$MAT_IMAGE_TAG" ]] || die "MAT_IMAGE_TAG is unset and the values file has no image.tag"
 [[ "$HOST_COUNT" =~ ^[0-9]+$ && "$DPU_PER_HOST" =~ ^[0-9]+$ ]] \
     || die "could not determine hostCount/dpuPerHostCount from $VALUES_FILE (set HOST_COUNT / DPU_PER_HOST)"
+# Switches take one NVOS lease each from the underlay pool. Sum the hostCount
+# of every machine group whose hwType names a switch (same dependency-free
+# line walk as the multipod validator; commented-out groups are ignored).
+SWITCH_COUNT="${SWITCH_COUNT:-$(python3 - "$VALUES_FILE" <<'PY'
+import re, sys
+total, cur, ind = 0, None, None
+for raw in open(sys.argv[1]).read().splitlines():
+    if not raw.strip() or raw.lstrip().startswith("#"):
+        continue
+    indent = len(raw) - len(raw.lstrip())
+    m = re.match(r'\s*([A-Za-z0-9_.-]+)\s*:\s*(\S.*)?$', raw)
+    if not m:
+        continue
+    key, val = m.group(1), re.sub(r"\s+#.*$", "", m.group(2) or "").strip().strip('"\'')
+    if cur is not None and indent < ind:
+        total += cur["hosts"] if "switch" in cur["hw"] else 0
+        cur = None
+    if key in ("hostCount", "hwType") and cur is None:
+        cur, ind = {"hosts": 0, "hw": ""}, indent
+    if key == "hostCount":
+        cur["hosts"] = int(re.sub(r"\D", "", val) or 0)
+    elif key == "hwType":
+        cur["hw"] = val.lower()
+if cur is not None and "switch" in cur["hw"]:
+    total += cur["hosts"]
+print(total)
+PY
+)}"
+[[ "$SWITCH_COUNT" =~ ^[0-9]+$ ]] || die "SWITCH_COUNT must be a number (got '${SWITCH_COUNT}')"
 # Passwords are inlined into sh -c JSON heredocs on the vault pod; quotes,
 # backslashes, or whitespace would break quoting or corrupt the JSON silently.
 for _pw in "$BMC_PASSWORD" "$UEFI_DPU_PASSWORD" "$UEFI_HOST_PASSWORD"; do
@@ -844,6 +878,20 @@ reserve_first = {env["SCALE_RESERVE"]}
 # ("Resource pool lo-ip is empty"). Pools DO reconcile at startup (unlike
 # networks), so appending a simulated range takes effect on restart.
 SIM_LO = ', { start = "10.103.0.1", end = "10.103.63.254" }]'
+import re
+def stanza_values(txt, name):
+    """(prefix, gateway) of an existing [networks.<name>] stanza, or None."""
+    m = re.search(r'^\[networks\.' + re.escape(name) + r'\][ \t]*$(.*?)(?=^\[|\Z)', txt, re.M | re.S)
+    if not m:
+        return None
+    pfx = re.search(r'^\s*prefix\s*=\s*"([^"]+)"', m.group(1), re.M)
+    gw = re.search(r'^\s*gateway\s*=\s*"([^"]+)"', m.group(1), re.M)
+    return (pfx.group(1) if pfx else "", gw.group(1) if gw else "")
+WANT = {
+    "simulated-oob": (env["SCALE_OOB_PREFIX"], env["SCALE_OOB_GW"]),
+    "simulated-admin": (env["SCALE_ADMIN_PREFIX"], env["SCALE_ADMIN_GW"]),
+    "simulated-underlay": (env["SCALE_UNDERLAY_PREFIX"], env["SCALE_UNDERLAY_GW"]),
+}
 changed = False
 for k, v in cm["data"].items():
     if "[site_explorer]" not in v:
@@ -889,6 +937,13 @@ for k, v in cm["data"].items():
             seen_secs.add(s)
             out.extend(tuning_secs[s][1])
     new = "\n".join(out) + ("\n" if v_work.endswith("\n") else "")
+    # A stanza left by an earlier run with other SCALE_* values would keep
+    # its old prefix while MAT relays to the new gateway; stop before apply.
+    for name, want in WANT.items():
+        have = stanza_values(new, name)
+        if have is not None and have != want:
+            print(f"mismatch [networks.{name}] has prefix {have[0]} gateway {have[1]}, requested {want[0]} gateway {want[1]}")
+            sys.exit(0)
     if "[networks.simulated-oob]" not in new:
         new = new.rstrip("\n") + "\n" + networks
     if "[networks.simulated-underlay]" not in new:
@@ -911,13 +966,16 @@ json.dump(cm, open(path, "w"))
 print("changed" if changed else "nochange")
 PY
 )"
+    if [[ "$_PATCH_RESULT" == mismatch* ]]; then
+        die "site config ${_PATCH_RESULT#mismatch } - keep the SCALE_* prefixes this site was set up with, or remove the stanza and its network segment before re-running"
+    fi
     if [[ "$_PATCH_RESULT" == "changed" ]]; then
         kubectl apply -f "$CM_JSON" >/dev/null
         info "scale config applied (proxy-direct bmc_proxy, simulated networks, knobs, lo-ip); restarting nico-api"
         kubectl rollout restart deployment/nico-api -n "$NICO_SYSTEM_NS" >/dev/null
         kubectl rollout status deployment/nico-api -n "$NICO_SYSTEM_NS" --timeout=180s >/dev/null \
             || warn "nico-api rollout did not complete in time; continuing"
-        ok "scale networks: oob ${SCALE_OOB_PREFIX} (gw ${SCALE_OOB_GW}), admin ${SCALE_ADMIN_PREFIX} (gw ${SCALE_ADMIN_GW})"
+        ok "scale networks: oob ${SCALE_OOB_PREFIX} (gw ${SCALE_OOB_GW}), admin ${SCALE_ADMIN_PREFIX} (gw ${SCALE_ADMIN_GW}), underlay ${SCALE_UNDERLAY_PREFIX} (gw ${SCALE_UNDERLAY_GW})"
         ok "site_explorer knobs: concurrent=${SCALE_CONCURRENT_EXPLORATIONS} per_run=${SCALE_EXPLORATIONS_PER_RUN} create/run=${SCALE_MACHINES_CREATED_PER_RUN}"
         [[ -n "${SCALE_RUN_INTERVAL:-}${SCALE_FW_CONCURRENCY:-}${SCALE_FW_RUN_INTERVAL:-}${SCALE_STATE_MAX_CONCURRENCY:-}" ]] && \
             ok "tuning overrides (#3738): se.run_interval=${SCALE_RUN_INTERVAL:-·} fw.concurrency=${SCALE_FW_CONCURRENCY:-·} fw.run_interval=${SCALE_FW_RUN_INTERVAL:-·} state.max_concurrency=${SCALE_STATE_MAX_CONCURRENCY:-·}"
@@ -936,7 +994,16 @@ PY
     _ensure_segment() {   # $1=name $2=type-ilike $3=prefix $4=gateway $5=reserve
         local name="$1" typ="$2" pfx="$3" gw="$4" rsv="$5"
         if [[ "$(psql_count "SELECT count(*) FROM network_segments WHERE name='${name}';")" != "0" ]]; then
-            ok "segment ${name} present"
+            # Re-runs with other SCALE_* values would leave MAT relaying to a
+            # gateway the persisted segment does not own; refuse to continue.
+            local have
+            have="$(psql_q "SELECT np.prefix::text || ' ' || host(np.gateway)
+                FROM network_prefixes np JOIN network_segments ns ON ns.id = np.segment_id
+                WHERE ns.name='${name}' ORDER BY np.prefix LIMIT 1;" || true)"
+            if [[ -n "$have" && "$have" != "${pfx} ${gw}" ]]; then
+                die "segment ${name} exists as ${have} but ${pfx} ${gw} was requested - keep the SCALE_* values this site was set up with, or delete the segment and its site-config stanza before re-running"
+            fi
+            ok "segment ${name} present (${have:-prefix not checked})"
             return
         fi
         warn "segment ${name} missing (config seeding is bootstrap-once on multi-domain sites) — creating from template"
@@ -1126,6 +1193,8 @@ fi
     || die "could not resolve DHCP relays; set OOB_DHCP_RELAY and ADMIN_DHCP_RELAY"
 ok "OOB:   relay ${OOB_DHCP_RELAY}   prefix ${OOB_PREFIX:-unknown}"
 ok "admin: pool ${ADMIN_PREFIX:-unknown}   DPU/switch DHCP relay ${ADMIN_DHCP_RELAY} (underlay pool ${UNDERLAY_PREFIX:-n/a})"
+# _usable <cidr> <reserve_first>: leases a pool can hand out (size minus the
+# reserved leading addresses and broadcast), floored at zero.
 _usable() { local m="${1##*/}" r="$2"; local u=$(( (1 << (32 - m)) - r - 1 )); (( u < 0 )) && u=0; echo "$u"; }
 # Demand per pool (measured live):
 #   OOB   = hostCount*(1 + dpuPerHost)   — one BMC IP per host and per DPU
@@ -1141,11 +1210,17 @@ if [[ "${OOB_PREFIX:-}" == */* && "${ADMIN_PREFIX:-}" == */* ]]; then
     FIT_ADMIN=$(( ADMIN_USABLE / (DPU_PER_HOST + 1) ))
     FIT=$(( FIT_OOB < FIT_ADMIN ? FIT_OOB : FIT_ADMIN ))
     FIT_NOTE=""
-    if [[ "${UNDERLAY_PREFIX:-}" == */* && "${DPU_PER_HOST:-0}" -gt 0 ]]; then
+    if [[ "${UNDERLAY_PREFIX:-}" == */* ]]; then
         UNDERLAY_USABLE="$(_usable "$UNDERLAY_PREFIX" "${UNDERLAY_RESERVE:-$ADMIN_RESERVE}")"
-        FIT_UNDERLAY=$(( UNDERLAY_USABLE / DPU_PER_HOST ))   # switch NVOS demand not counted
-        FIT=$(( FIT < FIT_UNDERLAY ? FIT : FIT_UNDERLAY ))
-        FIT_NOTE="; underlay ${UNDERLAY_PREFIX} ≈${UNDERLAY_USABLE} usable → ≤${FIT_UNDERLAY} hosts"
+        # one NVOS lease per switch comes off the top, the rest is DPU OOB
+        UNDERLAY_FOR_DPUS=$(( UNDERLAY_USABLE - SWITCH_COUNT )); (( UNDERLAY_FOR_DPUS < 0 )) && UNDERLAY_FOR_DPUS=0
+        if (( DPU_PER_HOST > 0 )); then
+            FIT_UNDERLAY=$(( UNDERLAY_FOR_DPUS / DPU_PER_HOST ))
+            FIT=$(( FIT < FIT_UNDERLAY ? FIT : FIT_UNDERLAY ))
+            FIT_NOTE="; underlay ${UNDERLAY_PREFIX} ≈${UNDERLAY_USABLE} usable, ${SWITCH_COUNT} switch leases → ≤${FIT_UNDERLAY} hosts"
+        elif [[ "${MAT_MULTIPOD:-0}" != "1" ]] && (( SWITCH_COUNT > UNDERLAY_USABLE )); then   # multipod: MPCHK checks per relay
+            die "underlay ${UNDERLAY_PREFIX} provides ~${UNDERLAY_USABLE} leases but ${SWITCH_COUNT} switches need one each - widen SCALE_UNDERLAY_PREFIX or lower the switch count"
+        fi
     fi
     info "pool fit: OOB ${OOB_PREFIX} ≈${OOB_USABLE} usable → ≤${FIT_OOB} hosts; admin ${ADMIN_PREFIX} ≈${ADMIN_USABLE} usable → ≤${FIT_ADMIN} hosts${FIT_NOTE}"
     if [[ "${MAT_MULTIPOD:-0}" == "1" ]]; then
@@ -1155,10 +1230,14 @@ if [[ "${OOB_PREFIX:-}" == */* && "${ADMIN_PREFIX:-}" == */* ]]; then
         #   * pods SHARING a relay          -> their demand is additive on one
         #                                      pool, and must be checked
         # Parse every pod group out of the values file and validate per relay.
-        _MP_REPORT="$(python3 - "$VALUES_FILE" "$OOB_PREFIX" "$OOB_RESERVE" <<'MPCHK'
+        _MP_REPORT="$(python3 - "$VALUES_FILE" "$OOB_PREFIX" "$OOB_RESERVE" \
+            "${UNDERLAY_PREFIX:-}" "${ADMIN_DHCP_RELAY:-}" "${UNDERLAY_RESERVE:-$ADMIN_RESERVE}" <<'MPCHK'
 import ipaddress, re, sys
 
 values_file, default_prefix, default_reserve = sys.argv[1], sys.argv[2], sys.argv[3]
+# Shared underlay pool (DPU OOB + switch NVOS leases): known in scale mode,
+# empty in override mode where only a documented prefix can size it.
+underlay_prefix, underlay_gw, underlay_reserve = sys.argv[4], sys.argv[5], sys.argv[6]
 text = open(values_file).read()
 
 def groups_from_yaml(doc):
@@ -1177,6 +1256,8 @@ def groups_from_yaml(doc):
                 "hosts": hosts,
                 "dpus": int(grp.get("dpuPerHostCount") or 0),
                 "relay": str(grp.get("oobDhcpRelayAddress") or "").strip(),
+                "hw": str(grp.get("hwType") or "").lower(),
+                "urelay": str(grp.get("adminDhcpRelayAddress") or "").strip(),
             })
     return out
 
@@ -1203,19 +1284,23 @@ for raw in text.splitlines():
     m = re.match(r'\s*([A-Za-z0-9_.-]+)\s*:\s*(\S.*)?$', raw)
     if not m:
         continue
-    key, val = m.group(1), (m.group(2) or "").strip()
+    key, val = m.group(1), re.sub(r"\s+#.*$", "", m.group(2) or "").strip()
     # Close the group only on a real dedent: sibling keys (dpuRebootDelay, etc.)
     # sit at the same indent as hostCount and must not end the group.
     if cur is not None and cur_indent is not None and indent < cur_indent:
         groups.append(cur); cur, cur_indent = None, None
+    if key in ("hostCount", "hwType") and cur is None:
+        cur, cur_indent = {"hosts": 0, "dpus": 0, "relay": "", "hw": "", "urelay": ""}, indent
     if key == "hostCount":
-        if cur is None:
-            cur, cur_indent = {"hosts": 0, "dpus": 0, "relay": ""}, indent
         cur["hosts"] = int(re.sub(r"\D", "", val) or 0)
+    elif key == "hwType" and cur is not None:
+        cur["hw"] = val.strip('"\'').lower()
     elif key == "dpuPerHostCount" and cur is not None:
         cur["dpus"] = int(re.sub(r"\D", "", val) or 0)
     elif key == "oobDhcpRelayAddress" and cur is not None:
         cur["relay"] = val.strip('"\'')
+    elif key == "adminDhcpRelayAddress" and cur is not None:
+        cur["urelay"] = val.strip('"\'')
 if cur is not None:
     groups.append(cur)
 
@@ -1261,6 +1346,41 @@ for relay, need in sorted(demand.items()):
     if not ok:
         problems.append(f"relay {relay} needs {need} IPs but {cidr} only provides ~{cap}")
 
+# Underlay demand is additive across every group that relays DPU OOB / switch
+# NVOS DHCP to the same adminDhcpRelayAddress: one lease per DPU, one per switch.
+underlay = {}
+for g in groups:
+    need = g["hosts"] * g["dpus"] + (g["hosts"] if "switch" in g["hw"] else 0)
+    if need:
+        r = g["urelay"] or "<default>"
+        underlay[r] = underlay.get(r, 0) + need
+
+def underlay_prefix_for(relay):
+    if underlay_prefix and relay == underlay_gw:
+        return underlay_prefix
+    if relay == "<default>":
+        return None
+    best = None
+    for cand in re.findall(r'([0-9]+(?:\.[0-9]+){3}/[0-9]+)', text):
+        try:
+            net = ipaddress.ip_network(cand, strict=False)
+            if ipaddress.ip_address(relay) in net and (best is None or net.prefixlen > best.prefixlen):
+                best = net
+        except ValueError:
+            pass
+    return str(best) if best else None
+
+for relay, need in sorted(underlay.items()):
+    cidr = underlay_prefix_for(relay)
+    if cidr is None:
+        lines.append(f"  underlay relay {relay}: needs {need} IPs, pool prefix unknown (not checked)")
+        continue
+    cap = usable(cidr, underlay_reserve or default_reserve)
+    ok = need <= cap
+    lines.append(f"  underlay relay {relay}: needs {need} IPs, {cidr} provides ~{cap} -> {'OK' if ok else 'TOO SMALL'}")
+    if not ok:
+        problems.append(f"underlay relay {relay} needs {need} IPs but {cidr} only provides ~{cap}")
+
 print("\n".join(lines))
 if problems:
     print("FAIL " + "; ".join(problems))
@@ -1279,7 +1399,7 @@ MPCHK
         fi
         ok "multipod sizing validated across all pod groups"
     elif (( HOST_COUNT > FIT )); then
-        (( FIT < 1 )) && die "pools too small for even 1 host × ${DPU_PER_HOST} DPUs — widen the admin/OOB prefixes or lower DPU_PER_HOST"
+        (( FIT < 1 )) && die "pools too small for even 1 host × ${DPU_PER_HOST} DPUs — widen the admin/OOB/underlay prefixes or lower DPU_PER_HOST or the switch count"
         warn "requested ${HOST_COUNT} hosts exceeds pool capacity (${FIT}) — auto-fitting hostCount=${FIT}"
         warn "  (override with HOST_COUNT/DPU_PER_HOST env vars, or widen the site's DHCP prefixes)"
         confirm "Proceed with hostCount=${FIT} × ${DPU_PER_HOST} DPUs?" || die "aborted on sizing"

--- a/helm-prereqs/values/machine-a-tron-multipod.yaml
+++ b/helm-prereqs/values/machine-a-tron-multipod.yaml
@@ -9,7 +9,7 @@
 #       -n nico-system -f <your-copy>.yaml
 #
 # Requirements:
-#  * oobDhcpRelayAddress must be within Kubernetes ServiceCIDR
+#  * bmcDhcpRelayAddress must be within Kubernetes ServiceCIDR
 #    - vanilla k8s: 10.96.0.0/12
 #    - kind: 10.96.0.0/16
 #    - k3d: 10.43.0.0/16
@@ -65,16 +65,16 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 100
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
+        underlayDhcpRelayAddress: "192.168.176.1"
   mat-1:
     machines:
       compute:
         hwType: wiwynn_gb200_nvl
         hostCount: 100
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
+        underlayDhcpRelayAddress: "192.168.176.1"
 
 resources:
   limits:

--- a/helm-prereqs/values/machine-a-tron-multipod.yaml
+++ b/helm-prereqs/values/machine-a-tron-multipod.yaml
@@ -66,7 +66,7 @@ pods:
         hostCount: 100
         dpuPerHostCount: 2
         bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-        underlayDhcpRelayAddress: "192.168.176.1"
+        underlayDhcpRelayAddress: "10.104.0.1"  # simulated-underlay gateway (SCALE_UNDERLAY_GW)
   mat-1:
     machines:
       compute:
@@ -74,7 +74,7 @@ pods:
         hostCount: 100
         dpuPerHostCount: 2
         bmcDhcpRelayAddress: "10.96.64.1"  # NICo assigns unique IPs
-        underlayDhcpRelayAddress: "192.168.176.1"
+        underlayDhcpRelayAddress: "10.104.0.1"  # simulated-underlay gateway (SCALE_UNDERLAY_GW)
 
 resources:
   limits:

--- a/helm-prereqs/values/machine-a-tron-scale-4500-proxy.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500-proxy.yaml
@@ -114,8 +114,8 @@ pods:
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
         # Simulated networks (Phase 5/6 constants), not Service CIDR carve-outs.
-        oobDhcpRelayAddress: "10.96.64.1"
-        adminDhcpRelayAddress: "10.104.0.1"
+        bmcDhcpRelayAddress: "10.96.64.1"
+        underlayDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
 extraEnv:
   - name: RUST_LOG

--- a/helm-prereqs/values/machine-a-tron-scale-4500-proxy.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500-proxy.yaml
@@ -115,7 +115,7 @@ pods:
         networkStatusRunInterval: "120s"
         # Simulated networks (Phase 5/6 constants), not Service CIDR carve-outs.
         oobDhcpRelayAddress: "10.96.64.1"
-        adminDhcpRelayAddress: "10.102.0.1"
+        adminDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
 extraEnv:
   - name: RUST_LOG

--- a/helm-prereqs/values/machine-a-tron-scale-4500.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500.yaml
@@ -109,7 +109,7 @@ pods:
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
         oobDhcpRelayAddress: "10.233.16.1"
-        adminDhcpRelayAddress: "10.102.0.1"
+        adminDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
   mat-1:
     machines:
@@ -124,7 +124,7 @@ pods:
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
         oobDhcpRelayAddress: "10.233.32.1"
-        adminDhcpRelayAddress: "10.102.0.1"
+        adminDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
   mat-2:
     machines:
@@ -139,7 +139,7 @@ pods:
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
         oobDhcpRelayAddress: "10.233.8.1"
-        adminDhcpRelayAddress: "10.102.0.1"
+        adminDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
 
 extraEnv:

--- a/helm-prereqs/values/machine-a-tron-scale-4500.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale-4500.yaml
@@ -108,8 +108,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.233.16.1"
-        adminDhcpRelayAddress: "10.104.0.1"
+        bmcDhcpRelayAddress: "10.233.16.1"
+        underlayDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
   mat-1:
     machines:
@@ -123,8 +123,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.233.32.1"
-        adminDhcpRelayAddress: "10.104.0.1"
+        bmcDhcpRelayAddress: "10.233.32.1"
+        underlayDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
   mat-2:
     machines:
@@ -138,8 +138,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.233.8.1"
-        adminDhcpRelayAddress: "10.104.0.1"
+        bmcDhcpRelayAddress: "10.233.8.1"
+        underlayDhcpRelayAddress: "10.104.0.1"
         dpusInNicMode: false
 
 extraEnv:

--- a/helm-prereqs/values/machine-a-tron-scale.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale.yaml
@@ -129,7 +129,7 @@ pods:
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
         bmcDhcpRelayAddress: "10.96.64.1"  # Must be within K8s ServiceCIDR
-        underlayDhcpRelayAddress: "192.168.176.1"
+        underlayDhcpRelayAddress: "10.104.0.1"  # simulated-underlay gateway (SCALE_UNDERLAY_GW)
         dpusInNicMode: false
 
 extraEnv:

--- a/helm-prereqs/values/machine-a-tron-scale.yaml
+++ b/helm-prereqs/values/machine-a-tron-scale.yaml
@@ -17,7 +17,7 @@
 #       prefix = "10.96.64.0/18"
 #       gateway = "10.96.64.1"
 #       mtu = 1500
-#   - oobDhcpRelayAddress must be within Kubernetes ServiceCIDR
+#   - bmcDhcpRelayAddress must be within Kubernetes ServiceCIDR
 # =============================================================================
 
 image:
@@ -128,8 +128,8 @@ pods:
         runIntervalWorking: "5s"
         runIntervalIdle: "60s"
         networkStatusRunInterval: "120s"
-        oobDhcpRelayAddress: "10.96.64.1"  # Must be within K8s ServiceCIDR
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # Must be within K8s ServiceCIDR
+        underlayDhcpRelayAddress: "192.168.176.1"
         dpusInNicMode: false
 
 extraEnv:

--- a/helm-prereqs/values/machine-a-tron.yaml
+++ b/helm-prereqs/values/machine-a-tron.yaml
@@ -94,9 +94,9 @@ pods:
         networkStatusRunInterval: "20s"
         # Set to the gateway of the OOB/underlay network in nico-core site config.
         # (setup-machine-a-tron.sh fills this from the running nico-core config.)
-        oobDhcpRelayAddress: "FILL_IN"
+        bmcDhcpRelayAddress: "FILL_IN"
         # Set to the gateway of the admin network in nico-core site config.
-        adminDhcpRelayAddress: "FILL_IN"
+        underlayDhcpRelayAddress: "FILL_IN"
         dpusInNicMode: false
 
 extraEnv:

--- a/helm-prereqs/values/machine-a-tron.yaml
+++ b/helm-prereqs/values/machine-a-tron.yaml
@@ -92,10 +92,11 @@ pods:
         runIntervalWorking: "1s"
         runIntervalIdle: "10s"
         networkStatusRunInterval: "20s"
-        # Set to the gateway of the OOB/underlay network in nico-core site config.
-        # (setup-machine-a-tron.sh fills this from the running nico-core config.)
+        # Gateway of the BMC (OOB) network in nico-core site config; relay for BMC DHCP.
+        # (setup-machine-a-tron.sh fills both relays from the running nico-core config.)
         bmcDhcpRelayAddress: "FILL_IN"
-        # Set to the gateway of the admin network in nico-core site config.
+        # Gateway of the underlay segment that serves DPU OOB and switch NVOS DHCP
+        # (simulated-underlay in scale mode).
         underlayDhcpRelayAddress: "FILL_IN"
         dpusInNicMode: false
 

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -134,7 +134,7 @@ pods:
         hostCount: 5
         dpuPerHostCount: 2
         bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-        underlayDhcpRelayAddress: "192.168.176.1"
+        underlayDhcpRelayAddress: "10.104.0.1"
   mat-1:
     machines:
       rack-machines:
@@ -142,7 +142,7 @@ pods:
         hostCount: 5
         dpuPerHostCount: 2
         bmcDhcpRelayAddress: "10.96.64.1"
-        underlayDhcpRelayAddress: "192.168.176.1"
+        underlayDhcpRelayAddress: "10.104.0.1"
 
 macAddressPool:
   enabled: true
@@ -263,7 +263,7 @@ pods:
         hostCount: 10
         dpuPerHostCount: 2
         bmcDhcpRelayAddress: "10.96.64.1"
-        underlayDhcpRelayAddress: "192.168.176.1"
+        underlayDhcpRelayAddress: "10.104.0.1"
 ```
 
 ### IPMI/SOL Simulation

--- a/helm/charts/nico-machine-a-tron/README.md
+++ b/helm/charts/nico-machine-a-tron/README.md
@@ -117,7 +117,7 @@ dynamically creates/updates/deletes Kubernetes Services as machines come online.
 
 ### Setup
 
-All pods can share the same `oobDhcpRelayAddress` - NICo assigns unique IPs
+All pods can share the same `bmcDhcpRelayAddress` - NICo assigns unique IPs
 from the subnet.
 
 ```yaml
@@ -133,16 +133,16 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 5
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"  # All pods share same relay
+        underlayDhcpRelayAddress: "192.168.176.1"
   mat-1:
     machines:
       rack-machines:
         hwType: wiwynn_gb200_nvl
         hostCount: 5
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"
+        underlayDhcpRelayAddress: "192.168.176.1"
 
 macAddressPool:
   enabled: true
@@ -210,7 +210,7 @@ adds a dynamic target UDP port for IPMI access.
 
 ### Requirements
 
-- `oobDhcpRelayAddress` must be within Kubernetes ServiceCIDR
+- `bmcDhcpRelayAddress` must be within Kubernetes ServiceCIDR
 - NICo assigns unique BMC IPs from the configured network
 - Default ServiceCIDR ranges:
   - `10.96.0.0/12` - vanilla Kubernetes (kubeadm)
@@ -262,8 +262,8 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 10
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "10.96.64.1"
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "10.96.64.1"
+        underlayDhcpRelayAddress: "192.168.176.1"
 ```
 
 ### IPMI/SOL Simulation
@@ -484,7 +484,7 @@ provided IP is already allocated
 
 The BMC IP conflicts with an existing Service. Either:
 
-- Use a different `oobDhcpRelayAddress` range
+- Use a different `bmcDhcpRelayAddress` range
 - Reserve a ServiceCIDR for machine-a-tron (K8s 1.29+)
 
 ### ClusterIP outside ServiceCIDR

--- a/helm/charts/nico-machine-a-tron/templates/configmap.yaml
+++ b/helm/charts/nico-machine-a-tron/templates/configmap.yaml
@@ -193,11 +193,11 @@ data:
     acceleration_factor = {{ $section.acceleration_factor | default $defaults.accelerationFactor | default 1.0 }}
     discovery_retry_interval = {{ $section.discovery_retry_interval | default $defaults.discoveryRetryInterval | default "60s" | quote }}
     {{- if $dhcpRelayEnabled }}
-    oob_dhcp_relay_address = {{ $relayIP | quote }}
+    bmc_dhcp_relay_address = {{ $relayIP | quote }}
     {{- else }}
-    oob_dhcp_relay_address = {{ $section.oob_dhcp_relay_address | quote }}
+    bmc_dhcp_relay_address = {{ coalesce $section.bmc_dhcp_relay_address $section.oob_dhcp_relay_address | quote }}
     {{- end }}
-    admin_dhcp_relay_address = {{ $section.admin_dhcp_relay_address | quote }}
+    underlay_dhcp_relay_address = {{ coalesce $section.underlay_dhcp_relay_address $section.admin_dhcp_relay_address | quote }}
     {{- end }}
 
     {{- range $sectionName, $section := $machines }}
@@ -218,11 +218,11 @@ data:
     run_interval_idle = {{ $section.runIntervalIdle | default $defaults.runIntervalIdle | default "10s" | quote }}
     network_status_run_interval = {{ $section.networkStatusRunInterval | default $defaults.networkStatusRunInterval | default "20s" | quote }}
     {{- if $dhcpRelayEnabled }}
-    oob_dhcp_relay_address = {{ $relayIP | quote }}
+    bmc_dhcp_relay_address = {{ $relayIP | quote }}
     {{- else }}
-    oob_dhcp_relay_address = {{ $section.oobDhcpRelayAddress | default "192.168.192.1" | quote }}
+    bmc_dhcp_relay_address = {{ coalesce $section.bmcDhcpRelayAddress $section.oobDhcpRelayAddress "192.168.192.1" | quote }}
     {{- end }}
-    admin_dhcp_relay_address = {{ $section.adminDhcpRelayAddress | default "192.168.176.1" | quote }}
+    underlay_dhcp_relay_address = {{ coalesce $section.underlayDhcpRelayAddress $section.adminDhcpRelayAddress "192.168.176.1" | quote }}
     dpus_in_nic_mode = {{ $section.dpusInNicMode | default $defaults.dpusInNicMode | default false }}
     {{- $hostFw := ternary $section.hostFirmwareVersions (default $defaults.hostFirmwareVersions $section.hostFirmwareVersions) (hasKey $section "hostFirmwareVersions") }}
     {{- with $hostFw }}

--- a/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/configmap_test.yaml
@@ -93,8 +93,8 @@ tests:
               dpu_reboot_delay: 20
               host_reboot_delay: 10
               acceleration_factor: 0.03
-              oob_dhcp_relay_address: 10.96.64.1
-              admin_dhcp_relay_address: 192.168.176.1
+              bmc_dhcp_relay_address: 10.96.64.1
+              underlay_dhcp_relay_address: 192.168.176.1
     asserts:
       - matchRegex:
           path: data["mat.toml"]
@@ -124,8 +124,8 @@ tests:
                 - rack-001
               dpu_reboot_delay: 20
               host_reboot_delay: 10
-              oob_dhcp_relay_address: 10.96.64.1
-              admin_dhcp_relay_address: 192.168.176.1
+              bmc_dhcp_relay_address: 10.96.64.1
+              underlay_dhcp_relay_address: 192.168.176.1
     asserts:
       - matchRegex:
           path: data["mat.toml"]
@@ -175,3 +175,42 @@ tests:
       - matchRegex:
           path: data["mat.toml"]
           pattern: "enable_ipmi_simulation = true"
+
+  - it: should render the DHCP relay values under the machine-a-tron key names
+    set:
+      pods:
+        mat-0:
+          machines:
+            dell-hosts:
+              hostCount: 2
+              dpuPerHostCount: 2
+              bmcDhcpRelayAddress: "10.96.64.1"
+              underlayDhcpRelayAddress: "10.104.0.1"
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'bmc_dhcp_relay_address = "10.96.64.1"'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'underlay_dhcp_relay_address = "10.104.0.1"'
+      - notMatchRegex:
+          path: data["mat.toml"]
+          pattern: '(oob|admin)_dhcp_relay_address'
+
+  - it: should still accept the deprecated oobDhcpRelayAddress and adminDhcpRelayAddress names
+    set:
+      pods:
+        mat-0:
+          machines:
+            dell-hosts:
+              hostCount: 2
+              dpuPerHostCount: 2
+              oobDhcpRelayAddress: "10.96.64.1"
+              adminDhcpRelayAddress: "10.104.0.1"
+    asserts:
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'bmc_dhcp_relay_address = "10.96.64.1"'
+      - matchRegex:
+          path: data["mat.toml"]
+          pattern: 'underlay_dhcp_relay_address = "10.104.0.1"'

--- a/helm/charts/nico-machine-a-tron/tests/deployment_test.yaml
+++ b/helm/charts/nico-machine-a-tron/tests/deployment_test.yaml
@@ -197,8 +197,8 @@ tests:
               rack_profile_id: NVL72
               ids:
                 - rack-001
-              oob_dhcp_relay_address: 10.96.64.1
-              admin_dhcp_relay_address: 192.168.176.1
+              bmc_dhcp_relay_address: 10.96.64.1
+              underlay_dhcp_relay_address: 192.168.176.1
     asserts:
       - equal:
           path: metadata.name

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -294,9 +294,11 @@ hwMacAddressRanges:
 ##   - hwType: Hardware type (required)
 ##   - hostCount: Number of hosts (required)
 ##   - dpuPerHostCount: DPUs per host (default: 0)
-##   - oobDhcpRelayAddress: OOB network gateway
-##   - adminDhcpRelayAddress: DHCP relay for DPU OOB and switch NVOS traffic
-##     (an underlay segment gateway; MAT reads it as underlay_dhcp_relay_address)
+##   - bmcDhcpRelayAddress: BMC (OOB) network gateway, the relay for BMC DHCP
+##   - underlayDhcpRelayAddress: underlay segment gateway, the relay for DPU OOB
+##     and switch NVOS DHCP
+##     (bmcDhcpRelayAddress and underlayDhcpRelayAddress are accepted as deprecated
+##     aliases; rack groups use bmc_dhcp_relay_address / underlay_dhcp_relay_address)
 ##
 ## All other settings inherit from machineDefaults above.
 ##
@@ -323,8 +325,8 @@ pods:
         hwType: wiwynn_gb200_nvl
         hostCount: 10
         dpuPerHostCount: 2
-        oobDhcpRelayAddress: "192.168.192.1"
-        adminDhcpRelayAddress: "192.168.176.1"
+        bmcDhcpRelayAddress: "192.168.192.1"
+        underlayDhcpRelayAddress: "192.168.176.1"
         ## Host firmware upgrade simulation (optional).
         ## Set initial versions older than the API's desired versions to trigger
         ## the upgrade flow: version detection -> upload -> task polling ->
@@ -345,18 +347,18 @@ pods:
 #        hwType: wiwynn_gb200_nvl
 #        hostCount: 252       # 18 trays × 14 racks
 #        dpuPerHostCount: 2   # 2 BF3 per tray
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
 #      switches:
 #        hwType: nvidia_switch_nd5200_ld
 #        hostCount: 126       # 9 switches × 14 racks
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
 #      power:
 #        hwType: liteon_power_shelf
 #        hostCount: 112       # 8 shelves × 14 racks
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
 #
 #  mat-1:
 #    machines:
@@ -364,8 +366,8 @@ pods:
 #        hwType: wiwynn_gb200_nvl
 #        hostCount: 252
 #        dpuPerHostCount: 2
-#        oobDhcpRelayAddress: "10.96.64.1"
-#        adminDhcpRelayAddress: "192.168.176.1"
+#        bmcDhcpRelayAddress: "10.96.64.1"
+#        underlayDhcpRelayAddress: "192.168.176.1"
 #      # ... same pattern
 
 ## Persistence volume for machine state

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -295,7 +295,8 @@ hwMacAddressRanges:
 ##   - hostCount: Number of hosts (required)
 ##   - dpuPerHostCount: DPUs per host (default: 0)
 ##   - oobDhcpRelayAddress: OOB network gateway
-##   - adminDhcpRelayAddress: Admin network gateway
+##   - adminDhcpRelayAddress: DHCP relay for DPU OOB and switch NVOS traffic
+##     (an underlay segment gateway; MAT reads it as underlay_dhcp_relay_address)
 ##
 ## All other settings inherit from machineDefaults above.
 ##

--- a/helm/charts/nico-machine-a-tron/values.yaml
+++ b/helm/charts/nico-machine-a-tron/values.yaml
@@ -297,8 +297,8 @@ hwMacAddressRanges:
 ##   - bmcDhcpRelayAddress: BMC (OOB) network gateway, the relay for BMC DHCP
 ##   - underlayDhcpRelayAddress: underlay segment gateway, the relay for DPU OOB
 ##     and switch NVOS DHCP
-##     (bmcDhcpRelayAddress and underlayDhcpRelayAddress are accepted as deprecated
-##     aliases; rack groups use bmc_dhcp_relay_address / underlay_dhcp_relay_address)
+##     (the previous names oobDhcpRelayAddress and adminDhcpRelayAddress are accepted as
+##     deprecated aliases; rack groups use bmc_dhcp_relay_address / underlay_dhcp_relay_address)
 ##
 ## All other settings inherit from machineDefaults above.
 ##


### PR DESCRIPTION
Scale mode relayed DPU OOB and switch NVOS DHCP through the admin-typed `simulated-admin` segment. NICo only accepts DHCP for a predicted DPU oob interface from an underlay-typed segment, so every simulated DPU stalled in discovery. Scale mode now creates a third segment, `simulated-underlay` (`SCALE_UNDERLAY_PREFIX`, default `10.104.0.0/18`), and relays DPU and switch DHCP through its gateway; `simulated-admin` stays the host admin pool and override mode is unchanged. The chart values are renamed to `bmcDhcpRelayAddress` and `underlayDhcpRelayAddress` to match the machine-a-tron config keys, with the old names kept as deprecated aliases. The pool-fit check now counts switch NVOS leases, and a re-run with different `SCALE_*` prefixes stops instead of leaving the relay pointed at a segment that does not own it.

## Related issues
Closes #5972

## Type of Change
- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`bash -n`, `helm lint` and `helm unittest` (32/32, two new alias tests) pass; the sizing validators were exercised on synthetic values files with both key spellings. The relay change ran in scale-mode bring-ups of simulated sites from 57 to 250 racks with no segment type mismatch rejections.

## Additional Notes
`SCALE_UNDERLAY_PREFIX` must not overlap the ServiceCIDR carve-outs. Rack groups use the snake_case twins `bmc_dhcp_relay_address` and `underlay_dhcp_relay_address`.
