### PR TITLE
fix(nico-api): serialize IPv6 address assignment

### DIFF
--- a/crates/api-core/src/dhcp/discover.rs
+++ b/crates/api-core/src/dhcp/discover.rs
@@ -19,6 +19,7 @@ use std::net::{IpAddr, Ipv4Addr};
 use ::rpc::forge as rpc;
 use carbide_network::ip::{IdentifyAddressFamily, IpAddressFamily};
 use carbide_uuid::machine::HostMachineId;
+use carbide_uuid::network::NetworkSegmentId;
 use db::dhcp_entry::DhcpEntry;
 use db::{self, expected_machine, machine_interface};
 use mac_address::MacAddress;
@@ -258,25 +259,54 @@ async fn ensure_dhcp_address_for_family(
     segment: &NetworkSegment,
     parsed_mac: MacAddress,
     address_family: IpAddressFamily,
+    locked_segment_ids: &[NetworkSegmentId],
 ) -> Result<(), CarbideError> {
-    let existing_allocation_type = db::machine_interface_address::find_allocation_type_for_family(
+    let mut existing_allocation_type =
+        db::machine_interface_address::find_allocation_type_for_family(
+            &mut *txn,
+            machine_interface.id,
+            address_family,
+        )
+        .await?;
+
+    // Fixed preallocation may already have assigned an authoritative address.
+    if matches!(
+        existing_allocation_type,
+        Some(AllocationType::Dhcp | AllocationType::Static)
+    ) {
+        return Ok(());
+    }
+
+    if !locked_segment_ids.contains(&segment.id) {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "network segment {} changed during DHCP interface reconciliation",
+            segment.id,
+        )));
+    }
+
+    // The segment is already locked. Both families need the interface lock
+    // before inserting: otherwise the insert can wait on a static writer's
+    // parent lock while that writer waits on our address-family index entry.
+    let current_segment_id =
+        db::machine_interface::lock_for_address_assignment(&mut *txn, machine_interface.id).await?;
+    existing_allocation_type = db::machine_interface_address::find_allocation_type_for_family(
         &mut *txn,
         machine_interface.id,
         address_family,
     )
     .await?;
