### PR TITLE
feat(dpf-sim-controller): create DPUs under the DPUDeployment that selects their node

### DIFF
--- a/dev/k8s/dpf-sim-controller/config/rbac/role.yaml
+++ b/dev/k8s/dpf-sim-controller/config/rbac/role.yaml
@@ -35,7 +35,17 @@ rules:
     verbs: ["get", "list", "watch", "create"]
   - apiGroups: ["provisioning.dpu.nvidia.com"]
     resources: ["dpus"]
-    verbs: ["get", "list", "watch", "create", "update", "patch"]
+    # delete: a DPU whose immutable flavor no longer matches the deployment
+    # selecting its node is deleted and recreated, as the DPF DPUSet controller does.
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["svc.dpu.nvidia.com"]
+    resources: ["dpudeployments"]
+    verbs: ["get", "list", "watch", "patch"]
+  - apiGroups: ["svc.dpu.nvidia.com"]
+    # The real DPUDeployment controller reports DPUSetsReconciled; NICo will not
+    # look at a deployment's DPUs until that condition is True.
+    resources: ["dpudeployments/status"]
+    verbs: ["get", "update", "patch"]
   - apiGroups: ["provisioning.dpu.nvidia.com"]
     resources: ["dpus/status"]
     verbs: ["get", "update", "patch"]

--- a/dev/k8s/dpf-sim-controller/config/rbac/role.yaml
+++ b/dev/k8s/dpf-sim-controller/config/rbac/role.yaml
@@ -5,7 +5,9 @@
 # Namespaced Role/RoleBinding on purpose: the manager cache and reconciler are
 # scoped to one namespace, so the grants are too — the simulator must not be
 # able to touch DPF resources anywhere else (e.g. a real DPF install elsewhere
-# on the cluster). No `delete` verb: DPU cleanup rides the ownerRef GC.
+# on the cluster). DPU cleanup rides the ownerRef GC; `delete` on dpus exists
+# only to recreate a DPU whose immutable flavor drifted from the deployment
+# selecting its node.
 #
 # IMPORTANT: every `namespace:` below AND the Deployment namespace
 # (config/manager/manager.yaml) must equal the value passed to
@@ -40,7 +42,7 @@ rules:
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: ["svc.dpu.nvidia.com"]
     resources: ["dpudeployments"]
