### PR TITLE
feat(vpc): allow exact VNIs when changing routing profiles

### DIFF
--- a/crates/api-core/src/handlers/vpc.rs
+++ b/crates/api-core/src/handlers/vpc.rs
@@ -366,9 +366,26 @@ pub(crate) async fn change_routing_profile(
     }
     // The active VNI becomes retained and must remain releasable too.
     validate_transition_vni(allocations.active_vni)?;
-    let destination_vni = match allocations.inactive {
-        Some((_, vni)) => vni,
-        None => {
+    if change.vni == Some(allocations.active_vni) {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "requested VNI `{}` is already active on this VPC",
+            allocations.active_vni,
+        ))
+        .into());
+    }
+    let destination_vni = match (allocations.inactive, change.vni) {
+        (Some((_, retained_vni)), Some(requested_vni)) if retained_vni != requested_vni => {
+            return Err(CarbideError::FailedPrecondition(format!(
+                "requested VNI `{requested_vni}` must match retained VNI `{retained_vni}` in pool `{}`",
+                destination_pool.name(),
+            ))
+            .into());
+        }
+        (Some((_, vni)), _) => vni,
+        (None, Some(vni)) => {
+            allocate_exact_vpc_vni(destination_pool, &mut txn, &vpc.id.to_string(), vni).await?
+        }
+        (None, None) => {
             allocate_vpc_vni(
                 api,
                 &mut txn,
@@ -999,6 +1016,37 @@ async fn allocate_vpc_vni(
             Err(err.into())
         }
     }
+}
+
+/// `allocate_exact_vpc_vni` claims a requested VNI from the already validated pool.
+/// Unlike VPC creation, routing changes accept either assignment partition.
+async fn allocate_exact_vpc_vni(
+    pool: &resource_pool::ResourcePool<i32>,
+    txn: &mut PgConnection,
+    owner_id: &str,
+    vni: i32,
+) -> Result<i32, CarbideError> {
+    db::resource_pool::allocate_exact(pool, txn, resource_pool::OwnerType::Vpc, owner_id, vni)
+        .await
+        .map_err(|error| {
+            if matches!(error, db::DatabaseError::FailedPrecondition(_)) {
+                db::resource_pool::emit_requested_vni_unavailable(
+                    pool.value_type,
+                    owner_id,
+                    vni,
+                    pool.name(),
+                );
+            } else {
+                db::resource_pool::emit_database_allocation_failure(
+                    pool.value_type,
+                    owner_id,
+                    true,
+                    pool.name(),
+                    &error,
+                );
+            }
+            CarbideError::from(error)
+        })
 }
 
 /// Resolution of routing-related state for a VPC at create time. The

--- a/crates/api-core/src/tests/vpc.rs
+++ b/crates/api-core/src/tests/vpc.rs
@@ -187,6 +187,18 @@ async fn change_vpc_routing_profile_retains_allocations_and_creation_intent(
             .as_ref()
             .and_then(|status| status.vni)
             .expect("active VNI");
+        let destination_vni = if requested_vni.is_some() {
+            let (_, value, _) = vpc_vni_pool_state(&env)
+                .await?
+                .into_iter()
+                .find(|(name, _, state)| {
+                    name == external_pool && state.0 == ResourcePoolEntryState::Free
+                })
+                .expect("free automatic external VNI");
+            Some(value.parse::<u32>()?)
+        } else {
+            None
+        };
         let forward = env
             .api
             .change_vpc_routing_profile(tonic::Request::new(
@@ -194,6 +206,7 @@ async fn change_vpc_routing_profile_retains_allocations_and_creation_intent(
                     id: Some(vpc_id),
                     if_version_match: Some(before.version.clone()),
                     routing_profile_type: "EXTERNAL".to_string(),
+                    vni: destination_vni,
                 },
             ))
             .await?
@@ -201,6 +214,9 @@ async fn change_vpc_routing_profile_retains_allocations_and_creation_intent(
         assert_eq!(forward.id, Some(vpc_id));
         assert_eq!(forward.routing_profile_type.as_deref(), Some("EXTERNAL"));
         assert_ne!(forward.active_vni, internal_vni);
+        if let Some(vni) = destination_vni {
+            assert_eq!(forward.active_vni, vni);
+        }
         assert_eq!(
             forward.retained_allocation,
             Some(rpc::forge::VpcRetainedVniAllocation {
@@ -244,6 +260,29 @@ async fn change_vpc_routing_profile_retains_allocations_and_creation_intent(
                 .await?;
         }
         let allocations_before_reverse = vpc_vni_pool_state(&env).await?;
+        if requested_vni.is_some() {
+            let other_vni = internal_vni + 1;
+            assert_eq!(
+                resource_pool_entry_state(&env, internal_pool, i32::try_from(other_vni)?).await?,
+                ResourcePoolEntryState::Free
+            );
+            let error = env
+                .api
+                .change_vpc_routing_profile(tonic::Request::new(
+                    rpc::forge::VpcChangeRoutingProfileRequest {
+                        id: Some(vpc_id),
+                        if_version_match: Some(forward.version.clone()),
+                        routing_profile_type: "INTERNAL".to_string(),
+                        vni: Some(other_vni),
+                    },
+                ))
+                .await
+                .expect_err("a free VNI cannot replace a retained allocation");
+            assert_eq!(error.code(), tonic::Code::FailedPrecondition);
+            assert!(error.message().contains(&other_vni.to_string()), "{error}");
+            assert_eq!(find_test_vpc(&env, vpc_id).await?, after);
+            assert_eq!(vpc_vni_pool_state(&env).await?, allocations_before_reverse);
+        }
         let reverse = env
             .api
             .change_vpc_routing_profile(tonic::Request::new(
@@ -251,6 +290,7 @@ async fn change_vpc_routing_profile_retains_allocations_and_creation_intent(
                     id: Some(vpc_id),
                     if_version_match: Some(forward.version),
                     routing_profile_type: "INTERNAL".to_string(),
+                    vni: requested_vni.map(|_| internal_vni),
                 },
             ))
             .await?
@@ -298,6 +338,7 @@ async fn change_vpc_routing_profile_rechecks_tenant_access_for_retained_vni(
                 id: Some(vpc_id),
                 if_version_match: Some(created.version),
                 routing_profile_type: "EXTERNAL".to_string(),
+                vni: None,
             },
         ))
         .await?
@@ -311,6 +352,7 @@ async fn change_vpc_routing_profile_rechecks_tenant_access_for_retained_vni(
                 id: Some(vpc_id),
                 if_version_match: Some(forward.version),
                 routing_profile_type: "INTERNAL".to_string(),
+                vni: None,
             },
         ))
         .await
@@ -340,20 +382,100 @@ async fn change_vpc_routing_profile_rolls_back_allocation_on_write_failure(
     sqlx::query("ALTER TABLE vpcs ADD CONSTRAINT reject_profile_change CHECK (routing_profile_type <> 'EXTERNAL') NOT VALID")
         .execute(&env.pool)
         .await?;
-    let error = env
-        .api
-        .change_vpc_routing_profile(tonic::Request::new(
-            rpc::forge::VpcChangeRoutingProfileRequest {
-                id: Some(vpc_id),
-                if_version_match: Some(before.version.clone()),
-                routing_profile_type: "EXTERNAL".to_string(),
-            },
-        ))
-        .await
-        .expect_err("injected VPC write failure");
-    assert!(error.message().contains("reject_profile_change"), "{error}");
-    assert_eq!(find_test_vpc(&env, vpc_id).await?, before);
-    assert_eq!(vpc_vni_pool_state(&env).await?, allocations_before);
+    for vni in [None, Some(50001)] {
+        let error = env
+            .api
+            .change_vpc_routing_profile(tonic::Request::new(
+                rpc::forge::VpcChangeRoutingProfileRequest {
+                    id: Some(vpc_id),
+                    if_version_match: Some(before.version.clone()),
+                    routing_profile_type: "EXTERNAL".to_string(),
+                    vni,
+                },
+            ))
+            .await
+            .expect_err("injected VPC write failure");
+        assert!(
+            error.message().contains("reject_profile_change"),
+            "{vni:?}: {error}"
+        );
+        assert_eq!(find_test_vpc(&env, vpc_id).await?, before, "{vni:?}");
+        assert_eq!(
+            vpc_vni_pool_state(&env).await?,
+            allocations_before,
+            "{vni:?}"
+        );
+    }
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn change_vpc_routing_profile_rejects_unavailable_exact_vni_without_changes(
+    pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    struct Case<'a> {
+        scenario: &'static str,
+        vni: u32,
+        message_contains: &'a str,
+    }
+
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+    let before = create_routing_profile_vpc(&env, "unavailable-exact-vni", None).await?;
+    let vpc_id = before.id.expect("VPC ID");
+    let active_vni = before
+        .status
+        .as_ref()
+        .and_then(|status| status.vni)
+        .expect("active VNI");
+    let allocations_before = vpc_vni_pool_state(&env).await?;
+
+    for case in [
+        Case {
+            scenario: "missing destination value",
+            vni: 50000,
+            message_contains: env.common_pools.ethernet.pool_external_vpc_vni.name(),
+        },
+        Case {
+            scenario: "already active",
+            vni: active_vni,
+            message_contains: "already active",
+        },
+    ] {
+        let scenario = case.scenario;
+        let error = env
+            .api
+            .change_vpc_routing_profile(tonic::Request::new(
+                rpc::forge::VpcChangeRoutingProfileRequest {
+                    id: Some(vpc_id),
+                    if_version_match: Some(before.version.clone()),
+                    routing_profile_type: "EXTERNAL".to_string(),
+                    vni: Some(case.vni),
+                },
+            ))
+            .await
+            .expect_err(scenario);
+        assert_eq!(
+            error.code(),
+            tonic::Code::FailedPrecondition,
+            "{scenario}: {error}"
+        );
+        assert!(
+            error.message().contains(&case.vni.to_string()),
+            "{scenario}: {error}"
+        );
+        assert!(
+            error.message().contains(case.message_contains),
+            "{scenario}: {error}"
+        );
+        assert_eq!(find_test_vpc(&env, vpc_id).await?, before, "{scenario}");
+        assert_eq!(
+            vpc_vni_pool_state(&env).await?,
+            allocations_before,
+            "{scenario}"
+        );
+    }
     Ok(())
 }
 
@@ -538,6 +660,7 @@ async fn change_vpc_routing_profile_rejects_unsupported_state_without_changes(
                     id: Some(vpc_id),
                     if_version_match: Some(before.version.clone()),
                     routing_profile_type: expected.destination.to_string(),
+                    vni: None,
                 },
             ))
             .await
