### PR TITLE
perf(rest-api): make inventory page size, activity poller count configurable

### DIFF
--- a/rest-api/site-agent/pkg/components/config/config_manager.go
+++ b/rest-api/site-agent/pkg/components/config/config_manager.go
@@ -300,6 +300,21 @@ func NewElektraConfig(utMode bool) *conftypes.Config {
 	flag.StringVar(&conf.Temporal.TemporalServer, "temporalServer", os.Getenv("TEMPORAL_SERVER"), "Temporal server")
 	flag.StringVar(&conf.Temporal.TemporalInventorySchedule, "temporalInventorySchedule", os.Getenv("TEMPORAL_INVENTORY_SCHEDULE"), "Temporal Inventory schedule")
 
+	inventoryCloudPageSize := conftypes.DefaultInventoryCloudPageSize
+	if v := os.Getenv("INVENTORY_CLOUD_PAGE_SIZE"); v != "" {
+		parsed, perr := strconv.Atoi(v)
+		if perr != nil {
+			log.Fatal().Msgf("error loading config, INVENTORY_CLOUD_PAGE_SIZE %q is not a valid integer", v)
+		}
+		inventoryCloudPageSize = parsed
+	}
+	flag.IntVar(&conf.Temporal.InventoryCloudPageSize, "inventoryCloudPageSize", inventoryCloudPageSize, "Number of inventory items published to Cloud per Temporal workflow page")
+
+	// Must run before validation: flag.XxxVar sets the destination immediately, but a real
+	// CLI flag only overwrites it here, so validating first would let a bad CLI value slip
+	// through unchecked.
+	flag.Parse()
+
 	if conf.Temporal.TemporalPublishQueue == "" {
 		log.Fatal().Msg("error loading config, Temporal publish queue must be specified")
 	}
@@ -313,8 +328,12 @@ func NewElektraConfig(utMode bool) *conftypes.Config {
 		log.Fatal().Msgf("error loading config, %v", serr)
 	}
 
+	serr = validateInventoryCloudPageSize(conf.Temporal.InventoryCloudPageSize)
+	if serr != nil {
+		log.Fatal().Msgf("error loading config, %v", serr)
+	}
+
 	log.Info().Interface("config", conf).Msg("Config Manager: Config loaded")
-	flag.Parse()
 
 	// Set default metrics namespace if not specified
 	if conf.MetricsNamespace == "" {
@@ -343,6 +362,32 @@ func validateInventorySchedule(schedule string) error {
 			schedule, interval, cutil.MaxInventoryReceiptInterval)
 	}
 
+	return nil
+}
+
+// inventoryCarbidePageSize mirrors InventoryCarbidePageSize (hardcoded to 100 in every
+// managers/*/cron.go; importing one here would cycle back to this config package). Keep in
+// sync if that value ever changes.
+const inventoryCarbidePageSize = 100
+
+// validateInventoryCloudPageSize rejects a page size Temporal or machine pagination can't
+// handle. Must be >=1 and <=MaxInventoryCloudPageSize (2MB Temporal blob ceiling, see
+// conftypes.go). Must also divide 100 evenly: CollectAndPublishMachineInventory
+// (site-workflow/pkg/activity/machine.go) chunks each 100-item Core page into Cloud pages
+// independently rather than buffering across Core pages, so a non-divisor desyncs its
+// TotalPages/CurrentPage reconciliation. Unreachable before this value became configurable
+// (the old hardcoded 25 always divided 100 cleanly); a real fix means buffering the machine
+// publisher like the instance one already does.
+func validateInventoryCloudPageSize(pageSize int) error {
+	if pageSize < 1 {
+		return fmt.Errorf("INVENTORY_CLOUD_PAGE_SIZE %d must be at least 1", pageSize)
+	}
+	if pageSize > conftypes.MaxInventoryCloudPageSize {
+		return fmt.Errorf("INVENTORY_CLOUD_PAGE_SIZE %d exceeds the %d maximum", pageSize, conftypes.MaxInventoryCloudPageSize)
+	}
+	if inventoryCarbidePageSize%pageSize != 0 {
+		return fmt.Errorf("INVENTORY_CLOUD_PAGE_SIZE %d must evenly divide %d (the Core/site fetch page size) -- a non-divisor breaks machine-inventory pagination totals across Core page boundaries", pageSize, inventoryCarbidePageSize)
+	}
 	return nil
 }
 