+    if current_segment_id != segment.id
+        && matches!(existing_allocation_type, None | Some(AllocationType::Slaac))
+    {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "network segment changed for interface {} during DHCP allocation",
+            machine_interface.id,
+        )));
+    }
 
     match existing_allocation_type {
         None => {}
         Some(AllocationType::Slaac) if address_family == IpAddressFamily::Ipv6 => {
-            // Take the segment lock before dropping the SLAAC row so the
-            // delete-then-allocate pair holds locks in the allocator order
-            // (segment advisory lock first, then address rows).
-            db::machine_interface::lock_network_segments_exclusive(
-                &mut *txn,
-                std::slice::from_ref(&segment.id),
-            )
-            .await?;
             db::machine_interface_address::delete_by_interface_family(
                 &mut *txn,
                 machine_interface.id,
@@ -519,136 +549,178 @@ pub(crate) async fn discover_dhcp(
     };
 
     let existing_machine_id =
-        match db::machine::find_existing_machine(&mut txn, parsed_mac, parsed_relay).await? {
-            Some(existing_machine) => Some(existing_machine),
-            None => {
-                if let Some(predicted_interface) =
-                    db::predicted_machine_interface::find_by_mac_address(&mut txn, parsed_mac)
-                        .await?
+        db::machine::find_existing_machine(&mut txn, parsed_mac, parsed_relay).await?;
+    let predicted_interface = if existing_machine_id.is_none() {
+        db::predicted_machine_interface::find_by_mac_address(&mut txn, parsed_mac).await?
+    } else {
+        None
+    };
+
+    // Promotion and expected-interface reconciliation can update interface
+    // rows before address allocation. Take the allocator locks first, including
+    // relay candidates that a concurrent first DHCP request may have selected.
+    // INFO_REQUEST needs no allocator lock unless it will promote a prediction.
+    let locked_segment_ids = if !is_v6_observation || predicted_interface.is_some() {
+        let mut segment_ids =
+            db::network_segment::for_relay_all(&mut txn, std::slice::from_ref(&parsed_relay))
+                .await?
+                .into_iter()
+                .map(|segment| segment.id)
+                .collect::<Vec<_>>();
+        segment_ids.extend(
+            db::machine_interface::find_by_mac_address(&mut txn, parsed_mac)
+                .await?
+                .into_iter()
+                .map(|interface| interface.segment_id),
+        );
+        if predicted_interface.is_some() {
+            // Primary-interface changes also participate in admin-address
+            // reconciliation. Acquire that lock set in the same sorted pass.
+            segment_ids.extend(
+                db::network_segment::list_segment_ids(&mut txn, Some(NetworkSegmentType::Admin))
+                    .await?,
+            );
+        }
+        if address_family == IpAddressFamily::Ipv4 && predicted_interface.is_none() {
+            // DHCPv4 creation filters out IPv6 prefixes before allocation, so
+            // it does not upgrade these shared locks to exclusive locks.
+            db::machine_interface::lock_network_segments_shared(&mut txn, &segment_ids).await?;
+        } else {
+            db::machine_interface::lock_network_segments_exclusive(&mut txn, &segment_ids).await?;
+        }
+        segment_ids
+    } else {
+        Vec::new()
+    };
+
+    let existing_machine_id = match existing_machine_id {
+        Some(existing_machine) => Some(existing_machine),
+        None => {
+            if let Some(predicted_interface) = predicted_interface {
+                if is_v6_observation {
+                    predicted_interface_for_observation = Some(predicted_interface);
+                    None
+                } else {
+                    // remember expected machine id for later rack update
+                    machine_interface::move_predicted_machine_interface_to_machine(
+                        &mut txn,
+                        &predicted_interface,
+                        parsed_relay,
+                        api.runtime_config.retained_boot_interface_window,
+                        &locked_segment_ids,
+                    )
+                    .await?;
+                    Some(predicted_interface.machine_id)
+                }
+            } else {
+                // DPA allocation is currently IPv4-only. The overlay
+                // uses u32 arithmetic (LSB toggle) and /31 linknets,
+                // and the underlay parses relay_address as Ipv4Addr.
+                // Skip the DPA path entirely for IPv6 relays.
+                if address_family == IpAddressFamily::Ipv4
+                    && let Some(resp) = handle_dhcp_from_dpa(
+                        api,
+                        &mut txn,
+                        parsed_mac,
+                        relay_address,
+                        desired_address_ip,
+                    )
+                    .await?
                 {
-                    if is_v6_observation {
-                        predicted_interface_for_observation = Some(predicted_interface);
-                        None
-                    } else {
-                        // remember expected machine id for later rack update
-                        machine_interface::move_predicted_machine_interface_to_machine(
+                    txn.commit().await?;
+                    return Ok(resp);
+                }
+
+                // ExpectedMachine is the ingestion template for an unknown
+                // interface, so this is where its role, segment guard, Host
+                // primary declaration, and allocation policy join the normal
+                // DHCP path.
+                //
+                // Why also materialize a fixed reservation here? An operator
+                // may force-delete a machine and all of its interfaces. The
+                // next DHCP request is then the first point where we see that
+                // MAC again, so the idempotent preallocation rebuilds the
+                // reservation before the common find-or-create path runs.
+                // The top-level BMC MAC is the ExpectedMachine alternate
+                // key, so resolve it before searching the nested JSON
+                // list. Otherwise another declaration using the same MAC
+                // could make DHCP treat a host BMC as a data interface.
+                if let Some(m) = expected_machine::find_by_bmc_mac_address(&mut txn, parsed_mac)
+                    .await
+                    .map_err(CarbideError::from)?
+                {
+                    let interface = m.effective_host_bmc();
+                    if interface
+                        .fixed_ip
+                        .is_some_and(|fixed_ip| fixed_ip.is_address_family(address_family))
+                    {
+                        db::machine_interface::preallocate_expected_machine_interface(
                             &mut txn,
-                            &predicted_interface,
-                            parsed_relay,
+                            &interface,
                             api.runtime_config.retained_boot_interface_window,
                         )
                         .await?;
-                        Some(predicted_interface.machine_id)
                     }
-                } else {
-                    // DPA allocation is currently IPv4-only. The overlay
-                    // uses u32 arithmetic (LSB toggle) and /31 linknets,
-                    // and the underlay parses relay_address as Ipv4Addr.
-                    // Skip the DPA path entirely for IPv6 relays.
-                    if address_family == IpAddressFamily::Ipv4
-                        && let Some(resp) = handle_dhcp_from_dpa(
-                            api,
-                            &mut txn,
-                            parsed_mac,
-                            relay_address,
-                            desired_address_ip,
-                        )
-                        .await?
-                    {
-                        txn.commit().await?;
-                        return Ok(resp);
-                    }
-
-                    // ExpectedMachine is the ingestion template for an unknown
-                    // interface, so this is where its role, segment guard, Host
-                    // primary declaration, and allocation policy join the normal
-                    // DHCP path.
-                    //
-                    // Why also materialize a fixed reservation here? An operator
-                    // may force-delete a machine and all of its interfaces. The
-                    // next DHCP request is then the first point where we see that
-                    // MAC again, so the idempotent preallocation rebuilds the
-                    // reservation before the common find-or-create path runs.
-                    // The top-level BMC MAC is the ExpectedMachine alternate
-                    // key, so resolve it before searching the nested JSON
-                    // list. Otherwise another declaration using the same MAC
-                    // could make DHCP treat a host BMC as a data interface.
-                    if let Some(m) = expected_machine::find_by_bmc_mac_address(&mut txn, parsed_mac)
+                    expected_interface = Some(interface);
+                } else if let Some(m) =
+                    expected_machine::find_by_interface_mac_address(&mut txn, parsed_mac)
                         .await
                         .map_err(CarbideError::from)?
-                    {
-                        let interface = m.effective_host_bmc();
+                {
+                    expected_interface = m
+                        .data
+                        .interfaces
+                        .iter()
+                        .find(|interface| interface.mac_address == parsed_mac)
+                        .cloned();
+                    if let Some(interface) = expected_interface.as_ref() {
+                        if interface.role.is_host()
+                            && let Some(declared_primary_mac) = m.data.declared_primary_mac()
+                        {
+                            host_primary_declaration = Some(declared_primary_mac == parsed_mac);
+                        }
                         if interface
                             .fixed_ip
                             .is_some_and(|fixed_ip| fixed_ip.is_address_family(address_family))
                         {
+                            // The fixed reservation must exist before the common
+                            // path looks up this MAC. This call also applies the
+                            // interface's role and segment guard while the row is
+                            // still unassociated.
                             db::machine_interface::preallocate_expected_machine_interface(
                                 &mut txn,
-                                &interface,
+                                interface,
                                 api.runtime_config.retained_boot_interface_window,
                             )
                             .await?;
                         }
-                        expected_interface = Some(interface);
-                    } else if let Some(m) =
-                        expected_machine::find_by_interface_mac_address(&mut txn, parsed_mac)
-                            .await
-                            .map_err(CarbideError::from)?
-                    {
-                        expected_interface = m
-                            .data
-                            .interfaces
-                            .iter()
-                            .find(|interface| interface.mac_address == parsed_mac)
-                            .cloned();
-                        if let Some(interface) = expected_interface.as_ref() {
-                            if interface.role.is_host()
-                                && let Some(declared_primary_mac) = m.data.declared_primary_mac()
-                            {
-                                host_primary_declaration = Some(declared_primary_mac == parsed_mac);
-                            }
-                            if interface
-                                .fixed_ip
-                                .is_some_and(|fixed_ip| fixed_ip.is_address_family(address_family))
-                            {
-                                // The fixed reservation must exist before the common
-                                // path looks up this MAC. This call also applies the
-                                // interface's role and segment guard while the row is
-                                // still unassociated.
-                                db::machine_interface::preallocate_expected_machine_interface(
-                                    &mut txn,
-                                    interface,
-                                    api.runtime_config.retained_boot_interface_window,
-                                )
-                                .await?;
-                            }
-                        }
-                    } else if let Some(s) =
-                        db::expected_switch::find_by_nvos_mac_address(&mut txn, parsed_mac)
-                            .await
-                            .map_err(CarbideError::from)?
-                        && let Some(nvos_ip) = s.nvos_ip_address
-                        && nvos_ip.is_address_family(address_family)
-                    {
-                        // The parsed MAC matches the single wired NVOS port of an expected
-                        // switch with a configured static IP. Mirrors the ExpectedInterface
-                        // fixed_ip path: ensure the (mac, nvos_ip) row exists so the static
-                        // reservation gets served by the find_or_create_machine_interface
-                        // step below. Data variant (NVOS is a data interface, not a BMC).
-                        // Races against site-explorer's reconciliation pass are handled
-                        // inside preallocate.
-                        db::machine_interface::preallocate_machine_interface(
-                            &mut txn,
-                            parsed_mac,
-                            nvos_ip,
-                            api.runtime_config.retained_boot_interface_window,
-                        )
-                        .await?;
                     }
-                    None
+                } else if let Some(s) =
+                    db::expected_switch::find_by_nvos_mac_address(&mut txn, parsed_mac)
+                        .await
+                        .map_err(CarbideError::from)?
+                    && let Some(nvos_ip) = s.nvos_ip_address
+                    && nvos_ip.is_address_family(address_family)
+                {
+                    // The parsed MAC matches the single wired NVOS port of an expected
+                    // switch with a configured static IP. Mirrors the ExpectedInterface
+                    // fixed_ip path: ensure the (mac, nvos_ip) row exists so the static
+                    // reservation gets served by the find_or_create_machine_interface
+                    // step below. Data variant (NVOS is a data interface, not a BMC).
+                    // Races against site-explorer's reconciliation pass are handled
+                    // inside preallocate.
+                    db::machine_interface::preallocate_machine_interface(
+                        &mut txn,
+                        parsed_mac,
+                        nvos_ip,
+                        api.runtime_config.retained_boot_interface_window,
+                    )
+                    .await?;
                 }
+                None
             }
-        };
+        }
+    };
 
     if is_v6_observation {
         let network_segments = db::machine_interface::network_segments_for_dhcp_relays(
@@ -743,6 +815,7 @@ pub(crate) async fn discover_dhcp(
                 &predicted_interface,
                 parsed_relay,
                 api.runtime_config.retained_boot_interface_window,
+                &locked_segment_ids,
             )
             .await?;
         }
@@ -774,6 +847,7 @@ pub(crate) async fn discover_dhcp(
                 retained_window: api.runtime_config.retained_boot_interface_window,
             },
             address_family,
+            &locked_segment_ids,
         )
         .await?
     };
@@ -784,6 +858,7 @@ pub(crate) async fn discover_dhcp(
             &predicted_interface,
             parsed_relay,
             api.runtime_config.retained_boot_interface_window,
+            &locked_segment_ids,
         )
         .await?;
         machine_interface = db::machine_interface::find_one(&mut txn, machine_interface.id).await?;
@@ -832,6 +907,7 @@ pub(crate) async fn discover_dhcp(
             &segment,
             parsed_mac,
             address_family,
+            &locked_segment_ids,
         )
         .await?;
     }
@@ -855,6 +931,11 @@ pub(crate) async fn discover_dhcp(
         }
     }
 
+    // Lock the parent before inserting vendor rows. Otherwise a request that
+    // already locked the interface can wait for a vendor insertion whose
+    // foreign-key check is itself waiting for that interface.
+    db::machine_interface::update_last_dhcp(&mut txn, machine_interface.id, None).await?;
+
     // Save vendor string, this is allowed to fail due to dhcp happening more than once on the same machine/vendor string
     if let Some(vendor) = vendor_string {
         let res = db::dhcp_entry::persist(
@@ -872,8 +953,6 @@ pub(crate) async fn discover_dhcp(
             } // This should not fail the discover call, dhcp happens many times
         }
     }
-
-    db::machine_interface::update_last_dhcp(&mut txn, machine_interface.id, None).await?;
 
     let options_only_record = if is_v6_observation {
         machine_interface = db::machine_interface::find_one(&mut txn, machine_interface.id).await?;

--- a/crates/api-core/src/dhcp/v6.rs
+++ b/crates/api-core/src/dhcp/v6.rs
@@ -83,14 +83,10 @@ pub(super) async fn infer_slaac_eui64_address(
         return Ok(());
     };
 
-    // TODO(chet): Serialize same-interface IPv6 selection and replacement
-    // across SLAAC observation, static assignment, and stateful DHCPv6. The
-    // `unique_address_family_on_interface` index keeps us from storing two IPv6
-    // rows for one interface, but it does not decide which concurrent writer
-    // should win. The losing writer currently returns a database error and
-    // aborts its DHCP transaction.
-    //
-    // A stateful/static IPv6 address already owns this interface family.
+    // Read the family after taking the interface row lock: a DHCPv6 or
+    // static assignment may commit while inference waits for this interface.
+    let current_segment_id =
+        db::machine_interface::lock_for_address_assignment(&mut *txn, interface_id).await?;
     if db::machine_interface_address::has_address_for_family(
         &mut *txn,
         interface_id,
@@ -99,6 +95,12 @@ pub(super) async fn infer_slaac_eui64_address(
     .await?
     {
         return Ok(());
+    }
+
+    if current_segment_id != segment.id {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "network segment changed for interface {interface_id} during SLAAC inference"
+        )));
     }
 
     // Persist the inferred address and refresh DNS naming from the new state.

--- a/crates/api-core/src/handlers/machine_interface_address.rs
+++ b/crates/api-core/src/handlers/machine_interface_address.rs
@@ -156,7 +156,14 @@ async fn update_preallocated_machine_interface_with_settings(
     };
     let existing = db::machine_interface::find_by_mac_address(&mut *txn, mac_address).await?;
 
-    if let Some(iface) = existing.first() {
+    if let Some(mut iface) = existing.into_iter().next() {
+        // Skip the lock when the initial read already has an address.
+        // Expected-device callers do not all acquire interface and inventory
+        // locks in the same order.
+        if iface.addresses.is_empty() {
+            db::machine_interface::lock_for_address_assignment(&mut *txn, iface.id).await?;
+            iface = db::machine_interface::find_one(&mut *txn, iface.id).await?;
+        }
         if iface.addresses.is_empty() {
             // No addresses -- safe to assign the static IP.
             db::machine_interface_address::assign_static(txn, iface.id, ip_address).await?;
@@ -461,7 +468,11 @@ pub(crate) async fn find_interface_addresses(
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use carbide_instrument::testing::capture_logs;
+    use carbide_uuid::machine::MachineInterfaceId;
+    use carbide_uuid::network::NetworkSegmentId;
 
     use super::*;
 
@@ -476,5 +487,151 @@ mod tests {
 
         assert_eq!(logs.len(), 1);
         assert_eq!(logs[0].level, tracing::Level::WARN);
+    }
+
+    #[crate::sqlx_test]
+    async fn expected_update_skips_addressed_interfaces_without_locking(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut setup = pool.begin().await?;
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('expected-update-skip', 'V1-T0') RETURNING id",
+        )
+        .fetch_one(&mut *setup)
+        .await?;
+        let mac_address: MacAddress = "02:00:00:00:53:99".parse()?;
+        let interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces (segment_id, mac_address, hostname, primary_interface)
+             VALUES ($1, $2, 'expected-update-skip', true) RETURNING id",
+        )
+        .bind(segment_id)
+        .bind(mac_address)
+        .fetch_one(&mut *setup)
+        .await?;
+        let address = "2001:db8::5398".parse()?;
+        db::machine_interface_address::insert(
+            &mut setup,
+            interface_id,
+            address,
+            AllocationType::Static,
+        )
+        .await?;
+        setup.commit().await?;
+
+        let mut update_txn = pool.begin().await?;
+        let result = update_preallocated_machine_interface(
+            &mut update_txn,
+            mac_address,
+            "2001:db8::5399".parse()?,
+            None,
+        )
+        .await?;
+        assert_eq!(result, PreallocationSuccess::Skipped);
+
+        // Keep the expected update open. A primary-interface or inventory
+        // writer must still be able to lock the skipped interface.
+        let mut competing_txn = pool.begin().await?;
+        sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE NOWAIT")
+            .bind(interface_id)
+            .execute(&mut *competing_txn)
+            .await?;
+        let addresses =
+            db::machine_interface_address::find_for_interface(&mut competing_txn, interface_id)
+                .await?;
+        assert_eq!(addresses.len(), 1);
+        assert_eq!(addresses[0].address, address);
+        assert_eq!(addresses[0].allocation_type, AllocationType::Static);
+        competing_txn.commit().await?;
+        update_txn.commit().await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn expected_update_preserves_an_address_committed_while_waiting(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut setup = pool.begin().await?;
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('expected-update-race', 'V1-T0') RETURNING id",
+        )
+        .fetch_one(&mut *setup)
+        .await?;
+        let mac_address: MacAddress = "02:00:00:00:53:98".parse()?;
+        let interface_id: MachineInterfaceId = sqlx::query_scalar(
+            "INSERT INTO machine_interfaces (segment_id, mac_address, hostname, primary_interface)
+             VALUES ($1, $2, 'expected-update-race', true) RETURNING id",
+        )
+        .bind(segment_id)
+        .bind(mac_address)
+        .fetch_one(&mut *setup)
+        .await?;
+        setup.commit().await?;
+
+        let inferred_address = "2001:db8::5398".parse()?;
+        let mut holder = pool.begin().await?;
+        sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+            .bind(interface_id)
+            .execute(&mut *holder)
+            .await?;
+        db::machine_interface_address::insert(
+            &mut holder,
+            interface_id,
+            inferred_address,
+            AllocationType::Slaac,
+        )
+        .await?;
+        let holder_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *holder)
+            .await?;
+        let mut waiter = pool.begin().await?;
+        let waiter_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *waiter)
+            .await?;
+
+        // The expected-data update starts with an addressless snapshot. Its
+        // skip decision must use the SLAAC row committed while it waits.
+        let update = async {
+            let result = update_preallocated_machine_interface(
+                &mut waiter,
+                mac_address,
+                "2001:db8::5399".parse()?,
+                None,
+            )
+            .await?;
+            waiter.commit().await?;
+            Ok::<_, Box<dyn std::error::Error>>(result)
+        };
+        let release = async {
+            loop {
+                let blocked: bool = sqlx::query_scalar("SELECT $1 = ANY(pg_blocking_pids($2))")
+                    .bind(holder_pid)
+                    .bind(waiter_pid)
+                    .fetch_one(&pool)
+                    .await?;
+                if blocked {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+            holder.commit().await?;
+            Ok::<_, Box<dyn std::error::Error>>(())
+        };
+        let (updated, released) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(update, release)
+        })
+        .await?;
+        released?;
+        assert_eq!(updated?, PreallocationSuccess::Skipped);
+
+        let mut connection = pool.acquire().await?;
+        let addresses =
+            db::machine_interface_address::find_for_interface(&mut connection, interface_id)
+                .await?;
+        assert_eq!(addresses.len(), 1);
+        assert_eq!(addresses[0].address, inferred_address);
+        assert_eq!(addresses[0].allocation_type, AllocationType::Slaac);
+        Ok(())
     }
 }

--- a/crates/api-core/src/tests/machine_dhcp.rs
+++ b/crates/api-core/src/tests/machine_dhcp.rs
@@ -17,6 +17,7 @@
 
 use std::net::{IpAddr, Ipv6Addr};
 use std::str::FromStr;
+use std::time::Duration;
 
 use carbide_network::ip::IpAddressFamily;
 use carbide_uuid::machine::{AsMachineId, MachineIdSubtypeTrait, MachineInterfaceId};
@@ -41,6 +42,7 @@ use model::expected_machine::{
     ExpectedMachine, ExpectedMachineData,
 };
 use model::machine_interface::InterfaceType;
+use model::machine_interface_address::MachineInterfaceAssociation;
 use model::network_segment::NetworkSegmentType;
 use model::test_support::ManagedHostConfig;
 use rpc::forge::forge_server::Forge;
@@ -49,6 +51,7 @@ use rpc::forge::{ExpireDhcpLeaseRequest, ManagedHostNetworkConfigRequest};
 use crate::DatabaseError;
 use crate::test_support::fixture_config::{FixtureDefault as _, ManagedHostConfigExt as _};
 use crate::tests::common;
+use crate::tests::common::postgres::wait_for_blocked_query;
 use crate::tests::common::rpc_builder::DhcpDiscovery;
 
 const RPC_ADDRESS_FAMILY_V4: i32 = rpc::forge::AddressFamily::V4 as i32;
@@ -246,6 +249,42 @@ async fn interface_addresses_for_mac(
         db::machine_interface_address::find_for_interface(&mut txn, interface_id).await?;
     txn.rollback().await?;
     Ok((interface_id, addresses))
+}
+
+async fn wait_for_blocked_dhcp_request(
+    pool: &sqlx::PgPool,
+    blocker_pids: &[i32],
+    excluded_pid: Option<i32>,
+    query_fragments: &[&str],
+) -> Result<i32, Box<dyn std::error::Error>> {
+    Ok(tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            let blocked_pid = sqlx::query_scalar::<_, i32>(
+                r#"SELECT activity.pid
+                   FROM pg_stat_activity AS activity
+                   WHERE activity.datname = current_database()
+                     AND activity.wait_event_type = 'Lock'
+                     AND $1::integer[] && pg_blocking_pids(activity.pid)
+                     AND ($2::integer IS NULL OR activity.pid != $2)
+                     AND EXISTS (
+                         SELECT 1 FROM unnest($3::text[]) AS fragment
+                         WHERE strpos(lower(activity.query), lower(fragment)) > 0
+                     )
+                   ORDER BY activity.pid
+                   LIMIT 1"#,
+            )
+            .bind(blocker_pids)
+            .bind(excluded_pid)
+            .bind(query_fragments)
+            .fetch_optional(pool)
+            .await?;
+            if let Some(blocked_pid) = blocked_pid {
+                return Ok::<i32, sqlx::Error>(blocked_pid);
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    })
+    .await??)
 }
 
 #[crate::sqlx_test]
@@ -1056,6 +1095,108 @@ async fn machine_interface_discovery_persists_vendor_strings(
     // DHCP with a previously known vendor string
     // This should not fail
     let _ = dhcp_with_vendor(&env, mac_address, Some("vendor2")).await;
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_dhcp_v6_concurrent_vendor_bookkeeping_preserves_lease(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let mac: MacAddress = "02:00:00:00:95:01".parse()?;
+    let relay = "2001:db8:95::1";
+    let vendor = "concurrent-dhcpv6-vendor";
+    add_ipv6_prefix(&pool, env.admin_segment(), "2001:db8:95::/64", None).await?;
+    enable_slaac_eui64_inference(&pool, env.admin_segment()).await?;
+
+    let initial_response = env
+        .api
+        .discover_dhcp(dhcpv6_discovery(mac, relay, RPC_MESSAGE_KIND_V6_SOLICIT))
+        .await?
+        .into_inner();
+    let interface_id = initial_response
+        .machine_interface_id
+        .expect("the first stateful request should create an interface");
+    let initial_address: IpAddr = initial_response.address.parse()?;
+    sqlx::query("UPDATE machine_interfaces SET last_dhcp = NULL WHERE id = $1")
+        .bind(interface_id)
+        .execute(&pool)
+        .await?;
+
+    let mut info_request = dhcpv6_discovery(mac, relay, RPC_MESSAGE_KIND_V6_INFO_REQUEST);
+    info_request.get_mut().vendor_string = Some(vendor.to_string());
+    let mut stateful_request = dhcpv6_discovery(mac, relay, RPC_MESSAGE_KIND_V6_SOLICIT);
+    stateful_request.get_mut().vendor_string = Some(vendor.to_string());
+
+    let (info_response, stateful_response) = tokio::time::timeout(
+        Duration::from_secs(15),
+        async {
+            let mut gate = pool.begin().await?;
+            sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+                .bind(interface_id)
+                .execute(&mut *gate)
+                .await?;
+            let gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+                .fetch_one(&mut *gate)
+                .await?;
+
+            // Queue inference first. A stateful request must not insert the
+            // same vendor key before waiting for this interface; otherwise
+            // inference waits for that key while its writer waits for us.
+            let info = env.api.discover_dhcp(info_request);
+            tokio::pin!(info);
+            let info_blockers = [gate_pid];
+            let info_pid = tokio::select! {
+                result = &mut info => panic!("information-request bypassed the interface gate: {result:?}"),
+                blocked = wait_for_blocked_dhcp_request(
+                    &pool,
+                    &info_blockers,
+                    None,
+                    &[
+                        "SELECT segment_id FROM machine_interfaces",
+                        "INSERT INTO dhcp_entries",
+                    ],
+                ) => blocked?,
+            };
+
+            let stateful = env.api.discover_dhcp(stateful_request);
+            tokio::pin!(stateful);
+            let stateful_blockers = [gate_pid, info_pid];
+            tokio::select! {
+                result = &mut stateful => panic!("stateful request bypassed the interface gate: {result:?}"),
+                blocked = wait_for_blocked_dhcp_request(
+                    &pool,
+                    &stateful_blockers,
+                    Some(info_pid),
+                    &[
+                        "UPDATE machine_interfaces SET last_dhcp",
+                        "INSERT INTO dhcp_entries",
+                    ],
+                ) => { blocked?; },
+            }
+
+            gate.rollback().await?;
+            let (info, stateful) = tokio::join!(&mut info, &mut stateful);
+            Ok::<_, Box<dyn std::error::Error>>((info?.into_inner(), stateful?.into_inner()))
+        },
+    )
+    .await??;
+
+    assert_eq!(info_response.machine_interface_id, Some(interface_id));
+    assert!(info_response.address.is_empty());
+    assert!(info_response.prefix.is_empty());
+    assert_eq!(stateful_response.machine_interface_id, Some(interface_id));
+    assert_eq!(stateful_response.address, initial_response.address);
+    assert_eq!(stateful_response.fqdn, initial_response.fqdn);
+
+    let (_, addresses) = interface_addresses_for_mac(&pool, mac).await?;
+    assert_eq!(addresses.len(), 1);
+    assert_eq!(addresses[0].address, initial_address);
+    assert_eq!(addresses[0].allocation_type, AllocationType::Dhcp);
+    let interface = db::machine_interface::find_one(&pool, interface_id).await?;
+    assert_eq!(interface.vendors, vec![vendor.to_string()]);
+    assert!(interface.last_dhcp.is_some());
 
     Ok(())
 }
@@ -2785,6 +2926,242 @@ async fn test_dhcp_v6_info_request_does_not_add_slaac_after_stateful(
 }
 
 #[crate::sqlx_test]
+async fn test_dhcp_v4_locks_interface_before_inserting_address(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let mac: MacAddress = "02:00:00:00:94:03".parse()?;
+    let initial_response = env
+        .api
+        .discover_dhcp(DhcpDiscovery::builder(mac, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request())
+        .await?
+        .into_inner();
+    let interface_id = initial_response
+        .machine_interface_id
+        .expect("DHCPv4 should create the interface before its lease is removed");
+    let mut removal_txn = pool.begin().await?;
+    assert!(
+        db::machine_interface_address::delete_by_interface_family(
+            &mut removal_txn,
+            interface_id,
+            IpAddressFamily::Ipv4,
+            AllocationType::Dhcp,
+        )
+        .await?
+    );
+    removal_txn.commit().await?;
+
+    // Hold the interface without inserting an address yet. DHCP must wait
+    // here, before its insert can hold an index entry that static needs.
+    let mut assignment_txn = pool.begin().await?;
+    db::machine_interface::lock_for_address_assignment(&mut assignment_txn, interface_id).await?;
+    let assignment_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *assignment_txn)
+        .await?;
+    let static_address: IpAddr = "192.0.2.90".parse()?;
+
+    let request = async {
+        let response = env
+            .api
+            .discover_dhcp(DhcpDiscovery::builder(mac, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request())
+            .await?
+            .into_inner();
+        Ok::<_, Box<dyn std::error::Error>>(response)
+    };
+    let assign_static = async {
+        wait_for_blocked_dhcp_request(
+            &pool,
+            &[assignment_pid],
+            None,
+            &["SELECT segment_id FROM machine_interfaces WHERE id = $1 FOR UPDATE"],
+        )
+        .await?;
+        db::machine_interface_address::assign_static(
+            &mut assignment_txn,
+            interface_id,
+            static_address,
+        )
+        .await?;
+        assignment_txn.commit().await?;
+        Ok::<(), Box<dyn std::error::Error>>(())
+    };
+    let (response, ()) = tokio::time::timeout(Duration::from_secs(10), async {
+        tokio::try_join!(request, assign_static)
+    })
+    .await??;
+
+    assert_eq!(response.machine_interface_id, Some(interface_id));
+    assert_eq!(response.address, static_address.to_string());
+    assert_eq!(response.prefix, initial_response.prefix);
+    let (persisted_id, addresses) = interface_addresses_for_mac(&pool, mac).await?;
+    assert_eq!(persisted_id, interface_id);
+    assert_eq!(addresses.len(), 1);
+    assert_eq!(addresses[0].address, static_address);
+    assert_eq!(addresses[0].allocation_type, AllocationType::Static);
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_dhcp_v6_reads_static_assignment_after_concurrent_commit(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env(pool.clone()).await;
+    let prefix = "2001:db8:94::/64";
+    add_ipv6_prefix(&pool, env.admin_segment(), prefix, None).await?;
+    enable_slaac_eui64_inference(&pool, env.admin_segment()).await?;
+
+    struct Case {
+        name: &'static str,
+        mac: &'static str,
+        static_address: &'static str,
+        prior_slaac: bool,
+        message_kind: i32,
+        expected_address: &'static str,
+        expected_prefix: &'static str,
+    }
+
+    for case in [
+        Case {
+            name: "information-request skips inference after a static assignment commits",
+            mac: "02:00:00:00:94:01",
+            static_address: "2001:db8:94::55",
+            prior_slaac: false,
+            message_kind: RPC_MESSAGE_KIND_V6_INFO_REQUEST,
+            expected_address: "",
+            expected_prefix: "",
+        },
+        Case {
+            name: "stateful request preserves a static replacement of its prior SLAAC row",
+            mac: "02:00:00:00:94:02",
+            static_address: "2001:db8:94::56",
+            prior_slaac: true,
+            message_kind: RPC_MESSAGE_KIND_V6_SOLICIT,
+            expected_address: "2001:db8:94::56",
+            expected_prefix: prefix,
+        },
+    ] {
+        let mac: MacAddress = case.mac.parse()?;
+        let static_address: IpAddr = case.static_address.parse()?;
+        let v4_response = env
+            .api
+            .discover_dhcp(DhcpDiscovery::builder(mac, FIXTURE_DHCP_RELAY_ADDRESS).tonic_request())
+            .await?
+            .into_inner();
+        let ipv4_address: IpAddr = v4_response.address.parse()?;
+        let interface_id = v4_response
+            .machine_interface_id
+            .expect("DHCPv4 should create the interface before the competing requests");
+
+        if case.prior_slaac {
+            let mut setup_txn = pool.begin().await?;
+            db::machine_interface_address::insert(
+                &mut setup_txn,
+                interface_id,
+                expected_slaac_address("2001:db8:94::".parse()?, mac),
+                AllocationType::Slaac,
+            )
+            .await?;
+            setup_txn.commit().await?;
+        }
+
+        // The competing writer uses the DB assignment entry point, not an
+        // RPC. Keep its address uncommitted so DHCP initially sees either no
+        // IPv6 row or the SLAAC row being replaced.
+        let mut assignment_txn = pool.begin().await?;
+        sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+            .bind(interface_id)
+            .execute(&mut *assignment_txn)
+            .await?;
+        db::machine_interface_address::assign_static(
+            &mut assignment_txn,
+            interface_id,
+            static_address,
+        )
+        .await?;
+        let assignment_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *assignment_txn)
+            .await?;
+
+        let request = tokio::time::timeout(
+            Duration::from_secs(10),
+            env.api
+                .discover_dhcp(dhcpv6_discovery(mac, "2001:db8:94::1", case.message_kind)),
+        );
+        let commit_assignment = async {
+            // Check the actual database wait before committing. Accept the
+            // address write too: without the selection lock, that is where
+            // the stale decision waits and then fails after this commit.
+            tokio::time::timeout(Duration::from_secs(5), async {
+                loop {
+                    let request_is_blocked: bool = sqlx::query_scalar(
+                        r#"SELECT EXISTS (
+                            SELECT 1 FROM pg_stat_activity AS activity
+                            WHERE activity.datname = current_database()
+                              AND activity.wait_event_type = 'Lock'
+                              AND $1 = ANY(pg_blocking_pids(activity.pid))
+                              AND (
+                                  activity.query ILIKE '%FROM machine_interfaces%FOR UPDATE%'
+                                  OR activity.query ILIKE '%INSERT INTO machine_interface_addresses%'
+                                  OR activity.query ILIKE '%DELETE FROM machine_interface_addresses%'
+                              )
+                        )"#,
+                    )
+                    .bind(assignment_pid)
+                    .fetch_one(&pool)
+                    .await?;
+                    if request_is_blocked {
+                        return Ok::<(), sqlx::Error>(());
+                    }
+                    tokio::time::sleep(Duration::from_millis(10)).await;
+                }
+            })
+            .await
+            .unwrap_or_else(|_| panic!("{}: DHCP never waited for the static assignment", case.name))?;
+            assignment_txn.commit().await?;
+            Ok::<(), Box<dyn std::error::Error>>(())
+        };
+        let (response, committed) = tokio::join!(request, commit_assignment);
+        committed?;
+        let response = response
+            .unwrap_or_else(|_| {
+                panic!("{}: DHCP did not finish after the static commit", case.name)
+            })
+            .unwrap_or_else(|error| panic!("{}: {error}", case.name))
+            .into_inner();
+
+        assert_eq!(
+            response.machine_interface_id,
+            Some(interface_id),
+            "{}",
+            case.name,
+        );
+        assert_eq!(response.address, case.expected_address, "{}", case.name);
+        assert_eq!(response.prefix, case.expected_prefix, "{}", case.name);
+        assert_eq!(response.fqdn, v4_response.fqdn, "{}", case.name);
+        let (persisted_id, addresses) = interface_addresses_for_mac(&pool, mac).await?;
+        assert_eq!(persisted_id, interface_id, "{}", case.name);
+        assert_eq!(addresses.len(), 2, "{}: {addresses:?}", case.name);
+        assert!(
+            addresses.iter().any(|address| {
+                address.address == ipv4_address && address.allocation_type == AllocationType::Dhcp
+            }),
+            "{}: IPv4 lease changed: {addresses:?}",
+            case.name,
+        );
+        assert!(
+            addresses.iter().any(|address| {
+                address.address == static_address
+                    && address.allocation_type == AllocationType::Static
+            }),
+            "{}: static IPv6 assignment changed: {addresses:?}",
+            case.name,
+        );
+    }
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn test_dhcp_v6_solicit_exact_link_exhaustion_does_not_fallback_to_prefix_candidate(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -3292,6 +3669,168 @@ async fn test_dhcp_v6_solicit_promotes_predicted_interface_by_link_address(
     assert_eq!(addresses.len(), 1);
     assert_eq!(addresses[0].allocation_type, AllocationType::Dhcp);
     assert_eq!(addresses[0].address, response_address);
+    txn.rollback().await?;
+
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn test_dhcp_v6_reserved_prediction_promotion_serializes_primary_request(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_host_inband(pool.clone()).await;
+    let mock_host = ManagedHostConfig {
+        dpus: vec![],
+        ..ManagedHostConfig::default()
+    };
+    let predicted_mac = *mock_host.non_dpu_macs.first().unwrap();
+    let mock_host = mock_host.with_expected_machine_data(ExpectedMachineData {
+        interfaces: vec![ExpectedInterface {
+            mac_address: predicted_mac,
+            primary: Some(true),
+            ..Default::default()
+        }],
+        ..Default::default()
+    });
+    let _mock = site_explorer::ingest_zero_dpu_host_awaiting_first_lease(&env, mock_host).await?;
+    let (prediction, segment_id) = {
+        let mut txn = pool.begin().await?;
+        let prediction =
+            db::predicted_machine_interface::find_by_mac_address(&mut txn, predicted_mac)
+                .await?
+                .expect("zero-DPU ingest should create a predicted interface");
+        assert!(prediction.primary_interface);
+        let segment = db::network_segment::for_relay(
+            &mut txn,
+            FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.ip(),
+        )
+        .await?
+        .expect("the fixture gateway should resolve the host-inband segment");
+        txn.rollback().await?;
+        (prediction, segment.id)
+    };
+
+    let existing_mac: MacAddress = "02:00:00:00:96:01".parse()?;
+    let existing_response = env
+        .api
+        .discover_dhcp(
+            DhcpDiscovery::builder(
+                existing_mac,
+                FIXTURE_HOST_INBAND_NETWORK_SEGMENT_GATEWAY.ip(),
+            )
+            .tonic_request(),
+        )
+        .await?
+        .into_inner();
+    let existing_id = existing_response
+        .machine_interface_id
+        .expect("the first IPv4 request should create an interface");
+    let ipv4_address: IpAddr = existing_response.address.parse()?;
+    assert!(ipv4_address.is_ipv4());
+    let mut txn = pool.begin().await?;
+    db::machine_interface::associate_interface_with_machine(
+        &existing_id,
+        MachineInterfaceAssociation::Machine(prediction.machine_id),
+        &mut txn,
+    )
+    .await?;
+    db::machine_interface::set_primary_interface(&existing_id, true, &mut txn).await?;
+    txn.commit().await?;
+    let initial_interface = db::machine_interface::find_one(&pool, existing_id).await?;
+    assert!(initial_interface.primary_interface);
+    assert_eq!(initial_interface.machine_id, Some(prediction.machine_id));
+    assert_eq!(initial_interface.segment_id, segment_id);
+    assert_eq!(initial_interface.addresses, vec![ipv4_address]);
+
+    let relay = "2001:db8:96::1";
+    add_ipv6_prefix(&pool, segment_id, "2001:db8:96::/64", None).await?;
+    set_segment_reserved(&pool, segment_id).await?;
+
+    let (promotion, existing) = tokio::time::timeout(Duration::from_secs(15), async {
+        let mut gate = pool.begin().await?;
+        sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+            .bind(existing_id)
+            .execute(&mut *gate)
+            .await?;
+        let gate_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *gate)
+            .await?;
+
+        // Promotion must reserve the segment before demoting the primary.
+        // Otherwise its row lock can block a lease request that owns the
+        // segment lock promotion will need next.
+        let promotion = env.api.discover_dhcp(dhcpv6_discovery(
+            predicted_mac,
+            relay,
+            RPC_MESSAGE_KIND_V6_SOLICIT,
+        ));
+        tokio::pin!(promotion);
+        let promotion_pid = tokio::select! {
+            result = &mut promotion => panic!("promotion bypassed the primary interface gate: {result:?}"),
+            blocked = wait_for_blocked_query(
+                &pool,
+                gate_pid,
+                "UPDATE machine_interfaces SET primary_interface=false",
+            ) => blocked,
+        };
+
+        let existing = env.api.discover_dhcp(dhcpv6_discovery(
+            existing_mac,
+            relay,
+            RPC_MESSAGE_KIND_V6_SOLICIT,
+        ));
+        tokio::pin!(existing);
+        tokio::select! {
+            result = &mut existing => panic!("lease request bypassed promotion's segment lock: {result:?}"),
+            _ = wait_for_blocked_query(
+                &pool,
+                promotion_pid,
+                "pg_advisory_xact_lock",
+            ) => {},
+        }
+
+        gate.rollback().await?;
+        let results = tokio::join!(&mut promotion, &mut existing);
+        Ok::<_, Box<dyn std::error::Error>>(results)
+    })
+    .await??;
+
+    for result in [promotion, existing] {
+        let status = result.expect_err("Reserved segments require a static IPv6 reservation");
+        assert_eq!(status.code(), tonic::Code::Internal);
+        assert!(
+            status
+                .message()
+                .contains("configured for static DHCP leases only; no static reservation"),
+            "unexpected allocation failure: {status}",
+        );
+    }
+
+    let existing_interface = db::machine_interface::find_one(&pool, existing_id).await?;
+    assert!(existing_interface.primary_interface);
+    assert_eq!(existing_interface.machine_id, Some(prediction.machine_id));
+    assert_eq!(existing_interface.segment_id, segment_id);
+    assert_eq!(existing_interface.addresses, vec![ipv4_address]);
+    assert_eq!(existing_interface.last_dhcp, initial_interface.last_dhcp);
+    let (_, addresses) = interface_addresses_for_mac(&pool, existing_mac).await?;
+    assert_eq!(addresses.len(), 1);
+    assert_eq!(addresses[0].address, ipv4_address);
+    assert_eq!(addresses[0].allocation_type, AllocationType::Dhcp);
+
+    let mut txn = pool.begin().await?;
+    let retained_prediction =
+        db::predicted_machine_interface::find_by_mac_address(&mut txn, predicted_mac)
+            .await?
+            .expect("failed promotion should leave the prediction available for retry");
+    assert_eq!(retained_prediction.id, prediction.id);
+    assert_eq!(retained_prediction.machine_id, prediction.machine_id);
+    assert_eq!(retained_prediction.mac_address, predicted_mac);
+    assert!(retained_prediction.primary_interface);
+    assert!(
+        db::machine_interface::find_by_mac_address(&mut *txn, predicted_mac)
+            .await?
+            .is_empty()
+    );
     txn.rollback().await?;
 
     Ok(())

--- a/crates/api-db/src/machine_interface.rs
+++ b/crates/api-db/src/machine_interface.rs
@@ -572,6 +572,27 @@ pub async fn find_one(
     }
 }
 
+/// Lock an interface for address selection and return its current segment.
+///
+/// Call inside a transaction, then read the current addresses before deciding
+/// whether to insert or replace one. The parent row also serializes writers
+/// when the requested address family has no row yet. Callers that allocate
+/// from a pool must take the segment advisory lock before this row lock.
+pub async fn lock_for_address_assignment(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+) -> DatabaseResult<NetworkSegmentId> {
+    let query = "SELECT segment_id FROM machine_interfaces WHERE id = $1 FOR UPDATE";
+    sqlx::query_scalar(query)
+        .bind(interface_id)
+        .fetch_optional(txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))?
+        .ok_or(DatabaseError::FindOneReturnedNoResultsError(
+            interface_id.into(),
+        ))
+}
+
 /// Optional metadata used while finding or creating a DHCP machine interface.
 ///
 /// DHCPv4 and DHCPv6 for the same NIC intentionally converge on one
@@ -612,12 +633,15 @@ pub async fn find_or_create_machine_interface(
             retained_window,
         },
         None,
+        None,
     )
     .await
 }
 
 /// Find or create a DHCP interface, allocating only the requested family for a
-/// brand-new dynamic row.
+/// brand-new dynamic row. Callers must lock `locked_segment_ids` before any
+/// interface writes; a newly selected allocation segment outside that set
+/// returns `FailedPrecondition` rather than acquiring another lock out of order.
 pub async fn find_or_create_machine_interface_for_family(
     txn: &mut PgConnection,
     machine_id: Option<MachineId>,
@@ -625,6 +649,7 @@ pub async fn find_or_create_machine_interface_for_family(
     relays: &[IpAddr],
     options: FindOrCreateMachineInterfaceOptions,
     address_family: IpAddressFamily,
+    locked_segment_ids: &[NetworkSegmentId],
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     find_or_create_machine_interface_inner(
         txn,
@@ -633,6 +658,7 @@ pub async fn find_or_create_machine_interface_for_family(
         relays,
         options,
         Some(address_family),
+        Some(locked_segment_ids),
     )
     .await
 }
@@ -644,6 +670,7 @@ async fn find_or_create_machine_interface_inner(
     relays: &[IpAddr],
     options: FindOrCreateMachineInterfaceOptions,
     address_family: Option<IpAddressFamily>,
+    locked_segment_ids: Option<&[NetworkSegmentId]>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     let FindOrCreateMachineInterfaceOptions {
         expected_interface,
@@ -669,6 +696,7 @@ async fn find_or_create_machine_interface_inner(
                 expected_interface,
                 retained_window,
                 address_family,
+                locked_segment_ids,
             )
             .await?;
             apply_primary_declaration(&mut *txn, &mut interface, is_primary).await?;
@@ -1055,6 +1083,7 @@ pub async fn validate_existing_mac_and_create(
         expected_interface,
         retained_window,
         None,
+        None,
     )
     .await
 }
@@ -1069,6 +1098,7 @@ async fn validate_existing_mac_and_create_inner(
     expected_interface: Option<ExpectedInterface>,
     retained_window: Option<chrono::Duration>,
     address_family: Option<IpAddressFamily>,
+    locked_segment_ids: Option<&[NetworkSegmentId]>,
 ) -> DatabaseResult<MachineInterfaceSnapshot> {
     let expected_interface_type = expected_interface
         .as_ref()
@@ -1155,6 +1185,17 @@ async fn validate_existing_mac_and_create_inner(
                 // preallocate_machine_interface, preallocate_bmc_machine_interface, or
                 // preallocate_expected_machine_interface.
                 // (`create` recovers any retained boot interface id onto the new row.)
+                if let Some(locked_segment_ids) = locked_segment_ids
+                    && let Some(segment) = network_segments
+                        .iter()
+                        .find(|segment| !locked_segment_ids.contains(&segment.id))
+                {
+                    return Err(DatabaseError::FailedPrecondition(format!(
+                        "network segment {} was not locked before DHCP interface reconciliation",
+                        segment.id,
+                    )));
+                }
+
                 let v = create_with_type(
                     txn,
                     &network_segments,
@@ -1345,6 +1386,19 @@ async fn retain_address_by_mac_and_type(
     interface_type: InterfaceType,
     segment_type_guard: Option<NetworkSegmentType>,
 ) -> DatabaseResult<()> {
+    // Retention changes the allocation type used by assignment's delete
+    // predicate. Serialize that change with address replacement too, and limit
+    // later queries to these IDs so newly visible interfaces cannot enter unlocked.
+    let query = "SELECT id FROM machine_interfaces
+        WHERE mac_address = $1 AND interface_type = $2
+        ORDER BY id FOR UPDATE";
+    let interface_ids: Vec<MachineInterfaceId> = sqlx::query_scalar(query)
+        .bind(mac_address)
+        .bind(interface_type)
+        .fetch_all(&mut *txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))?;
+
     if let Some(segment_type_guard) = segment_type_guard {
         let query = "SELECT ns.network_segment_type
             FROM machine_interfaces mi
@@ -1354,11 +1408,13 @@ async fn retain_address_by_mac_and_type(
               AND mi.interface_type = $2
               AND mia.allocation_type = 'dhcp'
               AND ns.network_segment_type != $3
+              AND mi.id = ANY($4)
             LIMIT 1";
         let mismatched_segment_type: Option<NetworkSegmentType> = sqlx::query_scalar(query)
             .bind(mac_address)
             .bind(interface_type)
             .bind(segment_type_guard)
+            .bind(&interface_ids)
             .fetch_optional(&mut *txn)
             .await
             .map_err(|err| DatabaseError::query(query, err))?;
@@ -1378,11 +1434,13 @@ async fn retain_address_by_mac_and_type(
                   WHERE mi.mac_address = $1
                     AND mi.interface_type = $2
                     AND ns.network_segment_type = $3
+                    AND mi.id = ANY($4)
               )";
         return sqlx::query(query)
             .bind(mac_address)
             .bind(interface_type)
             .bind(segment_type_guard)
+            .bind(&interface_ids)
             .execute(txn)
             .await
             .map(|_| ())
@@ -1395,10 +1453,12 @@ async fn retain_address_by_mac_and_type(
           AND interface_id IN (
               SELECT id FROM machine_interfaces
               WHERE mac_address = $1 AND interface_type = $2
+                AND id = ANY($3)
           )";
     sqlx::query(query)
         .bind(mac_address)
         .bind(interface_type)
+        .bind(&interface_ids)
         .execute(txn)
         .await
         .map(|_| ())
@@ -1453,6 +1513,8 @@ async fn reconcile_existing_preallocation(
     let Some(iface) = existing.first() else {
         return Ok(false);
     };
+    lock_for_address_assignment(&mut *txn, iface.id).await?;
+    let iface = find_one(&mut *txn, iface.id).await?;
 
     let family = static_ip.address_family();
     let addresses =
@@ -2289,12 +2351,7 @@ async fn lock_network_segment_shared(
     txn: &mut PgTransaction<'_>,
     segment: &NetworkSegment,
 ) -> DatabaseResult<()> {
-    let query = "SELECT pg_advisory_xact_lock_shared(hashtextextended($1::text, 0))";
-    sqlx::query_scalar(query)
-        .bind(format!("network_segment.{}", segment.id))
-        .fetch_one(txn.as_mut())
-        .await
-        .map_err(|e| DatabaseError::query(query, e))
+    lock_network_segments_shared(txn.as_mut(), std::slice::from_ref(&segment.id)).await
 }
 
 async fn lock_network_segment_exclusive(
@@ -2307,9 +2364,8 @@ async fn lock_network_segment_exclusive(
 
 /// Advisory-lock every segment in `segment_ids`, in ascending id order --
 /// the allocator convention: segment advisory lock first, then machine
-/// interface/address row locks. This is the one home for the lock key and
-/// ordering; every segment-lock helper funnels through it. Must run inside a
-/// transaction: the locks are `pg_advisory_xact_lock`-scoped and release on
+/// interface/address row locks. Must run inside a transaction: the locks are
+/// `pg_advisory_xact_lock`-scoped and release on
 /// commit or rollback.
 pub async fn lock_network_segments_exclusive(
     txn: &mut PgConnection,
@@ -2320,6 +2376,28 @@ pub async fn lock_network_segments_exclusive(
     ids.dedup();
     for id in ids {
         let query = "SELECT pg_advisory_xact_lock(hashtextextended($1::text, 0))";
+        sqlx::query_scalar::<_, ()>(query)
+            .bind(format!("network_segment.{id}"))
+            .fetch_one(&mut *txn)
+            .await
+            .map_err(|e| DatabaseError::query(query, e))?;
+    }
+    Ok(())
+}
+
+/// Acquire shared segment locks in ascending ID order within a transaction.
+/// IPv4 DHCP takes these before interface updates, matching its allocator's
+/// shared locks. Callers that can allocate IPv6 or a whole prefix must use
+/// exclusive locks from the start rather than upgrade shared locks later.
+pub async fn lock_network_segments_shared(
+    txn: &mut PgConnection,
+    segment_ids: &[NetworkSegmentId],
+) -> DatabaseResult<()> {
+    let mut ids = segment_ids.to_vec();
+    ids.sort_unstable();
+    ids.dedup();
+    for id in ids {
+        let query = "SELECT pg_advisory_xact_lock_shared(hashtextextended($1::text, 0))";
         sqlx::query_scalar::<_, ()>(query)
             .bind(format!("network_segment.{id}"))
             .fetch_one(&mut *txn)
@@ -2415,7 +2493,7 @@ pub async fn find_optional_for_update_by_ip(
         FROM machine_interface_addresses mia
         JOIN machine_interfaces mi ON mi.id = mia.interface_id
         WHERE mia.address = $1::inet
-        FOR UPDATE OF mia, mi
+        FOR UPDATE OF mi
     "#;
     let interface_ids: Vec<(MachineInterfaceId,)> = sqlx::query_as(query)
         .bind(remote_ip)
@@ -2425,7 +2503,23 @@ pub async fn find_optional_for_update_by_ip(
 
     match interface_ids.as_slice() {
         [] => Ok(None),
-        [(interface_id,)] => find_one(txn, *interface_id).await.map(Some),
+        [(interface_id,)] => {
+            // Assignment locks the interface before its address rows. The address
+            // may have been replaced while we waited, so recheck this exact owner
+            // before accepting it as the discovery source.
+            let query = "SELECT interface_id FROM machine_interface_addresses
+                WHERE interface_id = $1 AND address = $2::inet FOR UPDATE";
+            let owner = sqlx::query_scalar::<_, MachineInterfaceId>(query)
+                .bind(interface_id)
+                .bind(remote_ip)
+                .fetch_optional(&mut *txn)
+                .await
+                .map_err(|e| DatabaseError::query(query, e))?;
+            if owner.is_none() {
+                return Ok(None);
+            }
+            find_one(txn, *interface_id).await.map(Some)
+        }
         // The address uniqueness constraint makes this unreachable on a valid schema. Keep the
         // guard so discovery fails closed if database invariants are bypassed.
         _ => Err(DatabaseError::internal(format!(
@@ -2579,11 +2673,16 @@ pub async fn get_machine_interface_primary(
 
 /// Move an entry from predicted_machine_interfaces to machine_interfaces, using the given relay IP
 /// to know what network segment to assign.
+///
+/// The caller must acquire `locked_segment_ids` exclusively, including every
+/// admin segment, before updating interface rows. Reject a relay segment that
+/// appeared after that lookup so later DHCP allocation cannot lock it out of order.
 pub async fn move_predicted_machine_interface_to_machine(
     txn: &mut PgConnection,
     predicted_machine_interface: &PredictedMachineInterface,
     relay_ip: IpAddr,
     retained_window: Option<chrono::Duration>,
+    locked_segment_ids: &[NetworkSegmentId],
 ) -> Result<(), DatabaseError> {
     tracing::info!(
         machine_id=%predicted_machine_interface.machine_id,
@@ -2605,6 +2704,13 @@ pub async fn move_predicted_machine_interface_to_machine(
             predicted_machine_interface.mac_address,
             network_segment.id,
             predicted_machine_interface.expected_network_segment_type,
+        )));
+    }
+
+    if !locked_segment_ids.contains(&network_segment.id) {
+        return Err(DatabaseError::FailedPrecondition(format!(
+            "network segment {} changed before predicted interface promotion",
+            network_segment.id,
         )));
     }
 

--- a/crates/api-db/src/machine_interface/tests.rs
+++ b/crates/api-db/src/machine_interface/tests.rs
@@ -132,6 +132,130 @@ async fn create_managed_segment(
 }
 
 #[crate::sqlx_test]
+async fn discovery_lookup_rechecks_address_after_assignment(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    create_managed_segment(
+        &pool,
+        "discovery-static-race",
+        "192.0.2.0/24",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let mac: MacAddress = "02:00:00:00:53:9a".parse()?;
+    let original_address: IpAddr = "192.0.2.98".parse()?;
+    let replacement_address: IpAddr = "192.0.2.99".parse()?;
+    let mut setup = pool.begin().await?;
+    preallocate_machine_interface(&mut setup, mac, original_address, None).await?;
+    let interface_id = find_by_mac_address(&mut *setup, mac).await?[0].id;
+    setup.commit().await?;
+
+    let mut holder = pool.begin().await?;
+    lock_for_address_assignment(&mut holder, interface_id).await?;
+    let holder_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *holder)
+        .await?;
+    let mut waiter = pool.begin().await?;
+    let waiter_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *waiter)
+        .await?;
+
+    let lookup = async {
+        let result = find_optional_for_update_by_ip(&mut waiter, original_address).await?;
+        waiter.commit().await?;
+        Ok::<_, Box<dyn std::error::Error>>(result)
+    };
+    let replace = async {
+        loop {
+            let blocked: bool = sqlx::query_scalar("SELECT $1 = ANY(pg_blocking_pids($2))")
+                .bind(holder_pid)
+                .bind(waiter_pid)
+                .fetch_one(&pool)
+                .await?;
+            if blocked {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let result = db::machine_interface_address::assign_static(
+            &mut holder,
+            interface_id,
+            replacement_address,
+        )
+        .await?;
+        holder.commit().await?;
+        Ok::<_, Box<dyn std::error::Error>>(result)
+    };
+    let (lookup, replacement) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        tokio::join!(lookup, replace)
+    })
+    .await?;
+    assert_eq!(
+        replacement?,
+        model::allocation_type::AssignStaticResult::ReplacedStatic
+    );
+    assert!(
+        lookup?.is_none(),
+        "discovery must not accept an address replaced while it waited"
+    );
+
+    let mut connection = pool.acquire().await?;
+    let addresses =
+        db::machine_interface_address::find_for_interface(&mut connection, interface_id).await?;
+    assert_eq!(addresses.len(), 1);
+    assert_eq!(addresses[0].address, replacement_address);
+    assert_eq!(addresses[0].allocation_type, AllocationType::Static);
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn dhcp_creation_rejects_a_segment_selected_after_locking(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_id = create_managed_segment(
+        &pool,
+        "new-dhcp-candidate",
+        "2001:db8:5398::/64",
+        NetworkSegmentType::Underlay,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let mac_address: MacAddress = "02:00:00:00:53:99".parse()?;
+    let mut txn = pool.begin().await?;
+
+    // The caller's earlier routing lookup did not include this segment.
+    // Reject before creation rather than add an allocator lock after writes.
+    let error = find_or_create_machine_interface_for_family(
+        &mut txn,
+        None,
+        mac_address,
+        &["2001:db8:5398::1".parse()?],
+        FindOrCreateMachineInterfaceOptions {
+            expected_interface: None,
+            is_primary: None,
+            retained_window: None,
+        },
+        IpAddressFamily::Ipv6,
+        &[],
+    )
+    .await
+    .expect_err("an unlocked allocation candidate must be rejected");
+    assert!(
+        matches!(error, DatabaseError::FailedPrecondition(ref message)
+        if message.contains(&segment_id.to_string())),
+        "unexpected allocation error: {error:?}"
+    );
+    assert!(
+        find_by_mac_address(&mut *txn, mac_address)
+            .await?
+            .is_empty()
+    );
+    txn.commit().await?;
+    Ok(())
+}
+
+#[crate::sqlx_test]
 async fn find_by_machine_id_for_update_locks_non_bmc_interfaces_in_id_order(
     pool: sqlx::PgPool,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -545,6 +669,105 @@ async fn test_preallocate_machine_interface_rejects_conflicting_ip(
         "preallocating a different IP for the same MAC should be rejected, got {result:?}"
     );
 
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn fixed_preallocation_rechecks_static_address_after_waiting(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_id = create_managed_segment(
+        &pool,
+        "fixed-address-after-wait",
+        "2001:db8:5398::/64",
+        NetworkSegmentType::HostInband,
+        AllocationStrategy::Reserved,
+    )
+    .await?;
+    let mac: MacAddress = "7A:7B:7C:7D:7E:56".parse()?;
+    let mut setup = pool.begin().await?;
+    let interface_id: MachineInterfaceId = sqlx::query_scalar(
+        "INSERT INTO machine_interfaces
+            (segment_id, mac_address, primary_interface, hostname)
+         VALUES ($1, $2, false, 'fixed-address-after-wait') RETURNING id",
+    )
+    .bind(segment_id)
+    .bind(mac)
+    .fetch_one(&mut *setup)
+    .await?;
+    setup.commit().await?;
+
+    let committed_address: IpAddr = "2001:db8:5398::20".parse()?;
+    let requested_address: IpAddr = "2001:db8:5398::21".parse()?;
+    let mut holder = pool.begin().await?;
+    sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+        .bind(interface_id)
+        .fetch_one(&mut *holder)
+        .await?;
+    db::machine_interface_address::insert(
+        &mut holder,
+        interface_id,
+        committed_address,
+        AllocationType::Static,
+    )
+    .await?;
+    let holder_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *holder)
+        .await?;
+    let mut waiter = pool.begin().await?;
+    let waiter_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *waiter)
+        .await?;
+
+    // Preallocation must reject the different static address after waiting;
+    // only the explicit assignment API may replace it.
+    let preallocate = async {
+        let result = preallocate_machine_interface(&mut waiter, mac, requested_address, None).await;
+        if result.is_ok() {
+            waiter.commit().await?;
+        } else {
+            waiter.rollback().await?;
+        }
+        Ok::<_, Box<dyn std::error::Error>>(result)
+    };
+    let commit_static_address = async {
+        loop {
+            let blocked: bool = sqlx::query_scalar("SELECT $1 = ANY(pg_blocking_pids($2))")
+                .bind(holder_pid)
+                .bind(waiter_pid)
+                .fetch_one(&pool)
+                .await?;
+            if blocked {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        holder.commit().await?;
+        Ok::<(), Box<dyn std::error::Error>>(())
+    };
+    let (preallocation, assignment) =
+        tokio::time::timeout(std::time::Duration::from_secs(5), async {
+            tokio::join!(preallocate, commit_static_address)
+        })
+        .await?;
+    assignment?;
+    let error = preallocation?.expect_err("a different static reservation must be rejected");
+    match error {
+        DatabaseError::InvalidArgument(message) => {
+            assert!(
+                message.contains(&committed_address.to_string()),
+                "{message}"
+            );
+        }
+        error => panic!("expected an invalid-argument error, got {error:?}"),
+    }
+
+    let mut connection = pool.acquire().await?;
+    let addresses =
+        db::machine_interface_address::find_for_interface(&mut connection, interface_id).await?;
+    assert_eq!(addresses.len(), 1);
+    assert_eq!(addresses[0].address, committed_address);
+    assert_eq!(addresses[0].allocation_type, AllocationType::Static);
     Ok(())
 }
 
@@ -1300,6 +1523,108 @@ async fn test_expected_interface_retained_policy_pins_all_dhcp_address_families(
         AllocationType::Dhcp,
     );
 
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn retention_preserves_static_assignment_after_waiting(
+    pool: sqlx::PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let segment_id = create_managed_segment(
+        &pool,
+        "retention-after-static-assignment",
+        "2001:db8:5398::/64",
+        NetworkSegmentType::HostInband,
+        AllocationStrategy::Dynamic,
+    )
+    .await?;
+    let mac: MacAddress = "7A:7B:7C:7D:7E:57".parse()?;
+    let mut setup = pool.begin().await?;
+    let interface_id: MachineInterfaceId = sqlx::query_scalar(
+        "INSERT INTO machine_interfaces
+            (segment_id, mac_address, interface_type, primary_interface, hostname)
+         VALUES ($1, $2, $3, false, 'retention-after-static-assignment') RETURNING id",
+    )
+    .bind(segment_id)
+    .bind(mac)
+    .bind(InterfaceType::Data)
+    .fetch_one(&mut *setup)
+    .await?;
+    db::machine_interface_address::insert(
+        &mut setup,
+        interface_id,
+        "2001:db8:5398::30".parse()?,
+        AllocationType::Dhcp,
+    )
+    .await?;
+    setup.commit().await?;
+
+    let expected_interface = ExpectedInterface {
+        mac_address: mac,
+        role: ExpectedInterfaceRole::Host,
+        ip_allocation: Some(ExpectedInterfaceIpAllocation::Retained),
+        ..Default::default()
+    };
+    let static_address: IpAddr = "2001:db8:5398::31".parse()?;
+    let mut holder = pool.begin().await?;
+    sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+        .bind(interface_id)
+        .fetch_one(&mut *holder)
+        .await?;
+    let holder_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *holder)
+        .await?;
+    let mut waiter = pool.begin().await?;
+    let waiter_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(&mut *waiter)
+        .await?;
+
+    let retain_address = async {
+        retain_expected_machine_interface_address(&mut waiter, &expected_interface).await?;
+        waiter.commit().await?;
+        Ok::<(), Box<dyn std::error::Error>>(())
+    };
+    let assign_address = async {
+        loop {
+            let blocked: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                    SELECT 1 FROM pg_stat_activity
+                    WHERE pid = $2
+                      AND $1 = ANY(pg_blocking_pids(pid))
+                      AND query ILIKE '%FROM machine_interfaces%FOR UPDATE%'
+                )",
+            )
+            .bind(holder_pid)
+            .bind(waiter_pid)
+            .fetch_one(&pool)
+            .await?;
+            if blocked {
+                break;
+            }
+            tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+        }
+        let result =
+            db::machine_interface_address::assign_static(&mut holder, interface_id, static_address)
+                .await?;
+        holder.commit().await?;
+        Ok::<_, Box<dyn std::error::Error>>(result)
+    };
+    let (retention, assignment) = tokio::time::timeout(std::time::Duration::from_secs(5), async {
+        tokio::join!(retain_address, assign_address)
+    })
+    .await?;
+    retention?;
+    assert_eq!(
+        assignment?,
+        model::allocation_type::AssignStaticResult::ReplacedDhcp,
+    );
+
+    let mut connection = pool.acquire().await?;
+    let addresses =
+        db::machine_interface_address::find_for_interface(&mut connection, interface_id).await?;
+    assert_eq!(addresses.len(), 1);
+    assert_eq!(addresses[0].address, static_address);
+    assert_eq!(addresses[0].allocation_type, AllocationType::Static);
     Ok(())
 }
 

--- a/crates/api-db/src/machine_interface_address.rs
+++ b/crates/api-db/src/machine_interface_address.rs
@@ -94,6 +94,7 @@ pub async fn delete(
     txn: &mut PgConnection,
     interface_id: &MachineInterfaceId,
 ) -> Result<(), DatabaseError> {
+    lock_interface_for_deletion(&mut *txn, *interface_id).await?;
     let query = "DELETE FROM machine_interface_addresses WHERE interface_id = $1";
     sqlx::query(query)
         .bind(interface_id)
@@ -101,6 +102,22 @@ pub async fn delete(
         .await
         .map(|_| ())
         .map_err(|e| DatabaseError::query(query, e))
+}
+
+/// Lock the parent before touching its address rows. Unlike assignment,
+/// deletion still succeeds when the interface has already disappeared.
+/// Must run inside a transaction that remains open through the following address delete.
+async fn lock_interface_for_deletion(
+    txn: &mut PgConnection,
+    interface_id: MachineInterfaceId,
+) -> Result<(), DatabaseError> {
+    let query = "SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE";
+    sqlx::query(query)
+        .bind(interface_id)
+        .execute(txn)
+        .await
+        .map(|_| ())
+        .map_err(|error| DatabaseError::query(query, error))
 }
 
 /// Find all addresses for an interface, including their allocation type.
@@ -136,6 +153,7 @@ pub async fn find_allocation_type_for_family(
 
 /// Delete the address for a given interface, address family, and
 /// allocation type. Returns true if a row was deleted.
+/// The caller must hold the interface lock before deleting its address.
 pub async fn delete_by_interface_family(
     txn: &mut PgConnection,
     interface_id: MachineInterfaceId,
@@ -163,6 +181,7 @@ pub async fn delete_by_interface_and_address(
     address: IpAddr,
     allocation_type: AllocationType,
 ) -> Result<bool, DatabaseError> {
+    lock_interface_for_deletion(&mut *txn, interface_id).await?;
     let query = "DELETE FROM machine_interface_addresses WHERE interface_id = $1 AND address = $2::inet AND allocation_type = $3";
     sqlx::query(query)
         .bind(interface_id)
@@ -244,11 +263,16 @@ pub async fn insert(
 /// - `Static`: the old static address is replaced.
 /// - `Dhcp` or `Slaac`: the managed allocation is removed and
 ///   replaced with the static assignment.
+///
+/// Must run inside a transaction. This locks the interface before selecting an
+/// address. Callers with their own address-dependent skip or conflict rules must
+/// acquire that lock before reading the state used by those rules.
 pub async fn assign_static(
     txn: &mut PgConnection,
     interface_id: MachineInterfaceId,
     address: IpAddr,
 ) -> Result<AssignStaticResult, DatabaseError> {
+    crate::machine_interface::lock_for_address_assignment(&mut *txn, interface_id).await?;
     let family = address.address_family();
 
     let existing = find_allocation_type_for_family(&mut *txn, interface_id, family).await?;
@@ -274,18 +298,15 @@ pub async fn assign_static(
 /// Delete an address allocation of the given type. Returns at most one owning
 /// interface in a vector so callers can share the hostname-resync path with
 /// MAC-scoped deletion.
+///
+/// If the matching allocation moves to another interface while this waits for
+/// its original owner, leave it allocated and return an empty vector.
 pub async fn delete_by_address(
     txn: &mut PgConnection,
     address: IpAddr,
     allocation_type: AllocationType,
 ) -> Result<Vec<MachineInterfaceId>, DatabaseError> {
-    let query = "DELETE FROM machine_interface_addresses WHERE address = $1::inet AND allocation_type = $2 RETURNING interface_id";
-    sqlx::query_scalar(query)
-        .bind(address)
-        .bind(allocation_type)
-        .fetch_all(txn)
-        .await
-        .map_err(|e| DatabaseError::query(query, e))
+    delete_address_allocation(txn, address, None, allocation_type).await
 }
 
 /// Delete an address allocation for a given (ip, mac) pair, which
@@ -294,26 +315,53 @@ pub async fn delete_by_address(
 /// Returns the interfaces that owned the deleted allocations (normally one,
 /// empty if the pair matched nothing) so callers can resync each one's hostname
 /// against the authoritative deleted rows rather than a separate lookup.
+/// A matching allocation moved to another interface while waiting for its
+/// original owner is left allocated, returning an empty vector.
 pub async fn delete_by_address_and_mac(
     txn: &mut PgConnection,
     address: IpAddr,
     mac_address: mac_address::MacAddress,
     allocation_type: AllocationType,
 ) -> Result<Vec<MachineInterfaceId>, DatabaseError> {
-    let query = "DELETE FROM machine_interface_addresses mia
-        USING machine_interfaces mi
-        WHERE mia.interface_id = mi.id
-          AND mia.address = $1::inet
+    delete_address_allocation(txn, address, Some(mac_address), allocation_type).await
+}
+
+async fn delete_address_allocation(
+    txn: &mut PgConnection,
+    address: IpAddr,
+    mac_address: Option<MacAddress>,
+    allocation_type: AllocationType,
+) -> Result<Vec<MachineInterfaceId>, DatabaseError> {
+    let query = "SELECT mi.id
+        FROM machine_interfaces mi
+        JOIN machine_interface_addresses mia ON mia.interface_id = mi.id
+        WHERE mia.address = $1::inet
           AND mia.allocation_type = $2
-          AND mi.mac_address = $3::macaddr
-        RETURNING mia.interface_id";
-    sqlx::query_scalar(query)
+          AND ($3::macaddr IS NULL OR mi.mac_address = $3::macaddr)
+        FOR UPDATE OF mi";
+    let Some(interface_id) = sqlx::query_scalar::<_, MachineInterfaceId>(query)
         .bind(address)
         .bind(allocation_type)
         .bind(mac_address)
+        .fetch_optional(&mut *txn)
+        .await
+        .map_err(|error| DatabaseError::query(query, error))?
+    else {
+        return Ok(Vec::new());
+    };
+
+    // Read again after the parent lock, but keep the selected owner. An
+    // address moved to another interface while we waited must survive.
+    let query = "DELETE FROM machine_interface_addresses
+        WHERE interface_id = $1 AND address = $2::inet AND allocation_type = $3
+        RETURNING interface_id";
+    sqlx::query_scalar(query)
+        .bind(interface_id)
+        .bind(address)
+        .bind(allocation_type)
         .fetch_all(txn)
         .await
-        .map_err(|e| DatabaseError::query(query, e))
+        .map_err(|error| DatabaseError::query(query, error))
 }
 
 /// Check whether an interface has any address assigned for the
@@ -355,6 +403,7 @@ pub struct MachineInterfaceSearchResult {
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
+    use std::time::Duration;
 
     use super::*;
 
@@ -398,6 +447,32 @@ mod tests {
         }
     }
 
+    async fn wait_for_interface_lock(
+        pool: &sqlx::PgPool,
+        holder_pid: i32,
+        waiter_pid: i32,
+    ) -> Result<(), sqlx::Error> {
+        loop {
+            let blocked: bool = sqlx::query_scalar(
+                "SELECT EXISTS (
+                    SELECT 1 FROM pg_stat_activity
+                    WHERE pid = $2
+                      AND $1 = ANY(pg_blocking_pids(pid))
+                      AND strpos(lower(query), 'from machine_interfaces') > 0
+                      AND strpos(lower(query), 'for update') > 0
+                )",
+            )
+            .bind(holder_pid)
+            .bind(waiter_pid)
+            .fetch_one(pool)
+            .await?;
+            if blocked {
+                return Ok(());
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+    }
+
     /// Verifies the new SLAAC allocation type survives a database round trip.
     #[crate::sqlx_test]
     async fn slaac_allocation_type_round_trips(
@@ -436,6 +511,242 @@ mod tests {
         assert_eq!(addresses[0].allocation_type, AllocationType::Slaac);
 
         txn.rollback().await?;
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn static_assignment_rechecks_slaac_after_waiting(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut setup = pool.begin().await?;
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('static-after-slaac', 'V1-T0') RETURNING id",
+        )
+        .fetch_one(&mut *setup)
+        .await?;
+        let interface_id = create_test_interface(
+            &mut setup,
+            segment_id,
+            "02:00:00:00:00:15".parse()?,
+            "static-after-slaac",
+        )
+        .await?;
+        setup.commit().await?;
+
+        let mut holder = pool.begin().await?;
+        sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+            .bind(interface_id)
+            .fetch_one(&mut *holder)
+            .await?;
+        insert(
+            &mut holder,
+            interface_id,
+            "2001:db8::15".parse()?,
+            AllocationType::Slaac,
+        )
+        .await?;
+        let holder_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *holder)
+            .await?;
+        let mut waiter = pool.begin().await?;
+        let waiter_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *waiter)
+            .await?;
+        let static_address: IpAddr = "2001:db8::16".parse()?;
+
+        // The SLAAC row is uncommitted when static assignment starts. Wait for
+        // PostgreSQL to confirm the blocked writer before making it visible.
+        let assign_address = async {
+            let result = assign_static(&mut waiter, interface_id, static_address).await?;
+            waiter.commit().await?;
+            Ok::<_, Box<dyn std::error::Error>>(result)
+        };
+        let commit_observation = async {
+            wait_for_interface_lock(&pool, holder_pid, waiter_pid).await?;
+            holder.commit().await?;
+            Ok::<(), Box<dyn std::error::Error>>(())
+        };
+        let (assignment, observation) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(assign_address, commit_observation)
+        })
+        .await?;
+        observation?;
+        assert_eq!(assignment?, AssignStaticResult::ReplacedDhcp);
+
+        let mut connection = pool.acquire().await?;
+        let addresses = find_for_interface(&mut connection, interface_id).await?;
+        assert_eq!(addresses.len(), 1);
+        assert_eq!(addresses[0].address, static_address);
+        assert_eq!(addresses[0].allocation_type, AllocationType::Static);
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn address_deletion_preserves_owner_changed_while_waiting(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut setup = pool.begin().await?;
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('expiry-after-owner-move', 'V1-T0') RETURNING id",
+        )
+        .fetch_one(&mut *setup)
+        .await?;
+        let source_interface_id = create_test_interface(
+            &mut setup,
+            segment_id,
+            "02:00:00:00:00:16".parse()?,
+            "expiry-source",
+        )
+        .await?;
+        let destination_interface_id = create_test_interface(
+            &mut setup,
+            segment_id,
+            "02:00:00:00:00:17".parse()?,
+            "expiry-destination",
+        )
+        .await?;
+        let address: IpAddr = "2001:db8::20".parse()?;
+        insert(
+            &mut setup,
+            source_interface_id,
+            address,
+            AllocationType::Dhcp,
+        )
+        .await?;
+        setup.commit().await?;
+
+        let mut holder = pool.begin().await?;
+        let mut interface_ids = [source_interface_id, destination_interface_id];
+        interface_ids.sort();
+        for interface_id in interface_ids {
+            sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+                .bind(interface_id)
+                .fetch_one(&mut *holder)
+                .await?;
+        }
+        let holder_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *holder)
+            .await?;
+        let mut waiter = pool.begin().await?;
+        let waiter_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *waiter)
+            .await?;
+
+        let expire_address = async {
+            let deleted = delete_by_address(&mut waiter, address, AllocationType::Dhcp).await?;
+            waiter.commit().await?;
+            Ok::<_, Box<dyn std::error::Error>>(deleted)
+        };
+        let move_address = async {
+            wait_for_interface_lock(&pool, holder_pid, waiter_pid).await?;
+            // Admin reconciliation can move an existing DHCP row between
+            // interfaces. Expiry must not follow it to its new owner.
+            let moved = sqlx::query(
+                "UPDATE machine_interface_addresses SET interface_id = $1
+                 WHERE interface_id = $2 AND address = $3::inet AND allocation_type = 'dhcp'",
+            )
+            .bind(destination_interface_id)
+            .bind(source_interface_id)
+            .bind(address)
+            .execute(&mut *holder)
+            .await?;
+            assert_eq!(moved.rows_affected(), 1);
+            holder.commit().await?;
+            Ok::<(), Box<dyn std::error::Error>>(())
+        };
+        let (deletion, movement) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(expire_address, move_address)
+        })
+        .await?;
+        movement?;
+        assert!(deletion?.is_empty());
+
+        let mut connection = pool.acquire().await?;
+        assert!(
+            find_for_interface(&mut connection, source_interface_id)
+                .await?
+                .is_empty()
+        );
+        let addresses = find_for_interface(&mut connection, destination_interface_id).await?;
+        assert_eq!(addresses.len(), 1);
+        assert_eq!(addresses[0].address, address);
+        assert_eq!(addresses[0].allocation_type, AllocationType::Dhcp);
+        Ok(())
+    }
+
+    #[crate::sqlx_test]
+    async fn static_removal_preserves_replacement_after_waiting(
+        pool: sqlx::PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut setup = pool.begin().await?;
+        let segment_id: NetworkSegmentId = sqlx::query_scalar(
+            "INSERT INTO network_segments (name, version)
+             VALUES ('static-removal-after-replacement', 'V1-T0') RETURNING id",
+        )
+        .fetch_one(&mut *setup)
+        .await?;
+        let interface_id = create_test_interface(
+            &mut setup,
+            segment_id,
+            "02:00:00:00:00:18".parse()?,
+            "static-removal-after-replacement",
+        )
+        .await?;
+        let original_address: IpAddr = "2001:db8::30".parse()?;
+        let replacement_address: IpAddr = "2001:db8::31".parse()?;
+        insert(
+            &mut setup,
+            interface_id,
+            original_address,
+            AllocationType::Static,
+        )
+        .await?;
+        setup.commit().await?;
+
+        let mut holder = pool.begin().await?;
+        sqlx::query("SELECT id FROM machine_interfaces WHERE id = $1 FOR UPDATE")
+            .bind(interface_id)
+            .fetch_one(&mut *holder)
+            .await?;
+        let holder_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *holder)
+            .await?;
+        let mut waiter = pool.begin().await?;
+        let waiter_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+            .fetch_one(&mut *waiter)
+            .await?;
+
+        let remove_address = async {
+            let deleted = delete_by_interface_and_address(
+                &mut waiter,
+                interface_id,
+                original_address,
+                AllocationType::Static,
+            )
+            .await?;
+            waiter.commit().await?;
+            Ok::<_, Box<dyn std::error::Error>>(deleted)
+        };
+        let replace_address = async {
+            wait_for_interface_lock(&pool, holder_pid, waiter_pid).await?;
+            let result = assign_static(&mut holder, interface_id, replacement_address).await?;
+            holder.commit().await?;
+            Ok::<_, Box<dyn std::error::Error>>(result)
+        };
+        let (removal, replacement) = tokio::time::timeout(Duration::from_secs(5), async {
+            tokio::join!(remove_address, replace_address)
+        })
+        .await?;
+        assert_eq!(replacement?, AssignStaticResult::ReplacedStatic);
+        assert!(!removal?);
+
+        let mut connection = pool.acquire().await?;
+        let addresses = find_for_interface(&mut connection, interface_id).await?;
+        assert_eq!(addresses.len(), 1);
+        assert_eq!(addresses[0].address, replacement_address);
+        assert_eq!(addresses[0].allocation_type, AllocationType::Static);
         Ok(())
     }
 


### PR DESCRIPTION
> [!NOTE]
> While this PR seems large at first glance, just FYI that it contains:
>
> - +864/-0 lines of test changes.
>
> Don't let it scare you!

`nico-api` records interface IPv6 addresses through SLAAC inference, stateful DHCPv6, and explicit static assignment. Concurrent requests can read incomplete address state and fail with a same-family conflict. For example, an `INFORMATION-REQUEST` can see no IPv6 address while a static assignment remains uncommitted. It tries to insert an inferred address, then fails after the static address commits.

Serialize these decisions on the interface row and reread after waiting. Inference adds an address only when IPv6 is absent. Stateful DHCPv6 replaces SLAAC but preserves DHCP and static addresses. Explicit assignment can add or replace IPv6; fixed reservations still reject conflicting static addresses. Expected-device updates skip already-addressed interfaces without locking them. DHCPv4 also locks the interface before inserting, preventing a deadlock with static assignment. IPv4 address selection and conflicts with other interfaces are unchanged.

DHCP takes allocator segment locks before interface updates, with matching ordering for promotion, removal, expiry, retention, discovery, and vendor bookkeeping. Expiry preserves an address that moved to another interface while waiting and returns `NotFound`. Stateful IPv6 requests sharing a segment serialize; IPv4 uses shared segment locks. `INFORMATION-REQUEST` takes allocator locks only for a predicted interface. During a rolling upgrade, overlapping old and new writers can still deadlock because older instances lock address rows first. PostgreSQL aborts one transaction; avoiding that overlap requires rollout coordination.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/5398

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same complete trees. Codex's final closure found no additional issues.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 46 | 14 | 32 |
| common-nits-reviewer | 1 | 1 | 0 |
| **Total** | **48** | **16** | **32** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted:** Discovery now locks the parent before revalidating the exact address and owner.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted:** Promotion testing now requires the specific segment-lock wait.
2. **Adopted:** Document expiry preserving an address whose owner changed.
3. **Declined:** Address uniqueness already guarantees at most one deletion result.
4. **Declined:** Unchanged `MacAddress` qualification needs no incidental cleanup.
5. **Declined:** Existing shared/exclusive key duplication needs no mode abstraction.
6. **Adopted:** Reflow the changed transaction-contract comment.
7. **Adopted:** Explain family scope; DHCPv4 now participates in parent locking.
8. **Adopted:** Reuse promotion's polling helper; retain vendor-specific selectors.
9. **Adopted:** Use literal query fragments, avoiding wildcard underscore matches.
10. **Adopted:** Reuse the local assignment-test interface-lock helper.
11. **Declined:** Explicit-PID loops do not justify cross-module test infrastructure.
12. **Adopted:** Explain locking before upstream policy checks.
13. **Declined:** Broader missing-interface error mapping is outside scope.
14. **Declined:** Apparent renewal snapshots can become stale before locking.
15. **Declined:** Narrower promotion locks require additional membership revalidation.
16. **Declined:** Promotion documentation does not promise every demoted segment's lock.
17. **Declined:** Actual callers supply both optional arguments together.
18. **Declined:** Extracting lock preparation does not eliminate early reads.
19. **Declined:** Assignment requires a parent; deletion tolerates absence.
20. **Adopted:** Explain retention queries using only locked interface IDs.
21. **Declined:** Acquisition sorts IDs; returned membership needs no sorting.
22. **Declined:** Cross-file import normalization is unrelated.
23. **Adopted:** Include the actual allocation error in regression failures.
24. **Declined:** Retention coverage protects distinct assignment returns and ordering.
25. **Declined:** Removal coverage protects distinct replacement/deletion returns and ordering.
26. **Adopted:** Explain why IPv4 family filtering permits shared locks.
27. **Declined:** Nightly format checking passes; column counting suggested otherwise.
28. **Declined:** Membership guards and stale-segment checks cannot share the proposed helper.
29. **Declined:** DHCP preparation belongs in orchestration; extraction removes no ordering dependency.
30. **Declined:** A shared/exclusive abstraction adds no necessary correction.
31. **Declined:** Existing transaction-lifetime documentation is accurate despite preferred wrapping.
32. **Declined:** Cross-crate waiter infrastructure expands distinct local test requirements.
33. **Adopted:** Limit the unlocked skip comment to initially addressed interfaces.
34. **Adopted:** Document family deletion's caller-held interface lock.
35. **Declined:** Different missing-parent semantics justify separate assignment/deletion lock helpers.
36. **Adopted:** Narrow the vendor test's parent query selector.
37. **Declined:** Vendor regression prose already matches what it exercises.
38. **Declined:** The shadowed binding represents the resolved machine identity.
39. **Declined:** Existing lookup comments already explain parent-first ownership revalidation.
40. **Declined:** Unchanged qualified `MacAddress` spelling needs no harmonization.
41. **Declined:** Per-candidate IPv6 allocation is a separate allocator redesign.
42. **Declined:** Rack-load measurement is separate operational work; no throughput claim.
43. **Declined:** Shared-lock queueing is acknowledged; no unacceptable latency demonstrated.
44. **Declined:** The supposedly test-only creation entry point has production callers.
45. **Declined:** Exact inferred claims differ from pool selection; uniqueness remains enforced.
46. **Declined:** Demotion does not allocate from omitted segments; no concrete cycle.

### common-nits-reviewer

1. **Adopted:** Independently identified discovery's lock inversion; the same parent-first ownership recheck resolves it.

</details>


Closes #5398