@@ -608,6 +731,7 @@ async fn change_vpc_routing_profile_same_version_commits_once(
         id: Some(vpc_id),
         if_version_match: Some(before.version.clone()),
         routing_profile_type: "EXTERNAL".to_string(),
+        vni: None,
     };
     let (first, second) = tokio::join!(
         env.api
@@ -643,6 +767,69 @@ async fn change_vpc_routing_profile_same_version_commits_once(
 }
 
 #[crate::sqlx_test]
+async fn change_vpc_routing_profile_exact_vni_has_one_owner_under_concurrent_requests(
+    pool: sqlx::PgPool,
+) -> Result<(), eyre::Report> {
+    let env =
+        create_test_env_with_overrides(pool, TestEnvOverrides::default().with_fnn_config(None))
+            .await;
+    let before = [
+        create_routing_profile_vpc(&env, "first-exact-vni-request", None).await?,
+        create_routing_profile_vpc(&env, "second-exact-vni-request", None).await?,
+    ];
+    let external_pool = env.common_pools.ethernet.pool_external_vpc_vni.name();
+    let mut expected_allocations = vpc_vni_pool_state(&env).await?;
+    let requested_vni = 50001;
+    let requests = before
+        .each_ref()
+        .map(|vpc| rpc::forge::VpcChangeRoutingProfileRequest {
+            id: vpc.id,
+            if_version_match: Some(vpc.version.clone()),
+            routing_profile_type: "EXTERNAL".to_string(),
+            vni: Some(requested_vni),
+        });
+    let (first, second) = tokio::join!(
+        env.api
+            .change_vpc_routing_profile(tonic::Request::new(requests[0].clone())),
+        env.api
+            .change_vpc_routing_profile(tonic::Request::new(requests[1].clone())),
+    );
+    let (winner, changed, rejected) = match (first, second) {
+        (Ok(changed), Err(rejected)) => (0, changed.into_inner(), rejected),
+        (Err(rejected), Ok(changed)) => (1, changed.into_inner(), rejected),
+        other => panic!("exactly one VPC must claim the requested VNI: {other:?}"),
+    };
+    let winner_before = &before[winner];
+    let winner_id = winner_before.id.expect("winning VPC ID");
+    let loser_before = &before[1 - winner];
+    assert_eq!(rejected.code(), tonic::Code::FailedPrecondition);
+    assert!(
+        rejected.message().contains(&requested_vni.to_string()),
+        "{rejected}"
+    );
+    assert!(rejected.message().contains(external_pool), "{rejected}");
+    assert_eq!(changed.id, Some(winner_id));
+    assert_eq!(changed.routing_profile_type.as_deref(), Some("EXTERNAL"));
+    assert_eq!(changed.active_vni, requested_vni);
+    assert_eq!(
+        find_test_vpc(&env, loser_before.id.expect("losing VPC ID")).await?,
+        *loser_before
+    );
+    let (_, _, state) = expected_allocations
+        .iter_mut()
+        .find(|(name, value, _)| name == external_pool && value == &requested_vni.to_string())
+        .expect("requested external VNI");
+    assert_eq!(state.0, ResourcePoolEntryState::Free);
+    *state = sqlx::types::Json(ResourcePoolEntryState::Allocated {
+        owner: winner_id.to_string(),
+        owner_type: OwnerType::Vpc.to_string(),
+    });
+    let allocations_after = vpc_vni_pool_state(&env).await?;
+    assert_eq!(allocations_after, expected_allocations);
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn change_vpc_routing_profile_rejects_site_global_vni(
     pool: sqlx::PgPool,
 ) -> Result<(), eyre::Report> {
@@ -663,6 +850,7 @@ async fn change_vpc_routing_profile_rejects_site_global_vni(
                 id: Some(vpc_id),
                 if_version_match: Some(before.version.clone()),
                 routing_profile_type: "EXTERNAL".to_string(),
+                vni: None,
             },
         ))
         .await
@@ -699,6 +887,7 @@ async fn change_vpc_routing_profile_requires_fnn_configuration(
                 id: Some(vpc_id),
                 if_version_match: Some(before.version.clone()),
                 routing_profile_type: "EXTERNAL".to_string(),
+                vni: None,
             },
         ))
         .await

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -396,6 +396,7 @@ async fn change_vpc_routing_profile_preserves_workload_and_checks_interface_over
         id: Some(vpc_id),
         if_version_match: Some(before.version.clone()),
         routing_profile_type: "EXTERNAL".to_string(),