-    verbs: ["get", "list", "watch", "patch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["svc.dpu.nvidia.com"]
     # The real DPUDeployment controller reports DPUSetsReconciled; NICo will not
     # look at a deployment's DPUs until that condition is True.

--- a/dev/k8s/dpf-sim-controller/internal/carbide/labels.go
+++ b/dev/k8s/dpf-sim-controller/internal/carbide/labels.go
@@ -22,6 +22,11 @@ const (
 	LabelHostBMCIP       = "carbide.nvidia.com/host-bmc-ip"
 	LabelIsPrimaryDPU    = "carbide.nvidia.com/is-primary-dpu"
 	LabelControlledNode2 = "carbide.nvidia.com/controlled.node.v2" // on DPUNode
+	// LabelOwnedByDPUDeployment is set by the DPF DPUSet controller on every DPU it
+	// creates from a DPUDeployment. NICo lists DPUs by this label when a node's
+	// deployment type resolves to a DPUDeployment (the GB200 path), so the
+	// simulator must stamp it the same way or NICo never finds the DPU.
+	LabelOwnedByDPUDeployment = "svc.dpu.nvidia.com/owned-by-dpudeployment"
 )
 
 // Annotations exchanged on the DPF CRs.

--- a/dev/k8s/dpf-sim-controller/internal/controller/dpudevice_controller.go
+++ b/dev/k8s/dpf-sim-controller/internal/controller/dpudevice_controller.go
@@ -51,13 +51,17 @@ type DPUDeviceReconciler struct {
 	Concurrency int
 }
 
-// RBAC — least privilege on exactly the DPF CRs the simulator touches. No
-// delete verb: DPU cleanup rides the ownerRef GC when the DPUDevice goes away.
+// RBAC - least privilege on exactly the DPF CRs the simulator touches. DPU
+// cleanup rides the ownerRef GC when the DPUDevice goes away; delete on dpus
+// exists only to recreate a DPU whose immutable flavor drifted from the
+// deployment selecting its node.
 //+kubebuilder:rbac:groups=provisioning.dpu.nvidia.com,resources=dpudevices,verbs=get;list;watch
 //+kubebuilder:rbac:groups=provisioning.dpu.nvidia.com,resources=dpunodes,verbs=get;list;watch;update;patch
 //+kubebuilder:rbac:groups=provisioning.dpu.nvidia.com,resources=dpunodemaintenances,verbs=get;list;watch;create
-//+kubebuilder:rbac:groups=provisioning.dpu.nvidia.com,resources=dpus,verbs=get;list;watch;create;update;patch
+//+kubebuilder:rbac:groups=provisioning.dpu.nvidia.com,resources=dpus,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=provisioning.dpu.nvidia.com,resources=dpus/status,verbs=get;update;patch
+//+kubebuilder:rbac:groups=svc.dpu.nvidia.com,resources=dpudeployments,verbs=get;list;watch
+//+kubebuilder:rbac:groups=svc.dpu.nvidia.com,resources=dpudeployments/status,verbs=get;update;patch
 
 // errNoReferencingNode reports that no DPUNode currently lists the DPUDevice —
 // the expected transient at creation time (NICo creates the two CRs in either
@@ -251,7 +255,7 @@ func (r *DPUDeviceReconciler) resolveNodeID(ctx context.Context, device *provisi
 // and a controller ownerRef to the DPUDevice for GC and Owns() re-enqueue.
 // dpuDeploymentGVK addresses DPUDeployment without importing the svc API
 // package: the pinned doca-platform module does not ship it, and the simulator
-// needs only three fields from the object.
+// reads only a few spec.dpus fields and status.conditions from the object.
 var dpuDeploymentGVK = schema.GroupVersionKind{
 	Group: "svc.dpu.nvidia.com", Version: "v1alpha1", Kind: "DPUDeployment",
 }
@@ -260,13 +264,54 @@ var dpuDeploymentGVK = schema.GroupVersionKind{
 // DPUDeployment whose dpuNodeSelector matches its DPUNode's labels. NICo uses
 // the same rule when it resolves a node's deployment type to a DPUDeployment,
 // so the simulator must land on the same object or NICo waits for a DPU that
-// never appears. ok=false means no deployment selects the node; the legacy
-// "sim" flavor is kept and NICo's name-based lookup still works.
+// never appears. ok=false means no usable deployment selects the node; the
+// legacy "sim" flavor is kept and NICo's name-based lookup still works.
+//
+// A deployment provisions from exactly one of spec.dpus.bfb or
+// spec.dpus.blueFieldSoftware and names exactly one of spec.dpus.flavor or
+// spec.dpus.flavorTemplate (both enforced by the DPUDeployment CRD). NICo
+// compares a Ready DPU's status.bfbFile against bfb or spec.blueFieldSoftware
+// against blueFieldSoftware, and spec.dpuFlavor against flavor. It does not
+// compare dpuFlavor for flavorTemplate deployments because real DPF renders the
+// template into a per-DPU DPUFlavor; the simulator has nothing to render, so it
+// uses the template name as the flavor: non-empty as the DPU CRD requires,
+// stable across recreates, and never compared by NICo.
 type selectedDeployment struct {
-	name, flavor, bfb string
+	name, flavor, bfb, blueFieldSoftware string
+}
+
+// deploymentFields reads the provisioning source and flavor off a
+// DPUDeployment. usable=false means the deployment declares no single source
+// or no flavor and must not be selected; err reports a field of the wrong type.
+func deploymentFields(d *unstructured.Unstructured) (dep selectedDeployment, usable bool, err error) {
+	get := func(field string) (string, error) {
+		v, _, err := unstructured.NestedString(d.Object, "spec", "dpus", field)
+		if err != nil {
+			return "", fmt.Errorf("spec.dpus.%s: %w", field, err)
+		}
+		return v, nil
+	}
+	dep.name = d.GetName()
+	if dep.bfb, err = get("bfb"); err != nil {
+		return dep, false, err
+	}
+	if dep.blueFieldSoftware, err = get("blueFieldSoftware"); err != nil {
+		return dep, false, err
+	}
+	if dep.flavor, err = get("flavor"); err != nil {
+		return dep, false, err
+	}
+	if dep.flavor == "" {
+		if dep.flavor, err = get("flavorTemplate"); err != nil {
+			return dep, false, err
+		}
+	}
+	usable = (dep.bfb != "") != (dep.blueFieldSoftware != "") && dep.flavor != ""
+	return dep, usable, nil
 }
 
 func (r *DPUDeviceReconciler) selectDeployment(ctx context.Context, nodeName string) (selectedDeployment, bool, error) {
+	l := log.FromContext(ctx)
 	var node provisioningv1.DPUNode
 	if err := r.Get(ctx, types.NamespacedName{Namespace: r.Namespace, Name: nodeName}, &node); err != nil {
 		return selectedDeployment{}, false, client.IgnoreNotFound(err)
@@ -282,11 +327,19 @@ func (r *DPUDeviceReconciler) selectDeployment(ctx context.Context, nodeName str
 	var matchIdx []int
 	for i := range list.Items {
 		d := &list.Items[i]
-		sets, _, _ := unstructured.NestedSlice(d.Object, "spec", "dpus", "dpuSets")
+		sets, _, err := unstructured.NestedSlice(d.Object, "spec", "dpus", "dpuSets")
+		if err != nil {
+			l.V(1).Info("DPUDeployment spec.dpus.dpuSets has unexpected type; ignoring", "deployment", d.GetName(), "err", err.Error())
+			continue
+		}
 		selects := false
 		for _, raw := range sets {
 			set, _ := raw.(map[string]interface{})
-			ml, _, _ := unstructured.NestedStringMap(set, "dpuNodeSelector", "matchLabels")
+			ml, _, err := unstructured.NestedStringMap(set, "dpuNodeSelector", "matchLabels")
+			if err != nil {
+				l.V(1).Info("DPUDeployment dpuNodeSelector.matchLabels has unexpected type; ignoring DPUSet", "deployment", d.GetName(), "err", err.Error())
+				continue
+			}
 			if len(ml) == 0 {
 				continue
 			}
@@ -305,12 +358,28 @@ func (r *DPUDeviceReconciler) selectDeployment(ctx context.Context, nodeName str
 		if !selects {
 			continue
 		}
-		flavor, _, _ := unstructured.NestedString(d.Object, "spec", "dpus", "flavor")
-		bfb, _, _ := unstructured.NestedString(d.Object, "spec", "dpus", "bfb")
-		matches = append(matches, selectedDeployment{name: d.GetName(), flavor: flavor, bfb: bfb})
+		dep, usable, err := deploymentFields(d)
+		if err != nil {
+			l.V(1).Info("DPUDeployment field has unexpected type; ignoring", "deployment", d.GetName(), "err", err.Error())
+			continue
+		}
+		if !usable {
+			l.Info("DPUDeployment selects the node but declares no usable provisioning source or flavor; ignoring",
+				"deployment", d.GetName(), "node", nodeName)
+			continue
+		}
+		matches = append(matches, dep)
 		matchIdx = append(matchIdx, i)
 	}
-	if len(matches) != 1 {
+	if len(matches) == 0 {
+		return selectedDeployment{}, false, nil
+	}
+	if len(matches) > 1 {
+		names := make([]string, len(matches))
+		for i, m := range matches {
+			names[i] = m.name
+		}
+		l.Info("several DPUDeployments select the node; not selecting any", "node", nodeName, "deployments", names)
 		return selectedDeployment{}, false, nil
 	}
 	if err := r.markDeploymentReady(ctx, &list.Items[matchIdx[0]]); err != nil {
@@ -324,17 +393,25 @@ func (r *DPUDeviceReconciler) selectDeployment(ctx context.Context, nodeName str
 // deployment's DPUSets. NICo refuses to look at any DPU under a deployment
 // whose DPUSetsReconciled condition is not True at the current generation, so
 // without this every host waits forever for a DPU that is already there.
-// Idempotent: a current condition is left untouched.
+// Idempotent: a current condition is left untouched. Only DPUSetsReconciled is
+// replaced; the merge patch carries the whole conditions array, so the other
+// conditions are copied through unchanged.
 func (r *DPUDeviceReconciler) markDeploymentReady(ctx context.Context, d *unstructured.Unstructured) error {
 	gen := d.GetGeneration()
-	conds, _, _ := unstructured.NestedSlice(d.Object, "status", "conditions")
+	conds, _, err := unstructured.NestedSlice(d.Object, "status", "conditions")
+	if err != nil {
+		return fmt.Errorf("DPUDeployment %s status.conditions: %w", d.GetName(), err)
+	}
+	kept := make([]interface{}, 0, len(conds)+1)
 	for _, raw := range conds {
 		c, _ := raw.(map[string]interface{})
-		if c["type"] == "DPUSetsReconciled" && c["status"] == "True" {
-			if og, ok := c["observedGeneration"]; ok {
-				if n, ok := og.(int64); ok && n == gen {
-					return nil
-				}
+		if c["type"] != "DPUSetsReconciled" {
+			kept = append(kept, raw)
+			continue
+		}
+		if c["status"] == "True" {
+			if n, ok := c["observedGeneration"].(int64); ok && n == gen {
+				return nil
 			}
 		}
 	}
@@ -348,8 +425,12 @@ func (r *DPUDeviceReconciler) markDeploymentReady(ctx context.Context, d *unstru
 		"lastTransitionTime": now,
 		"observedGeneration": gen,
 	}
-	_ = unstructured.SetNestedSlice(patch.Object, []interface{}{cond}, "status", "conditions")
-	_ = unstructured.SetNestedField(patch.Object, gen, "status", "observedGeneration")
+	if err := unstructured.SetNestedSlice(patch.Object, append(kept, cond), "status", "conditions"); err != nil {
+		return err
+	}
+	if err := unstructured.SetNestedField(patch.Object, gen, "status", "observedGeneration"); err != nil {
+		return err
+	}
 	return r.Status().Patch(ctx, patch, client.MergeFrom(d))
 }
 
@@ -384,9 +465,13 @@ func (r *DPUDeviceReconciler) ensureDPU(
 			// the deployment existed (or under the legacy "sim" flavor) cannot
 			// be patched into compliance. Real DPF deletes the source-owned DPU
 			// and lets the target deployment recreate it; do the same.
-			if dpu.Spec.DPUFlavor != dep.flavor && dpu.DeletionTimestamp == nil {
-				if err := r.Delete(ctx, &dpu); err != nil && !apierrors.IsNotFound(err) {
-					return nil, err
+			// A DPU already terminating needs no second Delete, but is still
+			// not ours to relabel or advance.
+			if dpu.Spec.DPUFlavor != dep.flavor {
+				if dpu.DeletionTimestamp == nil {
+					if err := r.Delete(ctx, &dpu); err != nil && !apierrors.IsNotFound(err) {
+						return nil, err
+					}
 				}
 				return nil, errDPURecreating
 			}
@@ -425,7 +510,10 @@ func (r *DPUDeviceReconciler) ensureDPU(
 		return nil, fmt.Errorf("%w: label %s is empty on %s", errDeviceNotReady, carbide.LabelHostBMCIP, device.Name)
 	}
 
-	flavor, bfb := "sim", "sim"
+	// Fallback when no usable deployment selects the node: the CRD requires
+	// dpuFlavor and exactly one of bfb/blueFieldSoftware, none of which mean
+	// anything to the simulator, so placeholder values keep the create accepted.
+	flavor, bfb, blueFieldSoftware := "sim", "sim", ""
 	labels := map[string]string{
 		// MUST propagate: NICo maps DPU events back to a machine by this.
 		carbide.LabelDPUMachineID: device.Labels[carbide.LabelDPUMachineID],
@@ -439,7 +527,7 @@ func (r *DPUDeviceReconciler) ensureDPU(
 	if dep, ok, derr := r.selectDeployment(ctx, nodeName); derr != nil {
 		return nil, derr
 	} else if ok {
-		flavor, bfb = dep.flavor, dep.bfb
+		flavor, bfb, blueFieldSoftware = dep.flavor, dep.bfb, dep.blueFieldSoftware
 		labels[carbide.LabelOwnedByDPUDeployment] = r.ownedByValue(dep)
 	}
 	noEffect := true
@@ -461,10 +549,13 @@ func (r *DPUDeviceReconciler) ensureDPU(
 			// machine when the DPU reaches Rebooting. NOT the DPU's own BMC
 			// (DPUDevice.spec.bmcIp) — NICo publishes the host's on this label.
 			BMCIP: device.Labels[carbide.LabelHostBMCIP],
-			// DPUFlavor and BFB are required by the CRD but have no meaning for
-			// the simulator; use placeholder values so the CR is accepted.
-			DPUFlavor: flavor,
-			BFB:       bfb,
+			// Inherited from the selecting deployment (see selectedDeployment)
+			// or the fallback above. The pinned doca-platform DPUSpec has no
+			// omitempty on bfb, so a blueFieldSoftware-only DPU is created
+			// below as unstructured with spec.bfb removed.
+			DPUFlavor:         flavor,
+			BFB:               bfb,
+			BlueFieldSoftware: blueFieldSoftware,
 			// NoEffect: the simulator never touches real K8s node taints/drains.
 			// NodeEffect embeds Action; NoEffect lives on Action, not NodeEffect directly.
 			NodeEffect: provisioningv1.NodeEffect{
@@ -480,7 +571,23 @@ func (r *DPUDeviceReconciler) ensureDPU(
 		controllerutil.WithBlockOwnerDeletion(false)); err != nil {
 		return nil, err
 	}
-	if err := r.Create(ctx, &dpu); err != nil {
+	if blueFieldSoftware != "" && bfb == "" {
+		// Unstructured only because the pinned type cannot omit bfb: the CRD
+		// rejects an empty bfb next to blueFieldSoftware.
+		obj, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&dpu)
+		if err != nil {
+			return nil, err
+		}
+		unstructured.RemoveNestedField(obj, "spec", "bfb")
+		u := &unstructured.Unstructured{Object: obj}
+		u.SetGroupVersionKind(provisioningv1.DPUGroupVersionKind)
+		if err := r.Create(ctx, u); err != nil {
+			return nil, err
+		}
+		if err := runtime.DefaultUnstructuredConverter.FromUnstructured(u.Object, &dpu); err != nil {
+			return nil, err
+		}
+	} else if err := r.Create(ctx, &dpu); err != nil {
 		return nil, err
 	}
 	// Create does not persist the status subresource, so write the initial

--- a/dev/k8s/dpf-sim-controller/internal/controller/dpudevice_controller.go
+++ b/dev/k8s/dpf-sim-controller/internal/controller/dpudevice_controller.go
@@ -7,6 +7,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"time"
 
 	provisioningv1 "github.com/nvidia/doca-platform/api/provisioning/v1alpha1"
@@ -101,6 +103,10 @@ func (r *DPUDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	//    ownerRef set to the DPUDevice.
 	dpu, err := r.ensureDPU(ctx, &device, dpuName, nodeName)
 	if err != nil {
+		if errors.Is(err, errDPURecreating) {
+			l.Info("DPU recreated under its DPUDeployment", "dpu", dpuName)
+			return ctrl.Result{RequeueAfter: r.PhaseDwell}, nil
+		}
 		if errors.Is(err, errDeviceNotReady) {
 			// NICo has not finished populating the DPUDevice; poll until it has.
 			l.V(1).Info("DPUDevice not fully populated yet; requeueing", "device", device.Name, "reason", err.Error())
@@ -178,6 +184,12 @@ func (r *DPUDeviceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{RequeueAfter: r.PhaseDwell}, nil
 	}
 	dpu.Status.Phase = next
+	if next == provisioningv1.DPUReady && dpu.Spec.BFB != "" {
+		// NICo checks a Ready DPU against its DPUDeployment by comparing the
+		// basename of status.bfbFile with "<namespace>-<bfb>.bfb"; a missing
+		// or different file is treated as a failed deployment migration.
+		dpu.Status.BFBFile = r.bfbFileFor(dpu.Spec.BFB)
+	}
 	if err := r.Status().Update(ctx, dpu); err != nil {
 		if apierrors.IsConflict(err) {
 			l.V(1).Info("phase advance conflicted; retrying", "dpu", dpuName, "phase", next)
@@ -237,12 +249,163 @@ func (r *DPUDeviceReconciler) resolveNodeID(ctx context.Context, device *provisi
 // ensureDPU creates the DPU CR if absent, seeded at Initializing with the
 // machine-id label copied off the DPUDevice (required for NICo reverse lookup)
 // and a controller ownerRef to the DPUDevice for GC and Owns() re-enqueue.
+// dpuDeploymentGVK addresses DPUDeployment without importing the svc API
+// package: the pinned doca-platform module does not ship it, and the simulator
+// needs only three fields from the object.
+var dpuDeploymentGVK = schema.GroupVersionKind{
+	Group: "svc.dpu.nvidia.com", Version: "v1alpha1", Kind: "DPUDeployment",
+}
+
+// selectedDeployment mirrors the DPF DPUSet controller: a DPU belongs to the
+// DPUDeployment whose dpuNodeSelector matches its DPUNode's labels. NICo uses
+// the same rule when it resolves a node's deployment type to a DPUDeployment,
+// so the simulator must land on the same object or NICo waits for a DPU that
+// never appears. ok=false means no deployment selects the node; the legacy
+// "sim" flavor is kept and NICo's name-based lookup still works.
+type selectedDeployment struct {
+	name, flavor, bfb string
+}
+
+func (r *DPUDeviceReconciler) selectDeployment(ctx context.Context, nodeName string) (selectedDeployment, bool, error) {
+	var node provisioningv1.DPUNode
+	if err := r.Get(ctx, types.NamespacedName{Namespace: r.Namespace, Name: nodeName}, &node); err != nil {
+		return selectedDeployment{}, false, client.IgnoreNotFound(err)
+	}
+	list := &unstructured.UnstructuredList{}
+	list.SetGroupVersionKind(schema.GroupVersionKind{
+		Group: dpuDeploymentGVK.Group, Version: dpuDeploymentGVK.Version, Kind: dpuDeploymentGVK.Kind + "List",
+	})
+	if err := r.List(ctx, list, client.InNamespace(r.Namespace)); err != nil {
+		return selectedDeployment{}, false, err
+	}
+	var matches []selectedDeployment
+	var matchIdx []int
+	for i := range list.Items {
+		d := &list.Items[i]
+		sets, _, _ := unstructured.NestedSlice(d.Object, "spec", "dpus", "dpuSets")
+		selects := false
+		for _, raw := range sets {
+			set, _ := raw.(map[string]interface{})
+			ml, _, _ := unstructured.NestedStringMap(set, "dpuNodeSelector", "matchLabels")
+			if len(ml) == 0 {
+				continue
+			}
+			all := true
+			for k, v := range ml {
+				if node.Labels[k] != v {
+					all = false
+					break
+				}
+			}
+			if all {
+				selects = true
+				break
+			}
+		}
+		if !selects {
+			continue
+		}
+		flavor, _, _ := unstructured.NestedString(d.Object, "spec", "dpus", "flavor")
+		bfb, _, _ := unstructured.NestedString(d.Object, "spec", "dpus", "bfb")
+		matches = append(matches, selectedDeployment{name: d.GetName(), flavor: flavor, bfb: bfb})
+		matchIdx = append(matchIdx, i)
+	}
+	if len(matches) != 1 {
+		return selectedDeployment{}, false, nil
+	}
+	if err := r.markDeploymentReady(ctx, &list.Items[matchIdx[0]]); err != nil {
+		return selectedDeployment{}, false, err
+	}
+	return matches[0], true, nil
+}
+
+// markDeploymentReady reports the DPUDeployment as reconciled, which is what
+// the real DPF DPUDeployment controller does once it has created the
+// deployment's DPUSets. NICo refuses to look at any DPU under a deployment
+// whose DPUSetsReconciled condition is not True at the current generation, so
+// without this every host waits forever for a DPU that is already there.
+// Idempotent: a current condition is left untouched.
+func (r *DPUDeviceReconciler) markDeploymentReady(ctx context.Context, d *unstructured.Unstructured) error {
+	gen := d.GetGeneration()
+	conds, _, _ := unstructured.NestedSlice(d.Object, "status", "conditions")
+	for _, raw := range conds {
+		c, _ := raw.(map[string]interface{})
+		if c["type"] == "DPUSetsReconciled" && c["status"] == "True" {
+			if og, ok := c["observedGeneration"]; ok {
+				if n, ok := og.(int64); ok && n == gen {
+					return nil
+				}
+			}
+		}
+	}
+	patch := d.DeepCopy()
+	now := time.Now().UTC().Format(time.RFC3339)
+	cond := map[string]interface{}{
+		"type":               "DPUSetsReconciled",
+		"status":             "True",
+		"reason":             "Simulated",
+		"message":            "dpf-sim-controller: DPUSets reconciled",
+		"lastTransitionTime": now,
+		"observedGeneration": gen,
+	}
+	_ = unstructured.SetNestedSlice(patch.Object, []interface{}{cond}, "status", "conditions")
+	_ = unstructured.SetNestedField(patch.Object, gen, "status", "observedGeneration")
+	return r.Status().Patch(ctx, patch, client.MergeFrom(d))
+}
+
+// ownedByValue is the label value NICo computes: "<namespace>_<deployment>".
+func (r *DPUDeviceReconciler) ownedByValue(dep selectedDeployment) string {
+	return r.Namespace + "_" + dep.name
+}
+
+// bfbFileFor is the installed-image filename NICo compares against a Ready
+// DPU: "<namespace>-<bfb CR name>.bfb".
+func (r *DPUDeviceReconciler) bfbFileFor(bfb string) string {
+	return r.Namespace + "-" + bfb + ".bfb"
+}
+
+// errDPURecreating reports that an existing DPU was deleted because its
+// immutable spec no longer matches the deployment selecting its node; the
+// next reconcile recreates it.
+var errDPURecreating = errors.New("DPU deleted for recreation under its DPUDeployment")
+
 func (r *DPUDeviceReconciler) ensureDPU(
 	ctx context.Context, device *provisioningv1.DPUDevice, dpuName, nodeName string,
 ) (*provisioningv1.DPU, error) {
 	var dpu provisioningv1.DPU
 	err := r.Get(ctx, types.NamespacedName{Namespace: r.Namespace, Name: dpuName}, &dpu)
 	if err == nil {
+		dep, ok, derr := r.selectDeployment(ctx, nodeName)
+		if derr != nil {
+			return nil, derr
+		}
+		if ok {
+			// spec.dpuFlavor is immutable on the CRD, so a DPU created before
+			// the deployment existed (or under the legacy "sim" flavor) cannot
+			// be patched into compliance. Real DPF deletes the source-owned DPU
+			// and lets the target deployment recreate it; do the same.
+			if dpu.Spec.DPUFlavor != dep.flavor && dpu.DeletionTimestamp == nil {
+				if err := r.Delete(ctx, &dpu); err != nil && !apierrors.IsNotFound(err) {
+					return nil, err
+				}
+				return nil, errDPURecreating
+			}
+			wantCtl := device.Labels[carbide.LabelControlledDev]
+			if dpu.Labels[carbide.LabelOwnedByDPUDeployment] != r.ownedByValue(dep) ||
+				(wantCtl != "" && dpu.Labels[carbide.LabelControlledDev] != wantCtl) {
+				patch := client.MergeFrom(dpu.DeepCopy())
+				if dpu.Labels == nil {
+					dpu.Labels = map[string]string{}
+				}
+				dpu.Labels[carbide.LabelOwnedByDPUDeployment] = r.ownedByValue(dep)
+				if wantCtl != "" {
+					dpu.Labels[carbide.LabelControlledDev] = wantCtl
+				}
+				if err := r.Patch(ctx, &dpu, patch); err != nil {
+					return nil, err
+				}
+			}
+		}
 		return &dpu, nil
 	}
 	if !apierrors.IsNotFound(err) {
@@ -262,16 +425,29 @@ func (r *DPUDeviceReconciler) ensureDPU(
 		return nil, fmt.Errorf("%w: label %s is empty on %s", errDeviceNotReady, carbide.LabelHostBMCIP, device.Name)
 	}
 
+	flavor, bfb := "sim", "sim"
+	labels := map[string]string{
+		// MUST propagate: NICo maps DPU events back to a machine by this.
+		carbide.LabelDPUMachineID: device.Labels[carbide.LabelDPUMachineID],
+		carbide.LabelHostBMCIP:    device.Labels[carbide.LabelHostBMCIP],
+	}
+	// NICo scopes its DPU watch to controlled devices; the real DPUSet
+	// controller carries this label from the DPUDevice onto the DPU.
+	if v := device.Labels[carbide.LabelControlledDev]; v != "" {
+		labels[carbide.LabelControlledDev] = v
+	}
+	if dep, ok, derr := r.selectDeployment(ctx, nodeName); derr != nil {
+		return nil, derr
+	} else if ok {
+		flavor, bfb = dep.flavor, dep.bfb
+		labels[carbide.LabelOwnedByDPUDeployment] = r.ownedByValue(dep)
+	}
 	noEffect := true
 	dpu = provisioningv1.DPU{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      dpuName,
 			Namespace: r.Namespace,
-			Labels: map[string]string{
-				// MUST propagate — NICo maps DPU events back to a machine by this.
-				carbide.LabelDPUMachineID: device.Labels[carbide.LabelDPUMachineID],
-				carbide.LabelHostBMCIP:    device.Labels[carbide.LabelHostBMCIP],
-			},
+			Labels:    labels,
 			Annotations: map[string]string{
 				carbide.AnnSimPhaseEnteredAt: time.Now().UTC().Format(time.RFC3339),
 			},
@@ -287,8 +463,8 @@ func (r *DPUDeviceReconciler) ensureDPU(
 			BMCIP: device.Labels[carbide.LabelHostBMCIP],
 			// DPUFlavor and BFB are required by the CRD but have no meaning for
 			// the simulator; use placeholder values so the CR is accepted.
-			DPUFlavor: "sim",
-			BFB:       "sim",
+			DPUFlavor: flavor,
+			BFB:       bfb,
 			// NoEffect: the simulator never touches real K8s node taints/drains.
 			// NodeEffect embeds Action; NoEffect lives on Action, not NodeEffect directly.
 			NodeEffect: provisioningv1.NodeEffect{

--- a/dev/k8s/dpf-sim-controller/internal/controller/dpudevice_controller_test.go
+++ b/dev/k8s/dpf-sim-controller/internal/controller/dpudevice_controller_test.go
@@ -1,0 +1,437 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package controller
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	provisioningv1 "github.com/nvidia/doca-platform/api/provisioning/v1alpha1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	"github.com/nvidia/infra-controller/dev/k8s/dpf-sim-controller/internal/carbide"
+)
+
+const testNamespace = "dpf-operator-system"
+
+var (
+	testNodeLabels = map[string]string{"dpu-enabled": "true", "deployment-type": "gb200"}
+	// testSelector is a DPUSet dpuNodeSelector that matches testNodeLabels.
+	testSelector = map[string]string{"dpu-enabled": "true", "deployment-type": "gb200"}
+	// otherSelector matches no test node.
+	otherSelector = map[string]string{"dpu-enabled": "true", "deployment-type": "bf4"}
+)
+
+// newDeployment builds a DPUDeployment (generation 3) whose single DPUSet
+// selects DPUNodes carrying selector; dpus holds the other spec.dpus fields.
+func newDeployment(t *testing.T, name string, selector map[string]string, dpus map[string]interface{}) *unstructured.Unstructured {
+	t.Helper()
+	d := &unstructured.Unstructured{}
+	d.SetGroupVersionKind(dpuDeploymentGVK)
+	d.SetNamespace(testNamespace)
+	d.SetName(name)
+	d.SetGeneration(3)
+	spec := map[string]interface{}{}
+	for k, v := range dpus {
+		spec[k] = v
+	}
+	matchLabels := map[string]interface{}{}
+	for k, v := range selector {
+		matchLabels[k] = v
+	}
+	spec["dpuSets"] = []interface{}{
+		map[string]interface{}{
+			"nameSuffix":      "default",
+			"dpuNodeSelector": map[string]interface{}{"matchLabels": matchLabels},
+		},
+	}
+	if err := unstructured.SetNestedField(d.Object, spec, "spec", "dpus"); err != nil {
+		t.Fatal(err)
+	}
+	return d
+}
+
+func newNode(name string, labels map[string]string) *provisioningv1.DPUNode {
+	return &provisioningv1.DPUNode{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: name, Labels: labels},
+	}
+}
+
+func newReconciler(t *testing.T, objs ...client.Object) *DPUDeviceReconciler {
+	t.Helper()
+	s := runtime.NewScheme()
+	if err := provisioningv1.AddToScheme(s); err != nil {
+		t.Fatal(err)
+	}
+	dep := &unstructured.Unstructured{}
+	dep.SetGroupVersionKind(dpuDeploymentGVK)
+	c := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objs...).
+		WithStatusSubresource(dep, &provisioningv1.DPU{}).
+		Build()
+	return &DPUDeviceReconciler{Client: c, Scheme: s, Namespace: testNamespace}
+}
+
+// recordCreates appends a copy of every object handed to Create, as the
+// reconciler sent it. The fake client stores a DPU typed whatever form it was
+// created in, so a Get afterwards cannot show which fields were on the wire.
+func recordCreates(t *testing.T, r *DPUDeviceReconciler, created *[]client.Object) {
+	t.Helper()
+	ww, ok := r.Client.(client.WithWatch)
+	if !ok {
+		t.Fatalf("client %T is not a client.WithWatch", r.Client)
+	}
+	r.Client = interceptor.NewClient(ww, interceptor.Funcs{
+		Create: func(ctx context.Context, c client.WithWatch, obj client.Object, opts ...client.CreateOption) error {
+			*created = append(*created, obj.DeepCopyObject().(client.Object))
+			return c.Create(ctx, obj, opts...)
+		},
+	})
+}
+
+func getDeployment(t *testing.T, r *DPUDeviceReconciler, name string) *unstructured.Unstructured {
+	t.Helper()
+	d := &unstructured.Unstructured{}
+	d.SetGroupVersionKind(dpuDeploymentGVK)
+	if err := r.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: name}, d); err != nil {
+		t.Fatalf("get DPUDeployment %s: %v", name, err)
+	}
+	return d
+}
+
+// conditionsByType indexes status.conditions by type, failing on duplicates.
+func conditionsByType(t *testing.T, d *unstructured.Unstructured) map[string]map[string]interface{} {
+	t.Helper()
+	conds, _, err := unstructured.NestedSlice(d.Object, "status", "conditions")
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]map[string]interface{}{}
+	for _, raw := range conds {
+		c, ok := raw.(map[string]interface{})
+		if !ok {
+			t.Fatalf("condition %v is %T, want map", raw, raw)
+		}
+		typ, _ := c["type"].(string)
+		if _, dup := out[typ]; dup {
+			t.Fatalf("condition %q appears twice: %v", typ, conds)
+		}
+		out[typ] = c
+	}
+	return out
+}
+
+func TestSelectDeployment(t *testing.T) {
+	bfb := map[string]interface{}{"bfb": "bf-bundle", "flavor": "gb200-flavor"}
+	bfs := map[string]interface{}{"blueFieldSoftware": "bfs-abc", "flavor": "bf4-flavor"}
+	template := map[string]interface{}{"blueFieldSoftware": "bfs-abc", "flavorTemplate": "astra-template"}
+	noSource := map[string]interface{}{"flavor": "gb200-flavor"}
+	bothSources := map[string]interface{}{"bfb": "bf-bundle", "blueFieldSoftware": "bfs-abc", "flavor": "gb200-flavor"}
+	noFlavor := map[string]interface{}{"bfb": "bf-bundle"}
+
+	cases := []struct {
+		name        string
+		deployments []*unstructured.Unstructured
+		want        selectedDeployment
+		wantOK      bool
+	}{
+		{
+			name:        "bfb and flavor",
+			deployments: []*unstructured.Unstructured{newDeployment(t, "gb200", testSelector, bfb)},
+			want:        selectedDeployment{name: "gb200", flavor: "gb200-flavor", bfb: "bf-bundle"},
+			wantOK:      true,
+		},
+		{
+			name:        "blueFieldSoftware and flavor",
+			deployments: []*unstructured.Unstructured{newDeployment(t, "bf4", testSelector, bfs)},
+			want:        selectedDeployment{name: "bf4", flavor: "bf4-flavor", blueFieldSoftware: "bfs-abc"},
+			wantOK:      true,
+		},
+		{
+			name:        "blueFieldSoftware and flavorTemplate uses the template name as flavor",
+			deployments: []*unstructured.Unstructured{newDeployment(t, "astra", testSelector, template)},
+			want:        selectedDeployment{name: "astra", flavor: "astra-template", blueFieldSoftware: "bfs-abc"},
+			wantOK:      true,
+		},
+		{
+			name: "two deployments select the node",
+			deployments: []*unstructured.Unstructured{
+				newDeployment(t, "gb200-a", testSelector, bfb),
+				newDeployment(t, "gb200-b", testSelector, bfb),
+			},
+		},
+		{
+			name:        "no provisioning source",
+			deployments: []*unstructured.Unstructured{newDeployment(t, "gb200", testSelector, noSource)},
+		},
+		{
+			name:        "both provisioning sources",
+			deployments: []*unstructured.Unstructured{newDeployment(t, "gb200", testSelector, bothSources)},
+		},
+		{
+			name:        "no flavor",
+			deployments: []*unstructured.Unstructured{newDeployment(t, "gb200", testSelector, noFlavor)},
+		},
+		{
+			name: "unusable deployment does not shadow a usable one",
+			deployments: []*unstructured.Unstructured{
+				newDeployment(t, "broken", testSelector, noSource),
+				newDeployment(t, "gb200", testSelector, bfb),
+			},
+			want:   selectedDeployment{name: "gb200", flavor: "gb200-flavor", bfb: "bf-bundle"},
+			wantOK: true,
+		},
+		{
+			name:        "selector does not match the node",
+			deployments: []*unstructured.Unstructured{newDeployment(t, "bf4", otherSelector, bfs)},
+		},
+		{
+			name: "no deployments",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			objs := []client.Object{newNode("node-a", testNodeLabels)}
+			for _, d := range tc.deployments {
+				objs = append(objs, d)
+			}
+			r := newReconciler(t, objs...)
+			got, ok, err := r.selectDeployment(context.Background(), "node-a")
+			if err != nil {
+				t.Fatalf("selectDeployment: %v", err)
+			}
+			if ok != tc.wantOK {
+				t.Fatalf("ok = %v, want %v (got %+v)", ok, tc.wantOK, got)
+			}
+			if got != tc.want {
+				t.Fatalf("selected = %+v, want %+v", got, tc.want)
+			}
+			if !ok {
+				// Nothing selected, so nothing was marked reconciled.
+				for _, d := range tc.deployments {
+					if c := conditionsByType(t, getDeployment(t, r, d.GetName()))["DPUSetsReconciled"]; c != nil {
+						t.Fatalf("DPUSetsReconciled set on unselected %s: %v", d.GetName(), c)
+					}
+				}
+				return
+			}
+			// The selected deployment is reported reconciled at its generation.
+			d := getDeployment(t, r, got.name)
+			c := conditionsByType(t, d)["DPUSetsReconciled"]
+			if c == nil || c["status"] != "True" || c["observedGeneration"] != d.GetGeneration() {
+				t.Fatalf("DPUSetsReconciled = %v, want True at generation %d", c, d.GetGeneration())
+			}
+		})
+	}
+}
+
+func TestMarkDeploymentReadyPreservesOtherConditions(t *testing.T) {
+	d := newDeployment(t, "gb200", testSelector, map[string]interface{}{"bfb": "bf-bundle", "flavor": "gb200-flavor"})
+	d.SetGeneration(4)
+	ready := map[string]interface{}{
+		"type": "Ready", "status": "False", "reason": "Pending", "message": "",
+		"lastTransitionTime": "2026-01-01T00:00:00Z",
+	}
+	stale := map[string]interface{}{
+		"type": "DPUSetsReconciled", "status": "True", "reason": "Success", "message": "",
+		"lastTransitionTime": "2026-01-01T00:00:00Z", "observedGeneration": int64(3),
+	}
+	if err := unstructured.SetNestedSlice(d.Object, []interface{}{ready, stale}, "status", "conditions"); err != nil {
+		t.Fatal(err)
+	}
+	r := newReconciler(t, d)
+	ctx := context.Background()
+
+	if err := r.markDeploymentReady(ctx, getDeployment(t, r, "gb200")); err != nil {
+		t.Fatalf("markDeploymentReady: %v", err)
+	}
+	after := getDeployment(t, r, "gb200")
+	conds := conditionsByType(t, after)
+	if len(conds) != 2 {
+		t.Fatalf("got %d conditions, want Ready and DPUSetsReconciled: %v", len(conds), conds)
+	}
+	if got := conds["Ready"]; got == nil || got["status"] != "False" || got["reason"] != "Pending" {
+		t.Fatalf("Ready condition changed: %v", got)
+	}
+	if got := conds["DPUSetsReconciled"]; got == nil || got["status"] != "True" || got["observedGeneration"] != int64(4) {
+		t.Fatalf("DPUSetsReconciled = %v, want True at generation 4", got)
+	}
+	if og, _, _ := unstructured.NestedInt64(after.Object, "status", "observedGeneration"); og != 4 {
+		t.Fatalf("status.observedGeneration = %d, want 4", og)
+	}
+
+	// A current condition is left untouched.
+	if err := r.markDeploymentReady(ctx, after); err != nil {
+		t.Fatalf("second markDeploymentReady: %v", err)
+	}
+	if again := getDeployment(t, r, "gb200"); again.GetResourceVersion() != after.GetResourceVersion() {
+		t.Fatalf("second call rewrote the deployment: resourceVersion %s -> %s", after.GetResourceVersion(), again.GetResourceVersion())
+	}
+}
+
+func newDevice() *provisioningv1.DPUDevice {
+	return &provisioningv1.DPUDevice{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: testNamespace,
+			Name:      carbide.DPUDeviceName("d1"),
+			Labels: map[string]string{
+				carbide.LabelDPUMachineID:  "machine-1",
+				carbide.LabelHostBMCIP:     "10.0.0.1",
+				carbide.LabelControlledDev: "true",
+			},
+		},
+		Spec: provisioningv1.DPUDeviceSpec{SerialNumber: "SN1"},
+	}
+}
+
+func TestEnsureDPUInheritsDeploymentSpec(t *testing.T) {
+	cases := []struct {
+		name string
+		dpus map[string]interface{}
+		want provisioningv1.DPUSpec
+		// unstructuredCreate: the DPU is sent unstructured with spec.bfb
+		// removed, because the pinned typed DPUSpec cannot omit bfb.
+		unstructuredCreate bool
+	}{
+		{
+			name: "bfb deployment",
+			dpus: map[string]interface{}{"bfb": "bf-bundle", "flavor": "gb200-flavor"},
+			want: provisioningv1.DPUSpec{DPUFlavor: "gb200-flavor", BFB: "bf-bundle"},
+		},
+		{
+			name:               "blueFieldSoftware deployment",
+			dpus:               map[string]interface{}{"blueFieldSoftware": "bfs-abc", "flavor": "bf4-flavor"},
+			want:               provisioningv1.DPUSpec{DPUFlavor: "bf4-flavor", BlueFieldSoftware: "bfs-abc"},
+			unstructuredCreate: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			nodeName := carbide.DPUNodeName("a")
+			device := newDevice()
+			r := newReconciler(t, newNode(nodeName, testNodeLabels), device, newDeployment(t, "dep", testSelector, tc.dpus))
+			var created []client.Object
+			recordCreates(t, r, &created)
+			dpuName := carbide.DPUName("a", "d1")
+
+			dpu, err := r.ensureDPU(context.Background(), device, dpuName, nodeName)
+			if err != nil {
+				t.Fatalf("ensureDPU: %v", err)
+			}
+			if len(created) != 1 {
+				t.Fatalf("Create called %d times, want 1", len(created))
+			}
+			switch obj := created[0].(type) {
+			case *provisioningv1.DPU:
+				if tc.unstructuredCreate {
+					t.Fatalf("DPU created typed with bfb %q, want unstructured without spec.bfb", obj.Spec.BFB)
+				}
+			case *unstructured.Unstructured:
+				if !tc.unstructuredCreate {
+					t.Fatalf("DPU created unstructured, want typed")
+				}
+				if obj.GroupVersionKind() != provisioningv1.DPUGroupVersionKind {
+					t.Fatalf("created GVK = %v", obj.GroupVersionKind())
+				}
+				if _, has, _ := unstructured.NestedFieldNoCopy(obj.Object, "spec", "bfb"); has {
+					t.Fatalf("spec.bfb sent on a blueFieldSoftware DPU: %v", obj.Object["spec"])
+				}
+				if got, _, _ := unstructured.NestedString(obj.Object, "spec", "blueFieldSoftware"); got != tc.want.BlueFieldSoftware {
+					t.Fatalf("sent spec.blueFieldSoftware = %q, want %q", got, tc.want.BlueFieldSoftware)
+				}
+			default:
+				t.Fatalf("Create received %T", obj)
+			}
+			if dpu.Spec.DPUFlavor != tc.want.DPUFlavor || dpu.Spec.BFB != tc.want.BFB || dpu.Spec.BlueFieldSoftware != tc.want.BlueFieldSoftware {
+				t.Fatalf("spec flavor/bfb/blueFieldSoftware = %q/%q/%q, want %q/%q/%q",
+					dpu.Spec.DPUFlavor, dpu.Spec.BFB, dpu.Spec.BlueFieldSoftware,
+					tc.want.DPUFlavor, tc.want.BFB, tc.want.BlueFieldSoftware)
+			}
+			if got := dpu.Labels[carbide.LabelOwnedByDPUDeployment]; got != testNamespace+"_dep" {
+				t.Fatalf("owned-by label = %q", got)
+			}
+			if dpu.Status.Phase != provisioningv1.DPUInitializing {
+				t.Fatalf("phase = %q, want Initializing", dpu.Status.Phase)
+			}
+		})
+	}
+}
+
+func TestEnsureDPUTerminatingMismatchIsRecreating(t *testing.T) {
+	nodeName := carbide.DPUNodeName("a")
+	dpuName := carbide.DPUName("a", "d1")
+	device := newDevice()
+	now := metav1.Now()
+	existing := &provisioningv1.DPU{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         testNamespace,
+			Name:              dpuName,
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"test/keep"},
+		},
+		Spec: provisioningv1.DPUSpec{
+			DPUNodeName: nodeName, DPUDeviceName: device.Name, SerialNumber: "SN1",
+			DPUFlavor: "sim", BFB: "sim",
+		},
+	}
+	dep := newDeployment(t, "dep", testSelector, map[string]interface{}{"bfb": "bf-bundle", "flavor": "gb200-flavor"})
+	r := newReconciler(t, newNode(nodeName, testNodeLabels), device, dep, existing)
+	key := types.NamespacedName{Namespace: testNamespace, Name: dpuName}
+	var before provisioningv1.DPU
+	if err := r.Get(context.Background(), key, &before); err != nil {
+		t.Fatalf("get DPU: %v", err)
+	}
+
+	_, err := r.ensureDPU(context.Background(), device, dpuName, nodeName)
+	if !errors.Is(err, errDPURecreating) {
+		t.Fatalf("err = %v, want errDPURecreating", err)
+	}
+	// The terminating DPU was neither relabeled nor deleted again.
+	var got provisioningv1.DPU
+	if err := r.Get(context.Background(), key, &got); err != nil {
+		t.Fatalf("get DPU: %v", err)
+	}
+	if _, labeled := got.Labels[carbide.LabelOwnedByDPUDeployment]; labeled {
+		t.Fatalf("terminating DPU was relabeled: %v", got.Labels)
+	}
+	if got.ResourceVersion != before.ResourceVersion {
+		t.Fatalf("terminating DPU was written: resourceVersion %s -> %s", before.ResourceVersion, got.ResourceVersion)
+	}
+}
+
+// A live DPU whose immutable flavor differs from the deployment selecting its
+// node is deleted so the next reconcile recreates it.
+func TestEnsureDPUFlavorDriftDeletesDPU(t *testing.T) {
+	nodeName := carbide.DPUNodeName("a")
+	dpuName := carbide.DPUName("a", "d1")
+	device := newDevice()
+	existing := &provisioningv1.DPU{
+		ObjectMeta: metav1.ObjectMeta{Namespace: testNamespace, Name: dpuName},
+		Spec: provisioningv1.DPUSpec{
+			DPUNodeName: nodeName, DPUDeviceName: device.Name, SerialNumber: "SN1",
+			DPUFlavor: "sim", BFB: "sim",
+		},
+	}
+	dep := newDeployment(t, "dep", testSelector, map[string]interface{}{"bfb": "bf-bundle", "flavor": "gb200-flavor"})
+	r := newReconciler(t, newNode(nodeName, testNodeLabels), device, dep, existing)
+
+	_, err := r.ensureDPU(context.Background(), device, dpuName, nodeName)
+	if !errors.Is(err, errDPURecreating) {
+		t.Fatalf("err = %v, want errDPURecreating", err)
+	}
+	var got provisioningv1.DPU
+	err = r.Get(context.Background(), types.NamespacedName{Namespace: testNamespace, Name: dpuName}, &got)
+	if !apierrors.IsNotFound(err) {
+		t.Fatalf("get DPU after flavor drift: err = %v, want NotFound", err)
+	}
+}


### PR DESCRIPTION
NICo's GB200 DPF path waits for the `DPUDeployment` to report `DPUSetsReconciled = True` and for DPUs that carry the owned-by-dpudeployment label, the deployment's flavor and `status.bfbFile`. The simulator created DPUs directly under the `DPUNode` with placeholder values, so simulated GB200 racks never passed that gate. The controller now selects the `DPUDeployment` whose `DPUSet` matches the device's node, marks it reconciled at its observed generation, and creates or adopts DPUs under it with the inherited flavor, BFB or BlueField software and labels (recreating on flavor mismatch). Deployments without a usable provisioning source or flavor, or several deployments selecting one node, are logged and skipped. RBAC gains `dpus` delete and read access plus status patch on `dpudeployments`.

## Related issues
Closes #5971
Refs #5970

## Type of Change
- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

`gofmt`, `go vet`, `go build` and `go test ./...` are clean; new fake-client tests cover deployment selection, condition handling, spec inheritance and DPU recreation. Ran against a simulated 250-rack GB200 site: all 9,000 DPUs were created under the deployment and it reported `DPUSetsReconciled = True`.

## Additional Notes
Pairs with #5970: under DPF a simulated DPU must also start with the DPU agent installed. A DPU under a `blueFieldSoftware` deployment is created as unstructured because the pinned doca-platform type cannot omit `spec.bfb`.