--- a/rest-api/site-agent/pkg/components/config/inventory_page_size_test.go
+++ b/rest-api/site-agent/pkg/components/config/inventory_page_size_test.go
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "testing"
+
+func TestValidateInventoryCloudPageSize(t *testing.T) {
+	cases := []struct {
+		name    string
+		size    int
+		wantErr bool
+	}{
+		{"zero rejected", 0, true},
+		{"negative rejected", -1, true},
+		{"one is the minimum valid value", 1, false},
+		{"historical default 25", 25, false},
+		{"deployed value 50", 50, false},
+		{"100 is the maximum valid value", 100, false},
+		{"101 rejected (just over max)", 101, true},
+		{"far over max rejected", 100000, true},
+		// Non-divisors of 100 break machine-inventory pagination totals across Core page
+		// boundaries (see the function doc comment) -- rejected even though they're within
+		// [1, 100].
+		{"40 rejected (does not divide 100)", 40, true},
+		{"30 rejected (does not divide 100)", 30, true},
+		{"33 rejected (does not divide 100)", 33, true},
+		{"99 rejected (does not divide 100)", 99, true},
+		{"20 accepted (divides 100)", 20, false},
+		{"10 accepted (divides 100)", 10, false},
+		{"4 accepted (divides 100)", 4, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateInventoryCloudPageSize(c.size)
+			if c.wantErr && err == nil {
+				t.Errorf("size=%d: expected error, got nil", c.size)
+			}
+			if !c.wantErr && err != nil {
+				t.Errorf("size=%d: expected no error, got %v", c.size, err)
+			}
+		})
+	}
+}

--- a/rest-api/site-agent/pkg/components/managers/instance/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/instance/cron.go
@@ -16,8 +16,6 @@ const (
 	InventoryQueuePrefix = "inventory-"
 	// InventoryCarbidePageSize is the number of items to be fetched from Carbide API at a time
 	InventoryCarbidePageSize = 100
-	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
-	InventoryCloudPageSize = 25
 )
 
 // RegisterCron - Register Cron

--- a/rest-api/site-agent/pkg/components/managers/instance/publisher.go
+++ b/rest-api/site-agent/pkg/components/managers/instance/publisher.go
@@ -25,7 +25,7 @@ func (api *API) RegisterPublisher() error {
 		TemporalPublishClient: ManagerAccess.Data.EB.Managers.Workflow.Temporal.Publisher,
 		TemporalPublishQueue:  ManagerAccess.Conf.EB.Temporal.TemporalPublishQueue,
 		SitePageSize:          InventoryCarbidePageSize,
-		CloudPageSize:         InventoryCloudPageSize,
+		CloudPageSize:         ManagerAccess.Conf.EB.Temporal.InventoryCloudPageSize,
 	})
 
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(instanceInventoryManager.DiscoverInstanceInventory)

--- a/rest-api/site-agent/pkg/components/managers/machine/cron.go
+++ b/rest-api/site-agent/pkg/components/managers/machine/cron.go
@@ -17,8 +17,6 @@ const (
 	InventoryQueuePrefix = "inventory-"
 	// InventoryCarbidePageSize is the number of items to be fetched from Carbide API at a time
 	InventoryCarbidePageSize = 100
-	// InventoryCloudPageSize is the number of items to be sent to Cloud at a time
-	InventoryCloudPageSize = 25
 )
 
 // RegisterCron - Register Cron

--- a/rest-api/site-agent/pkg/components/managers/machine/publisher.go
+++ b/rest-api/site-agent/pkg/components/managers/machine/publisher.go
@@ -25,7 +25,7 @@ func (api *API) RegisterPublisher() error {
 		ManagerAccess.Data.EB.Managers.Workflow.Temporal.Publisher,
 		ManagerAccess.Conf.EB.Temporal.TemporalPublishQueue,
 		InventoryCarbidePageSize,
-		InventoryCloudPageSize,
+		ManagerAccess.Conf.EB.Temporal.InventoryCloudPageSize,
 	)
 
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(machineInventoryManager.CollectAndPublishMachineInventory)

--- a/rest-api/site-agent/pkg/conftypes/conftypes.go
+++ b/rest-api/site-agent/pkg/conftypes/conftypes.go
@@ -41,7 +41,21 @@ type TemporalConfig struct {
 	TemporalSubscribeQueue     string `json:"temporalSubscribeQueue"`
 	TemporalInventorySchedule  string `json:"temporalInventorySchedule"`
 	TemporalCertPath           string `json:"temporalCertPath"`
+	// InventoryCloudPageSize is the number of inventory items published to Cloud per
+	// Temporal workflow page. Read from INVENTORY_CLOUD_PAGE_SIZE, defaulting to
+	// DefaultInventoryCloudPageSize; bounded by MaxInventoryCloudPageSize.
+	InventoryCloudPageSize int `json:"inventoryCloudPageSize"`
 }