+        vni: None,
     };
     for case in [
         InterfaceCase {
@@ -492,6 +493,7 @@ async fn change_vpc_routing_profile_preserves_workload_and_checks_interface_over
             id: Some(vpc_id),
             if_version_match: Some(before_reverse.version.clone()),
             routing_profile_type: "INTERNAL".to_string(),
+            vni: None,
         }))
         .await
         .expect_err("new tenant-managed prefix prevents reversal");

--- a/crates/api-db/src/resource_pool.rs
+++ b/crates/api-db/src/resource_pool.rs
@@ -266,7 +266,10 @@ where
     Ok(())
 }
 
-/// Get a resource from the pool
+/// `allocate` reserves a value from the automatic or explicit assignment partition.
+/// An omitted `requested_value` requires `auto_assign=true`; an exact request
+/// requires `auto_assign=false`. Use [`allocate_exact`] when an exact request
+/// may claim a free value from either partition.
 pub async fn allocate<T>(
     value: &ResourcePool<T>,
     txn: &mut PgConnection,
@@ -373,6 +376,50 @@ RETURNING allocate.value
             owner_id: owner_id.to_string(),
         })?;
     Ok(out)
+}
+
+/// `allocate_exact` reserves a specific free value from either assignment partition.
+///
+/// Unlike [`allocate`], this accepts and preserves either `auto_assign` setting.
+/// It records the owner and allocation time, then returns the requested value.
+/// Missing or allocated values return [`DatabaseError::FailedPrecondition`],
+/// including values already reserved by the same owner. Callers must handle
+/// retained allocations separately. The claim participates in the supplied
+/// transaction and waits for conflicting row locks.
+pub async fn allocate_exact<T>(
+    pool: &ResourcePool<T>,
+    txn: &mut PgConnection,
+    owner_type: OwnerType,
+    owner_id: &str,
+    requested_value: T,
+) -> Result<T, DatabaseError>
+where
+    T: ToString + FromStr + Send + Sync + 'static,
+    <T as FromStr>::Err: std::error::Error,
+{
+    let requested_value_text = requested_value.to_string();
+    let allocated_state = ResourcePoolEntryState::Allocated {
+        owner: owner_id.to_string(),
+        owner_type: owner_type.to_string(),
+    };
+    let query = "UPDATE resource_pool SET state = $1, allocated = NOW()
+        WHERE name = $2 AND value = $3 AND state = $4";
+    let result = sqlx::query(query)
+        .bind(sqlx::types::Json(&allocated_state))
+        .bind(pool.name())
+        .bind(&requested_value_text)
+        .bind(sqlx::types::Json(ResourcePoolEntryState::Free))
+        .execute(txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))?;
+    if result.rows_affected() == 0 {
+        return Err(DatabaseError::FailedPrecondition(format!(
+            "`{requested_value_text}` not an available value for resource-pool `{}`",
+            pool.name()
+        )));
+    }
+
+    Ok(requested_value)
 }
 
 /// Returns the value already reserved by one owner in this pool.
