### PR TITLE
test(integration): wait for power health convergence

### DIFF
--- a/crates/api-test-helper/src/instance.rs
+++ b/crates/api-test-helper/src/instance.rs
@@ -16,6 +16,7 @@
  */
 
 use std::net::SocketAddr;
+use std::time::Duration;
 
 use carbide_uuid::machine::{MachineId, StableHostMachineId};
 use eyre::{ContextCompat, WrapErr};
@@ -28,8 +29,35 @@ use rpc::forge::{
     InstancesByIdsRequest, InterfaceFunctionType, Metadata, TenantConfig, TenantState,
 };
 
-use super::machine::wait_for_state;
+use super::machine::{get_by_id as get_machine_by_id, wait_for_state};
 use crate::api_client;
+
+const POWERED_OFF_ALERT_CLEAR_RETRIES: usize = 60;
+
+async fn wait_for_powered_off_alert_to_clear(
+    addrs: &[SocketAddr],
+    host_machine_id: &StableHostMachineId,
+) -> eyre::Result<()> {
+    let machine_id = MachineId::from(host_machine_id);
+
+    for _ in 0..POWERED_OFF_ALERT_CLEAR_RETRIES {
+        let machine = get_machine_by_id(addrs, &machine_id).await?;
+
+        let powered_off = machine
+            .status
+            .as_ref()
+            .and_then(|status| status.health.as_ref())
+            .is_some_and(|health| health.alerts.iter().any(|alert| alert.id == "PoweredOff"));
+
+        if !powered_off {
+            return Ok(());
+        }
+
+        tokio::time::sleep(Duration::from_millis(500)).await;
+    }
+
+    eyre::bail!("machine {host_machine_id} still has a PoweredOff health alert")
+}
 
 pub async fn create(
     addrs: &[SocketAddr],
@@ -100,6 +128,8 @@ async fn create_with_network(
     wait_until_ready: bool,
     keyset_ids: &[&str],
 ) -> eyre::Result<String> {
+    wait_for_powered_off_alert_to_clear(addrs, host_machine_id).await?;
+
     let request = InstanceAllocationRequest {
         machine_id: Some(*host_machine_id),
         config: Some(InstanceConfig {
@@ -194,6 +224,9 @@ pub async fn create_with_vpc_prefixes(
         ipv6_interface_config,
         ..Default::default()
     };
+
+    wait_for_powered_off_alert_to_clear(addrs, host_machine_id).await?;
+
     let request = InstanceAllocationRequest {
         machine_id: Some(*host_machine_id),
         config: Some(InstanceConfig {


### PR DESCRIPTION
Integration allocation can begin after a simulated machine reaches `Ready` while Site Explorer still reports a transient `PoweredOff` alert. Health admission then rejects the allocation.

The instance test helper now polls up to 60 times at 500 ms intervals for that specific alert to clear before allocation. Other health alerts remain subject to normal admission checks, and a persistent `PoweredOff` alert fails the test helper.

## Related Issues

Fixes #5996

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)