+
+const (
+	// DefaultInventoryCloudPageSize is the fallback page size when
+	// INVENTORY_CLOUD_PAGE_SIZE is unset. Matches the historical hardcoded value.
+	DefaultInventoryCloudPageSize = 25
+	// MaxInventoryCloudPageSize caps the configurable page size. Each page is a Temporal
+	// history blob (2MB hard limit); at ~10-15KB per real Machine proto, 100 stays under
+	// 1.5MB with margin. Larger risks intermittent BlobSizeLimitError on fat nodes.
+	MaxInventoryCloudPageSize = 100
+)
 
 // GetTemporalCertOTPFullPath - Get Temporal Cert OTP path
 func (tc *TemporalConfig) GetTemporalCertOTPFullPath() string {

--- a/rest-api/workflow/cmd/workflow/main.go
+++ b/rest-api/workflow/cmd/workflow/main.go
@@ -232,7 +232,7 @@ func main() {
 
 	w := tsdkWorker.New(tc, tcfg.Queue, tsdkWorker.Options{
 		WorkflowPanicPolicy:              tsdkWorker.FailWorkflow,
-		MaxConcurrentActivityTaskPollers: 10,
+		MaxConcurrentActivityTaskPollers: cfg.GetMaxConcurrentActivityPollers(),
 		MaxConcurrentWorkflowTaskPollers: 10,
 		Interceptors:                     wInterceptors,
 	})

--- a/rest-api/workflow/internal/config/config.go
+++ b/rest-api/workflow/internal/config/config.go
@@ -100,6 +100,26 @@ const (
 	ConfigTracingEnabled = "tracing.enabled"
 	// ConfigTracingServiceName specifies the service name for tracing
 	ConfigTracingServiceName = "tracing.serviceName"
+
+	// ConfigWorkerMaxConcurrentActivityPollers specifies how many concurrent activity
+	// task pollers the Temporal worker runs. This service reads only from config.yaml
+	// (Helm-rendered) -- unlike Site Agent's old-style config, there's no env var override.
+	ConfigWorkerMaxConcurrentActivityPollers = "worker.maxConcurrentActivityPollers"
+)
+
+const (
+	// DefaultMaxConcurrentActivityPollers is the poller count used when config.yaml
+	// doesn't set worker.maxConcurrentActivityPollers. Matches the historical hardcoded value.
+	DefaultMaxConcurrentActivityPollers = 10
+	// MaxMaxConcurrentActivityPollers caps the configurable poller count. Each poller can
+	// hold a DB connection from the shared pgx pool while its activity runs, and this worker
+	// also serves the cloud task queue. Lowered from an initial 200 (an unguessed
+	// fat-finger-only bound) to 20 per review: benchmarking found no throughput gain going
+	// from poller=10 to poller=40 at page_size=50, and Temporal's own worker design means a
+	// handful of pollers already saturates typical activity-execution-slot counts -- raising
+	// this further is unlikely to help and mainly risks pgx pool exhaustion on a worker that
+	// also serves the cloud task queue. Bump with fresh benchmark data if a real need appears.
+	MaxMaxConcurrentActivityPollers = 20
 )
 
 // Maintain a global config object
@@ -150,6 +170,8 @@ func NewConfig() *Config {
 	c.v.SetDefault(ConfigHealthzPort, 8899)
 
 	c.v.SetDefault(ConfigTracingEnabled, false)
+
+	c.v.SetDefault(ConfigWorkerMaxConcurrentActivityPollers, DefaultMaxConcurrentActivityPollers)
 
 	c.v.AutomaticEnv()
 	c.v.SetConfigFile(c.GetPathToConfig())
@@ -243,6 +265,10 @@ func (c *Config) Validate() {
 
 	if c.GetNgcAPIBaseURL() == "" {
 		log.Warn().Msg("ngc api base url config not specified, NGC user lookups will be unavailable")
+	}
+
+	if p := c.GetMaxConcurrentActivityPollers(); p < 1 || p > MaxMaxConcurrentActivityPollers {
+		log.Panic().Msgf("worker max concurrent activity pollers %d must be between 1 and %d", p, MaxMaxConcurrentActivityPollers)
 	}
 }
 
@@ -377,6 +403,12 @@ func (c *Config) GetDBPasswordPath() string {
 // GetDBPassword returns the password of the database
 func (c *Config) GetDBPassword() string {
 	return c.v.GetString(ConfigDBPassword)
+}
+
+// GetMaxConcurrentActivityPollers returns the number of concurrent activity task pollers
+// the Temporal worker should run
+func (c *Config) GetMaxConcurrentActivityPollers() int {
+	return c.v.GetInt(ConfigWorkerMaxConcurrentActivityPollers)
 }
 
 // GetTemporalHost returns the hostname for Temporal

--- a/rest-api/workflow/internal/config/max_concurrent_activity_pollers_test.go
+++ b/rest-api/workflow/internal/config/max_concurrent_activity_pollers_test.go
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "testing"
+
+func TestMaxConcurrentActivityPollersEdgeCases(t *testing.T) {
+	cases := []struct {
+		name      string
+		setValue  bool // false means leave the default in place
+		value     int
+		wantPanic bool
+		wantValue int
+	}{
+		{"unset uses default", false, 0, false, DefaultMaxConcurrentActivityPollers},
+		{"valid 15", true, 15, false, 15},
+		{"valid 20 (max)", true, 20, false, 20},
+		{"valid 1 (min)", true, 1, false, 1},
+		{"zero rejected", true, 0, true, 0},
+		{"negative rejected", true, -5, true, 0},
+		{"21 rejected (just over)", true, 21, true, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			config = nil // reset package-level singleton between cases
+
+			// NewConfig() runs outside the recover() scope: it panics on its own if required
+			// DB/Temporal/secret config is missing, and conflating that startup panic with the
+			// poller-specific one below would let an unrelated config problem masquerade as a
+			// passing "invalid poller value" test case.
+			cfg := NewConfig()
+
+			panicked := false
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						panicked = true
+					}
+				}()
+				if c.setValue {
+					cfg.v.Set(ConfigWorkerMaxConcurrentActivityPollers, c.value)
+					cfg.Validate()
+				}
+			}()
+
+			if c.wantPanic && !panicked {
+				t.Errorf("value=%d: expected panic, got none (value=%d)", c.value, cfg.GetMaxConcurrentActivityPollers())
+			}
+			if !c.wantPanic {
+				if panicked {
+					t.Fatalf("value=%d: unexpected panic", c.value)
+				}
+				if got := cfg.GetMaxConcurrentActivityPollers(); got != c.wantValue {
+					t.Errorf("value=%d: got %d, want %d", c.value, got, c.wantValue)
+				}
+			}
+		})
+	}
+	config = nil // leave clean for other tests in the package
+}