@@ -2040,6 +2087,57 @@ mod tests {
         );
 
         txn.rollback().await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn allocate_exact_preserves_assignment_partitions(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let pool_handle =
+            ResourcePool::<i32>::new("test-exact-pool".to_string(), ValueType::Integer);
+        for auto_assign in [true, false] {
+            let mut txn = pool.begin().await?;
+            populate(&pool_handle, &mut txn, vec![41, 42], auto_assign).await?;
+            let allocated =
+                allocate_exact(&pool_handle, &mut txn, OwnerType::Vpc, "owner", 42).await?;
+            assert_eq!(allocated, 42);
+
+            let rows: Vec<(
+                i32,
+                sqlx::types::Json<ResourcePoolEntryState>,
+                Option<bool>,
+                bool,
+            )> = sqlx::query_as(
+                "SELECT value::integer, state, allocated = NOW(), auto_assign
+                     FROM resource_pool WHERE name = $1 ORDER BY value::integer",
+            )
+            .bind(pool_handle.name())
+            .fetch_all(&mut *txn)
+            .await?;
+            assert_eq!(
+                rows,
+                vec![
+                    (
+                        41,
+                        sqlx::types::Json(ResourcePoolEntryState::Free),
+                        None,
+                        auto_assign,
+                    ),
+                    (
+                        42,
+                        sqlx::types::Json(ResourcePoolEntryState::Allocated {
+                            owner: "owner".to_string(),
+                            owner_type: OwnerType::Vpc.to_string(),
+                        }),
+                        Some(true),
+                        auto_assign,
+                    ),
+                ],
+                "auto_assign={auto_assign}",
+            );
+            txn.rollback().await?;
+        }
         Ok(())
     }
 

