### PR TITLE
fix(site-agent): report loaded Temporal client certificate expiration

### DIFF
--- a/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/client_golang/prometheus/promauto"
 
 	"github.com/rs/zerolog/log"
 
@@ -44,10 +43,6 @@ import (
 var (
 	// ErrInvalidBootstrapSecret invalid bootstrap secret
 	ErrInvalidBootstrapSecret = errors.New("invalid bootstrap secret")
-	// CertExpirationMetric is a prometheus metric for Site Agent Temporal
-	// certificate expiration. Registered in Init rather than here, because the
-	// namespace comes from config that is not loaded yet at package init.
-	CertExpirationMetric prometheus.Gauge
 )
 
 const (
@@ -142,14 +137,6 @@ func initK8sClient(ns string) coreV1Types.SecretInterface {
 // Init - initialize the bootstrap manager
 func (bs *BoostrapAPI) Init() {
 	ManagerAccess.Data.EB.Log.Info().Msg("Boostrap: Initializing the Site bootstrap manager")
-
-	// Registered ahead of the early returns below so every pod exposes the
-	// series, which is what a package-level promauto var used to do.
-	CertExpirationMetric = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: ManagerAccess.Conf.EB.MetricsNamespace,
-		Name:      "temporal_cert_expiration",
-		Help:      "The expiration date of the Temporal certificate",
-	})
 
 	// Only master pod of the statefulset should run the bootstrap
 	if !ManagerAccess.Conf.EB.IsMasterPod {

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
@@ -497,12 +497,11 @@ func (bs *BoostrapAPI) downloadCredentials(ctx context.Context) (*bootstraptypes
 		return nil, fmt.Errorf("failed to decode certificate PEM CACertificate %v", credsResponse.CACertificate)
 	}
 
-	cert, err := x509.ParseCertificate(block.Bytes)
+	_, err = x509.ParseCertificate(block.Bytes)
 	if err != nil {
 		log.Error().Err(err).Msgf("Bootstrap: failed to parse certificate")
 		return nil, fmt.Errorf("failed to parse certificate %w", err)
 	}
 
-	CertExpirationMetric.Set(float64(cert.NotAfter.UTC().Unix()))
 	return credsResponse, nil
 }

--- a/rest-api/site-agent/pkg/components/managers/workflow/init.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/init.go
@@ -8,9 +8,15 @@ import (
 
 	computils "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/utils"
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/zerolog/log"
 	"gopkg.in/fsnotify.v1"
 )
+
+// CertExpirationMetric is a prometheus metric for Site Agent Temporal
+// certificate expiration. Registered in Init rather than here, because the
+// namespace comes from config that is not loaded yet at package init.
+var CertExpirationMetric prometheus.Gauge
 
 const (
 	// MetricTemporalConnAttempted - Metric Temporal Conn Attempted
@@ -24,6 +30,12 @@ const (
 // Init - initialize the workflow orchestrator
 func (wflow *API) Init() {
 	ManagerAccess.Data.EB.Log.Info().Msg("Workflow: Initializing workflow orchestrator")
+
+	CertExpirationMetric = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: ManagerAccess.Conf.EB.MetricsNamespace,
+		Name:      "temporal_cert_expiration",
+		Help:      "The expiration date of the Temporal certificate",
+	})
 
 	prometheus.MustRegister(
 		prometheus.NewCounterFunc(prometheus.CounterOpts{

--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
@@ -21,7 +21,6 @@ import (
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/worker"
 
-	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/bootstrap"
 	computils "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/utils"
 	swu "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
 )
@@ -120,8 +119,8 @@ func workflowOrchestrator() error {
 			// GODEBUG=x509keypairleaf=0 leaves Leaf unset after a successful load.
 			leaf, err = x509.ParseCertificate(clientcert.Certificate[0])
 		}
-		if err == nil && leaf != nil && bootstrap.CertExpirationMetric != nil {
-			bootstrap.CertExpirationMetric.Set(float64(leaf.NotAfter.Unix()))
+		if err == nil && leaf != nil && CertExpirationMetric != nil {
+			CertExpirationMetric.Set(float64(leaf.NotAfter.Unix()))
 		} else {
 			log.Warn().Err(err).Msg("Workflow: Unable to update Temporal certificate expiration metric")
 		}

--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
@@ -21,6 +21,7 @@ import (
 	"go.temporal.io/sdk/interceptor"
 	"go.temporal.io/sdk/worker"
 
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/bootstrap"
 	computils "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/utils"
 	swu "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/util"
 )
@@ -111,6 +112,13 @@ func workflowOrchestrator() error {
 		if err != nil {
 			log.Error().Msg("Workflow: Unable to read client certificates")
 			return err
+		}
+
+		// Each pod loads its own certificate on startup and reload.
+		if clientcert.Leaf != nil && bootstrap.CertExpirationMetric != nil {
+			bootstrap.CertExpirationMetric.Set(float64(clientcert.Leaf.NotAfter.Unix()))
+		} else {
+			log.Warn().Msg("Workflow: Unable to update Temporal certificate expiration metric")
 		}
 
 		// Load server cert

--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator.go
@@ -115,10 +115,15 @@ func workflowOrchestrator() error {
 		}
 
 		// Each pod loads its own certificate on startup and reload.
-		if clientcert.Leaf != nil && bootstrap.CertExpirationMetric != nil {
-			bootstrap.CertExpirationMetric.Set(float64(clientcert.Leaf.NotAfter.Unix()))
+		leaf := clientcert.Leaf
+		if leaf == nil {
+			// GODEBUG=x509keypairleaf=0 leaves Leaf unset after a successful load.
+			leaf, err = x509.ParseCertificate(clientcert.Certificate[0])
+		}
+		if err == nil && leaf != nil && bootstrap.CertExpirationMetric != nil {
+			bootstrap.CertExpirationMetric.Set(float64(leaf.NotAfter.Unix()))
 		} else {
-			log.Warn().Msg("Workflow: Unable to update Temporal certificate expiration metric")
+			log.Warn().Err(err).Msg("Workflow: Unable to update Temporal certificate expiration metric")
 		}
 
 		// Load server cert

--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
@@ -20,10 +20,10 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/bootstrap"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/managerapi"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/conftypes"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/elektratypes"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/managertypes"
 )
 
 func TestWorkflowOrchestrator(t *testing.T) {
@@ -69,13 +69,11 @@ func TestWorkflowOrchestrator(t *testing.T) {
 				t.Setenv("GODEBUG", os.Getenv("GODEBUG")+",x509keypairleaf=0")
 			}
 			previousAccess := ManagerAccess
-			previousBootstrapAccess := bootstrap.ManagerAccess
-			previousGauge := bootstrap.CertExpirationMetric
+			previousGauge := CertExpirationMetric
 			previousRegisterer := prometheus.DefaultRegisterer
 			t.Cleanup(func() {
 				ManagerAccess = previousAccess
-				bootstrap.ManagerAccess = previousBootstrapAccess
-				bootstrap.CertExpirationMetric = previousGauge
+				CertExpirationMetric = previousGauge
 				prometheus.DefaultRegisterer = previousRegisterer
 			})
 
@@ -90,11 +88,10 @@ func TestWorkflowOrchestrator(t *testing.T) {
 					TemporalCertPath: t.TempDir(),
 				},
 			}
-			data := &elektratypes.Elektra{Log: zerolog.Nop()}
+			data := &elektratypes.Elektra{Log: zerolog.Nop(), Managers: managertypes.NewManagerType()}
 			managerConf := &managerapi.ManagerConf{EB: conf}
-			bootstrap.NewBootstrapManager(data, nil, managerConf).Init()
-			NewWorkflowManager(data, nil, managerConf)
-			gauge := bootstrap.CertExpirationMetric
+			NewWorkflowManager(data, nil, managerConf).Init()
+			gauge := CertExpirationMetric
 			gaugeValue := func() float64 {
 				t.Helper()
 				metric := &dto.Metric{}
@@ -104,7 +101,7 @@ func TestWorkflowOrchestrator(t *testing.T) {
 			}
 			require.Zero(t, gaugeValue())
 			if tt.nilGauge {
-				bootstrap.CertExpirationMetric = nil
+				CertExpirationMetric = nil
 			}
 
 			writeCertificate := func(notAfter time.Time) {
@@ -151,8 +148,17 @@ func TestWorkflowOrchestrator(t *testing.T) {
 			assert.Equal(t, float64(expiration.Unix()), gaugeValue())
 			metrics, gatherErr := registry.Gather()
 			require.NoError(t, gatherErr)
-			require.Len(t, metrics, 1)
-			assert.Equal(t, "nico_rest_site_agent_temporal_cert_expiration", metrics[0].GetName())
+			require.Len(t, metrics, 4)
+			var expirationMetric *dto.MetricFamily
+			for _, metric := range metrics {
+				if metric.GetName() == "nico_rest_site_agent_temporal_cert_expiration" {
+					expirationMetric = metric
+					break
+				}
+			}
+			require.NotNil(t, expirationMetric)
+			require.Len(t, expirationMetric.GetMetric(), 1)
+			assert.Equal(t, float64(expiration.Unix()), expirationMetric.GetMetric()[0].GetGauge().GetValue())
 			if tt.failedReload {
 				err = os.WriteFile(conf.Temporal.GetTemporalClientKeyFullPath(), []byte("invalid PEM"), 0600)
 				require.NoError(t, err)

--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
@@ -47,15 +47,17 @@ func TestWorkflowOrchestrator(t *testing.T) {
 	expiration := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
 
 	tests := []struct {
-		name       string
-		master     bool
-		reload     bool
-		invalidKey bool
-		nilGauge   bool
+		name         string
+		master       bool
+		reload       bool
+		failedReload bool
+		invalidKey   bool
+		nilGauge     bool
 	}{
 		{name: "master loads existing client certificate", master: true},
 		{name: "non-master loads existing client certificate"},
 		{name: "reload updates client expiration", reload: true},
+		{name: "failed reload retains previous expiration", failedReload: true},
 		{name: "invalid key leaves metric unchanged", invalidKey: true},
 		{name: "missing gauge does not interrupt certificate loading", nilGauge: true},
 	}
@@ -146,6 +148,13 @@ func TestWorkflowOrchestrator(t *testing.T) {
 			require.NoError(t, gatherErr)
 			require.Len(t, metrics, 1)
 			assert.Equal(t, "nico_rest_site_agent_temporal_cert_expiration", metrics[0].GetName())
+			if tt.failedReload {
+				err = os.WriteFile(conf.Temporal.GetTemporalClientKeyFullPath(), []byte("invalid PEM"), 0600)
+				require.NoError(t, err)
+				loadErr = workflowOrchestrator()
+				require.ErrorContains(t, loadErr, "PEM data in key input")
+				assert.Equal(t, float64(expiration.Unix()), gaugeValue())
+			}
 			if tt.reload {
 				newExpiration := expiration.Add(24 * time.Hour)
 				writeCertificate(newExpiration)

--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
@@ -51,18 +51,23 @@ func TestWorkflowOrchestrator(t *testing.T) {
 		master       bool
 		reload       bool
 		failedReload bool
+		omitLeaf     bool
 		invalidKey   bool
 		nilGauge     bool
 	}{
 		{name: "master loads existing client certificate", master: true},
 		{name: "non-master loads existing client certificate"},
 		{name: "reload updates client expiration", reload: true},
+		{name: "load and reload without cached leaf", omitLeaf: true, reload: true},
 		{name: "failed reload retains previous expiration", failedReload: true},
 		{name: "invalid key leaves metric unchanged", invalidKey: true},
 		{name: "missing gauge does not interrupt certificate loading", nilGauge: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			if tt.omitLeaf {
+				t.Setenv("GODEBUG", os.Getenv("GODEBUG")+",x509keypairleaf=0")
+			}
 			previousAccess := ManagerAccess
 			previousBootstrapAccess := bootstrap.ManagerAccess
 			previousGauge := bootstrap.CertExpirationMetric

--- a/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
+++ b/rest-api/site-agent/pkg/components/managers/workflow/orchestrator_test.go
@@ -1,0 +1,158 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package workflow
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/rs/zerolog"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/bootstrap"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/managerapi"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/conftypes"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/elektratypes"
+)
+
+func TestWorkflowOrchestrator(t *testing.T) {
+	caPublicKey, caKey, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	ca := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		NotBefore:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:              time.Date(2035, 1, 1, 0, 0, 0, 0, time.UTC),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, ca, ca, caPublicKey, caKey)
+	require.NoError(t, err)
+	publicKey, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	keyDER, err := x509.MarshalPKCS8PrivateKey(key)
+	require.NoError(t, err)
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: keyDER})
+	expiration := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name       string
+		master     bool
+		reload     bool
+		invalidKey bool
+		nilGauge   bool
+	}{
+		{name: "master loads existing client certificate", master: true},
+		{name: "non-master loads existing client certificate"},
+		{name: "reload updates client expiration", reload: true},
+		{name: "invalid key leaves metric unchanged", invalidKey: true},
+		{name: "missing gauge does not interrupt certificate loading", nilGauge: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previousAccess := ManagerAccess
+			previousBootstrapAccess := bootstrap.ManagerAccess
+			previousGauge := bootstrap.CertExpirationMetric
+			previousRegisterer := prometheus.DefaultRegisterer
+			t.Cleanup(func() {
+				ManagerAccess = previousAccess
+				bootstrap.ManagerAccess = previousBootstrapAccess
+				bootstrap.CertExpirationMetric = previousGauge
+				prometheus.DefaultRegisterer = previousRegisterer
+			})
+
+			registry := prometheus.NewRegistry()
+			prometheus.DefaultRegisterer = registry
+			conf := &conftypes.Config{
+				EnableTLS:        true,
+				DisableBootstrap: true,
+				IsMasterPod:      tt.master,
+				MetricsNamespace: conftypes.DefaultMetricsNamespace,
+				Temporal: conftypes.TemporalConfig{
+					TemporalCertPath: t.TempDir(),
+				},
+			}
+			data := &elektratypes.Elektra{Log: zerolog.Nop()}
+			managerConf := &managerapi.ManagerConf{EB: conf}
+			bootstrap.NewBootstrapManager(data, nil, managerConf).Init()
+			NewWorkflowManager(data, nil, managerConf)
+			gauge := bootstrap.CertExpirationMetric
+			gaugeValue := func() float64 {
+				t.Helper()
+				metric := &dto.Metric{}
+				writeErr := gauge.Write(metric)
+				require.NoError(t, writeErr)
+				return metric.GetGauge().GetValue()
+			}
+			require.Zero(t, gaugeValue())
+			if tt.nilGauge {
+				bootstrap.CertExpirationMetric = nil
+			}
+
+			writeCertificate := func(notAfter time.Time) {
+				t.Helper()
+				cert := &x509.Certificate{
+					SerialNumber: big.NewInt(notAfter.Unix()),
+					NotBefore:    ca.NotBefore,
+					NotAfter:     notAfter,
+					KeyUsage:     x509.KeyUsageDigitalSignature,
+					ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+				}
+				certDER, certErr := x509.CreateCertificate(rand.Reader, cert, ca, publicKey, caKey)
+				require.NoError(t, certErr)
+				chain := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+				chain = append(chain, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caDER})...)
+				certErr = os.WriteFile(conf.Temporal.GetTemporalClientCertFullPath(), chain, 0600)
+				require.NoError(t, certErr)
+			}
+			err = os.MkdirAll(filepath.Dir(conf.Temporal.GetTemporalClientCertFullPath()), 0700)
+			require.NoError(t, err)
+			writeCertificate(expiration)
+			err = os.WriteFile(conf.Temporal.GetTemporalClientKeyFullPath(), keyPEM, 0600)
+			require.NoError(t, err)
+			if tt.invalidKey {
+				err = os.WriteFile(conf.Temporal.GetTemporalClientKeyFullPath(), []byte("invalid PEM"), 0600)
+				require.NoError(t, err)
+			}
+
+			// Omit the CA file to stop after loading the client certificate, before
+			// dialing Temporal. The chain has different leaf and CA expirations.
+			loadErr := workflowOrchestrator()
+			if tt.invalidKey {
+				require.ErrorContains(t, loadErr, "PEM data in key input")
+				assert.Zero(t, gaugeValue())
+				return
+			}
+			var pathErr *os.PathError
+			require.ErrorAs(t, loadErr, &pathErr)
+			assert.Equal(t, filepath.Join(conf.Temporal.TemporalCertPath, "ca", "ca.crt"), pathErr.Path)
+			if tt.nilGauge {
+				assert.Zero(t, gaugeValue())
+				return
+			}
+			assert.Equal(t, float64(expiration.Unix()), gaugeValue())
+			metrics, gatherErr := registry.Gather()
+			require.NoError(t, gatherErr)
+			require.Len(t, metrics, 1)
+			assert.Equal(t, "nico_rest_site_agent_temporal_cert_expiration", metrics[0].GetName())
+			if tt.reload {
+				newExpiration := expiration.Add(24 * time.Hour)
+				writeCertificate(newExpiration)
+				loadErr = workflowOrchestrator()
+				require.ErrorAs(t, loadErr, &pathErr)
+				assert.Equal(t, float64(newExpiration.Unix()), gaugeValue())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Update the existing expiration metric whenever a Site Agent pod loads or reloads its Temporal client certificate, including when credentials already exist at startup. Previously, the metric was set only during credential download and used the CA certificate expiration.

- Read expiration from the loaded client certificate instead of the CA.
- Move the gauge declaration and registration into workflow.Init alongside the other workflow metrics, keeping the metric name, namespace, and help text unchanged.
- If a replacement client certificate cannot be loaded, the metric retains its previous value.

## Related issues
Internal

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
None.

## Testing
- [x] Unit tests added/updated
- Site Agent test suite passed with race detection (`make test-site-agent`).
- Seven test cases cover master/non-master loading, successful and failed reloads, loading and reloading with GODEBUG=x509keypairleaf=0, invalid keys, and a missing gauge.
- Tests initialize workflow and verify the client certificate expiration and unchanged metric name among its four registered metrics.
- Kubernetes Secret watcher delivery was not integration-tested.
- Strict lint: 53 pre-existing findings; none in the added or modified lines.