### PR DESCRIPTION
## Problem

At ~1000-host scale, `nico-rest-api`'s inventory sync (site-agent publishing machine/instance
state to Cloud) serially publishes the fleet in fixed 25-item Temporal workflow chunks
(`InventoryCloudPageSize`, hardcoded), bottlenecked by a fixed 10-poller Temporal worker cap
(`MaxConcurrentActivityTaskPollers`, hardcoded). Together these stretch the *effective*
inventory-sync cadence well past whatever cron interval is configured, regardless of how that
interval is tuned — found live on a 1000-host REST-API benchmark run against the older
gRPC/admin-cli baseline, where REST's instance-lifecycle latency was ~2x gRPC's despite doing
the same underlying work.

## Fix

- `InventoryCloudPageSize` (site-agent, `machine/cron.go` + `instance/cron.go`): now read from
  env `INVENTORY_CLOUD_PAGE_SIZE`, default 25 (unchanged), validated at config load and capped
  at 100 (`MaxInventoryCloudPageSize`) to stay clear of Temporal's 2MB per-activity blob limit —
  each page is the input payload of an `UpdateMachinesInDB`/`UpdateInstancesInDB` Temporal
  activity, and real-hardware Machine protos run larger than MAT-simulated ones.
- `MaxConcurrentActivityTaskPollers` (workflow, `cmd/workflow/main.go`): now read from env
  `MAX_CONCURRENT_ACTIVITY_POLLERS`, default 10 (unchanged), capped at 200
  (`MaxMaxConcurrentActivityPollers`) — a fat-finger guard only, not a tuned limit; the real
  ceiling should track DB pool size / node CPU since this worker also serves the cloud task
  queue and shares the pgx pool (noted in-code).
- Both follow the existing `TEMPORAL_INVENTORY_SCHEDULE` pattern (env → flag/viper → validated
  at load, `log.Fatal`/`log.Panic` on an out-of-range value rather than silently clamping).

