### PR TITLE
docs(pxe): Clarify blank virtio disk selection

### DIFF
--- a/docs/configuration/image-based-operating-systems.md
+++ b/docs/configuration/image-based-operating-systems.md
@@ -18,7 +18,7 @@ calls it `imageDisk`. Set the value according to the following table:
 | `smallest` | Selects the smallest enumerated whole disk. If multiple disks have the same smallest size, NICo prefers one containing an existing EFI System Partition; otherwise it makes a deterministic name-based choice. |
 | `/dev/nvme<controller>n<namespace>` | Selects an NVMe namespace, for example `/dev/nvme0n1`. |
 | `/dev/sd<letters>` | Selects a SCSI-style whole disk, for example `/dev/sda` or `/dev/sdaa`. |
-| `/dev/vd<letters>` | Selects a virtio whole disk, for example `/dev/vda` or `/dev/vdaa`. |
+| `/dev/vd<letters>` | Selects a virtio whole disk, for example `/dev/vda` or `/dev/vdaa`. For a host with only a blank virtio disk, set this path explicitly or use `smallest`; omitted or empty selection does not fall back to virtio disks without an EFI System Partition. |
 | `/dev/disk/by-id/<identifier>` | Resolves a stable Linux disk identifier to its backing device. The identifier cannot contain a slash or whitespace. |
 | Omitted or empty on creation | Prefers the first deterministically ordered disk containing an EFI System Partition, then `/dev/nvme0n1`, then `/dev/sda`. |
 


### PR DESCRIPTION
A host with only a blank virtio disk needs an explicit disk selector. This documents `/dev/vda` or `smallest` in the existing table without changing the installer fallback.

## Related issues
Follow-up to #5948 and #6000.

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [x] No testing required (docs, internal refactor, etc.)

Verified the text against `find_bootdisk` and REST disk-selector validation. Markdown lint and Fern MDX checks passed. `fern check` reported no errors; the redirect check was skipped without authentication.

## Additional Notes
Documentation only; automatic selection of a blank virtio disk remains outside this change.