--- a/crates/api-model/src/vpc/mod.rs
+++ b/crates/api-model/src/vpc/mod.rs
@@ -164,6 +164,9 @@ pub struct ChangeVpcRoutingProfile {
     pub if_version_match: ConfigVersion,
     /// Configuration-defined destination profile name.
     pub routing_profile_type: String,
+    /// Optional exact destination VNI in 1..=16777215. Must match retained
+    /// destination ownership; omission reuses it or allocates automatically.
+    pub vni: Option<i32>,
 }
 
 /// UpdateVpcVirtualization exists as a mechanism to translate

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -10886,9 +10886,10 @@ message VpcRetainedVniAllocation {
 // Changes a supported FNN VPC between configured profiles with opposite
 // internal settings. The destination must satisfy the persisted tenant's
 // access tier (omitted tiers retain the creation-time default of zero).
-// Reuses an existing destination allocation, otherwise automatically selects
-// an available VNI from the destination pool. The previous allocation remains
-// reserved; ReleaseVpcInactiveVni is a separate operator action.
+// Reuses an existing destination allocation, otherwise claims the requested
+// VNI or automatically selects an available VNI from the destination pool.
+// The previous allocation remains reserved; ReleaseVpcInactiveVni is a
+// separate operator action.
 //
 // Requires FNN configuration, named source/destination profiles, distinct
 // nonoverlapping materialized pools, and VNIs in 1..16777215. Site-global VNIs,
@@ -10896,8 +10897,9 @@ message VpcRetainedVniAllocation {
 // attachments are unsupported. Empty override reset objects are allowed.
 // Same-polarity changes and a destination pool already holding the active VNI
 // are rejected. Unsupported configurations and inconsistent ownership fail
-// FAILED_PRECONDITION; missing profiles/VPCs fail NOT_FOUND; pool exhaustion
-// fails RESOURCE_EXHAUSTED. Rejected requests commit no changes.
+// FAILED_PRECONDITION; missing profiles/VPCs fail NOT_FOUND; automatic allocation
+// from an exhausted pool fails RESOURCE_EXHAUSTED. Rejected requests commit
+// no changes.
 //
 // Preserves the VPC ID, prefixes, instances, addresses, NSGs, metadata, and
 // creation-time requested VNI. External routing does not supply public
@@ -10920,4 +10922,15 @@ message VpcChangeRoutingProfileRequest {
   // Required nonempty configuration-defined destination name, not a closed
   // INTERNAL/EXTERNAL enum. Omission or an empty name fails INVALID_ARGUMENT.
   string routing_profile_type = 3;
+  // Optional exact destination VNI. Omission reuses a retained destination,
+  // otherwise allocates automatically. A retained destination must match an
+  // explicit request; a different value fails FAILED_PRECONDITION even if free.
+  // Without a retained destination, the requested value must be a free
+  // materialized destination-pool entry, regardless of its auto_assign flag.
+  // Missing or occupied entries and the active VNI fail FAILED_PRECONDITION
+  // without falling back. Zero and values above 16777215 fail INVALID_ARGUMENT.
+  // Use only when every serving Core supports this field: older Core ignores
+  // it and may choose another VNI. Verify the returned profile and active VNI;
+  // a mismatched or lost response does not undo a committed change.
+  optional uint32 vni = 4;
 }

--- a/crates/rpc/src/model/vpc.rs
+++ b/crates/rpc/src/model/vpc.rs
@@ -367,10 +367,24 @@ impl TryFrom<rpc::forge::VpcChangeRoutingProfileRequest> for ChangeVpcRoutingPro
                 "routing_profile_type must not be empty".to_string(),
             ));
         }