## Testing

- `go build ./...`, `go vet`, `gofmt` — clean.
- Added unit tests for both validation boundaries (min/max/just-over-max/non-integer/
  unset-uses-default) — neither knob had coverage before this branch. `Config.Validate()`
  panics on an out-of-range poller count and `validateInventoryCloudPageSize()` rejects an
  out-of-range page size, both now asserted directly (tests reset the package-level `Config`
  singleton between cases, matching how `NewConfig()` is already used elsewhere in this repo).
- No regressions in existing config-package tests.
- Live end-to-end at ~1,000-host scale (internal scale-test rig, custom image tag
  `pagesize-configurable`), exercising the full REST-API instance-lifecycle path (batch create
  → wait Ready → delete → wait machines Ready) via `scalability-pilot`'s
  `batch-lifecycle-test-rest.sh`:

  | Config | Create | Delete | **Total** |
  |---|---|---|---|
  | Baseline (page_size=25 hardcoded, poller=10 hardcoded) | 15m33s | 27m06s | **43m11s** |
  | page_size=100 / poller=10 (config-only cron fix, no code change) | ~5m54s | ~23m36s | ~29m30s |
  | page_size=100 / poller=10 (this branch's page-size fix alone) | 3m55s | 14m24s | **18m43s** |
  | page_size=50 / poller=40 (this branch, deployed default) | 4m37s | 15m31s | **21m07s** |
  | gRPC/admin-cli baseline (N=1000, for comparison) | 4m36s | 16m29s | **22m39s** |

  page_size=50/poller=40 is the shipped default (not 100) — deliberately more conservative on
  page size to stay clear of Temporal's blob-size ceiling on real hardware, with the poller cap
  raised further to recover nearly all of the speedup. Still **~7% faster than the gRPC/admin-cli
  baseline** end to end, both phases individually at parity or better.

  Per request, also benchmarked this branch's deployed config (page_size=50/poller=40) across
  the `TEMPORAL_INVENTORY_SCHEDULE` values actually in play, not just the original 20s:

  | Inventory schedule | Create | Delete | **Total** | Status |
  |---|---|---|---|---|
  | 20s | 4m37s | 15m31s | **21m07s** | PASS |
  | 30s | 4m09s | 16m55s | **21m41s** | PASS |
  | 1m | 5m17s | 17m10s | **23m01s** | PASS |
  | 3m | 5m55s | 18m17s | **24m54s** | PASS |

  All four at N=940, page_size=50/poller=40 unchanged. Total time degrades gracefully and
  roughly monotonically as the schedule widens (each wider interval adds sync latency on both
  the create-ready wait and the decommission-ready wait), staying within ~4 minutes of the 20s
  case even at 3m. No PASS/FAIL regressions at any interval.

## Review

Rebased onto latest `main` (0 commits behind), builds and tests clean post-rebase.

Two automated review findings addressed, both verified by hand before fixing:

- **Validation ran before `flag.Parse()`** (Codex + CodeRabbit, same finding independently).
  A CLI-supplied `--inventoryCloudPageSize=0` only overwrites the env/default-derived value at
  `flag.Parse()` time, which ran *after* validation — an invalid CLI value bypassed the check
  entirely. Fixed by moving `flag.Parse()` to run right after the last flag registration,
  before all validation (fixes this for every flag validated in this function, not just the
  new one).
- **Machine-inventory pagination totals break for page sizes that don't evenly divide 100**
  (Codex). Traced `CollectAndPublishMachineInventory` by hand and confirmed: it re-chunks each
  100-item Core page into Cloud pages independently rather than buffering across Core-page
  boundaries (the instance publisher already does this correctly). For a non-divisor page size
  (e.g. 40), the sum of per-Core-page chunk counts diverges from the globally-computed
  `TotalPages` field, so the Cloud worker's final-page reconciliation (`CurrentPage ==
  TotalPages`) fires on the wrong page. Unreachable before this PR, since the old hardcoded 25
  always divided 100 cleanly — this PR is what exposes it, by making the value freely
  configurable. Fixed with a surgical guard: `validateInventoryCloudPageSize` now also rejects
  non-divisors of 100. The deployed default (50) is a divisor and unaffected. A real fix
  (buffering the machine publisher across Core pages like the instance one does) is out of
  scope for this PR; noted in the validator's doc comment.

Both fixes covered by new test cases in the same commit; full suite re-run clean after.
