### PR TITLE
feat(site-explorer): remove NVOS credential seeding

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -515,7 +515,6 @@ shipped configuration selects a plaintext mode.
 | `explorations_per_run` | `u64` | `360` | Max nodes explored per run. |
 | `create_machines` | `bool` | `true` | When false, SiteExplorer skips creating ManagedHost state machines; the DPU agent (scout) must self-register via DiscoverMachine gRPC endpoint with create_machine=true. Dynamically toggleable. |
 | `machines_created_per_run` | `u64` | `100` | Max ManagedHosts created per run. |
-| `rotate_switch_nvos_credentials` | `bool` | `false` | Auto-rotate switch NVOS admin credentials. |
 | `override_target_ip` | `Option<String>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC IP override. |
 | `override_target_port` | `Option<u16>` | — | **Deprecated.** Use `bmc_proxy`. Debug BMC port override. |
 | `bmc_proxy` | `HostPortPair` | — | BMC proxy host:port for integration testing/dev. |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -6468,26 +6468,39 @@ path = "credentials.yaml"
         assert!(runtime_config.restart_ovs_on_use_admin_network_change);
     }
 
-    /// Real-world site TOMLs may still carry the now-removed
-    /// `force_dpu_nic_mode` setting (top-level and/or under
-    /// `[site_explorer]`). Keep that one compatibility exception explicit.
+    /// Site TOMLs may retain deprecated settings while operators migrate
+    /// configuration independently of the binary.
     #[test]
-    fn legacy_force_dpu_nic_mode_in_toml_still_parses() {
+    fn deprecated_site_explorer_settings_parse_but_are_not_serialized() {
         let config: CarbideConfig = Figment::new()
             .merge(Toml::file(format!("{TEST_DATA_DIR}/min_config.toml")))
             .merge(Toml::string(
                 "force_dpu_nic_mode = false\n\
                  [site_explorer]\n\
-                 force_dpu_nic_mode = true\n",
+                 force_dpu_nic_mode = true\n\
+                 rotate_switch_nvos_credentials = true\n",
             ))
             .extract()
-            .expect("legacy force_dpu_nic_mode in TOML must still parse");
+            .expect("deprecated site-explorer settings in TOML must still parse");
 
         assert_eq!(config.deprecated_force_dpu_nic_mode, Some(false));
         assert_eq!(
             config.site_explorer.deprecated_force_dpu_nic_mode,
             Some(true)
         );
+
+        assert_eq!(
+            config
+                .site_explorer
+                .deprecated_rotate_switch_nvos_credentials,
+            Some(true)
+        );
+
+        let serialized = serde_json::to_value(&config.site_explorer)
+            .expect("site-explorer configuration must serialize");
+
+        assert!(serialized.get("force_dpu_nic_mode").is_none());
+        assert!(serialized.get("rotate_switch_nvos_credentials").is_none());
     }
 
     #[test]

--- a/crates/api-core/src/cfg/load.rs
+++ b/crates/api-core/src/cfg/load.rs
@@ -237,14 +237,24 @@ pub fn parse_carbide_config(
 
     config.config_ctx = Some(merged_config);
 
-    for (path, is_set) in [
+    for (path, is_set, replacement) in [
         (
             "force_dpu_nic_mode",
             config.deprecated_force_dpu_nic_mode.is_some(),
+            "site_explorer.dpu_policy",
         ),
         (
             "site_explorer.force_dpu_nic_mode",
             config.site_explorer.deprecated_force_dpu_nic_mode.is_some(),
+            "site_explorer.dpu_policy",
+        ),
+        (
+            "site_explorer.rotate_switch_nvos_credentials",
+            config
+                .site_explorer
+                .deprecated_rotate_switch_nvos_credentials
+                .is_some(),
+            "no replacement",
         ),
     ] {
         if !is_set {
@@ -259,7 +269,7 @@ pub fn parse_carbide_config(
         tracing::warn!(
             config_key = path,
             config_source = %source,
-            replacement = "site_explorer.dpu_policy",
+            replacement,
             "Ignoring deprecated configuration key"
         );
     }
@@ -429,6 +439,43 @@ mod tests {
             let message = error.to_string();
             assert!(message.contains("unknown_root_field (base.toml)"));
             assert!(message.contains("site_explorer.unknown_nested_field (base.toml)"));
+            Ok(())
+        })
+    }
+
+    #[test]
+    #[allow(clippy::result_large_err)]
+    fn strict_mode_accepts_deprecated_switch_nvos_rotation_key() {
+        figment::Jail::expect_with(|jail| {
+            jail.create_file(
+                "base.toml",
+                r#"
+                database_url = "postgres://test"
+                listen = "[::]:1081"
+                asn = 1
+                deny_unknown_fields = true
+                [site_explorer]
+                rotate_switch_nvos_credentials = true
+                "#,
+            )?;
+
+            let figment = merged_carbide_config_figment(Path::new("base.toml"), None);
+            let (config, unknown_fields) = extract_with_unknown_fields::<CarbideConfig>(&figment)?;
+
+            let policy_result =
+                apply_unknown_field_policy(&unknown_fields, config.deny_unknown_fields);
+
+            assert!(unknown_fields.is_empty());
+
+            assert_eq!(
+                config
+                    .site_explorer
+                    .deprecated_rotate_switch_nvos_credentials,
+                Some(true)
+            );
+
+            assert!(policy_result.is_ok());
+
             Ok(())
         })
     }

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -59,7 +59,9 @@ use carbide_rack_controller::io::RackStateControllerIO;
 use carbide_redfish::libredfish::{BmcCredentialOps, RedfishClientPool};
 use carbide_secrets::certificates::CertificateProvider;
 use carbide_secrets::credentials::{CredentialManager, CredentialReader};
-use carbide_site_explorer::{AuthenticatedBmcClient, EndpointExplorationService, SiteExplorer};
+use carbide_site_explorer::{
+    AuthenticatedBmcClient, BmcEndpointExplorer, EndpointExplorationService, SiteExplorer,
+};
 use carbide_spdm_controller::context::SpdmStateHandlerServices;
 use carbide_spdm_controller::handler::SpdmAttestationStateHandler;
 use carbide_spdm_controller::io::SpdmStateControllerIO;
@@ -476,15 +478,11 @@ pub(crate) async fn start_runtime(
         ipmi_tool.clone(),
         credential_manager.clone(),
     ));
-    let bmc_explorer = carbide_site_explorer::new_bmc_explorer(
+    let bmc_explorer = Arc::new(BmcEndpointExplorer::new(
         bmc_client.clone(),
-        carbide_config
-            .site_explorer
-            .rotate_switch_nvos_credentials
-            .clone(),
         carbide_config.site_explorer.explore_mode,
-        db_pool.clone(),
-    );
+        Some(db_pool.clone()),
+    ));
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         db_pool.clone(),
         bmc_explorer.clone(),

--- a/crates/api-core/src/test_support/builder.rs
+++ b/crates/api-core/src/test_support/builder.rs
@@ -29,7 +29,8 @@ use carbide_secrets::test_support::credentials::TestCredentialManager;
 use carbide_site_explorer::config::SiteExplorerExploreMode;
 use carbide_site_explorer::test_support::MockEndpointExplorer;
 use carbide_site_explorer::{
-    AuthenticatedBmc, AuthenticatedBmcClient, EndpointExplorationService, EndpointExplorer,
+    AuthenticatedBmc, AuthenticatedBmcClient, BmcEndpointExplorer, EndpointExplorationService,
+    EndpointExplorer,
 };
 use carbide_utils::test_support::test_meter::TestMeter;
 use db::work_lock_manager::WorkLockManagerHandle;
@@ -239,12 +240,11 @@ impl TestApiBuilder {
             carbide_ipmi::test_support(),
             credential_manager.clone(),
         ));
-        let real_endpoint_explorer = carbide_site_explorer::new_bmc_explorer(
+        let real_endpoint_explorer = Arc::new(BmcEndpointExplorer::new(
             real_bmc_client.clone(),
-            Arc::new(std::sync::atomic::AtomicBool::new(false)),
             SiteExplorerExploreMode::NvRedfish,
-            self.db_pool.clone(),
-        );
+            Some(self.db_pool.clone()),
+        ));
         // A mock supplies both narrow interfaces so tests asserting on BMC calls
         // still see them; production-like tests use the independently constructed
         // authenticated client shared with the real explorer.

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1705,7 +1705,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
             power_shelves_created_per_run: 1,
             create_switches: Arc::new(true.into()),
             switches_created_per_run: 1,
-            rotate_switch_nvos_credentials: Arc::new(false.into()),
+            deprecated_rotate_switch_nvos_credentials: None,
             dpu_policy: None,
             deprecated_force_dpu_nic_mode: None,
             // Tests use MockEndpointExplorer. So this doesn't affect anything.

--- a/crates/bmc-explorer-cli/src/main.rs
+++ b/crates/bmc-explorer-cli/src/main.rs
@@ -105,7 +105,6 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             std::process::exit(1);
         }
     };
-    let rotate_switch_nvos_credentials = Default::default();
 
     let bmc_client = Arc::new(AuthenticatedBmcClient::new(
         redfish_client_pool,
@@ -115,13 +114,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         carbide_ipmi::test_support(),
         credential_provider.clone(),
     ));
-    let explorer = BmcEndpointExplorer::new(
-        bmc_client,
-        rotate_switch_nvos_credentials,
-        mode,
-        // Standalone debug tool: no database, so rotation bookkeeping is skipped.
-        None,
-    );
+    // Standalone debug tool: no database, so rotation bookkeeping is skipped.
+    let explorer = BmcEndpointExplorer::new(bmc_client, mode, None);
 
     let ip = args.bmc_ip.parse()?;
     let port = args.bmc_port;

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -18,7 +18,6 @@
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
 
 use bmc_explorer::Product;
@@ -31,7 +30,6 @@ use carbide_secrets::credentials::{CredentialManager, Credentials};
 use libredfish::model::service_root::RedfishVendor;
 use mac_address::MacAddress;
 use model::expected_entity::{BmcCredentialsData, ExpectedEntity};
-use model::expected_switch::ExpectedSwitch;
 use model::machine::MachineInterfaceSnapshot;
 use model::site_explorer::{
     BlueFieldOperatingMode, EndpointExplorationError, EndpointExplorationReport, LockdownStatus,
@@ -118,7 +116,6 @@ impl AuthenticatedBmcClient {
 /// An `EndpointExplorer` which uses redfish APIs to query the endpoint
 pub struct BmcEndpointExplorer {
     bmc_client: Arc<AuthenticatedBmcClient>,
-    rotate_switch_nvos_credentials: Arc<AtomicBool>,
     mode: SiteExplorerExploreMode,
     /// Used to record per-device BMC rotation convergence at the moment the
     /// device is moved onto the site-wide BMC root (see
@@ -132,13 +129,11 @@ impl BmcEndpointExplorer {
     /// Build an explorer over the shared authenticated BMC client.
     pub fn new(
         bmc_client: Arc<AuthenticatedBmcClient>,
-        rotate_switch_nvos_credentials: Arc<AtomicBool>,
         mode: SiteExplorerExploreMode,
         database_connection: Option<PgPool>,
     ) -> Self {
         Self {
             bmc_client,
-            rotate_switch_nvos_credentials,
             mode,
             database_connection,
         }
@@ -273,16 +268,6 @@ impl BmcEndpointExplorer {
         self.bmc_client
             .credential_client
             .get_dpu_factory_default_credentials(model)
-            .await
-    }
-
-    pub async fn get_switch_nvos_admin_credentials(
-        &self,
-        bmc_mac_address: MacAddress,
-    ) -> Result<Credentials, EndpointExplorationError> {
-        self.bmc_client
-            .credential_client
-            .get_switch_nvos_admin_credentials(bmc_mac_address)
             .await
     }
 
@@ -619,35 +604,6 @@ impl BmcEndpointExplorer {
         };
         Ok(vendor)
     }
-
-    // Handle switch NVOS admin credentials setup
-    // Store NVOS admin credentials in vault for the switch if they exist in expected_switch
-    pub async fn set_sitewide_switch_nvos_admin_credentials(
-        &self,
-        bmc_mac_address: MacAddress,
-        expected_switch: &ExpectedSwitch,
-    ) -> Result<(), EndpointExplorationError> {
-        if let (Some(nvos_username), Some(nvos_password)) = (
-            expected_switch.nvos_username.as_ref(),
-            expected_switch.nvos_password.as_ref(),
-        ) {
-            tracing::info!(
-                %bmc_mac_address,
-                "Storing NVOS admin credentials in vault"
-            );
-            self.bmc_client
-                .credential_client
-                .set_bmc_nvos_admin_credentials(
-                    bmc_mac_address,
-                    &Credentials::UsernamePassword {
-                        username: nvos_username.clone(),
-                        password: nvos_password.clone(),
-                    },
-                )
-                .await?;
-        }
-        Ok(())
-    }
 }
 
 impl AuthenticatedBmcClient {
@@ -934,40 +890,6 @@ impl EndpointExplorer for BmcEndpointExplorer {
                 return Err(e);
             }
         };
-
-        // Check for switch NVOS admin credentials if this is a switch
-        if let Some(ExpectedEntity::Switch(expected_switch)) = expected
-            && expected_switch.nvos_username.is_some()
-            && expected_switch.nvos_password.is_some()
-        {
-            // Only check if rotation is enabled
-            if self.rotate_switch_nvos_credentials.load(Ordering::Relaxed) {
-                match self
-                    .get_switch_nvos_admin_credentials(bmc_mac_address)
-                    .await
-                {
-                    Ok(_) => {
-                        tracing::trace!(
-                            %bmc_ip_address, %bmc_mac_address,
-                            "NVOS admin credentials already exist in vault"
-                        );
-                    }
-                    Err(e) => {
-                        tracing::info!(
-                            %bmc_ip_address,
-                            %bmc_mac_address,
-                            error = %e,
-                            "Failed to load NVOS admin credentials; attempting credential setup",
-                        );
-                        self.set_sitewide_switch_nvos_admin_credentials(
-                            bmc_mac_address,
-                            expected_switch,
-                        )
-                        .await?;
-                    }
-                }
-            }
-        }
 
         Ok(report)
     }
@@ -1953,12 +1875,7 @@ mod tests {
             carbide_ipmi::test_support(),
             Arc::new(TestCredentialManager::default()),
         ));
-        BmcEndpointExplorer::new(
-            bmc_client,
-            Arc::new(AtomicBool::new(false)),
-            SiteExplorerExploreMode::NvRedfish,
-            None,
-        )
+        BmcEndpointExplorer::new(bmc_client, SiteExplorerExploreMode::NvRedfish, None)
     }
 
     #[tokio::test]
@@ -2057,8 +1974,7 @@ mod tests {
             carbide_ipmi::test_support(),
             Arc::new(TestCredentialManager::default()),
         ));
-        let explorer =
-            BmcEndpointExplorer::new(bmc_client, Arc::new(AtomicBool::new(false)), mode, None);
+        let explorer = BmcEndpointExplorer::new(bmc_client, mode, None);
 
         explorer
             .generate_exploration_report(
@@ -2191,12 +2107,8 @@ mod tests {
             carbide_ipmi::test_support(),
             Arc::new(TestCredentialManager::default()),
         ));
-        let explorer = BmcEndpointExplorer::new(
-            bmc_client,
-            Arc::new(AtomicBool::new(false)),
-            SiteExplorerExploreMode::LibRedfish,
-            None,
-        );
+        let explorer =
+            BmcEndpointExplorer::new(bmc_client, SiteExplorerExploreMode::LibRedfish, None);
         let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().expect("valid test BMC address");
         let bmc_mac_address: MacAddress = "02:00:00:00:00:01".parse().expect("valid test BMC MAC");
         let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
@@ -2314,12 +2226,8 @@ mod tests {
             carbide_ipmi::test_support(),
             credential_manager.clone(),
         ));
-        let explorer = BmcEndpointExplorer::new(
-            bmc_client,
-            Arc::new(AtomicBool::new(false)),
-            SiteExplorerExploreMode::LibRedfish,
-            None,
-        );
+        let explorer =
+            BmcEndpointExplorer::new(bmc_client, SiteExplorerExploreMode::LibRedfish, None);
         let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().expect("valid test BMC address");
         let bmc_mac_address: MacAddress = "02:00:00:00:00:01".parse().expect("valid test BMC MAC");
         let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
@@ -2598,12 +2506,8 @@ mod tests {
             carbide_ipmi::test_support(),
             credential_manager,
         ));
-        let explorer = BmcEndpointExplorer::new(
-            bmc_client,
-            Arc::new(AtomicBool::new(false)),
-            SiteExplorerExploreMode::LibRedfish,
-            None,
-        );
+        let explorer =
+            BmcEndpointExplorer::new(bmc_client, SiteExplorerExploreMode::LibRedfish, None);
         let bmc_ip_address: SocketAddr = "127.0.0.1:443".parse().unwrap();
         let interface = MachineInterfaceSnapshot::mock_with_mac(bmc_mac_address);
 

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -83,13 +83,10 @@ pub struct SiteExplorerConfig {
     #[serde(default = "SiteExplorerConfig::default_machines_created_per_run")]
     pub machines_created_per_run: u64,
 
-    /// Whether SiteExplorer should rotate/update Switch NVOS admin credentials
-    #[serde(
-        default = "SiteExplorerConfig::default_rotate_switch_nvos_credentials",
-        deserialize_with = "deserialize_arc_atomic_bool",
-        serialize_with = "serialize_arc_atomic_bool"
-    )]
-    pub rotate_switch_nvos_credentials: Arc<AtomicBool>,
+    /// Deprecated compatibility key. This setting is ignored.
+    #[doc(hidden)]
+    #[serde(default, rename = "rotate_switch_nvos_credentials", skip_serializing)]
+    pub deprecated_rotate_switch_nvos_credentials: Option<bool>,
 
     /// DEPRECATED: Use `bmc_proxy` instead.
     /// The IP address to connect to instead of the BMC that made the dhcp request.
@@ -195,6 +192,7 @@ impl Default for SiteExplorerConfig {
             explorations_per_run: Self::default_explorations_per_run(),
             create_machines: Self::default_create_machines(),
             machines_created_per_run: Self::default_machines_created_per_run(),
+            deprecated_rotate_switch_nvos_credentials: None,
             override_target_ip: None,
             override_target_port: None,
             bmc_proxy: bmc_proxy(None),
@@ -205,7 +203,6 @@ impl Default for SiteExplorerConfig {
             power_shelves_created_per_run: Self::default_power_shelves_created_per_run(),
             create_switches: Self::default_create_switches(),
             switches_created_per_run: Self::default_switches_created_per_run(),
-            rotate_switch_nvos_credentials: Self::default_rotate_switch_nvos_credentials(),
             dpu_policy: None,
             deprecated_force_dpu_nic_mode: None,
             explore_mode: Self::default_explore_mode(),
@@ -225,7 +222,7 @@ impl PartialEq for SiteExplorerConfig {
             explorations_per_run,
             create_machines,
             machines_created_per_run,
-            rotate_switch_nvos_credentials,
+            deprecated_rotate_switch_nvos_credentials,
             override_target_ip,
             override_target_port,
             bmc_proxy,
@@ -249,10 +246,8 @@ impl PartialEq for SiteExplorerConfig {
             && create_machines.load(AtomicOrdering::Relaxed)
                 == other.create_machines.load(AtomicOrdering::Relaxed)
             && *machines_created_per_run == other.machines_created_per_run
-            && rotate_switch_nvos_credentials.load(AtomicOrdering::Relaxed)
-                == other
-                    .rotate_switch_nvos_credentials
-                    .load(AtomicOrdering::Relaxed)
+            && *deprecated_rotate_switch_nvos_credentials
+                == other.deprecated_rotate_switch_nvos_credentials
             && *override_target_ip == other.override_target_ip
             && *override_target_port == other.override_target_port
             && bmc_proxy.load_full() == other.bmc_proxy.load_full()
@@ -304,10 +299,6 @@ impl SiteExplorerConfig {
     /// independently of how many hosts exploration has identified.
     pub const fn default_machines_created_per_run() -> u64 {
         100
-    }
-
-    pub fn default_rotate_switch_nvos_credentials() -> Arc<AtomicBool> {
-        Arc::new(false.into())
     }
 
     pub const fn default_reset_rate_limit() -> Duration {

--- a/crates/site-explorer/src/credentials.rs
+++ b/crates/site-explorer/src/credentials.rs
@@ -32,10 +32,6 @@ pub(super) fn get_bmc_root_credential_key(bmc_mac_address: MacAddress) -> Creden
     }
 }
 
-fn get_bmc_nvos_admin_credential_key(bmc_mac_address: MacAddress) -> CredentialKey {
-    CredentialKey::SwitchNvosAdmin { bmc_mac_address }
-}
-
 #[derive(Clone)]
 pub(super) struct CredentialClient {
     credential_manager: Arc<dyn CredentialManager>,
@@ -230,15 +226,6 @@ impl CredentialClient {
         self.get_credentials(&bmc_root_credential_key).await
     }
 
-    pub(super) async fn get_switch_nvos_admin_credentials(
-        &self,
-        bmc_mac_address: MacAddress,
-    ) -> Result<Credentials, EndpointExplorationError> {
-        let switch_nvos_admin_credential_key = get_bmc_nvos_admin_credential_key(bmc_mac_address);
-        self.get_credentials(&switch_nvos_admin_credential_key)
-            .await
-    }
-
     pub(super) async fn set_bmc_root_credentials(
         &self,
         bmc_mac_address: MacAddress,
@@ -246,16 +233,6 @@ impl CredentialClient {
     ) -> Result<(), EndpointExplorationError> {
         let bmc_root_credential_key = get_bmc_root_credential_key(bmc_mac_address);
         self.set_credentials(&bmc_root_credential_key, credentials)
-            .await
-    }
-
-    pub(super) async fn set_bmc_nvos_admin_credentials(
-        &self,
-        bmc_mac_address: MacAddress,
-        credentials: &Credentials,
-    ) -> Result<(), EndpointExplorationError> {
-        let bmc_nvos_admin_credential_key = get_bmc_nvos_admin_credential_key(bmc_mac_address);
-        self.set_credentials(&bmc_nvos_admin_credential_key, credentials)
             .await
     }
 }

--- a/crates/site-explorer/src/lib.rs
+++ b/crates/site-explorer/src/lib.rs
@@ -102,7 +102,6 @@ use model::rack::Rack;
 pub use switch_creator::SwitchCreator;
 pub mod config;
 pub mod errors;
-use std::sync::atomic::AtomicBool;
 
 use errors::{SiteExplorerError, SiteExplorerResult};
 
@@ -112,7 +111,6 @@ use self::metrics::{
     SiteExplorerMachineSlotTrayFetchFailed, SiteExplorerMachineSlotTrayResponseMissing,
     SiteExplorerMachineSlotTrayValueInvalid, exploration_error_to_metric_label,
 };
-use crate::config::SiteExplorerExploreMode;
 use crate::explored_endpoint_index::ExploredEndpointIndex;
 
 /// Return whether a HostInband row can be treated as a Redfish endpoint.
@@ -128,23 +126,6 @@ fn should_scan_host_inband_interface_for_redfish(
     interface.interface_type == InterfaceType::Bmc
         || (interface.machine_id.is_none()
             && expected_host_bmc_macs.contains(&interface.mac_address))
-}
-
-/// Build an endpoint explorer over the authenticated BMC client supplied by
-/// the application composition root.
-pub fn new_bmc_explorer(
-    bmc_client: Arc<AuthenticatedBmcClient>,
-    rotate_switch_nvos_credentials: Arc<AtomicBool>,
-    mode: SiteExplorerExploreMode,
-    database_connection: PgPool,
-) -> Arc<BmcEndpointExplorer> {
-    BmcEndpointExplorer::new(
-        bmc_client,
-        rotate_switch_nvos_credentials,
-        mode,
-        Some(database_connection),
-    )
-    .into()
 }
 
 pub fn enrich_endpoint_exploration_report(

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -1925,7 +1925,7 @@ async fn test_site_explorer_audit_exploration_results(
         power_shelves_created_per_run: 1,
         create_switches: Arc::new(true.into()),
         switches_created_per_run: 1,
-        rotate_switch_nvos_credentials: Arc::new(false.into()),
+        deprecated_rotate_switch_nvos_credentials: None,
         dpu_policy: None,
         deprecated_force_dpu_nic_mode: None,
         // Tests use MockEndpointExplorer. So this doesn't affect anything.


### PR DESCRIPTION
Remove site-explorer's optional switch NVOS credential seeding path. Switch controller owns per-switch NVOS credential bootstrap, persistence, and reconciliation.

For config compatibility, configurations containing `site_explorer.rotate_switch_nvos_credentials` continue to load. The field is ignored, omitted during serialization, and produces a deprecation warning.

## Related Issues

Resolves #6001

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [x] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)