+        let vni = request
+            .vni
+            .map(|vni| {
+                i32::try_from(vni)
+                    .ok()
+                    .filter(|vni| (1..=0x00ff_ffff).contains(vni))
+                    .ok_or_else(|| {
+                        RpcDataConversionError::InvalidArgument(format!(
+                            "requested VNI `{vni}` must be between 1 and 16777215"
+                        ))
+                    })
+            })
+            .transpose()?;
         Ok(Self {
             id,
             if_version_match,
             routing_profile_type: request.routing_profile_type,
+            vni,
         })
     }
 }
@@ -417,6 +431,7 @@ mod tests {
             id: Some(vpc_id),
             if_version_match: Some("V1-T0".to_string()),
             routing_profile_type: "PARTNER".to_string(),
+            vni: None,
         };
         value_scenarios!(
             run = |input| ChangeVpcRoutingProfile::try_from(input)
@@ -426,6 +441,7 @@ mod tests {
                     id: vpc_id,
                     if_version_match: "V1-T0".parse().unwrap(),
                     routing_profile_type: "PARTNER".to_string(),
+                    vni: None,
                 }),
             }
             "missing ID" {
@@ -447,6 +463,31 @@ mod tests {
                 rpc::forge::VpcChangeRoutingProfileRequest {
                     routing_profile_type: String::new(), ..request
                 } => Err(tonic::Code::InvalidArgument),
+            }
+        );
+    }
+
+    #[test]
+    fn vpc_routing_change_validates_requested_vni() {
+        value_scenarios!(
+            run = |vni| ChangeVpcRoutingProfile::try_from(
+                rpc::forge::VpcChangeRoutingProfileRequest {
+                    id: Some(VpcId::new()),
+                    if_version_match: Some("V1-T0".to_string()),
+                    routing_profile_type: "EXTERNAL".to_string(),
+                    vni: Some(vni),
+                }
+            )
+            .map(|change| change.vni)
+            .map_err(|error| tonic::Status::from(error).code());
+            "valid exact VNI boundaries" {
+                1 => Ok(Some(1)),
+                16_777_215 => Ok(Some(16_777_215)),
+            }
+            "invalid exact VNI" {
+                0 => Err(tonic::Code::InvalidArgument),
+                16_777_216 => Err(tonic::Code::InvalidArgument),
+                u32::MAX => Err(tonic::Code::InvalidArgument),
             }
         );
     }

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -64473,9 +64473,10 @@ func (x *VpcRetainedVniAllocation) GetVni() uint32 {
 // Changes a supported FNN VPC between configured profiles with opposite
 // internal settings. The destination must satisfy the persisted tenant's
 // access tier (omitted tiers retain the creation-time default of zero).
-// Reuses an existing destination allocation, otherwise automatically selects
-// an available VNI from the destination pool. The previous allocation remains
-// reserved; ReleaseVpcInactiveVni is a separate operator action.
+// Reuses an existing destination allocation, otherwise claims the requested
+// VNI or automatically selects an available VNI from the destination pool.
+// The previous allocation remains reserved; ReleaseVpcInactiveVni is a
+// separate operator action.
 //
 // Requires FNN configuration, named source/destination profiles, distinct
 // nonoverlapping materialized pools, and VNIs in 1..16777215. Site-global VNIs,
@@ -64483,8 +64484,9 @@ func (x *VpcRetainedVniAllocation) GetVni() uint32 {
 // attachments are unsupported. Empty override reset objects are allowed.
 // Same-polarity changes and a destination pool already holding the active VNI
 // are rejected. Unsupported configurations and inconsistent ownership fail
-// FAILED_PRECONDITION; missing profiles/VPCs fail NOT_FOUND; pool exhaustion
-// fails RESOURCE_EXHAUSTED. Rejected requests commit no changes.
+// FAILED_PRECONDITION; missing profiles/VPCs fail NOT_FOUND; automatic allocation
+// from an exhausted pool fails RESOURCE_EXHAUSTED. Rejected requests commit
+// no changes.
 //
 // Preserves the VPC ID, prefixes, instances, addresses, NSGs, metadata, and
 // creation-time requested VNI. External routing does not supply public
@@ -64508,8 +64510,19 @@ type VpcChangeRoutingProfileRequest struct {
 	// Required nonempty configuration-defined destination name, not a closed
 	// INTERNAL/EXTERNAL enum. Omission or an empty name fails INVALID_ARGUMENT.
 	RoutingProfileType string `protobuf:"bytes,3,opt,name=routing_profile_type,json=routingProfileType,proto3" json:"routing_profile_type,omitempty"`
-	unknownFields      protoimpl.UnknownFields
-	sizeCache          protoimpl.SizeCache
+	// Optional exact destination VNI. Omission reuses a retained destination,
+	// otherwise allocates automatically. A retained destination must match an
+	// explicit request; a different value fails FAILED_PRECONDITION even if free.
+	// Without a retained destination, the requested value must be a free
+	// materialized destination-pool entry, regardless of its auto_assign flag.
+	// Missing or occupied entries and the active VNI fail FAILED_PRECONDITION
+	// without falling back. Zero and values above 16777215 fail INVALID_ARGUMENT.
+	// Use only when every serving Core supports this field: older Core ignores
+	// it and may choose another VNI. Verify the returned profile and active VNI;
+	// a mismatched or lost response does not undo a committed change.
+	Vni           *uint32 `protobuf:"varint,4,opt,name=vni,proto3,oneof" json:"vni,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
 }
 
 func (x *VpcChangeRoutingProfileRequest) Reset() {
@@ -64561,6 +64574,13 @@ func (x *VpcChangeRoutingProfileRequest) GetRoutingProfileType() string {
 		return x.RoutingProfileType
 	}
 	return ""
+}
+
+func (x *VpcChangeRoutingProfileRequest) GetVni() uint32 {
+	if x != nil && x.Vni != nil {
+		return *x.Vni
+	}
+	return 0
 }
 
 type DNSMessage_DNSQuestion struct {
@@ -71705,12 +71725,14 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x15_routing_profile_type\"I\n" +
 	"\x18VpcRetainedVniAllocation\x12\x1b\n" +
 	"\tpool_name\x18\x01 \x01(\tR\bpoolName\x12\x10\n" +
-	"\x03vni\x18\x02 \x01(\rR\x03vni\"\xb5\x01\n" +
+	"\x03vni\x18\x02 \x01(\rR\x03vni\"\xd4\x01\n" +
 	"\x1eVpcChangeRoutingProfileRequest\x12\x1d\n" +
 	"\x02id\x18\x01 \x01(\v2\r.common.VpcIdR\x02id\x12-\n" +
 	"\x10if_version_match\x18\x02 \x01(\tH\x00R\x0eifVersionMatch\x88\x01\x01\x120\n" +
-	"\x14routing_profile_type\x18\x03 \x01(\tR\x12routingProfileTypeB\x13\n" +
-	"\x11_if_version_match*s\n" +
+	"\x14routing_profile_type\x18\x03 \x01(\tR\x12routingProfileType\x12\x15\n" +
+	"\x03vni\x18\x04 \x01(\rH\x01R\x03vni\x88\x01\x01B\x13\n" +
+	"\x11_if_version_matchB\x06\n" +
+	"\x04_vni*s\n" +
 	"\x15SpdmAttestationStatus\x12\x18\n" +
 	"\x14SPDM_ATT_IN_PROGRESS\x10\x00\x12\x16\n" +
 	"\x12SPDM_ATT_CANCELLED\x10\x01\x12\x13\n" +

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -10464,9 +10464,10 @@ message VpcRetainedVniAllocation {
 // Changes a supported FNN VPC between configured profiles with opposite
 // internal settings. The destination must satisfy the persisted tenant's
 // access tier (omitted tiers retain the creation-time default of zero).
-// Reuses an existing destination allocation, otherwise automatically selects
-// an available VNI from the destination pool. The previous allocation remains
-// reserved; ReleaseVpcInactiveVni is a separate operator action.
+// Reuses an existing destination allocation, otherwise claims the requested
+// VNI or automatically selects an available VNI from the destination pool.
+// The previous allocation remains reserved; ReleaseVpcInactiveVni is a
+// separate operator action.
 //
 // Requires FNN configuration, named source/destination profiles, distinct
 // nonoverlapping materialized pools, and VNIs in 1..16777215. Site-global VNIs,
@@ -10474,8 +10475,9 @@ message VpcRetainedVniAllocation {
 // attachments are unsupported. Empty override reset objects are allowed.
 // Same-polarity changes and a destination pool already holding the active VNI
 // are rejected. Unsupported configurations and inconsistent ownership fail
-// FAILED_PRECONDITION; missing profiles/VPCs fail NOT_FOUND; pool exhaustion
-// fails RESOURCE_EXHAUSTED. Rejected requests commit no changes.
+// FAILED_PRECONDITION; missing profiles/VPCs fail NOT_FOUND; automatic allocation
+// from an exhausted pool fails RESOURCE_EXHAUSTED. Rejected requests commit
+// no changes.
 //
 // Preserves the VPC ID, prefixes, instances, addresses, NSGs, metadata, and
 // creation-time requested VNI. External routing does not supply public
@@ -10498,4 +10500,15 @@ message VpcChangeRoutingProfileRequest {
   // Required nonempty configuration-defined destination name, not a closed
   // INTERNAL/EXTERNAL enum. Omission or an empty name fails INVALID_ARGUMENT.
   string routing_profile_type = 3;
+  // Optional exact destination VNI. Omission reuses a retained destination,
+  // otherwise allocates automatically. A retained destination must match an
+  // explicit request; a different value fails FAILED_PRECONDITION even if free.
+  // Without a retained destination, the requested value must be a free
+  // materialized destination-pool entry, regardless of its auto_assign flag.
+  // Missing or occupied entries and the active VNI fail FAILED_PRECONDITION
+  // without falling back. Zero and values above 16777215 fail INVALID_ARGUMENT.
+  // Use only when every serving Core supports this field: older Core ignores
+  // it and may choose another VNI. Verify the returned profile and active VNI;
+  // a mismatched or lost response does not undo a committed change.
+  optional uint32 vni = 4;
 }


### PR DESCRIPTION
`ChangeVpcRoutingProfile` currently reuses a retained VNI or allocates one automatically. Add an optional `vni` so an operator can request a specific value from the destination pool.

If a destination VNI is already retained, require an exact request to match it. Otherwise, claim the requested free pool entry regardless of its `auto_assign` flag, without changing the generic allocator's behavior. Rejected requests leave the VPC and both pools unchanged.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5816

## Type of Change

- [x] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable pre-fix tree. A bounded final review verified the accepted changes and the complete final diff.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 9 | 6 | 3 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **9** | **6** | **3** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted** -- Exact allocation and its Event/error handling now use a helper beside the existing VPC allocator, accepting the already selected pool.
2. **Adopted** -- Requesting the active VNI returns `FailedPrecondition`; numeric invalidity remains `InvalidArgument`.
3. **Declined** -- Existing creation errors describe different allocation eligibility. Changing those unchanged paths isn't needed here; the new error identifies the requested value and pool.
4. **Adopted** -- The generic allocator documents its `auto_assign` rules and links to `allocate_exact`.
5. **Declined** -- Same-owner occupancy has no separate allocator branch, and Core handles retained ownership before allocation. Existing occupied-row and retained tests cover the relevant behavior.
6. **Declined** -- The manual's explanation of VNI assignment ranges belongs to the existing separate documentation task #5819.
7. **Adopted** -- The operation's documentation now distinguishes automatic pool exhaustion from an unavailable exact VNI.
8. **Adopted** -- Removed unnecessary reverse iteration when selecting a free test VNI.
9. **Adopted** -- Rejection cases state their expected message fragment directly, replacing the inferred conditional and redundant status field.

### common-nits-reviewer

No findings.

</details>

Closes #5816
