### PR TITLE
feat(api): add managed host reset

### DIFF
--- a/crates/api-core/src/api.rs
+++ b/crates/api-core/src/api.rs
@@ -1471,6 +1471,21 @@ impl Forge for Api {
         crate::handlers::host_reprovisioning::trigger_host_reprovisioning(self, request).await
     }
 
+    async fn trigger_managed_host_reset(
+        &self,
+        request: Request<rpc::ManagedHostResetRequest>,
+    ) -> Result<Response<()>, Status> {
+        crate::handlers::managed_host_reset::trigger_managed_host_reset(self, request).await
+    }
+
+    async fn list_managed_hosts_waiting_for_reset(
+        &self,
+        request: Request<rpc::ManagedHostResetListRequest>,
+    ) -> Result<Response<rpc::ManagedHostResetListResponse>, Status> {
+        crate::handlers::managed_host_reset::list_managed_hosts_waiting_for_reset(self, request)
+            .await
+    }
+
     async fn trigger_bmc_credential_rotation(
         &self,
         request: Request<rpc::BmcCredentialRotationRequest>,

--- a/crates/api-core/src/auth/internal_rbac_rules.rs
+++ b/crates/api-core/src/auth/internal_rbac_rules.rs
@@ -328,6 +328,8 @@ impl InternalRBACRules {
         x.perm("TriggerDpuReprovisioning", vec![ForgeAdminCLI, SiteAgent]);
         x.perm("TriggerHostReprovisioning", vec![ForgeAdminCLI, Flow]);
         x.perm("ListDpuWaitingForReprovisioning", vec![ForgeAdminCLI]);
+        x.perm("TriggerManagedHostReset", vec![ForgeAdminCLI]);
+        x.perm("ListManagedHostsWaitingForReset", vec![ForgeAdminCLI]);
         x.perm("MarkManualFirmwareUpgradeComplete", vec![ForgeAdminCLI]);
         x.perm(
             "ListHostsWaitingForReprovisioning",

--- a/crates/api-core/src/handlers/managed_host_reset.rs
+++ b/crates/api-core/src/handlers/managed_host_reset.rs
@@ -1,0 +1,200 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+use ::rpc::forge as rpc;
+use carbide_uuid::machine::MachineId;
+use itertools::Itertools;
+use model::machine::{LoadSnapshotOptions, ManagedHostState, ManagedHostStateSnapshot};
+use model::machine_update_module::HOST_UPDATE_HEALTH_PROBE_ID;
+use tonic::{Request, Response, Status};
+
+use crate::CarbideError;
+use crate::api::{Api, log_request_data};
+use crate::handlers::utils::convert_and_log_machine_id;
+
+/// Preconditions for requesting a reset; `Clear` only withdraws one and skips them.
+fn validate_managed_host_reset_request(
+    snapshot: &ManagedHostStateSnapshot,
+    machine_id: &MachineId,
+    allow_reset_with_instance: bool,
+) -> Result<(), CarbideError> {
+    // The state controller stops managing a force-deleting machine, so a reset would never run.
+    if matches!(snapshot.managed_state, ManagedHostState::ForceDeletion) {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "cannot reset host {machine_id}: machine is being force-deleted"
+        )));
+    }
+
+    // Re-ingestion re-registers the host's DPF CRs, which only exist for DPF-ingested hosts.
+    if !snapshot.host_snapshot.config.dpf.used_for_ingestion {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "cannot reset host {machine_id}: machine was not ingested via DPF"
+        )));
+    }
+
+    // The snapshot's instance join is unfiltered, so a terminated instance is still present.
+    let has_live_instance = snapshot
+        .instance
+        .as_ref()
+        .is_some_and(|instance| instance.deleted.is_none());
+    if has_live_instance && !allow_reset_with_instance {
+        return Err(CarbideError::FailedPrecondition(format!(
+            "host {machine_id} has a live instance; resetting destroys it and its data. \
+             pass --allow-reset-with-instance to proceed"
+        )));
+    }
+
+    let update_alert = snapshot
+        .aggregate_health
+        .alerts
+        .iter()
+        .find(|alert| alert.id == *HOST_UPDATE_HEALTH_PROBE_ID);
+    if !update_alert.is_some_and(|alert| {
+        alert
+            .classifications
+            .contains(&health_report::HealthAlertClassification::prevent_allocations())
+    }) {
+        return Err(CarbideError::InvalidArgument(format!(
+            "machine {machine_id} must have a 'HostUpdateInProgress' health alert with the \
+             'PreventAllocations' classification before resetting. set this precondition \
+             with: `machine health-report add --template host-update <id>`, or pass \
+             --update-message to `managed-host reset set`",
+        )));
+    }
+
+    Ok(())
+}
+
+pub(crate) async fn trigger_managed_host_reset(
+    api: &Api,
+    request: Request<rpc::ManagedHostResetRequest>,
+) -> Result<Response<()>, Status> {
+    use ::rpc::forge::managed_host_reset_request::Mode;
+
+    log_request_data(&request);
+    let req = request.into_inner();
+    let machine_id: MachineId = convert_and_log_machine_id(req.machine_id.as_ref())?;
+
+    // A reset tears down every attached DPU, so it is only expressible against the host.
+    if !machine_id.machine_type().is_host() {
+        return Err(CarbideError::InvalidArgument(format!(
+            "{machine_id} is not a host machine; reset targets the host, not an individual DPU"
+        ))
+        .into());
+    }
+
+    let mut txn = api.txn_begin().await?;
+
+    let snapshot = db::managed_host::load_snapshot(
+        &mut txn,
+        &machine_id,
+        LoadSnapshotOptions {
+            include_history: false,
+            // The live-instance precondition reads the instance row.
+            include_instance_data: true,
+            host_health_config: api.runtime_config.host_health,
+        },
+    )
+    .await?
+    .ok_or(CarbideError::NotFoundError {
+        kind: "machine",
+        id: machine_id.to_string(),
+    })?;
+
+    match req.mode() {
+        Mode::Set => {
+            validate_managed_host_reset_request(
+                &snapshot,
+                &machine_id,
+                req.allow_reset_with_instance,
+            )?;
+
+            // Re-requesting is allowed and restarts from scratch; the DB call clears `started_at`.
+            if let Some(previous) = &snapshot.host_snapshot.reset_requested {
+                tracing::warn!(
+                    %machine_id,
+                    previous_initiator = %previous.initiator,
+                    previous_requested_at = %previous.requested_at,
+                    previous_started = previous.started_at.is_some(),
+                    "Reset re-requested for a host that already had one; restarting it",
+                );
+            }
+
+            db::machine::trigger_managed_host_reset_request(
+                &mut txn,
+                req.initiator().as_str_name(),
+                &machine_id,
+            )
+            .await?;
+        }
+        Mode::Clear => {
+            // Once teardown has begun there is nothing to withdraw to.
+            if snapshot
+                .host_snapshot
+                .reset_requested
+                .as_ref()
+                .is_some_and(|request| request.started_at.is_some())
+            {
+                return Err(CarbideError::FailedPrecondition(format!(
+                    "reset for host {machine_id} has already started and cannot be cleared"
+                ))
+                .into());
+            }
+
+            db::machine::clear_managed_host_reset_request(&mut txn, &machine_id, true).await?;
+        }
+        // An omitted mode decodes here; reject rather than pick an action for it.
+        Mode::Unspecified => {
+            return Err(
+                CarbideError::InvalidArgument("mode must be set or clear".to_string()).into(),
+            );
+        }
+    }
+
+    txn.commit().await?;
+
+    Ok(Response::new(()))
+}
+
+pub(crate) async fn list_managed_hosts_waiting_for_reset(
+    api: &Api,
+    request: Request<rpc::ManagedHostResetListRequest>,
+) -> Result<Response<rpc::ManagedHostResetListResponse>, Status> {
+    log_request_data(&request);
+
+    let hosts = db::machine::list_machines_requested_for_reset(&api.database_connection)
+        .await?
+        .into_iter()
+        .map(
+            |x| rpc::managed_host_reset_list_response::ManagedHostResetListItem {
+                id: Some(*x.id.as_machine_id()),
+                state: x.current_state().to_string(),
+                requested_at: x.reset_requested.as_ref().map(|a| a.requested_at.into()),
+                initiator: x
+                    .reset_requested
+                    .as_ref()
+                    .map(|a| a.initiator.clone())
+                    .unwrap_or_default(),
+                started_at: x
+                    .reset_requested
+                    .as_ref()
+                    .and_then(|a| a.started_at.map(Into::into)),
+            },
+        )
+        .collect_vec();
+
+    Ok(Response::new(rpc::ManagedHostResetListResponse { hosts }))
+}

--- a/crates/api-core/src/handlers/mod.rs
+++ b/crates/api-core/src/handlers/mod.rs
@@ -61,6 +61,7 @@ pub(super) mod machine_quarantine;
 pub(super) mod machine_scout;
 pub(super) mod machine_validation;
 pub(super) mod managed_host;
+pub(super) mod managed_host_reset;
 pub(super) mod measured_boot;
 pub(super) mod mlx_admin;
 pub(super) mod network_devices;

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -468,6 +468,7 @@ impl TestEnv {
             ManagedHostState::RotatingBmc { .. } => state.clone(),
             ManagedHostState::RotatingHostUefi { .. } => state.clone(),
             ManagedHostState::Decommissioning { .. } => state.clone(),
+            ManagedHostState::Reset { .. } => state.clone(),
             ManagedHostState::RotatingDpuUefi { .. } => state.clone(),
             ManagedHostState::RotatingNicLockdown => state.clone(),
             ManagedHostState::BomValidating { .. } => state.clone(),

--- a/crates/api-core/src/tests/managed_host_reset.rs
+++ b/crates/api-core/src/tests/managed_host_reset.rs
@@ -1,0 +1,551 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Operator-requested managed host reset, as reached through
+//! `managed-host reset set|clear|list`.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
+use carbide_dpf::{DpuDeploymentType, DpuPhase};
+use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
+use carbide_uuid::machine::MachineId;
+use model::machine::{DpuDiscoveringState, ManagedHostState, ResetState};
+use rpc::forge::forge_server::Forge;
+use rpc::forge::managed_host_reset_request::Mode;
+use rpc::forge::{ManagedHostResetListRequest, ManagedHostResetRequest, UpdateInitiator};
+use tokio::time::timeout;
+use tonic::{Code, Request};
+
+use crate::tests::common::api_fixtures::test_managed_host::TestManagedHost;
+use crate::tests::common::api_fixtures::{
+    TestEnv, TestEnvOverrides, create_managed_host, create_managed_host_with_dpf, create_test_env,
+    create_test_env_with_overrides, get_config,
+};
+
+const TEST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Expectations for the initial provisioning flow, shared by every env below.
+fn provisioning_mock() -> MockDpfOperations {
+    let mut mock = MockDpfOperations::new();
+    mock.expect_register_dpu_device().returning(|_, _| Ok(()));
+    mock.expect_register_dpu_node().returning(|_| Ok(()));
+    mock.expect_release_maintenance_hold().returning(|_| Ok(()));
+    mock.expect_is_reboot_required().returning(|_| Ok(false));
+    mock.expect_get_dpu_phase()
+        .returning(|_, _| Ok(DpuPhase::Ready));
+    mock.expect_deployment_type_for_dpu()
+        .returning(|_, _| Ok(DpuDeploymentType::Bf3));
+    mock.expect_verify_node_labels().returning(|_, _| Ok(true));
+    mock
+}
+
+/// A reset is only offered to DPF-ingested hosts, and `create_managed_host_with_dpf`
+/// drives the real provisioning flow, so these tests need DPF enabled in config plus an
+/// SDK for it to register against. Same starting point as the `dpf` suites.
+async fn dpf_test_env(pool: sqlx::PgPool) -> TestEnv {
+    env_with_dpf_mock(pool, provisioning_mock()).await
+}
+
+/// What `snapshot_host` reports for the host's DPF CRs, which is the only thing
+/// `DeletingCrs` polls on.
+#[derive(Clone, Copy)]
+enum DpfCrs {
+    Present,
+    Gone,
+}
+
+async fn reset_controller_env(pool: sqlx::PgPool, crs: DpfCrs) -> TestEnv {
+    let mut mock = provisioning_mock();
+    mock.expect_force_delete_host().returning(|_, _| Ok(()));
+    mock.expect_snapshot_host()
+        .returning(move |_| Ok(host_dpf_snapshot(crs)));
+
+    env_with_dpf_mock(pool, mock).await
+}
+
+/// `create_managed_host_with_dpf` provisions a single DPU, so a present CR set is the
+/// DPUNode plus exactly one DPUDevice. Any other count reads as a half-drained set.
+fn host_dpf_snapshot(crs: DpfCrs) -> HostDpfSnapshot {
+    match crs {
+        DpfCrs::Gone => HostDpfSnapshot {
+            dpu_node: None,
+            dpu_devices: Vec::new(),
+            dpus: Vec::new(),
+        },
+        DpfCrs::Present => HostDpfSnapshot {
+            dpu_node: Some(DpuNodeSummary {
+                name: "node-mock".to_string(),
+                labels: Default::default(),
+                annotations: Default::default(),
+                dpu_device_refs: vec!["device-0".to_string()],
+            }),
+            dpu_devices: vec![DpuDeviceSummary {
+                name: "device-0".to_string(),
+                labels: Default::default(),
+                bmc_ip: None,
+                bmc_port: None,
+                serial_number: String::new(),
+            }],
+            dpus: Vec::new(),
+        },
+    }
+}
+
+async fn env_with_dpf_mock(pool: sqlx::PgPool, mock: MockDpfOperations) -> TestEnv {
+    let dpf_sdk: Arc<dyn DpfOperations> = Arc::new(mock);
+
+    let mut config = get_config();
+    config.dpf = crate::cfg::file::DpfConfig {
+        enabled: true,
+        deployments: crate::cfg::file::DpfDeploymentsConfig {
+            bf3: crate::cfg::file::DpfDeploymentConfig {
+                bfb_url: Some("http://example.com/test.bfb".to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    create_test_env_with_overrides(
+        pool,
+        TestEnvOverrides::with_config(config).with_dpf_sdk(dpf_sdk),
+    )
+    .await
+}
+
+async fn dpf_ingested_host(env: &TestEnv) -> TestManagedHost {
+    timeout(TEST_TIMEOUT, create_managed_host_with_dpf(env))
+        .await
+        .expect("timed out during initial provisioning")
+}
+
+fn reset_request(machine_id: MachineId, mode: Mode) -> Request<ManagedHostResetRequest> {
+    Request::new(ManagedHostResetRequest {
+        machine_id: Some(machine_id),
+        mode: mode.into(),
+        initiator: UpdateInitiator::AdminCli.into(),
+        allow_reset_with_instance: false,
+    })
+}
+
+/// The operator's acknowledgement that the reset may destroy a live instance.
+fn reset_request_allowing_instance(machine_id: MachineId) -> Request<ManagedHostResetRequest> {
+    let mut request = reset_request(machine_id, Mode::Set);
+    request.get_mut().allow_reset_with_instance = true;
+    request
+}
+
+/// A `Set` has to land in `machines.reset_requested` and become visible to both the
+/// controller and `reset list`. That column is the controller's only view of the request,
+/// so a persistence or projection break does not surface as an error: the request is
+/// accepted and the reset simply never happens. `started_at` must come back unset, since
+/// an unstarted request is exactly what the controller hinge fires on.
+#[crate::sqlx_test]
+async fn reset_set_records_a_request_that_the_pending_list_reports(pool: sqlx::PgPool) {
+    let env = dpf_test_env(pool).await;
+    let managed_host = dpf_ingested_host(&env).await;
+    managed_host.mark_machine_for_updates().await;
+    let host_id: MachineId = managed_host.id.into();
+
+    // Nothing is pending beforehand, so the list is selecting on the column rather than
+    // returning every host.
+    let listed = env
+        .api
+        .list_managed_hosts_waiting_for_reset(Request::new(ManagedHostResetListRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert!(listed.hosts.is_empty());
+
+    env.api
+        .trigger_managed_host_reset(reset_request(host_id, Mode::Set))
+        .await
+        .unwrap();
+
+    let mut txn = env.db_txn().await;
+    let request = managed_host
+        .host()
+        .db_machine(&mut txn)
+        .await
+        .reset_requested
+        .expect("the reset request should persist on the host row");
+    assert_eq!(request.initiator, UpdateInitiator::AdminCli.as_str_name());
+    assert!(
+        request.started_at.is_none(),
+        "a fresh request is unstarted, which is the condition the controller hinge fires on"
+    );
+
+    let listed = env
+        .api
+        .list_managed_hosts_waiting_for_reset(Request::new(ManagedHostResetListRequest {}))
+        .await
+        .unwrap()
+        .into_inner();
+    assert_eq!(listed.hosts.len(), 1);
+    assert_eq!(listed.hosts[0].id, Some(host_id));
+    assert_eq!(
+        listed.hosts[0].initiator,
+        UpdateInitiator::AdminCli.as_str_name()
+    );
+    assert!(listed.hosts[0].requested_at.is_some());
+    assert!(
+        listed.hosts[0].started_at.is_none(),
+        "the operator reads an absent Started At as 'the controller has not picked this up'"
+    );
+}
+
+/// A reset tears down every DPU attached to a host, so it is only expressible against the
+/// host; and the host-update alert is what takes the host out of allocation before its
+/// data is destroyed. Neither refusal may leave a half-recorded reset behind.
+#[crate::sqlx_test]
+async fn reset_set_rejects_a_dpu_target_and_an_unacknowledged_host(pool: sqlx::PgPool) {
+    let env = dpf_test_env(pool).await;
+    let managed_host = dpf_ingested_host(&env).await;
+
+    let error = env
+        .api
+        .trigger_managed_host_reset(reset_request(managed_host.dpu().id.into(), Mode::Set))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Code::InvalidArgument);
+    assert!(
+        error.message().contains("not a host machine"),
+        "unexpected message: {}",
+        error.message()
+    );
+
+    // DPF-ingested, but no operator has taken it out of service yet.
+    let error = env
+        .api
+        .trigger_managed_host_reset(reset_request(managed_host.id.into(), Mode::Set))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Code::InvalidArgument);
+    assert!(
+        error.message().contains("HostUpdateInProgress"),
+        "unexpected message: {}",
+        error.message()
+    );
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .reset_requested
+            .is_none()
+    );
+}
+
+/// Re-ingestion re-registers the host's DPF CRs, so a host that was never ingested through
+/// DPF has nothing to come back as and is refused before anything is recorded.
+#[crate::sqlx_test]
+async fn reset_set_rejects_a_host_not_ingested_through_dpf(pool: sqlx::PgPool) {
+    let env = create_test_env(pool).await;
+    let managed_host = create_managed_host(&env).await;
+    // Carries the alert, so the DPF gate is the only precondition it can fail.
+    managed_host.mark_machine_for_updates().await;
+
+    let error = env
+        .api
+        .trigger_managed_host_reset(reset_request(managed_host.id.into(), Mode::Set))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Code::FailedPrecondition);
+    assert!(
+        error.message().contains("not ingested via DPF"),
+        "unexpected message: {}",
+        error.message()
+    );
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .reset_requested
+            .is_none()
+    );
+}
+
+/// A reset destroys a live instance and its data, so the flag is the only thing allowing it.
+#[crate::sqlx_test]
+async fn reset_set_destroys_a_live_instance_only_when_the_operator_allows_it(pool: sqlx::PgPool) {
+    let env = dpf_test_env(pool).await;
+    let managed_host = dpf_ingested_host(&env).await;
+    let host_id: MachineId = managed_host.id.into();
+
+    // The required alert prevents allocation, so allocate before marking for updates.
+    let segment_id = env.create_vpc_and_tenant_segment().await;
+    let _instance = managed_host
+        .instance_builer(&env)
+        .single_interface_network_config(segment_id)
+        .build()
+        .await;
+    managed_host.mark_machine_for_updates().await;
+
+    let error = env
+        .api
+        .trigger_managed_host_reset(reset_request(host_id, Mode::Set))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Code::FailedPrecondition);
+    assert!(
+        error.message().contains("--allow-reset-with-instance"),
+        "the refusal has to name the flag that overrides it: {}",
+        error.message()
+    );
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .reset_requested
+            .is_none()
+    );
+    drop(txn);
+
+    // Same host, same live instance: the acknowledgement is the only thing that changes.
+    env.api
+        .trigger_managed_host_reset(reset_request_allowing_instance(host_id))
+        .await
+        .unwrap();
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .reset_requested
+            .is_some(),
+        "an acknowledged reset has to be recorded for the controller to act on"
+    );
+}
+
+/// The controller stops managing a force-deleting host, so a reset recorded there never runs.
+#[crate::sqlx_test]
+async fn reset_set_rejects_a_force_deleting_host(pool: sqlx::PgPool) {
+    let env = dpf_test_env(pool).await;
+    let managed_host = dpf_ingested_host(&env).await;
+    // Every other precondition is satisfied, so force-deletion is the only one left to fail.
+    managed_host.mark_machine_for_updates().await;
+
+    let mut txn = env.db_txn().await;
+    let host = managed_host.host().db_machine(&mut txn).await;
+    assert!(
+        db::machine::advance(&host, &mut txn, &ManagedHostState::ForceDeletion, None)
+            .await
+            .unwrap()
+    );
+    txn.commit().await.unwrap();
+
+    let error = env
+        .api
+        .trigger_managed_host_reset(reset_request(managed_host.id.into(), Mode::Set))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Code::FailedPrecondition);
+    assert!(
+        error.message().contains("force-deleted"),
+        "unexpected message: {}",
+        error.message()
+    );
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .reset_requested
+            .is_none()
+    );
+}
+
+/// `Clear` is the withdrawal path, and it closes once the controller stamps `started_at`
+/// and begins tearing the host down. Both halves matter: an operator has to be able to take
+/// back a request that has not started, and a late clear must not cancel a teardown that is
+/// already deleting the tenant instance and the host's DPF CRs.
+#[crate::sqlx_test]
+async fn reset_clear_withdraws_only_a_reset_that_has_not_started(pool: sqlx::PgPool) {
+    let env = dpf_test_env(pool).await;
+    let managed_host = dpf_ingested_host(&env).await;
+    managed_host.mark_machine_for_updates().await;
+    let host_id: MachineId = managed_host.id.into();
+
+    env.api
+        .trigger_managed_host_reset(reset_request(host_id, Mode::Set))
+        .await
+        .unwrap();
+    env.api
+        .trigger_managed_host_reset(reset_request(host_id, Mode::Clear))
+        .await
+        .unwrap();
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .reset_requested
+            .is_none()
+    );
+    drop(txn);
+
+    // Request again, then stamp it started the way the controller hinge does when it moves
+    // the host into `Reset`.
+    env.api
+        .trigger_managed_host_reset(reset_request(host_id, Mode::Set))
+        .await
+        .unwrap();
+    let mut txn = env.db_txn().await;
+    db::machine::update_managed_host_reset_start_time(&mut txn, &host_id)
+        .await
+        .unwrap();
+    txn.commit().await.unwrap();
+
+    let error = env
+        .api
+        .trigger_managed_host_reset(reset_request(host_id, Mode::Clear))
+        .await
+        .unwrap_err();
+    assert_eq!(error.code(), Code::FailedPrecondition);
+    assert!(
+        error.message().contains("already started"),
+        "unexpected message: {}",
+        error.message()
+    );
+
+    let mut txn = env.db_txn().await;
+    let request = managed_host
+        .host()
+        .db_machine(&mut txn)
+        .await
+        .reset_requested
+        .expect("the started reset should survive a refused clear");
+    assert!(request.started_at.is_some());
+}
+
+/// Records a reset the way an operator would, then drops the host straight into
+/// `DeletingCrs` so a single iteration exercises that substate on its own. `started_at` is
+/// stamped because the hinge fires on any unstarted request and would otherwise pull the
+/// host back to `DeletingInstance`.
+async fn enter_deleting_crs(env: &TestEnv, managed_host: &TestManagedHost) {
+    managed_host.mark_machine_for_updates().await;
+    let host_id: MachineId = managed_host.id.into();
+    env.api
+        .trigger_managed_host_reset(reset_request(host_id, Mode::Set))
+        .await
+        .unwrap();
+
+    let mut txn = env.db_txn().await;
+    db::machine::update_managed_host_reset_start_time(&mut txn, &host_id)
+        .await
+        .unwrap();
+    let host = managed_host.host().db_machine(&mut txn).await;
+    let deleting_crs = ManagedHostState::Reset {
+        reset_state: ResetState::DeletingCrs,
+    };
+    assert!(
+        db::machine::advance(&host, &mut txn, &deleting_crs, None)
+            .await
+            .unwrap()
+    );
+    txn.commit().await.unwrap();
+}
+
+async fn host_state(env: &TestEnv, managed_host: &TestManagedHost) -> ManagedHostState {
+    let mut txn = env.db_txn().await;
+    managed_host
+        .host()
+        .db_machine(&mut txn)
+        .await
+        .current_state()
+        .clone()
+}
+
+/// Registration refuses a CR that still carries a `deletionTimestamp`, so `DeletingCrs`
+/// waits for the delete to drain rather than for it to be accepted. Re-ingesting early
+/// would recreate nothing and strand the host.
+#[crate::sqlx_test]
+async fn reset_holds_in_deleting_crs_while_the_dpf_crs_remain(pool: sqlx::PgPool) {
+    let env = reset_controller_env(pool, DpfCrs::Present).await;
+    let managed_host = dpf_ingested_host(&env).await;
+    enter_deleting_crs(&env, &managed_host).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    let state = host_state(&env, &managed_host).await;
+    assert!(
+        matches!(
+            state,
+            ManagedHostState::Reset {
+                reset_state: ResetState::DeletingCrs
+            }
+        ),
+        "an undrained CR set has to hold the reset, got {state:?}"
+    );
+}
+
+/// A drained host has to re-enter discovery at `Initializing`, the only substate that
+/// reaches `DpfState::Provisioning` and so the only path that recreates the CRs this
+/// state just deleted. The request is cleared with the handoff, or the hinge re-fires.
+#[crate::sqlx_test]
+async fn reset_re_enters_dpu_discovery_once_the_dpf_crs_are_gone(pool: sqlx::PgPool) {
+    let env = reset_controller_env(pool, DpfCrs::Gone).await;
+    let managed_host = dpf_ingested_host(&env).await;
+    enter_deleting_crs(&env, &managed_host).await;
+
+    timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+        .await
+        .expect("timed out during state controller iteration");
+
+    match host_state(&env, &managed_host).await {
+        ManagedHostState::DpuDiscoveringState { dpu_states } => {
+            assert!(!dpu_states.states.is_empty());
+            for (dpu_id, dpu_state) in &dpu_states.states {
+                assert_eq!(
+                    *dpu_state,
+                    DpuDiscoveringState::Initializing,
+                    "DPU {dpu_id} has to re-enter discovery from the start"
+                );
+            }
+        }
+        other => panic!("a drained reset re-enters DPU discovery, got {other:?}"),
+    }
+
+    let mut txn = env.db_txn().await;
+    assert!(
+        managed_host
+            .host()
+            .db_machine(&mut txn)
+            .await
+            .reset_requested
+            .is_none()
+    );
+}

--- a/crates/api-core/src/tests/managed_host_reset.rs
+++ b/crates/api-core/src/tests/managed_host_reset.rs
@@ -25,7 +25,7 @@ use carbide_dpf::types::{DpuDeviceSummary, DpuNodeSummary, HostDpfSnapshot};
 use carbide_dpf::{DpuDeploymentType, DpuPhase};
 use carbide_machine_controller::dpf::{DpfOperations, MockDpfOperations};
 use carbide_uuid::machine::MachineId;
-use model::machine::{DpuDiscoveringState, ManagedHostState, ResetState};
+use model::machine::{DpuDiscoveringState, FailureDetails, ManagedHostState, ResetState};
 use rpc::forge::forge_server::Forge;
 use rpc::forge::managed_host_reset_request::Mode;
 use rpc::forge::{ManagedHostResetListRequest, ManagedHostResetRequest, UpdateInitiator};
@@ -547,5 +547,49 @@ async fn reset_re_enters_dpu_discovery_once_the_dpf_crs_are_gone(pool: sqlx::PgP
             .await
             .reset_requested
             .is_none()
+    );
+}
+
+/// A reset is requested precisely because the host is broken, so the global failure parking
+/// must not preempt it before the teardown runs.
+#[crate::sqlx_test]
+async fn reset_survives_a_failure_record_and_reaches_discovery(pool: sqlx::PgPool) {
+    let env = reset_controller_env(pool, DpfCrs::Gone).await;
+    let managed_host = dpf_ingested_host(&env).await;
+
+    let mut txn = env.db_txn().await;
+    let host = managed_host.host().db_machine(&mut txn).await;
+    db::machine::update_failure_details(
+        &host,
+        &mut txn,
+        FailureDetails {
+            cause: model::machine::FailureCause::NVMECleanFailed {
+                err: "corrupted DPU".to_string(),
+            },
+            failed_at: chrono::Utc::now(),
+            source: model::machine::FailureSource::Scout,
+        },
+    )
+    .await
+    .unwrap();
+    txn.commit().await.unwrap();
+
+    managed_host.mark_machine_for_updates().await;
+    env.api
+        .trigger_managed_host_reset(reset_request(managed_host.id.into(), Mode::Set))
+        .await
+        .unwrap();
+
+    // The hinge, then `DeletingInstance`, then `DeletingCrs`.
+    for _ in 0..3 {
+        timeout(TEST_TIMEOUT, env.run_machine_state_controller_iteration())
+            .await
+            .expect("timed out during state controller iteration");
+    }
+
+    let state = host_state(&env, &managed_host).await;
+    assert!(
+        matches!(state, ManagedHostState::DpuDiscoveringState { .. }),
+        "a failure record must not park a reset, got {state:?}"
     );
 }

--- a/crates/api-core/src/tests/mod.rs
+++ b/crates/api-core/src/tests/mod.rs
@@ -60,6 +60,7 @@ mod machine_update_manager;
 mod machine_validation;
 mod maintenance;
 mod managed_host_decommissioning;
+mod managed_host_reset;
 #[cfg(feature = "linux-build")]
 mod measured_boot;
 mod network_security_group;

--- a/crates/api-db/migrations/20260907121430_machine_reset_requested.sql
+++ b/crates/api-db/migrations/20260907121430_machine_reset_requested.sql
@@ -1,0 +1,6 @@
+-- Add reset_requested column to machines table.
+-- reset_requested: when set by an operator, the state controller tears down the host's
+-- instance and DPF resources, then re-ingests the host from DPU discovery.
+
+ALTER TABLE machines
+    ADD COLUMN reset_requested JSONB;

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -2256,7 +2256,8 @@ pub async fn list_machines_requested_for_reset(
 ) -> Result<Vec<HostMachine>, DatabaseError> {
     lazy_static! {
         static ref query: String = format!(
-            "{} WHERE m.reset_requested IS NOT NULL",
+            "{} WHERE m.reset_requested IS NOT NULL \
+             ORDER BY (m.reset_requested->>'requested_at')::timestamptz, m.id",
             JSON_MACHINE_SNAPSHOT_QUERY.deref()
         );
     }

--- a/crates/api-db/src/machine.rs
+++ b/crates/api-db/src/machine.rs
@@ -57,7 +57,7 @@ use model::machine::{
     DpuOsOperationalState, DpuRepresentorStatus, FailureDetails, HostMachine, HostProfile, Machine,
     MachineInterfaceSnapshot, MachineLastRebootRequested, MachineLastRebootRequestedMode,
     MachineMaintenanceOperation, MachineValidationContext, ManagedHostState, ReprovisionRequest,
-    UpgradeDecision,
+    ResetRequest, UpgradeDecision,
 };
 use model::machine_interface_address::MachineInterfaceAssociation;
 use model::metadata::Metadata;
@@ -2174,6 +2174,89 @@ pub async fn list_machines_requested_for_host_reprovisioning(
     lazy_static! {
         static ref query: String = format!(
             "{} WHERE m.host_reprovisioning_requested IS NOT NULL",
+            JSON_MACHINE_SNAPSHOT_QUERY.deref()
+        );
+    }
+    sqlx::query_as(sqlx::AssertSqlSafe(query.as_str()))
+        .fetch_all(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query.as_str(), e))
+}
+
+/// Records a reset request, replacing any previous one. Re-requesting is allowed and restarts
+/// the reset: the replacement clears `started_at`, so the controller hinge fires again.
+pub async fn trigger_managed_host_reset_request(
+    txn: &mut PgConnection,
+    initiator: &str,
+    machine_id: &MachineId,
+) -> Result<(), DatabaseError> {
+    let req = ResetRequest {
+        requested_at: chrono::Utc::now(),
+        initiator: initiator.to_string(),
+        started_at: None,
+    };
+
+    let query = "UPDATE machines SET reset_requested=$2 WHERE id=$1 RETURNING id";
+    let _id = sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .bind(sqlx::types::Json(req))
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(())
+}
+
+/// Marks the reset as started, which closes it to `Clear` and stops the hinge re-firing.
+/// Guarded on `IS NOT NULL` because `jsonb_set` on a `NULL` column reports success unchanged.
+pub async fn update_managed_host_reset_start_time(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+) -> Result<(), DatabaseError> {
+    let query = r#"UPDATE machines
+                        SET reset_requested=
+                                    jsonb_set(reset_requested, '{started_at}', $2, true)
+                       WHERE id=$1 AND reset_requested IS NOT NULL RETURNING id"#;
+    let _id = sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .bind(sqlx::types::Json(chrono::Utc::now()))
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::query(query, e))?;
+
+    Ok(())
+}
+
+/// Clears a reset request. With `validate_started_time` the row is left alone once the reset
+/// has started, so a controller that starts concurrently wins over a late `Clear`.
+pub async fn clear_managed_host_reset_request(
+    txn: &mut PgConnection,
+    machine_id: &MachineId,
+    validate_started_time: bool,
+) -> Result<(), DatabaseError> {
+    let query = if validate_started_time {
+        "UPDATE machines SET reset_requested=NULL
+            WHERE id=$1 AND reset_requested->'started_at' = 'null'::jsonb RETURNING id"
+    } else {
+        "UPDATE machines SET reset_requested=NULL
+            WHERE id=$1 RETURNING id"
+    };
+
+    let _id = sqlx::query_as::<_, MachineId>(query)
+        .bind(machine_id)
+        .fetch_one(txn)
+        .await
+        .map_err(|e| DatabaseError::new("clear reset_requested", e))?;
+
+    Ok(())
+}
+
+pub async fn list_machines_requested_for_reset(
+    txn: impl DbReader<'_>,
+) -> Result<Vec<HostMachine>, DatabaseError> {
+    lazy_static! {
+        static ref query: String = format!(
+            "{} WHERE m.reset_requested IS NOT NULL",
             JSON_MACHINE_SNAPSHOT_QUERY.deref()
         );
     }

--- a/crates/api-model/src/machine/json.rs
+++ b/crates/api-model/src/machine/json.rs
@@ -39,8 +39,8 @@ use crate::machine::topology::MachineTopology;
 use crate::machine::{
     AnyMachine, Dpf, DpuMachine, FailureDetails, HostMachine, HostProfile, HostReprovisionRequest,
     MachineConfig, MachineInterfaceSnapshot, MachineLastRebootRequested, MachineMaintenanceRequest,
-    MachineStatus, ManagedHostState, PredictedHostMachine, ReprovisionRequest, StableHostMachine,
-    UpgradeDecision,
+    MachineStatus, ManagedHostState, PredictedHostMachine, ReprovisionRequest, ResetRequest,
+    StableHostMachine, UpgradeDecision,
 };
 use crate::machine_boot_interface::{
     BootInterfaceSelection, BootInterfaceSelectionSource, BootInterfaceStatusObservation,
@@ -83,6 +83,7 @@ pub struct MachineSnapshotPgJson {
     pub failure_details: FailureDetails,
     pub reprovisioning_requested: Option<ReprovisionRequest>,
     pub host_reprovisioning_requested: Option<HostReprovisionRequest>,
+    pub reset_requested: Option<ResetRequest>,
     pub machine_maintenance_requested: Option<MachineMaintenanceRequest>,
     #[serde(default)]
     pub decommission_requested: bool,
@@ -378,6 +379,7 @@ impl TryFrom<MachineSnapshotPgJson> for AnyMachine {
             health_reports,
             reprovision_requested: value.reprovisioning_requested,
             host_reprovision_requested: value.host_reprovisioning_requested,
+            reset_requested: value.reset_requested,
             dpu_agent_upgrade_requested: value.dpu_agent_upgrade_requested,
             controller_state_outcome: value.controller_state_outcome,
             bios_password_set_time: value.bios_password_set_time,

--- a/crates/api-model/src/machine/mod.rs
+++ b/crates/api-model/src/machine/mod.rs
@@ -869,6 +869,10 @@ pub struct Machine<ID: MachineIdSubtypeTrait> {
     /// Last time when host reprovision requested
     pub host_reprovision_requested: Option<HostReprovisionRequest>,
 
+    /// When set by an operator, the state controller tears down the host's instance
+    /// and DPF resources, then re-ingests it.
+    pub reset_requested: Option<ResetRequest>,
+
     /// When set by an external entity, the state controller transitions the host into
     /// [`ManagedHostState::Maintenance`] to execute the requested operation.
     pub machine_maintenance_requested: Option<MachineMaintenanceRequest>,
@@ -956,6 +960,7 @@ impl<ID: MachineIdSubtypeTrait> Machine<ID> {
             health_reports: self.health_reports,
             reprovision_requested: self.reprovision_requested,
             host_reprovision_requested: self.host_reprovision_requested,
+            reset_requested: self.reset_requested,
             machine_maintenance_requested: self.machine_maintenance_requested,
             decommission_requested: self.decommission_requested,
             bmc_credential_rotation_requested: self.bmc_credential_rotation_requested,
@@ -1364,6 +1369,11 @@ pub enum ManagedHostState {
         decommissioning_state: DecommissioningState,
     },
 
+    /// Host is being torn down and re-ingested at an operator's request.
+    Reset {
+        reset_state: ResetState,
+    },
+
     /// An unassigned Ready host is converging its Redfish boot configuration
     /// to the desired boot interface persisted on the machine.
     ///
@@ -1572,6 +1582,19 @@ pub enum DeconfiguringDpuState {
     WaitForInstallComplete { task_id: String },
     WaitingForBootAfterBfbInstall,
     Complete,
+}
+
+/// Sub-states of [`ManagedHostState::Reset`]: delete the tenant instance, then delete
+/// the DPF CRs and wait for them to drain before re-ingesting from DPU discovery.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+#[serde(rename_all = "lowercase")]
+#[allow(clippy::enum_variant_names)] // Both steps delete; the object deleted is the distinction
+pub enum ResetState {
+    DeletingInstance,
+    /// Deletes the CRs and polls until they are gone. Registration refuses a CR that
+    /// still carries a deletionTimestamp, so re-ingestion has to wait for the drain
+    /// rather than for the delete to be accepted.
+    DeletingCrs,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
@@ -2694,6 +2717,14 @@ pub struct HostReprovisionRequest {
     pub request_reset: Option<bool>,
 }
 
+/// Struct to store information if a managed host reset is requested.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResetRequest {
+    pub requested_at: DateTime<Utc>,
+    pub initiator: String,
+    pub started_at: Option<DateTime<Utc>>,
+}
+
 pub use crate::rack::RackFirmwareUpgradeStatus;
 
 /// Should a forge-dpu-agent upgrade itself?
@@ -2913,6 +2944,7 @@ impl Display for ManagedHostState {
             ManagedHostState::Decommissioning {
                 decommissioning_state,
             } => write!(f, "Decommissioning/{decommissioning_state}"),
+            ManagedHostState::Reset { reset_state } => write!(f, "Reset/{reset_state:?}"),
             ManagedHostState::BootConfiguring {
                 boot_config_state, ..
             } => {
@@ -3027,6 +3059,7 @@ impl ManagedHostState {
             ManagedHostState::Decommissioning {
                 decommissioning_state,
             } => format!("Decommissioning/{decommissioning_state}"),
+            ManagedHostState::Reset { reset_state } => format!("Reset/{reset_state:?}"),
             ManagedHostState::BootConfiguring {
                 boot_config_state, ..
             } => {
@@ -3283,6 +3316,7 @@ pub fn state_sla(
             ),
             DecommissioningState::Decommissioned => StateSla::no_sla(),
         },
+        ManagedHostState::Reset { .. } => StateSla::with_sla(slas::RESET, time_in_state),
         ManagedHostState::BootConfiguring {
             boot_config_state: ReadyBootConfigState::Failed { .. },
             ..

--- a/crates/api-model/src/machine/slas.rs
+++ b/crates/api-model/src/machine/slas.rs
@@ -43,6 +43,10 @@ pub const FORCE_DELETION: Duration = Duration::from_secs(30 * 60);
 
 pub const DPU_REPROVISION: Duration = Duration::from_secs(30 * 60);
 
+// Host reset: delete the tenant instance and DPF CRs, then wait until they are gone.
+// Applies per sub-state, since each sub-state transition restarts the clock.
+pub const RESET: Duration = Duration::from_secs(30 * 60);
+
 pub const HOST_REPROVISION: Duration = Duration::from_secs(40 * 60);
 
 pub const MEASUREMENT_WAIT_FOR_MEASUREMENT: Duration = Duration::from_secs(30 * 60);

--- a/crates/api-model/src/test_support/machine_snapshot.rs
+++ b/crates/api-model/src/test_support/machine_snapshot.rs
@@ -446,6 +446,7 @@ pub fn machine_snapshot_pg_json(machine_id: impl MachineIdSubtypeTrait) -> Machi
         },
         reprovisioning_requested: None,
         host_reprovisioning_requested: None,
+        reset_requested: None,
         manual_firmware_upgrade_completed: Some(fixture_time(400)),
         bios_password_set_time: Some(fixture_time(350)),
         last_machine_validation_time: Some(fixture_time(1700)),

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -820,8 +820,11 @@ impl MachineStateHandler {
 
         // Don't update failed state failure cause everytime. Record first failure cause only,
         // otherwise first failure cause will be overwritten.
-        if !matches!(mh_state, ManagedHostState::Failed { .. })
-            && let Some((machine_id, details)) = get_failed_state(mh_snapshot)
+        // A reset is a deliberate teardown, so a failure record must not park it.
+        if !matches!(
+            mh_state,
+            ManagedHostState::Failed { .. } | ManagedHostState::Reset { .. }
+        ) && let Some((machine_id, details)) = get_failed_state(mh_snapshot)
         {
             let already_relocking_machine_failure = matches!(
                 &mh_state,

--- a/crates/machine-controller/src/handler.rs
+++ b/crates/machine-controller/src/handler.rs
@@ -84,8 +84,8 @@ use model::machine::{
     MachineLastRebootRequestedMode, MachineNextStateResolver, MachineState,
     MachineValidationContext, ManagedHostState, ManagedHostStateSnapshot, MeasuringState,
     NetworkConfigUpdateState, NextStateBFBSupport, PerformPowerOperation, PowerDrainState,
-    PowerState, ReadyBootConfigPostLockAction, ReadyBootConfigState, ReprovisionState, RetryInfo,
-    SecureEraseBossContext, SecureEraseBossState, SetBootOrderInfo, SetBootOrderState,
+    PowerState, ReadyBootConfigPostLockAction, ReadyBootConfigState, ReprovisionState, ResetState,
+    RetryInfo, SecureEraseBossContext, SecureEraseBossState, SetBootOrderInfo, SetBootOrderState,
     SetSecureBootState, SpdmMeasuringState, StateMachineArea, UefiSetupInfo, UefiSetupState,
     UnlockHostState, ValidationState, get_display_ids,
 };
@@ -138,6 +138,7 @@ mod machine_validation;
 mod maintenance;
 mod nic_lockdown_rotation;
 mod power;
+mod reset;
 mod rotation;
 mod sku;
 #[cfg(test)]
@@ -780,6 +781,28 @@ impl MachineStateHandler {
             return Ok(restart_transition);
         }
 
+        // A reset preempts the reprovision hinge below and the failure parking after it.
+        if managed_host_reset_needed(mh_snapshot) {
+            // Stamping `started_at` closes the reset to `clear` and stops the hinge re-firing.
+            let mut txn = ctx.services.db_pool.begin().await?;
+            db::machine::update_managed_host_reset_start_time(
+                &mut txn,
+                &mh_snapshot.host_snapshot.id,
+            )
+            .await?;
+
+            tracing::info!(
+                host_machine_id = %mh_snapshot.host_snapshot.id,
+                from_state = %mh_state,
+                "Managed host reset requested; tearing down the host for re-ingestion",
+            );
+
+            return Ok(StateHandlerOutcome::transition(ManagedHostState::Reset {
+                reset_state: ResetState::DeletingInstance,
+            })
+            .with_txn(txn));
+        }
+
         if dpu_reprovisioning_needed(&mh_snapshot.dpu_snapshots) {
             // Reprovision is started and user requested for restart of reprovision.
             let restart_reprov = can_restart_reprovision(
@@ -1021,6 +1044,17 @@ impl MachineStateHandler {
                 self.dpu_handler
                     .handle_object_state(host_machine_id, mh_snapshot, &mh_state, ctx)
                     .await
+            }
+
+            ManagedHostState::Reset { reset_state } => {
+                reset::handle_reset(
+                    reset_state,
+                    mh_snapshot,
+                    ctx,
+                    self.instance_handler.common_pools.as_deref(),
+                    self.dpu_handler.dpf_sdk.as_deref(),
+                )
+                .await
             }
 
             ManagedHostState::HostInit { .. } => {
@@ -2708,6 +2742,21 @@ fn dpu_reprovisioning_needed(dpu_snapshots: &[DpuMachine]) -> bool {
     dpu_snapshots
         .iter()
         .any(|x| x.reprovision_requested.is_some())
+}
+
+/// This function checks if an operator-requested reset is waiting to start.
+fn managed_host_reset_needed(state: &ManagedHostStateSnapshot) -> bool {
+    // A force-deleting host must not be resurrected.
+    if matches!(state.managed_state, ManagedHostState::ForceDeletion) {
+        return false;
+    }
+
+    // The API nulls `started_at` on every `set`, so a re-trigger restarts the reset.
+    state
+        .host_snapshot
+        .reset_requested
+        .as_ref()
+        .is_some_and(|request| request.started_at.is_none())
 }
 
 async fn handle_restart_verification(

--- a/crates/machine-controller/src/handler/reset.rs
+++ b/crates/machine-controller/src/handler/reset.rs
@@ -1,0 +1,175 @@
+/*
+ * SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+//! Operator-requested managed host reset: delete the tenant instance, delete the host's
+//! DPF CRs, then hand the host back to DPU discovery so DPF re-ingests it from scratch.
+
+use eyre::eyre;
+use model::machine::{
+    DpuDiscoveringState, DpuDiscoveringStates, ManagedHostState, ManagedHostStateSnapshot,
+    ResetState,
+};
+use model::resource_pool::common::CommonPools;
+use state_controller::state_handler::{
+    StateHandlerContext, StateHandlerError, StateHandlerOutcome,
+};
+
+use super::{release_network_segments_with_vpc_prefix, release_vpc_dpu_loopback};
+use crate::context::MachineStateHandlerContextObjects;
+use crate::dpf::{DpfOperations, dpf_dpudevices_and_dpunode_crs_noexist};
+
+pub(super) async fn handle_reset(
+    reset_state: &ResetState,
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    common_pools: Option<&CommonPools>,
+    dpf_sdk: Option<&dyn DpfOperations>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    match reset_state {
+        ResetState::DeletingInstance => handle_deleting_instance(state, ctx, common_pools).await,
+        ResetState::DeletingCrs => handle_deleting_crs(state, ctx, dpf_sdk).await,
+    }
+}
+
+async fn handle_deleting_instance(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    common_pools: Option<&CommonPools>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let next = ManagedHostState::Reset {
+        reset_state: ResetState::DeletingCrs,
+    };
+
+    let Some(instance) = state.instance.as_ref() else {
+        return Ok(StateHandlerOutcome::transition(next));
+    };
+
+    // The delete and the segment release must commit together, as in the Assigned
+    // termination path.
+    let mut txn = ctx.services.db_pool.begin().await?;
+    db::instance::delete(instance.id, &mut txn)
+        .await
+        .map_err(|err| StateHandlerError::GenericError(err.into()))?;
+
+    release_network_segments_with_vpc_prefix(&instance.config.network.interfaces, &mut txn).await?;
+
+    release_vpc_dpu_loopback(state, common_pools, &mut txn).await?;
+
+    Ok(StateHandlerOutcome::transition(next).with_txn(txn))
+}
+
+/// Deletes the host's DPF CRs and polls until they are gone.
+///
+/// Registration refuses a CR that still carries a deletionTimestamp, so re-ingestion has
+/// to wait for the drain. `force_delete_host` tolerates CRs that are already gone, so
+/// re-running it on each poll is safe.
+async fn handle_deleting_crs(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+    dpf_sdk: Option<&dyn DpfOperations>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let dpf_sdk = dpf_sdk.ok_or_else(|| {
+        StateHandlerError::GenericError(eyre!(
+            "managed host {} reset requires DPF, but DPF is not configured",
+            state.host_snapshot.id
+        ))
+    })?;
+
+    let host_dpf_id =
+        state
+            .host_snapshot
+            .dpf_id()
+            .ok_or_else(|| StateHandlerError::MissingData {
+                object_id: state.host_snapshot.id.to_string(),
+                missing: "dpf_id",
+            })?;
+    let dpu_dpf_ids = state
+        .dpu_snapshots
+        .iter()
+        .map(|dpu| {
+            dpu.dpf_id().ok_or_else(|| StateHandlerError::MissingData {
+                object_id: dpu.id.to_string(),
+                missing: "dpf_id",
+            })
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // Reused from decommissioning; deletes the host's DPUNode and DPUDevice CRs.
+    dpf_sdk
+        .force_delete_host(&host_dpf_id, &dpu_dpf_ids)
+        .await
+        .map_err(|error| {
+            StateHandlerError::GenericError(eyre!(
+                "failed to delete managed host {} from DPF: {error}",
+                state.host_snapshot.id
+            ))
+        })?;
+
+    if !dpf_dpudevices_and_dpunode_crs_noexist(state, dpf_sdk)
+        .await
+        .map_err(|error| StateHandlerError::GenericError(error.into()))?
+    {
+        return Ok(StateHandlerOutcome::wait(
+            "waiting for managed host DPF resources to be deleted".to_string(),
+        ));
+    }
+
+    start_host_reingestion(state, ctx).await
+}
+
+/// Hands the drained host back to DPU discovery so DPF re-registers it from scratch.
+///
+/// Discovery, not `DPUInit`, decides whether the host is DPF-provisioned; its
+/// `RebootAllDPUS` substate is the only path to `DpfState::Provisioning`, which recreates
+/// the CRs deleted above. Entering at `Initializing` matches fresh ingestion, so the
+/// re-ingested host also gets `EnableRshim` and the secure-boot substate that follows it.
+async fn start_host_reingestion(
+    state: &ManagedHostStateSnapshot,
+    ctx: &mut StateHandlerContext<'_, MachineStateHandlerContextObjects>,
+) -> Result<StateHandlerOutcome<ManagedHostState>, StateHandlerError> {
+    let host_id = &state.host_snapshot.id;
+
+    let mut dpu_states = std::collections::HashMap::new();
+    let mut txn = ctx.services.db_pool.begin().await?;
+
+    // A surviving failure record would re-park the host via `get_failed_state`.
+    db::machine::clear_failure_details(host_id, &mut txn).await?;
+    db::machine_topology::set_topology_update_needed(&mut txn, host_id, true).await?;
+
+    for dpu in &state.dpu_snapshots {
+        db::machine::clear_failure_details(&dpu.id, &mut txn).await?;
+        // A stale request would win the reprovision hinge once the reset stops firing.
+        db::machine::clear_dpu_reprovisioning_request(&mut txn, &dpu.id, false).await?;
+        db::machine_topology::set_topology_update_needed(&mut txn, &dpu.id, true).await?;
+
+        dpu_states.insert(dpu.id, DpuDiscoveringState::Initializing);
+    }
+
+    db::machine::clear_managed_host_reset_request(&mut txn, host_id, false).await?;
+
+    tracing::info!(
+        host_machine_id = %host_id,
+        "Managed host reset drained the host's DPF CRs; re-ingesting from DPU discovery",
+    );
+
+    Ok(
+        StateHandlerOutcome::transition(ManagedHostState::DpuDiscoveringState {
+            dpu_states: DpuDiscoveringStates { states: dpu_states },
+        })
+        .with_txn(txn),
+    )
+}

--- a/crates/machine-controller/src/io.rs
+++ b/crates/machine-controller/src/io.rs
@@ -364,6 +364,7 @@ impl StateControllerIO for MachineStateControllerIO {
             ManagedHostState::ForceDeletion => ("forcedeletion", ""),
             ManagedHostState::Failed { .. } => ("failed", ""),
             ManagedHostState::DPUReprovision { .. } => ("reprovisioning", ""),
+            ManagedHostState::Reset { .. } => ("reset", ""),
             ManagedHostState::HostReprovision { .. } => ("hostreprovisioning", ""),
             ManagedHostState::RotatingBmc { .. } => ("rotatingbmc", ""),
             ManagedHostState::RotatingHostUefi { .. } => ("rotatinghostuefi", ""),

--- a/crates/rpc/proto/forge.proto
+++ b/crates/rpc/proto/forge.proto
@@ -417,6 +417,13 @@ service Forge {
   rpc TriggerHostReprovisioning(HostReprovisioningRequest) returns (google.protobuf.Empty);
   // List hosts waiting for reprovisioning
   rpc ListHostsWaitingForReprovisioning(HostReprovisioningListRequest) returns (HostReprovisioningListResponse);
+
+  // Trigger a reset of a managed host: tear down its instance and DPF
+  // resources, then re-ingest it from DPU discovery.
+  rpc TriggerManagedHostReset(ManagedHostResetRequest) returns (google.protobuf.Empty);
+  // List managed hosts waiting for reset
+  rpc ListManagedHostsWaitingForReset(ManagedHostResetListRequest) returns (ManagedHostResetListResponse);
+
   // Operator "force-converge this BMC now" escape hatch for a single host/DPU
   // BMC. This is asynchronous: the handler only persists (Set) or removes
   // (Clear) the machine's `bmc_credential_rotation_requested` flag and returns;
@@ -10802,6 +10809,39 @@ message InterfaceAddressConfig {
   // and debugging; the tenant is not expected to access this address. Writers
   // must set this value on at most one family entry.
   optional string tenant_vrf_loopback_ip = 7;
+}
+
+message ManagedHostResetRequest {
+  enum Mode {
+    // Zero value so an omitted mode is rejected, not defaulted to an action.
+    Unspecified = 0;
+    Set = 1;
+    Clear = 2;
+  }
+  // Host to reset. Not a DPU: a reset tears down every DPU attached to the
+  // host, so it is only expressible against the host.
+  common.MachineId machine_id = 1;
+  Mode mode = 2;
+  UpdateInitiator initiator = 3;
+
+  // Operator acknowledgment that resetting an assigned host destroys the live
+  // tenant instance and its data. The server rejects a Set on an assigned host
+  // unless this is set.
+  bool allow_reset_with_instance = 4;
+}
+
+message ManagedHostResetListRequest {
+}
+
+message ManagedHostResetListResponse {
+  message ManagedHostResetListItem {
+    common.MachineId id = 1; // Host machine ID
+    string state = 2; // ManagedHost state
+    string initiator = 3; // Who requested this reset.
+    google.protobuf.Timestamp requested_at = 4; // When the reset was requested.
+    optional google.protobuf.Timestamp started_at = 5; // When the reset started.
+  }
+  repeated ManagedHostResetListItem hosts = 1;
 }
 
 // Selects a fixed, versioned mlxconfig profile for DPU provisioning.

--- a/docs/development/schema.md
+++ b/docs/development/schema.md
@@ -36,6 +36,7 @@ erDiagram
         character_varying maintenance_reference
         timestamp_with_time_zone maintenance_start_time
         jsonb reprovisioning_requested
+        jsonb reset_requested
         jsonb dpu_agent_upgrade_requested
     }
 

--- a/rest-api/proto/core/gen/v1/nico_nico.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico.pb.go
@@ -6018,6 +6018,56 @@ func (GetMachineBootInterfacesResponse_Reconciliation_State) EnumDescriptor() ([
 	return file_nico_nico_proto_rawDescGZIP(), []int{894, 0, 0}
 }
 
+type ManagedHostResetRequest_Mode int32
+
+const (
+	// Zero value so an omitted mode is rejected, not defaulted to an action.
+	ManagedHostResetRequest_Unspecified ManagedHostResetRequest_Mode = 0
+	ManagedHostResetRequest_Set         ManagedHostResetRequest_Mode = 1
+	ManagedHostResetRequest_Clear       ManagedHostResetRequest_Mode = 2
+)
+
+// Enum value maps for ManagedHostResetRequest_Mode.
+var (
+	ManagedHostResetRequest_Mode_name = map[int32]string{
+		0: "Unspecified",
+		1: "Set",
+		2: "Clear",
+	}
+	ManagedHostResetRequest_Mode_value = map[string]int32{
+		"Unspecified": 0,
+		"Set":         1,
+		"Clear":       2,
+	}
+)
+
+func (x ManagedHostResetRequest_Mode) Enum() *ManagedHostResetRequest_Mode {
+	p := new(ManagedHostResetRequest_Mode)
+	*p = x
+	return p
+}
+
+func (x ManagedHostResetRequest_Mode) String() string {
+	return protoimpl.X.EnumStringOf(x.Descriptor(), protoreflect.EnumNumber(x))
+}
+
+func (ManagedHostResetRequest_Mode) Descriptor() protoreflect.EnumDescriptor {
+	return file_nico_nico_proto_enumTypes[109].Descriptor()
+}
+
+func (ManagedHostResetRequest_Mode) Type() protoreflect.EnumType {
+	return &file_nico_nico_proto_enumTypes[109]
+}
+
+func (x ManagedHostResetRequest_Mode) Number() protoreflect.EnumNumber {
+	return protoreflect.EnumNumber(x)
+}
+
+// Deprecated: Use ManagedHostResetRequest_Mode.Descriptor instead.
+func (ManagedHostResetRequest_Mode) EnumDescriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{912, 0}
+}
+
 // Indicates the lifecycle state of a resource that is controlled by a state controller
 type LifecycleStatus struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
@@ -64145,6 +64195,159 @@ func (x *InterfaceAddressConfig) GetTenantVrfLoopbackIp() string {
 	return ""
 }
 
+type ManagedHostResetRequest struct {
+	state protoimpl.MessageState `protogen:"open.v1"`
+	// Host to reset. Not a DPU: a reset tears down every DPU attached to the
+	// host, so it is only expressible against the host.
+	MachineId *MachineId                   `protobuf:"bytes,1,opt,name=machine_id,json=machineId,proto3" json:"machine_id,omitempty"`
+	Mode      ManagedHostResetRequest_Mode `protobuf:"varint,2,opt,name=mode,proto3,enum=forge.ManagedHostResetRequest_Mode" json:"mode,omitempty"`
+	Initiator UpdateInitiator              `protobuf:"varint,3,opt,name=initiator,proto3,enum=forge.UpdateInitiator" json:"initiator,omitempty"`
+	// Operator acknowledgment that resetting an assigned host destroys the live
+	// tenant instance and its data. The server rejects a Set on an assigned host
+	// unless this is set.
+	AllowResetWithInstance bool `protobuf:"varint,4,opt,name=allow_reset_with_instance,json=allowResetWithInstance,proto3" json:"allow_reset_with_instance,omitempty"`
+	unknownFields          protoimpl.UnknownFields
+	sizeCache              protoimpl.SizeCache
+}
+
+func (x *ManagedHostResetRequest) Reset() {
+	*x = ManagedHostResetRequest{}
+	mi := &file_nico_nico_proto_msgTypes[912]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedHostResetRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedHostResetRequest) ProtoMessage() {}
+
+func (x *ManagedHostResetRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_nico_nico_proto_msgTypes[912]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagedHostResetRequest.ProtoReflect.Descriptor instead.
+func (*ManagedHostResetRequest) Descriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{912}
+}
+
+func (x *ManagedHostResetRequest) GetMachineId() *MachineId {
+	if x != nil {
+		return x.MachineId
+	}
+	return nil
+}
+
+func (x *ManagedHostResetRequest) GetMode() ManagedHostResetRequest_Mode {
+	if x != nil {
+		return x.Mode
+	}
+	return ManagedHostResetRequest_Unspecified
+}
+
+func (x *ManagedHostResetRequest) GetInitiator() UpdateInitiator {
+	if x != nil {
+		return x.Initiator
+	}
+	return UpdateInitiator_AdminCli
+}
+
+func (x *ManagedHostResetRequest) GetAllowResetWithInstance() bool {
+	if x != nil {
+		return x.AllowResetWithInstance
+	}
+	return false
+}
+
+type ManagedHostResetListRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagedHostResetListRequest) Reset() {
+	*x = ManagedHostResetListRequest{}
+	mi := &file_nico_nico_proto_msgTypes[913]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedHostResetListRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedHostResetListRequest) ProtoMessage() {}
+
+func (x *ManagedHostResetListRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_nico_nico_proto_msgTypes[913]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagedHostResetListRequest.ProtoReflect.Descriptor instead.
+func (*ManagedHostResetListRequest) Descriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{913}
+}
+
+type ManagedHostResetListResponse struct {
+	state         protoimpl.MessageState                                   `protogen:"open.v1"`
+	Hosts         []*ManagedHostResetListResponse_ManagedHostResetListItem `protobuf:"bytes,1,rep,name=hosts,proto3" json:"hosts,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagedHostResetListResponse) Reset() {
+	*x = ManagedHostResetListResponse{}
+	mi := &file_nico_nico_proto_msgTypes[914]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedHostResetListResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedHostResetListResponse) ProtoMessage() {}
+
+func (x *ManagedHostResetListResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_nico_nico_proto_msgTypes[914]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagedHostResetListResponse.ProtoReflect.Descriptor instead.
+func (*ManagedHostResetListResponse) Descriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{914}
+}
+
+func (x *ManagedHostResetListResponse) GetHosts() []*ManagedHostResetListResponse_ManagedHostResetListItem {
+	if x != nil {
+		return x.Hosts
+	}
+	return nil
+}
+
 // Releases the VNI retained after a routing-profile change. The active VNI and
 // VPC configuration remain unchanged. Before calling, operators must verify
 // that affected DPUs (including peers) and fabric routes no longer use the
@@ -64170,7 +64373,7 @@ type VpcReleaseInactiveVniRequest struct {
 
 func (x *VpcReleaseInactiveVniRequest) Reset() {
 	*x = VpcReleaseInactiveVniRequest{}
-	mi := &file_nico_nico_proto_msgTypes[912]
+	mi := &file_nico_nico_proto_msgTypes[915]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64182,7 +64385,7 @@ func (x *VpcReleaseInactiveVniRequest) String() string {
 func (*VpcReleaseInactiveVniRequest) ProtoMessage() {}
 
 func (x *VpcReleaseInactiveVniRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[912]
+	mi := &file_nico_nico_proto_msgTypes[915]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64195,7 +64398,7 @@ func (x *VpcReleaseInactiveVniRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcReleaseInactiveVniRequest.ProtoReflect.Descriptor instead.
 func (*VpcReleaseInactiveVniRequest) Descriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{912}
+	return file_nico_nico_proto_rawDescGZIP(), []int{915}
 }
 
 func (x *VpcReleaseInactiveVniRequest) GetId() *VpcId {
@@ -64231,7 +64434,7 @@ type VpcReleaseInactiveVniResult struct {
 
 func (x *VpcReleaseInactiveVniResult) Reset() {
 	*x = VpcReleaseInactiveVniResult{}
-	mi := &file_nico_nico_proto_msgTypes[913]
+	mi := &file_nico_nico_proto_msgTypes[916]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64243,7 +64446,7 @@ func (x *VpcReleaseInactiveVniResult) String() string {
 func (*VpcReleaseInactiveVniResult) ProtoMessage() {}
 
 func (x *VpcReleaseInactiveVniResult) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[913]
+	mi := &file_nico_nico_proto_msgTypes[916]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64256,7 +64459,7 @@ func (x *VpcReleaseInactiveVniResult) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcReleaseInactiveVniResult.ProtoReflect.Descriptor instead.
 func (*VpcReleaseInactiveVniResult) Descriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{913}
+	return file_nico_nico_proto_rawDescGZIP(), []int{916}
 }
 
 func (x *VpcReleaseInactiveVniResult) GetVpc() *Vpc {
@@ -64285,7 +64488,7 @@ type VpcRoutingStateRequest struct {
 
 func (x *VpcRoutingStateRequest) Reset() {
 	*x = VpcRoutingStateRequest{}
-	mi := &file_nico_nico_proto_msgTypes[914]
+	mi := &file_nico_nico_proto_msgTypes[917]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64297,7 +64500,7 @@ func (x *VpcRoutingStateRequest) String() string {
 func (*VpcRoutingStateRequest) ProtoMessage() {}
 
 func (x *VpcRoutingStateRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[914]
+	mi := &file_nico_nico_proto_msgTypes[917]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64310,7 +64513,7 @@ func (x *VpcRoutingStateRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcRoutingStateRequest.ProtoReflect.Descriptor instead.
 func (*VpcRoutingStateRequest) Descriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{914}
+	return file_nico_nico_proto_rawDescGZIP(), []int{917}
 }
 
 func (x *VpcRoutingStateRequest) GetId() *VpcId {
@@ -64351,7 +64554,7 @@ type VpcRoutingState struct {
 
 func (x *VpcRoutingState) Reset() {
 	*x = VpcRoutingState{}
-	mi := &file_nico_nico_proto_msgTypes[915]
+	mi := &file_nico_nico_proto_msgTypes[918]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64363,7 +64566,7 @@ func (x *VpcRoutingState) String() string {
 func (*VpcRoutingState) ProtoMessage() {}
 
 func (x *VpcRoutingState) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[915]
+	mi := &file_nico_nico_proto_msgTypes[918]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64376,7 +64579,7 @@ func (x *VpcRoutingState) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcRoutingState.ProtoReflect.Descriptor instead.
 func (*VpcRoutingState) Descriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{915}
+	return file_nico_nico_proto_rawDescGZIP(), []int{918}
 }
 
 func (x *VpcRoutingState) GetId() *VpcId {
@@ -64428,7 +64631,7 @@ type VpcRetainedVniAllocation struct {
 
 func (x *VpcRetainedVniAllocation) Reset() {
 	*x = VpcRetainedVniAllocation{}
-	mi := &file_nico_nico_proto_msgTypes[916]
+	mi := &file_nico_nico_proto_msgTypes[919]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64440,7 +64643,7 @@ func (x *VpcRetainedVniAllocation) String() string {
 func (*VpcRetainedVniAllocation) ProtoMessage() {}
 
 func (x *VpcRetainedVniAllocation) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[916]
+	mi := &file_nico_nico_proto_msgTypes[919]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64453,7 +64656,7 @@ func (x *VpcRetainedVniAllocation) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcRetainedVniAllocation.ProtoReflect.Descriptor instead.
 func (*VpcRetainedVniAllocation) Descriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{916}
+	return file_nico_nico_proto_rawDescGZIP(), []int{919}
 }
 
 func (x *VpcRetainedVniAllocation) GetPoolName() string {
@@ -64527,7 +64730,7 @@ type VpcChangeRoutingProfileRequest struct {
 
 func (x *VpcChangeRoutingProfileRequest) Reset() {
 	*x = VpcChangeRoutingProfileRequest{}
-	mi := &file_nico_nico_proto_msgTypes[917]
+	mi := &file_nico_nico_proto_msgTypes[920]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64539,7 +64742,7 @@ func (x *VpcChangeRoutingProfileRequest) String() string {
 func (*VpcChangeRoutingProfileRequest) ProtoMessage() {}
 
 func (x *VpcChangeRoutingProfileRequest) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[917]
+	mi := &file_nico_nico_proto_msgTypes[920]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64552,7 +64755,7 @@ func (x *VpcChangeRoutingProfileRequest) ProtoReflect() protoreflect.Message {
 
 // Deprecated: Use VpcChangeRoutingProfileRequest.ProtoReflect.Descriptor instead.
 func (*VpcChangeRoutingProfileRequest) Descriptor() ([]byte, []int) {
-	return file_nico_nico_proto_rawDescGZIP(), []int{917}
+	return file_nico_nico_proto_rawDescGZIP(), []int{920}
 }
 
 func (x *VpcChangeRoutingProfileRequest) GetId() *VpcId {
@@ -64594,7 +64797,7 @@ type DNSMessage_DNSQuestion struct {
 
 func (x *DNSMessage_DNSQuestion) Reset() {
 	*x = DNSMessage_DNSQuestion{}
-	mi := &file_nico_nico_proto_msgTypes[919]
+	mi := &file_nico_nico_proto_msgTypes[922]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64606,7 +64809,7 @@ func (x *DNSMessage_DNSQuestion) String() string {
 func (*DNSMessage_DNSQuestion) ProtoMessage() {}
 
 func (x *DNSMessage_DNSQuestion) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[919]
+	mi := &file_nico_nico_proto_msgTypes[922]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64652,7 +64855,7 @@ type DNSMessage_DNSResponse struct {
 
 func (x *DNSMessage_DNSResponse) Reset() {
 	*x = DNSMessage_DNSResponse{}
-	mi := &file_nico_nico_proto_msgTypes[920]
+	mi := &file_nico_nico_proto_msgTypes[923]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64664,7 +64867,7 @@ func (x *DNSMessage_DNSResponse) String() string {
 func (*DNSMessage_DNSResponse) ProtoMessage() {}
 
 func (x *DNSMessage_DNSResponse) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[920]
+	mi := &file_nico_nico_proto_msgTypes[923]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64696,7 +64899,7 @@ type DNSMessage_DNSResponse_DNSRR struct {
 
 func (x *DNSMessage_DNSResponse_DNSRR) Reset() {
 	*x = DNSMessage_DNSResponse_DNSRR{}
-	mi := &file_nico_nico_proto_msgTypes[921]
+	mi := &file_nico_nico_proto_msgTypes[924]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64708,7 +64911,7 @@ func (x *DNSMessage_DNSResponse_DNSRR) String() string {
 func (*DNSMessage_DNSResponse_DNSRR) ProtoMessage() {}
 
 func (x *DNSMessage_DNSResponse_DNSRR) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[921]
+	mi := &file_nico_nico_proto_msgTypes[924]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64742,7 +64945,7 @@ type MachineCredentialsUpdateRequest_Credentials struct {
 
 func (x *MachineCredentialsUpdateRequest_Credentials) Reset() {
 	*x = MachineCredentialsUpdateRequest_Credentials{}
-	mi := &file_nico_nico_proto_msgTypes[926]
+	mi := &file_nico_nico_proto_msgTypes[929]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64754,7 +64957,7 @@ func (x *MachineCredentialsUpdateRequest_Credentials) String() string {
 func (*MachineCredentialsUpdateRequest_Credentials) ProtoMessage() {}
 
 func (x *MachineCredentialsUpdateRequest_Credentials) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[926]
+	mi := &file_nico_nico_proto_msgTypes[929]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64801,7 +65004,7 @@ type ForgeAgentControlResponse_ForgeAgentControlExtraInfo struct {
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo) Reset() {
 	*x = ForgeAgentControlResponse_ForgeAgentControlExtraInfo{}
-	mi := &file_nico_nico_proto_msgTypes[927]
+	mi := &file_nico_nico_proto_msgTypes[930]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64813,7 +65016,7 @@ func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo) String() string {
 func (*ForgeAgentControlResponse_ForgeAgentControlExtraInfo) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[927]
+	mi := &file_nico_nico_proto_msgTypes[930]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64844,7 +65047,7 @@ type ForgeAgentControlResponse_Noop struct {
 
 func (x *ForgeAgentControlResponse_Noop) Reset() {
 	*x = ForgeAgentControlResponse_Noop{}
-	mi := &file_nico_nico_proto_msgTypes[928]
+	mi := &file_nico_nico_proto_msgTypes[931]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64856,7 +65059,7 @@ func (x *ForgeAgentControlResponse_Noop) String() string {
 func (*ForgeAgentControlResponse_Noop) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Noop) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[928]
+	mi := &file_nico_nico_proto_msgTypes[931]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64880,7 +65083,7 @@ type ForgeAgentControlResponse_Reset struct {
 
 func (x *ForgeAgentControlResponse_Reset) Reset() {
 	*x = ForgeAgentControlResponse_Reset{}
-	mi := &file_nico_nico_proto_msgTypes[929]
+	mi := &file_nico_nico_proto_msgTypes[932]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64892,7 +65095,7 @@ func (x *ForgeAgentControlResponse_Reset) String() string {
 func (*ForgeAgentControlResponse_Reset) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Reset) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[929]
+	mi := &file_nico_nico_proto_msgTypes[932]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64916,7 +65119,7 @@ type ForgeAgentControlResponse_Discovery struct {
 
 func (x *ForgeAgentControlResponse_Discovery) Reset() {
 	*x = ForgeAgentControlResponse_Discovery{}
-	mi := &file_nico_nico_proto_msgTypes[930]
+	mi := &file_nico_nico_proto_msgTypes[933]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64928,7 +65131,7 @@ func (x *ForgeAgentControlResponse_Discovery) String() string {
 func (*ForgeAgentControlResponse_Discovery) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Discovery) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[930]
+	mi := &file_nico_nico_proto_msgTypes[933]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64952,7 +65155,7 @@ type ForgeAgentControlResponse_Rebuild struct {
 
 func (x *ForgeAgentControlResponse_Rebuild) Reset() {
 	*x = ForgeAgentControlResponse_Rebuild{}
-	mi := &file_nico_nico_proto_msgTypes[931]
+	mi := &file_nico_nico_proto_msgTypes[934]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -64964,7 +65167,7 @@ func (x *ForgeAgentControlResponse_Rebuild) String() string {
 func (*ForgeAgentControlResponse_Rebuild) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Rebuild) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[931]
+	mi := &file_nico_nico_proto_msgTypes[934]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -64988,7 +65191,7 @@ type ForgeAgentControlResponse_Retry struct {
 
 func (x *ForgeAgentControlResponse_Retry) Reset() {
 	*x = ForgeAgentControlResponse_Retry{}
-	mi := &file_nico_nico_proto_msgTypes[932]
+	mi := &file_nico_nico_proto_msgTypes[935]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65000,7 +65203,7 @@ func (x *ForgeAgentControlResponse_Retry) String() string {
 func (*ForgeAgentControlResponse_Retry) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Retry) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[932]
+	mi := &file_nico_nico_proto_msgTypes[935]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65024,7 +65227,7 @@ type ForgeAgentControlResponse_Measure struct {
 
 func (x *ForgeAgentControlResponse_Measure) Reset() {
 	*x = ForgeAgentControlResponse_Measure{}
-	mi := &file_nico_nico_proto_msgTypes[933]
+	mi := &file_nico_nico_proto_msgTypes[936]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65036,7 +65239,7 @@ func (x *ForgeAgentControlResponse_Measure) String() string {
 func (*ForgeAgentControlResponse_Measure) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_Measure) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[933]
+	mi := &file_nico_nico_proto_msgTypes[936]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65060,7 +65263,7 @@ type ForgeAgentControlResponse_LogError struct {
 
 func (x *ForgeAgentControlResponse_LogError) Reset() {
 	*x = ForgeAgentControlResponse_LogError{}
-	mi := &file_nico_nico_proto_msgTypes[934]
+	mi := &file_nico_nico_proto_msgTypes[937]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65072,7 +65275,7 @@ func (x *ForgeAgentControlResponse_LogError) String() string {
 func (*ForgeAgentControlResponse_LogError) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_LogError) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[934]
+	mi := &file_nico_nico_proto_msgTypes[937]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65100,7 +65303,7 @@ type ForgeAgentControlResponse_MachineValidation struct {
 
 func (x *ForgeAgentControlResponse_MachineValidation) Reset() {
 	*x = ForgeAgentControlResponse_MachineValidation{}
-	mi := &file_nico_nico_proto_msgTypes[935]
+	mi := &file_nico_nico_proto_msgTypes[938]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65112,7 +65315,7 @@ func (x *ForgeAgentControlResponse_MachineValidation) String() string {
 func (*ForgeAgentControlResponse_MachineValidation) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MachineValidation) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[935]
+	mi := &file_nico_nico_proto_msgTypes[938]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65168,7 +65371,7 @@ type ForgeAgentControlResponse_MachineValidationFilter struct {
 
 func (x *ForgeAgentControlResponse_MachineValidationFilter) Reset() {
 	*x = ForgeAgentControlResponse_MachineValidationFilter{}
-	mi := &file_nico_nico_proto_msgTypes[936]
+	mi := &file_nico_nico_proto_msgTypes[939]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65180,7 +65383,7 @@ func (x *ForgeAgentControlResponse_MachineValidationFilter) String() string {
 func (*ForgeAgentControlResponse_MachineValidationFilter) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MachineValidationFilter) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[936]
+	mi := &file_nico_nico_proto_msgTypes[939]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65233,7 +65436,7 @@ type ForgeAgentControlResponse_MlxAction struct {
 
 func (x *ForgeAgentControlResponse_MlxAction) Reset() {
 	*x = ForgeAgentControlResponse_MlxAction{}
-	mi := &file_nico_nico_proto_msgTypes[937]
+	mi := &file_nico_nico_proto_msgTypes[940]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65245,7 +65448,7 @@ func (x *ForgeAgentControlResponse_MlxAction) String() string {
 func (*ForgeAgentControlResponse_MlxAction) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxAction) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[937]
+	mi := &file_nico_nico_proto_msgTypes[940]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65285,7 +65488,7 @@ type ForgeAgentControlResponse_MlxDeviceAction struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceAction) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceAction{}
-	mi := &file_nico_nico_proto_msgTypes[938]
+	mi := &file_nico_nico_proto_msgTypes[941]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65297,7 +65500,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceAction) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceAction) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceAction) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[938]
+	mi := &file_nico_nico_proto_msgTypes[941]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65419,7 +65622,7 @@ type ForgeAgentControlResponse_MlxDeviceNoop struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceNoop) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceNoop{}
-	mi := &file_nico_nico_proto_msgTypes[939]
+	mi := &file_nico_nico_proto_msgTypes[942]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65431,7 +65634,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceNoop) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceNoop) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceNoop) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[939]
+	mi := &file_nico_nico_proto_msgTypes[942]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65456,7 +65659,7 @@ type ForgeAgentControlResponse_MlxDeviceLock struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceLock) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceLock{}
-	mi := &file_nico_nico_proto_msgTypes[940]
+	mi := &file_nico_nico_proto_msgTypes[943]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65468,7 +65671,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceLock) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceLock) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceLock) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[940]
+	mi := &file_nico_nico_proto_msgTypes[943]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65500,7 +65703,7 @@ type ForgeAgentControlResponse_MlxDeviceUnlock struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceUnlock) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceUnlock{}
-	mi := &file_nico_nico_proto_msgTypes[941]
+	mi := &file_nico_nico_proto_msgTypes[944]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65512,7 +65715,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceUnlock) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceUnlock) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceUnlock) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[941]
+	mi := &file_nico_nico_proto_msgTypes[944]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65544,7 +65747,7 @@ type ForgeAgentControlResponse_MlxDeviceApplyProfile struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyProfile) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceApplyProfile{}
-	mi := &file_nico_nico_proto_msgTypes[942]
+	mi := &file_nico_nico_proto_msgTypes[945]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65556,7 +65759,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceApplyProfile) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceApplyProfile) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyProfile) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[942]
+	mi := &file_nico_nico_proto_msgTypes[945]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65588,7 +65791,7 @@ type ForgeAgentControlResponse_MlxDeviceApplyFirmware struct {
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyFirmware) Reset() {
 	*x = ForgeAgentControlResponse_MlxDeviceApplyFirmware{}
-	mi := &file_nico_nico_proto_msgTypes[943]
+	mi := &file_nico_nico_proto_msgTypes[946]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65600,7 +65803,7 @@ func (x *ForgeAgentControlResponse_MlxDeviceApplyFirmware) String() string {
 func (*ForgeAgentControlResponse_MlxDeviceApplyFirmware) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_MlxDeviceApplyFirmware) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[943]
+	mi := &file_nico_nico_proto_msgTypes[946]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65632,7 +65835,7 @@ type ForgeAgentControlResponse_FirmwareUpgrade struct {
 
 func (x *ForgeAgentControlResponse_FirmwareUpgrade) Reset() {
 	*x = ForgeAgentControlResponse_FirmwareUpgrade{}
-	mi := &file_nico_nico_proto_msgTypes[944]
+	mi := &file_nico_nico_proto_msgTypes[947]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65644,7 +65847,7 @@ func (x *ForgeAgentControlResponse_FirmwareUpgrade) String() string {
 func (*ForgeAgentControlResponse_FirmwareUpgrade) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_FirmwareUpgrade) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[944]
+	mi := &file_nico_nico_proto_msgTypes[947]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65677,7 +65880,7 @@ type ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair struct {
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) Reset() {
 	*x = ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair{}
-	mi := &file_nico_nico_proto_msgTypes[945]
+	mi := &file_nico_nico_proto_msgTypes[948]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65689,7 +65892,7 @@ func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) Stri
 func (*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) ProtoMessage() {}
 
 func (x *ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[945]
+	mi := &file_nico_nico_proto_msgTypes[948]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65730,7 +65933,7 @@ type MachineCleanupInfo_CleanupStepResult struct {
 
 func (x *MachineCleanupInfo_CleanupStepResult) Reset() {
 	*x = MachineCleanupInfo_CleanupStepResult{}
-	mi := &file_nico_nico_proto_msgTypes[946]
+	mi := &file_nico_nico_proto_msgTypes[949]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65742,7 +65945,7 @@ func (x *MachineCleanupInfo_CleanupStepResult) String() string {
 func (*MachineCleanupInfo_CleanupStepResult) ProtoMessage() {}
 
 func (x *MachineCleanupInfo_CleanupStepResult) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[946]
+	mi := &file_nico_nico_proto_msgTypes[949]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65787,7 +65990,7 @@ type DpuReprovisioningListResponse_DpuReprovisioningListItem struct {
 
 func (x *DpuReprovisioningListResponse_DpuReprovisioningListItem) Reset() {
 	*x = DpuReprovisioningListResponse_DpuReprovisioningListItem{}
-	mi := &file_nico_nico_proto_msgTypes[947]
+	mi := &file_nico_nico_proto_msgTypes[950]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65799,7 +66002,7 @@ func (x *DpuReprovisioningListResponse_DpuReprovisioningListItem) String() strin
 func (*DpuReprovisioningListResponse_DpuReprovisioningListItem) ProtoMessage() {}
 
 func (x *DpuReprovisioningListResponse_DpuReprovisioningListItem) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[947]
+	mi := &file_nico_nico_proto_msgTypes[950]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65878,7 +66081,7 @@ type HostReprovisioningListResponse_HostReprovisioningListItem struct {
 
 func (x *HostReprovisioningListResponse_HostReprovisioningListItem) Reset() {
 	*x = HostReprovisioningListResponse_HostReprovisioningListItem{}
-	mi := &file_nico_nico_proto_msgTypes[948]
+	mi := &file_nico_nico_proto_msgTypes[951]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65890,7 +66093,7 @@ func (x *HostReprovisioningListResponse_HostReprovisioningListItem) String() str
 func (*HostReprovisioningListResponse_HostReprovisioningListItem) ProtoMessage() {}
 
 func (x *HostReprovisioningListResponse_HostReprovisioningListItem) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[948]
+	mi := &file_nico_nico_proto_msgTypes[951]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -65977,7 +66180,7 @@ type MachineValidationTestUpdateRequest_Payload struct {
 
 func (x *MachineValidationTestUpdateRequest_Payload) Reset() {
 	*x = MachineValidationTestUpdateRequest_Payload{}
-	mi := &file_nico_nico_proto_msgTypes[949]
+	mi := &file_nico_nico_proto_msgTypes[952]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -65989,7 +66192,7 @@ func (x *MachineValidationTestUpdateRequest_Payload) String() string {
 func (*MachineValidationTestUpdateRequest_Payload) ProtoMessage() {}
 
 func (x *MachineValidationTestUpdateRequest_Payload) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[949]
+	mi := &file_nico_nico_proto_msgTypes[952]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66149,7 +66352,7 @@ type DPFStateResponse_DPFState struct {
 
 func (x *DPFStateResponse_DPFState) Reset() {
 	*x = DPFStateResponse_DPFState{}
-	mi := &file_nico_nico_proto_msgTypes[955]
+	mi := &file_nico_nico_proto_msgTypes[958]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66161,7 +66364,7 @@ func (x *DPFStateResponse_DPFState) String() string {
 func (*DPFStateResponse_DPFState) ProtoMessage() {}
 
 func (x *DPFStateResponse_DPFState) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[955]
+	mi := &file_nico_nico_proto_msgTypes[958]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66239,7 +66442,7 @@ type GetMachineBootInterfacesResponse_Reconciliation struct {
 
 func (x *GetMachineBootInterfacesResponse_Reconciliation) Reset() {
 	*x = GetMachineBootInterfacesResponse_Reconciliation{}
-	mi := &file_nico_nico_proto_msgTypes[956]
+	mi := &file_nico_nico_proto_msgTypes[959]
 	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 	ms.StoreMessageInfo(mi)
 }
@@ -66251,7 +66454,7 @@ func (x *GetMachineBootInterfacesResponse_Reconciliation) String() string {
 func (*GetMachineBootInterfacesResponse_Reconciliation) ProtoMessage() {}
 
 func (x *GetMachineBootInterfacesResponse_Reconciliation) ProtoReflect() protoreflect.Message {
-	mi := &file_nico_nico_proto_msgTypes[956]
+	mi := &file_nico_nico_proto_msgTypes[959]
 	if x != nil {
 		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
 		if ms.LoadMessageInfo() == nil {
@@ -66340,6 +66543,82 @@ func (x *GetMachineBootInterfacesResponse_Reconciliation) GetSelectionSource() B
 func (x *GetMachineBootInterfacesResponse_Reconciliation) GetSelectionUpdatedAt() *timestamppb.Timestamp {
 	if x != nil {
 		return x.SelectionUpdatedAt
+	}
+	return nil
+}
+
+type ManagedHostResetListResponse_ManagedHostResetListItem struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Id            *MachineId             `protobuf:"bytes,1,opt,name=id,proto3" json:"id,omitempty"`                                      // Host machine ID
+	State         string                 `protobuf:"bytes,2,opt,name=state,proto3" json:"state,omitempty"`                                // ManagedHost state
+	Initiator     string                 `protobuf:"bytes,3,opt,name=initiator,proto3" json:"initiator,omitempty"`                        // Who requested this reset.
+	RequestedAt   *timestamppb.Timestamp `protobuf:"bytes,4,opt,name=requested_at,json=requestedAt,proto3" json:"requested_at,omitempty"` // When the reset was requested.
+	StartedAt     *timestamppb.Timestamp `protobuf:"bytes,5,opt,name=started_at,json=startedAt,proto3,oneof" json:"started_at,omitempty"` // When the reset started.
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) Reset() {
+	*x = ManagedHostResetListResponse_ManagedHostResetListItem{}
+	mi := &file_nico_nico_proto_msgTypes[960]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*ManagedHostResetListResponse_ManagedHostResetListItem) ProtoMessage() {}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) ProtoReflect() protoreflect.Message {
+	mi := &file_nico_nico_proto_msgTypes[960]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use ManagedHostResetListResponse_ManagedHostResetListItem.ProtoReflect.Descriptor instead.
+func (*ManagedHostResetListResponse_ManagedHostResetListItem) Descriptor() ([]byte, []int) {
+	return file_nico_nico_proto_rawDescGZIP(), []int{914, 0}
+}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) GetId() *MachineId {
+	if x != nil {
+		return x.Id
+	}
+	return nil
+}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) GetState() string {
+	if x != nil {
+		return x.State
+	}
+	return ""
+}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) GetInitiator() string {
+	if x != nil {
+		return x.Initiator
+	}
+	return ""
+}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) GetRequestedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.RequestedAt
+	}
+	return nil
+}
+
+func (x *ManagedHostResetListResponse_ManagedHostResetListItem) GetStartedAt() *timestamppb.Timestamp {
+	if x != nil {
+		return x.StartedAt
 	}
 	return nil
 }
@@ -71702,7 +71981,28 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\n" +
 	"\b_gatewayB\t\n" +
 	"\a_svi_ipB\x19\n" +
-	"\x17_tenant_vrf_loopback_ip\"\xd4\x01\n" +
+	"\x17_tenant_vrf_loopback_ip\"\xa2\x02\n" +
+	"\x17ManagedHostResetRequest\x120\n" +
+	"\n" +
+	"machine_id\x18\x01 \x01(\v2\x11.common.MachineIdR\tmachineId\x127\n" +
+	"\x04mode\x18\x02 \x01(\x0e2#.forge.ManagedHostResetRequest.ModeR\x04mode\x124\n" +
+	"\tinitiator\x18\x03 \x01(\x0e2\x16.forge.UpdateInitiatorR\tinitiator\x129\n" +
+	"\x19allow_reset_with_instance\x18\x04 \x01(\bR\x16allowResetWithInstance\"+\n" +
+	"\x04Mode\x12\x0f\n" +
+	"\vUnspecified\x10\x00\x12\a\n" +
+	"\x03Set\x10\x01\x12\t\n" +
+	"\x05Clear\x10\x02\"\x1d\n" +
+	"\x1bManagedHostResetListRequest\"\xf4\x02\n" +
+	"\x1cManagedHostResetListResponse\x12R\n" +
+	"\x05hosts\x18\x01 \x03(\v2<.forge.ManagedHostResetListResponse.ManagedHostResetListItemR\x05hosts\x1a\xff\x01\n" +
+	"\x18ManagedHostResetListItem\x12!\n" +
+	"\x02id\x18\x01 \x01(\v2\x11.common.MachineIdR\x02id\x12\x14\n" +
+	"\x05state\x18\x02 \x01(\tR\x05state\x12\x1c\n" +
+	"\tinitiator\x18\x03 \x01(\tR\tinitiator\x12=\n" +
+	"\frequested_at\x18\x04 \x01(\v2\x1a.google.protobuf.TimestampR\vrequestedAt\x12>\n" +
+	"\n" +
+	"started_at\x18\x05 \x01(\v2\x1a.google.protobuf.TimestampH\x00R\tstartedAt\x88\x01\x01B\r\n" +
+	"\v_started_at\"\xd4\x01\n" +
 	"\x1cVpcReleaseInactiveVniRequest\x12\x1d\n" +
 	"\x02id\x18\x01 \x01(\v2\r.common.VpcIdR\x02id\x12-\n" +
 	"\x10if_version_match\x18\x02 \x01(\tH\x00R\x0eifVersionMatch\x88\x01\x01\x127\n" +
@@ -72246,7 +72546,7 @@ const file_nico_nico_proto_rawDesc = "" +
 	"!SITE_PREFIX_LIFECYCLE_STATE_ERROR\x10\x04*e\n" +
 	"\x12DpuNvConfigProfile\x12%\n" +
 	"!DPU_NV_CONFIG_PROFILE_UNSPECIFIED\x10\x00\x12(\n" +
-	"$DPU_NV_CONFIG_PROFILE_GB200_B3240_V1\x10\x012\xd0\xe8\x02\n" +
+	"$DPU_NV_CONFIG_PROFILE_GB200_B3240_V1\x10\x012\x8f\xea\x02\n" +
 	"\x05Forge\x122\n" +
 	"\aVersion\x12\x15.forge.VersionRequest\x1a\x10.forge.BuildInfo\x125\n" +
 	"\fCreateDomain\x12\x18.dns.CreateDomainRequest\x1a\v.dns.Domain\x125\n" +
@@ -72434,7 +72734,9 @@ const file_nico_nico_proto_rawDesc = "" +
 	"\x18TriggerDpuReprovisioning\x12\x1f.forge.DpuReprovisioningRequest\x1a\x16.google.protobuf.Empty\x12l\n" +
 	"\x1fListDpuWaitingForReprovisioning\x12#.forge.DpuReprovisioningListRequest\x1a$.forge.DpuReprovisioningListResponse\x12U\n" +
 	"\x19TriggerHostReprovisioning\x12 .forge.HostReprovisioningRequest\x1a\x16.google.protobuf.Empty\x12p\n" +
-	"!ListHostsWaitingForReprovisioning\x12$.forge.HostReprovisioningListRequest\x1a%.forge.HostReprovisioningListResponse\x12[\n" +
+	"!ListHostsWaitingForReprovisioning\x12$.forge.HostReprovisioningListRequest\x1a%.forge.HostReprovisioningListResponse\x12Q\n" +
+	"\x17TriggerManagedHostReset\x12\x1e.forge.ManagedHostResetRequest\x1a\x16.google.protobuf.Empty\x12j\n" +
+	"\x1fListManagedHostsWaitingForReset\x12\".forge.ManagedHostResetListRequest\x1a#.forge.ManagedHostResetListResponse\x12[\n" +
 	"\x1cTriggerBmcCredentialRotation\x12#.forge.BmcCredentialRotationRequest\x1a\x16.google.protobuf.Empty\x12]\n" +
 	"\x1dTriggerUefiCredentialRotation\x12$.forge.UefiCredentialRotationRequest\x1a\x16.google.protobuf.Empty\x12k\n" +
 	"$TriggerNicLockdownCredentialRotation\x12+.forge.NicLockdownCredentialRotationRequest\x1a\x16.google.protobuf.Empty\x12N\n" +
@@ -72766,8 +73068,8 @@ func file_nico_nico_proto_rawDescGZIP() []byte {
 	return file_nico_nico_proto_rawDescData
 }
 
-var file_nico_nico_proto_enumTypes = make([]protoimpl.EnumInfo, 109)
-var file_nico_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 957)
+var file_nico_nico_proto_enumTypes = make([]protoimpl.EnumInfo, 110)
+var file_nico_nico_proto_msgTypes = make([]protoimpl.MessageInfo, 961)
 var file_nico_nico_proto_goTypes = []any{
 	(SpdmAttestationStatus)(0),                      // 0: forge.SpdmAttestationStatus
 	(SpdmListAttestationMachinesRequestSelector)(0), // 1: forge.SpdmListAttestationMachinesRequestSelector
@@ -72878,3473 +73180,3489 @@ var file_nico_nico_proto_goTypes = []any{
 	(AdminPowerControlRequest_SystemPowerControl)(0),                          // 106: forge.AdminPowerControlRequest.SystemPowerControl
 	(GetRedfishJobStateResponse_RedfishJobState)(0),                           // 107: forge.GetRedfishJobStateResponse.RedfishJobState
 	(GetMachineBootInterfacesResponse_Reconciliation_State)(0),                // 108: forge.GetMachineBootInterfacesResponse.Reconciliation.State
-	(*LifecycleStatus)(nil),                                                   // 109: forge.LifecycleStatus
-	(*SpdmMachineAttestationStatus)(nil),                                      // 110: forge.SpdmMachineAttestationStatus
-	(*SpdmMachineAttestationTriggerResponse)(nil),                             // 111: forge.SpdmMachineAttestationTriggerResponse
-	(*SpdmAttestationDetails)(nil),                                            // 112: forge.SpdmAttestationDetails
-	(*SpdmGetAttestationMachineResponse)(nil),                                 // 113: forge.SpdmGetAttestationMachineResponse
-	(*SpdmMachineAttestationTriggerRequest)(nil),                              // 114: forge.SpdmMachineAttestationTriggerRequest
-	(*SpdmListAttestationMachinesRequest)(nil),                                // 115: forge.SpdmListAttestationMachinesRequest
-	(*SpdmListAttestationMachinesResponse)(nil),                               // 116: forge.SpdmListAttestationMachinesResponse
-	(*MachineIdentityRequest)(nil),                                            // 117: forge.MachineIdentityRequest
-	(*MachineIdentityResponse)(nil),                                           // 118: forge.MachineIdentityResponse
-	(*GetTenantIdentityConfigRequest)(nil),                                    // 119: forge.GetTenantIdentityConfigRequest
-	(*TenantIdentitySigningKey)(nil),                                          // 120: forge.TenantIdentitySigningKey
-	(*TenantIdentityConfig)(nil),                                              // 121: forge.TenantIdentityConfig
-	(*SetTenantIdentityConfigRequest)(nil),                                    // 122: forge.SetTenantIdentityConfigRequest
-	(*TenantIdentityConfigResponse)(nil),                                      // 123: forge.TenantIdentityConfigResponse
-	(*ClientSecretBasic)(nil),                                                 // 124: forge.ClientSecretBasic
-	(*ClientSecretBasicResponse)(nil),                                         // 125: forge.ClientSecretBasicResponse
-	(*TokenDelegationResponse)(nil),                                           // 126: forge.TokenDelegationResponse
-	(*GetTokenDelegationRequest)(nil),                                         // 127: forge.GetTokenDelegationRequest
-	(*TokenDelegation)(nil),                                                   // 128: forge.TokenDelegation
-	(*TokenDelegationRequest)(nil),                                            // 129: forge.TokenDelegationRequest
-	(*ReencryptTenantIdentitySecretsRequest)(nil),                             // 130: forge.ReencryptTenantIdentitySecretsRequest
-	(*ReencryptTenantIdentityFailure)(nil),                                    // 131: forge.ReencryptTenantIdentityFailure
-	(*ReencryptTenantIdentitySecretsResponse)(nil),                            // 132: forge.ReencryptTenantIdentitySecretsResponse
-	(*Jwks)(nil),                                                              // 133: forge.Jwks
-	(*OpenIdConfiguration)(nil),                                               // 134: forge.OpenIdConfiguration
-	(*JwksRequest)(nil),                                                       // 135: forge.JwksRequest
-	(*OpenIdConfigRequest)(nil),                                               // 136: forge.OpenIdConfigRequest
-	(*MachineIngestionStateResponse)(nil),                                     // 137: forge.MachineIngestionStateResponse
-	(*TpmCaAddedCaStatus)(nil),                                                // 138: forge.TpmCaAddedCaStatus
-	(*TpmCaCertId)(nil),                                                       // 139: forge.TpmCaCertId
-	(*TpmEkCertStatus)(nil),                                                   // 140: forge.TpmEkCertStatus
-	(*TpmEkCertStatusCollection)(nil),                                         // 141: forge.TpmEkCertStatusCollection
-	(*TpmCaCert)(nil),                                                         // 142: forge.TpmCaCert
-	(*TpmCaCertDetail)(nil),                                                   // 143: forge.TpmCaCertDetail
-	(*TpmCaCertDetailCollection)(nil),                                         // 144: forge.TpmCaCertDetailCollection
-	(*AttestKeyBindChallenge)(nil),                                            // 145: forge.AttestKeyBindChallenge
-	(*AttestQuoteRequest)(nil),                                                // 146: forge.AttestQuoteRequest
-	(*AttestQuoteResponse)(nil),                                               // 147: forge.AttestQuoteResponse
-	(*CredentialCreationRequest)(nil),                                         // 148: forge.CredentialCreationRequest
-	(*CredentialDeletionRequest)(nil),                                         // 149: forge.CredentialDeletionRequest
-	(*CredentialCreationResult)(nil),                                          // 150: forge.CredentialCreationResult
-	(*CredentialDeletionResult)(nil),                                          // 151: forge.CredentialDeletionResult
-	(*RotateCredentialRequest)(nil),                                           // 152: forge.RotateCredentialRequest
-	(*RotateCredentialResult)(nil),                                            // 153: forge.RotateCredentialResult
-	(*CredentialRotationStatusRequest)(nil),                                   // 154: forge.CredentialRotationStatusRequest
-	(*DeviceCredentialRotationStatus)(nil),                                    // 155: forge.DeviceCredentialRotationStatus
-	(*CredentialRotationStatusResult)(nil),                                    // 156: forge.CredentialRotationStatusResult
-	(*VersionRequest)(nil),                                                    // 157: forge.VersionRequest
-	(*BuildInfo)(nil),                                                         // 158: forge.BuildInfo
-	(*RuntimeConfig)(nil),                                                     // 159: forge.RuntimeConfig
-	(*EchoRequest)(nil),                                                       // 160: forge.EchoRequest
-	(*EchoResponse)(nil),                                                      // 161: forge.EchoResponse
-	(*DNSMessage)(nil),                                                        // 162: forge.DNSMessage
-	(*DnsRequest)(nil),                                                        // 163: forge.DnsRequest
-	(*DnsReply)(nil),                                                          // 164: forge.DnsReply
-	(*ConsoleInput)(nil),                                                      // 165: forge.ConsoleInput
-	(*ConsoleOutput)(nil),                                                     // 166: forge.ConsoleOutput
-	(*InstanceEvent)(nil),                                                     // 167: forge.InstanceEvent
-	(*VpcSearchQuery)(nil),                                                    // 168: forge.VpcSearchQuery
-	(*VpcSearchFilter)(nil),                                                   // 169: forge.VpcSearchFilter
-	(*VpcIdList)(nil),                                                         // 170: forge.VpcIdList
-	(*VpcsByIdsRequest)(nil),                                                  // 171: forge.VpcsByIdsRequest
-	(*TenantSearchQuery)(nil),                                                 // 172: forge.TenantSearchQuery
-	(*PrefixFilterPolicyEntries)(nil),                                         // 173: forge.PrefixFilterPolicyEntries
-	(*VpcRoutingProfileOverrides)(nil),                                        // 174: forge.VpcRoutingProfileOverrides
-	(*VpcEffectiveRoutingProfile)(nil),                                        // 175: forge.VpcEffectiveRoutingProfile
-	(*VpcConfig)(nil),                                                         // 176: forge.VpcConfig
-	(*VpcStatus)(nil),                                                         // 177: forge.VpcStatus
-	(*Vpc)(nil),                                                               // 178: forge.Vpc
-	(*VpcCreationRequest)(nil),                                                // 179: forge.VpcCreationRequest
-	(*VpcUpdateRequest)(nil),                                                  // 180: forge.VpcUpdateRequest
-	(*VpcUpdateResult)(nil),                                                   // 181: forge.VpcUpdateResult
-	(*VpcUpdateVirtualizationRequest)(nil),                                    // 182: forge.VpcUpdateVirtualizationRequest
-	(*VpcUpdateVirtualizationResult)(nil),                                     // 183: forge.VpcUpdateVirtualizationResult
-	(*VpcDeletionRequest)(nil),                                                // 184: forge.VpcDeletionRequest
-	(*VpcDeletionResult)(nil),                                                 // 185: forge.VpcDeletionResult
-	(*VpcList)(nil),                                                           // 186: forge.VpcList
-	(*VpcPrefix)(nil),                                                         // 187: forge.VpcPrefix
-	(*VpcPrefixConfig)(nil),                                                   // 188: forge.VpcPrefixConfig
-	(*VpcPrefixStatus)(nil),                                                   // 189: forge.VpcPrefixStatus
-	(*VpcPrefixCreationRequest)(nil),                                          // 190: forge.VpcPrefixCreationRequest
-	(*VpcPrefixSearchQuery)(nil),                                              // 191: forge.VpcPrefixSearchQuery
-	(*VpcPrefixGetRequest)(nil),                                               // 192: forge.VpcPrefixGetRequest
-	(*VpcPrefixIdList)(nil),                                                   // 193: forge.VpcPrefixIdList
-	(*VpcPrefixList)(nil),                                                     // 194: forge.VpcPrefixList
-	(*VpcPrefixUpdateRequest)(nil),                                            // 195: forge.VpcPrefixUpdateRequest
-	(*VpcPrefixDeletionRequest)(nil),                                          // 196: forge.VpcPrefixDeletionRequest
-	(*VpcPrefixDeletionResult)(nil),                                           // 197: forge.VpcPrefixDeletionResult
-	(*VpcPrefixStateHistoriesRequest)(nil),                                    // 198: forge.VpcPrefixStateHistoriesRequest
-	(*VpcPeering)(nil),                                                        // 199: forge.VpcPeering
-	(*VpcPeeringIdList)(nil),                                                  // 200: forge.VpcPeeringIdList
-	(*VpcPeeringList)(nil),                                                    // 201: forge.VpcPeeringList
-	(*VpcPeeringCreationRequest)(nil),                                         // 202: forge.VpcPeeringCreationRequest
-	(*VpcPeeringSearchFilter)(nil),                                            // 203: forge.VpcPeeringSearchFilter
-	(*VpcPeeringsByIdsRequest)(nil),                                           // 204: forge.VpcPeeringsByIdsRequest
-	(*VpcPeeringDeletionRequest)(nil),                                         // 205: forge.VpcPeeringDeletionRequest
-	(*VpcPeeringDeletionResult)(nil),                                          // 206: forge.VpcPeeringDeletionResult
-	(*IBPartitionConfig)(nil),                                                 // 207: forge.IBPartitionConfig
-	(*IBPartitionStatus)(nil),                                                 // 208: forge.IBPartitionStatus
-	(*IBPartition)(nil),                                                       // 209: forge.IBPartition
-	(*IBPartitionList)(nil),                                                   // 210: forge.IBPartitionList
-	(*IBPartitionCreationRequest)(nil),                                        // 211: forge.IBPartitionCreationRequest
-	(*IBPartitionUpdateRequest)(nil),                                          // 212: forge.IBPartitionUpdateRequest
-	(*IBPartitionDeletionRequest)(nil),                                        // 213: forge.IBPartitionDeletionRequest
-	(*IBPartitionDeletionResult)(nil),                                         // 214: forge.IBPartitionDeletionResult
-	(*IBPartitionSearchFilter)(nil),                                           // 215: forge.IBPartitionSearchFilter
-	(*IBPartitionsByIdsRequest)(nil),                                          // 216: forge.IBPartitionsByIdsRequest
-	(*IBPartitionIdList)(nil),                                                 // 217: forge.IBPartitionIdList
-	(*PowerShelfConfig)(nil),                                                  // 218: forge.PowerShelfConfig
-	(*PowerShelfStatus)(nil),                                                  // 219: forge.PowerShelfStatus
-	(*PowerShelf)(nil),                                                        // 220: forge.PowerShelf
-	(*PowerShelfList)(nil),                                                    // 221: forge.PowerShelfList
-	(*PowerShelfCreationRequest)(nil),                                         // 222: forge.PowerShelfCreationRequest
-	(*DecommissionPowerShelfRequest)(nil),                                     // 223: forge.DecommissionPowerShelfRequest
-	(*DecommissionPowerShelfResponse)(nil),                                    // 224: forge.DecommissionPowerShelfResponse
-	(*PowerShelfDeletionRequest)(nil),                                         // 225: forge.PowerShelfDeletionRequest
-	(*PowerShelfDeletionResult)(nil),                                          // 226: forge.PowerShelfDeletionResult
-	(*PowerShelfMaintenanceRequest)(nil),                                      // 227: forge.PowerShelfMaintenanceRequest
-	(*PowerShelfStateHistoriesRequest)(nil),                                   // 228: forge.PowerShelfStateHistoriesRequest
-	(*PowerShelfHealthHistoriesRequest)(nil),                                  // 229: forge.PowerShelfHealthHistoriesRequest
-	(*PowerShelfQuery)(nil),                                                   // 230: forge.PowerShelfQuery
-	(*PowerShelfSearchFilter)(nil),                                            // 231: forge.PowerShelfSearchFilter
-	(*PowerShelvesByIdsRequest)(nil),                                          // 232: forge.PowerShelvesByIdsRequest
-	(*ExpectedPowerShelf)(nil),                                                // 233: forge.ExpectedPowerShelf
-	(*ExpectedPowerShelfRequest)(nil),                                         // 234: forge.ExpectedPowerShelfRequest
-	(*ExpectedPowerShelfList)(nil),                                            // 235: forge.ExpectedPowerShelfList
-	(*LinkedExpectedPowerShelfList)(nil),                                      // 236: forge.LinkedExpectedPowerShelfList
-	(*LinkedExpectedPowerShelf)(nil),                                          // 237: forge.LinkedExpectedPowerShelf
-	(*SwitchConfig)(nil),                                                      // 238: forge.SwitchConfig
-	(*FabricManagerConfig)(nil),                                               // 239: forge.FabricManagerConfig
-	(*FabricManagerStatus)(nil),                                               // 240: forge.FabricManagerStatus
-	(*SwitchStatus)(nil),                                                      // 241: forge.SwitchStatus
-	(*PlacementInRack)(nil),                                                   // 242: forge.PlacementInRack
-	(*Switch)(nil),                                                            // 243: forge.Switch
-	(*SwitchList)(nil),                                                        // 244: forge.SwitchList
-	(*SwitchCreationRequest)(nil),                                             // 245: forge.SwitchCreationRequest
-	(*SwitchDeletionRequest)(nil),                                             // 246: forge.SwitchDeletionRequest
-	(*SwitchDeletionResult)(nil),                                              // 247: forge.SwitchDeletionResult
-	(*DecommissionSwitchRequest)(nil),                                         // 248: forge.DecommissionSwitchRequest
-	(*DecommissionSwitchResponse)(nil),                                        // 249: forge.DecommissionSwitchResponse
-	(*StateHistoryRecord)(nil),                                                // 250: forge.StateHistoryRecord
-	(*StateHistoryRecords)(nil),                                               // 251: forge.StateHistoryRecords
-	(*SwitchStateHistoriesRequest)(nil),                                       // 252: forge.SwitchStateHistoriesRequest
-	(*SwitchHealthHistoriesRequest)(nil),                                      // 253: forge.SwitchHealthHistoriesRequest
-	(*StateHistories)(nil),                                                    // 254: forge.StateHistories
-	(*SwitchQuery)(nil),                                                       // 255: forge.SwitchQuery
-	(*SwitchSearchFilter)(nil),                                                // 256: forge.SwitchSearchFilter
-	(*SwitchesByIdsRequest)(nil),                                              // 257: forge.SwitchesByIdsRequest
-	(*ExpectedSwitch)(nil),                                                    // 258: forge.ExpectedSwitch
-	(*ExpectedSwitchRequest)(nil),                                             // 259: forge.ExpectedSwitchRequest
-	(*ExpectedSwitchList)(nil),                                                // 260: forge.ExpectedSwitchList
-	(*LinkedExpectedSwitchList)(nil),                                          // 261: forge.LinkedExpectedSwitchList
-	(*LinkedExpectedSwitch)(nil),                                              // 262: forge.LinkedExpectedSwitch
-	(*ExpectedRack)(nil),                                                      // 263: forge.ExpectedRack
-	(*ExpectedRackRequest)(nil),                                               // 264: forge.ExpectedRackRequest
-	(*ExpectedRackList)(nil),                                                  // 265: forge.ExpectedRackList
-	(*IBFabricSearchFilter)(nil),                                              // 266: forge.IBFabricSearchFilter
-	(*IBFabricIdList)(nil),                                                    // 267: forge.IBFabricIdList
-	(*NetworkSegmentStateHistory)(nil),                                        // 268: forge.NetworkSegmentStateHistory
-	(*NetworkSegmentConfig)(nil),                                              // 269: forge.NetworkSegmentConfig
-	(*NetworkSegmentStatus)(nil),                                              // 270: forge.NetworkSegmentStatus
-	(*NetworkSegment)(nil),                                                    // 271: forge.NetworkSegment
-	(*NetworkSegmentCreationRequest)(nil),                                     // 272: forge.NetworkSegmentCreationRequest
-	(*NetworkSegmentDeletionRequest)(nil),                                     // 273: forge.NetworkSegmentDeletionRequest
-	(*AttachNetworkSegmentToVpcRequest)(nil),                                  // 274: forge.AttachNetworkSegmentToVpcRequest
-	(*NetworkSegmentDeletionResult)(nil),                                      // 275: forge.NetworkSegmentDeletionResult
-	(*NetworkSegmentStateHistoriesRequest)(nil),                               // 276: forge.NetworkSegmentStateHistoriesRequest
-	(*NetworkSegmentSearchConfig)(nil),                                        // 277: forge.NetworkSegmentSearchConfig
-	(*NetworkSegmentSearchFilter)(nil),                                        // 278: forge.NetworkSegmentSearchFilter
-	(*NetworkSegmentIdList)(nil),                                              // 279: forge.NetworkSegmentIdList
-	(*NetworkSegmentsByIdsRequest)(nil),                                       // 280: forge.NetworkSegmentsByIdsRequest
-	(*NetworkPrefix)(nil),                                                     // 281: forge.NetworkPrefix
-	(*MachineState)(nil),                                                      // 282: forge.MachineState
-	(*InstancePowerRequest)(nil),                                              // 283: forge.InstancePowerRequest
-	(*InstancePowerResult)(nil),                                               // 284: forge.InstancePowerResult
-	(*InstanceList)(nil),                                                      // 285: forge.InstanceList
-	(*Label)(nil),                                                             // 286: forge.Label
-	(*Metadata)(nil),                                                          // 287: forge.Metadata
-	(*InstanceSearchFilter)(nil),                                              // 288: forge.InstanceSearchFilter
-	(*InstanceIdList)(nil),                                                    // 289: forge.InstanceIdList
-	(*InstancesByIdsRequest)(nil),                                             // 290: forge.InstancesByIdsRequest
-	(*InstanceAllocationRequest)(nil),                                         // 291: forge.InstanceAllocationRequest
-	(*BatchInstanceAllocationRequest)(nil),                                    // 292: forge.BatchInstanceAllocationRequest
-	(*BatchInstanceAllocationResponse)(nil),                                   // 293: forge.BatchInstanceAllocationResponse
-	(*IpxeTemplateParameter)(nil),                                             // 294: forge.IpxeTemplateParameter
-	(*IpxeTemplateArtifact)(nil),                                              // 295: forge.IpxeTemplateArtifact
-	(*IpxeTemplate)(nil),                                                      // 296: forge.IpxeTemplate
-	(*TenantConfig)(nil),                                                      // 297: forge.TenantConfig
-	(*InstanceOperatingSystemConfig)(nil),                                     // 298: forge.InstanceOperatingSystemConfig
-	(*InlineIpxe)(nil),                                                        // 299: forge.InlineIpxe
-	(*InstanceConfig)(nil),                                                    // 300: forge.InstanceConfig
-	(*InstanceNetworkConfig)(nil),                                             // 301: forge.InstanceNetworkConfig
-	(*InstanceNetworkAutoConfig)(nil),                                         // 302: forge.InstanceNetworkAutoConfig
-	(*InstanceInfinibandConfig)(nil),                                          // 303: forge.InstanceInfinibandConfig
-	(*InstanceDpuExtensionServiceConfig)(nil),                                 // 304: forge.InstanceDpuExtensionServiceConfig
-	(*InstanceDpuExtensionServicesConfig)(nil),                                // 305: forge.InstanceDpuExtensionServicesConfig
-	(*InstanceNVLinkConfig)(nil),                                              // 306: forge.InstanceNVLinkConfig
-	(*InstanceSpxConfig)(nil),                                                 // 307: forge.InstanceSpxConfig
-	(*InstanceSpxAttachment)(nil),                                             // 308: forge.InstanceSpxAttachment
-	(*InstanceOperatingSystemUpdateRequest)(nil),                              // 309: forge.InstanceOperatingSystemUpdateRequest
-	(*InstanceConfigUpdateRequest)(nil),                                       // 310: forge.InstanceConfigUpdateRequest
-	(*InstanceStatus)(nil),                                                    // 311: forge.InstanceStatus
-	(*InstanceSpxStatus)(nil),                                                 // 312: forge.InstanceSpxStatus
-	(*InstanceSpxAttachmentStatus)(nil),                                       // 313: forge.InstanceSpxAttachmentStatus
-	(*InstanceNetworkStatus)(nil),                                             // 314: forge.InstanceNetworkStatus
-	(*InstanceInfinibandStatus)(nil),                                          // 315: forge.InstanceInfinibandStatus
-	(*DpuExtensionServiceStatus)(nil),                                         // 316: forge.DpuExtensionServiceStatus
-	(*InstanceDpuExtensionServiceStatus)(nil),                                 // 317: forge.InstanceDpuExtensionServiceStatus
-	(*InstanceDpuExtensionServicesStatus)(nil),                                // 318: forge.InstanceDpuExtensionServicesStatus
-	(*InstanceNVLinkStatus)(nil),                                              // 319: forge.InstanceNVLinkStatus
-	(*Instance)(nil),                                                          // 320: forge.Instance
-	(*InstanceUpdateStatus)(nil),                                              // 321: forge.InstanceUpdateStatus
-	(*InstanceInterfaceConfig)(nil),                                           // 322: forge.InstanceInterfaceConfig
-	(*InstanceInterfaceVpcSelection)(nil),                                     // 323: forge.InstanceInterfaceVpcSelection
-	(*InstanceInterfaceIpv6Config)(nil),                                       // 324: forge.InstanceInterfaceIpv6Config
-	(*InstanceInterfaceRoutingProfile)(nil),                                   // 325: forge.InstanceInterfaceRoutingProfile
-	(*InstanceIBInterfaceConfig)(nil),                                         // 326: forge.InstanceIBInterfaceConfig
-	(*InstanceInterfaceResolvedVpcPrefixes)(nil),                              // 327: forge.InstanceInterfaceResolvedVpcPrefixes
-	(*InstanceInterfaceStatus)(nil),                                           // 328: forge.InstanceInterfaceStatus
-	(*InstanceIBInterfaceStatus)(nil),                                         // 329: forge.InstanceIBInterfaceStatus
-	(*InstanceNVLinkGpuStatus)(nil),                                           // 330: forge.InstanceNVLinkGpuStatus
-	(*InstanceNVLinkGpuConfig)(nil),                                           // 331: forge.InstanceNVLinkGpuConfig
-	(*InstancePhoneHomeLastContactRequest)(nil),                               // 332: forge.InstancePhoneHomeLastContactRequest
-	(*InstancePhoneHomeLastContactResponse)(nil),                              // 333: forge.InstancePhoneHomeLastContactResponse
-	(*Issue)(nil),                                                             // 334: forge.Issue
-	(*DeleteInitiatedBy)(nil),                                                 // 335: forge.DeleteInitiatedBy
-	(*DeleteAttribution)(nil),                                                 // 336: forge.DeleteAttribution
-	(*InstanceReleaseRequest)(nil),                                            // 337: forge.InstanceReleaseRequest
-	(*InstanceReleaseResult)(nil),                                             // 338: forge.InstanceReleaseResult
-	(*BatchInstanceReleaseRequest)(nil),                                       // 339: forge.BatchInstanceReleaseRequest
-	(*InstanceReleaseOutcome)(nil),                                            // 340: forge.InstanceReleaseOutcome
-	(*BatchInstanceReleaseResponse)(nil),                                      // 341: forge.BatchInstanceReleaseResponse
-	(*MachinesByIdsRequest)(nil),                                              // 342: forge.MachinesByIdsRequest
-	(*MachineSearchConfig)(nil),                                               // 343: forge.MachineSearchConfig
-	(*MachineStateHistoriesRequest)(nil),                                      // 344: forge.MachineStateHistoriesRequest
-	(*MachineStateHistories)(nil),                                             // 345: forge.MachineStateHistories
-	(*MachineStateHistoryRecords)(nil),                                        // 346: forge.MachineStateHistoryRecords
-	(*MachineHealthHistoriesRequest)(nil),                                     // 347: forge.MachineHealthHistoriesRequest
-	(*HealthHistories)(nil),                                                   // 348: forge.HealthHistories
-	(*HealthHistoryRecords)(nil),                                              // 349: forge.HealthHistoryRecords
-	(*HealthHistoryRecord)(nil),                                               // 350: forge.HealthHistoryRecord
-	(*TenantByOrganizationIdsRequest)(nil),                                    // 351: forge.TenantByOrganizationIdsRequest
-	(*TenantSearchFilter)(nil),                                                // 352: forge.TenantSearchFilter
-	(*TenantList)(nil),                                                        // 353: forge.TenantList
-	(*TenantOrganizationIdList)(nil),                                          // 354: forge.TenantOrganizationIdList
-	(*InterfaceList)(nil),                                                     // 355: forge.InterfaceList
-	(*MachineList)(nil),                                                       // 356: forge.MachineList
-	(*InterfaceDeleteQuery)(nil),                                              // 357: forge.InterfaceDeleteQuery
-	(*InterfaceSearchQuery)(nil),                                              // 358: forge.InterfaceSearchQuery
-	(*AssignStaticAddressRequest)(nil),                                        // 359: forge.AssignStaticAddressRequest
-	(*AssignStaticAddressResponse)(nil),                                       // 360: forge.AssignStaticAddressResponse
-	(*RemoveStaticAddressRequest)(nil),                                        // 361: forge.RemoveStaticAddressRequest
-	(*RemoveStaticAddressResponse)(nil),                                       // 362: forge.RemoveStaticAddressResponse
-	(*FindInterfaceAddressesRequest)(nil),                                     // 363: forge.FindInterfaceAddressesRequest
-	(*InterfaceAddress)(nil),                                                  // 364: forge.InterfaceAddress
-	(*FindInterfaceAddressesResponse)(nil),                                    // 365: forge.FindInterfaceAddressesResponse
-	(*BmcInfo)(nil),                                                           // 366: forge.BmcInfo
-	(*SwitchNvosInfo)(nil),                                                    // 367: forge.SwitchNvosInfo
-	(*MachineConfig)(nil),                                                     // 368: forge.MachineConfig
-	(*MachineStatus)(nil),                                                     // 369: forge.MachineStatus
-	(*Machine)(nil),                                                           // 370: forge.Machine
-	(*DpfMachineState)(nil),                                                   // 371: forge.DpfMachineState
-	(*InstanceNetworkRestrictions)(nil),                                       // 372: forge.InstanceNetworkRestrictions
-	(*MachineMetadataUpdateRequest)(nil),                                      // 373: forge.MachineMetadataUpdateRequest
-	(*RackMetadataUpdateRequest)(nil),                                         // 374: forge.RackMetadataUpdateRequest
-	(*SwitchMetadataUpdateRequest)(nil),                                       // 375: forge.SwitchMetadataUpdateRequest
-	(*PowerShelfMetadataUpdateRequest)(nil),                                   // 376: forge.PowerShelfMetadataUpdateRequest
-	(*DpuAgentInventoryReport)(nil),                                           // 377: forge.DpuAgentInventoryReport
-	(*MachineComponentInventory)(nil),                                         // 378: forge.MachineComponentInventory
-	(*MachineInventorySoftwareComponent)(nil),                                 // 379: forge.MachineInventorySoftwareComponent
-	(*HealthSourceOrigin)(nil),                                                // 380: forge.HealthSourceOrigin
-	(*ControllerStateReason)(nil),                                             // 381: forge.ControllerStateReason
-	(*ControllerStateSourceReference)(nil),                                    // 382: forge.ControllerStateSourceReference
-	(*StateSla)(nil),                                                          // 383: forge.StateSla
-	(*InstanceTenantStatus)(nil),                                              // 384: forge.InstanceTenantStatus
-	(*MachineEvent)(nil),                                                      // 385: forge.MachineEvent
-	(*MachineInterface)(nil),                                                  // 386: forge.MachineInterface
-	(*InfinibandStatusObservation)(nil),                                       // 387: forge.InfinibandStatusObservation
-	(*MachineIbInterface)(nil),                                                // 388: forge.MachineIbInterface
-	(*DhcpDiscovery)(nil),                                                     // 389: forge.DhcpDiscovery
-	(*ExpireDhcpLeaseRequest)(nil),                                            // 390: forge.ExpireDhcpLeaseRequest
-	(*ExpireDhcpLeaseResponse)(nil),                                           // 391: forge.ExpireDhcpLeaseResponse
-	(*DhcpRecord)(nil),                                                        // 392: forge.DhcpRecord
-	(*NetworkSegmentList)(nil),                                                // 393: forge.NetworkSegmentList
-	(*SSHKeyValidationRequest)(nil),                                           // 394: forge.SSHKeyValidationRequest
-	(*SSHKeyValidationResponse)(nil),                                          // 395: forge.SSHKeyValidationResponse
-	(*GetBmcCredentialsRequest)(nil),                                          // 396: forge.GetBmcCredentialsRequest
-	(*GetSwitchNvosCredentialsRequest)(nil),                                   // 397: forge.GetSwitchNvosCredentialsRequest
-	(*GetBmcCredentialsResponse)(nil),                                         // 398: forge.GetBmcCredentialsResponse
-	(*BmcCredentials)(nil),                                                    // 399: forge.BmcCredentials
-	(*GetSiteExplorationRequest)(nil),                                         // 400: forge.GetSiteExplorationRequest
-	(*ClearSiteExplorationErrorRequest)(nil),                                  // 401: forge.ClearSiteExplorationErrorRequest
-	(*ReExploreEndpointRequest)(nil),                                          // 402: forge.ReExploreEndpointRequest
-	(*RefreshEndpointReportRequest)(nil),                                      // 403: forge.RefreshEndpointReportRequest
-	(*DeleteExploredEndpointRequest)(nil),                                     // 404: forge.DeleteExploredEndpointRequest
-	(*PauseExploredEndpointRemediationRequest)(nil),                           // 405: forge.PauseExploredEndpointRemediationRequest
-	(*DeleteExploredEndpointResponse)(nil),                                    // 406: forge.DeleteExploredEndpointResponse
-	(*BmcEndpointRequest)(nil),                                                // 407: forge.BmcEndpointRequest
-	(*SshTimeoutConfig)(nil),                                                  // 408: forge.SshTimeoutConfig
-	(*SshRequest)(nil),                                                        // 409: forge.SshRequest
-	(*CopyBfbToDpuRshimRequest)(nil),                                          // 410: forge.CopyBfbToDpuRshimRequest
-	(*UpdateMachineHardwareInfoRequest)(nil),                                  // 411: forge.UpdateMachineHardwareInfoRequest
-	(*MachineHardwareInfo)(nil),                                               // 412: forge.MachineHardwareInfo
-	(*ManagedHostNetworkConfigRequest)(nil),                                   // 413: forge.ManagedHostNetworkConfigRequest
-	(*ManagedHostNetworkConfigResponse)(nil),                                  // 414: forge.ManagedHostNetworkConfigResponse
-	(*ManagedHostDpuExtensionServiceConfig)(nil),                              // 415: forge.ManagedHostDpuExtensionServiceConfig
-	(*ManagedHostQuarantineState)(nil),                                        // 416: forge.ManagedHostQuarantineState
-	(*GetManagedHostQuarantineStateRequest)(nil),                              // 417: forge.GetManagedHostQuarantineStateRequest
-	(*GetManagedHostQuarantineStateResponse)(nil),                             // 418: forge.GetManagedHostQuarantineStateResponse
-	(*SetManagedHostQuarantineStateRequest)(nil),                              // 419: forge.SetManagedHostQuarantineStateRequest
-	(*SetManagedHostQuarantineStateResponse)(nil),                             // 420: forge.SetManagedHostQuarantineStateResponse
-	(*ClearManagedHostQuarantineStateRequest)(nil),                            // 421: forge.ClearManagedHostQuarantineStateRequest
-	(*ClearManagedHostQuarantineStateResponse)(nil),                           // 422: forge.ClearManagedHostQuarantineStateResponse
-	(*ManagedHostNetworkConfig)(nil),                                          // 423: forge.ManagedHostNetworkConfig
-	(*FlatInterfaceConfig)(nil),                                               // 424: forge.FlatInterfaceConfig
-	(*FlatInterfaceRoutingProfile)(nil),                                       // 425: forge.FlatInterfaceRoutingProfile
-	(*FlatInterfaceIpv6Config)(nil),                                           // 426: forge.FlatInterfaceIpv6Config
-	(*FlatInterfaceNetworkSecurityGroupConfig)(nil),                           // 427: forge.FlatInterfaceNetworkSecurityGroupConfig
-	(*ManagedHostNetworkStatusRequest)(nil),                                   // 428: forge.ManagedHostNetworkStatusRequest
-	(*ManagedHostNetworkStatusResponse)(nil),                                  // 429: forge.ManagedHostNetworkStatusResponse
-	(*DpuAgentUpgradeCheckRequest)(nil),                                       // 430: forge.DpuAgentUpgradeCheckRequest
-	(*DpuAgentUpgradeCheckResponse)(nil),                                      // 431: forge.DpuAgentUpgradeCheckResponse
-	(*DpuAgentUpgradePolicyRequest)(nil),                                      // 432: forge.DpuAgentUpgradePolicyRequest
-	(*DpuAgentUpgradePolicyResponse)(nil),                                     // 433: forge.DpuAgentUpgradePolicyResponse
-	(*AdminForceDeleteMachineRequest)(nil),                                    // 434: forge.AdminForceDeleteMachineRequest
-	(*DecommissionManagedHostRequest)(nil),                                    // 435: forge.DecommissionManagedHostRequest
-	(*DecommissionManagedHostResponse)(nil),                                   // 436: forge.DecommissionManagedHostResponse
-	(*AdminForceDeleteMachineResponse)(nil),                                   // 437: forge.AdminForceDeleteMachineResponse
-	(*DisableSecureBootResponse)(nil),                                         // 438: forge.DisableSecureBootResponse
-	(*LockdownRequest)(nil),                                                   // 439: forge.LockdownRequest
-	(*LockdownResponse)(nil),                                                  // 440: forge.LockdownResponse
-	(*LockdownStatusRequest)(nil),                                             // 441: forge.LockdownStatusRequest
-	(*MachineSetupStatusRequest)(nil),                                         // 442: forge.MachineSetupStatusRequest
-	(*MachineSetupRequest)(nil),                                               // 443: forge.MachineSetupRequest
-	(*MachineSetupResponse)(nil),                                              // 444: forge.MachineSetupResponse
-	(*SetDpuFirstBootOrderRequest)(nil),                                       // 445: forge.SetDpuFirstBootOrderRequest
-	(*SetDpuFirstBootOrderResponse)(nil),                                      // 446: forge.SetDpuFirstBootOrderResponse
-	(*AdminRebootRequest)(nil),                                                // 447: forge.AdminRebootRequest
-	(*AdminRebootResponse)(nil),                                               // 448: forge.AdminRebootResponse
-	(*AdminBmcResetRequest)(nil),                                              // 449: forge.AdminBmcResetRequest
-	(*AdminBmcResetResponse)(nil),                                             // 450: forge.AdminBmcResetResponse
-	(*EnableInfiniteBootRequest)(nil),                                         // 451: forge.EnableInfiniteBootRequest
-	(*EnableInfiniteBootResponse)(nil),                                        // 452: forge.EnableInfiniteBootResponse
-	(*IsInfiniteBootEnabledRequest)(nil),                                      // 453: forge.IsInfiniteBootEnabledRequest
-	(*IsInfiniteBootEnabledResponse)(nil),                                     // 454: forge.IsInfiniteBootEnabledResponse
-	(*BMCMetaDataGetRequest)(nil),                                             // 455: forge.BMCMetaDataGetRequest
-	(*BMCMetaDataGetResponse)(nil),                                            // 456: forge.BMCMetaDataGetResponse
-	(*MachineCredentialsUpdateRequest)(nil),                                   // 457: forge.MachineCredentialsUpdateRequest
-	(*MachineCredentialsUpdateResponse)(nil),                                  // 458: forge.MachineCredentialsUpdateResponse
-	(*ForgeAgentControlRequest)(nil),                                          // 459: forge.ForgeAgentControlRequest
-	(*ForgeAgentControlResponse)(nil),                                         // 460: forge.ForgeAgentControlResponse
-	(*MachineDiscoveryInfo)(nil),                                              // 461: forge.MachineDiscoveryInfo
-	(*MachineDiscoveryCompletedRequest)(nil),                                  // 462: forge.MachineDiscoveryCompletedRequest
-	(*MachineCleanupInfo)(nil),                                                // 463: forge.MachineCleanupInfo
-	(*MachineCertificate)(nil),                                                // 464: forge.MachineCertificate
-	(*MachineCertificateRenewRequest)(nil),                                    // 465: forge.MachineCertificateRenewRequest
-	(*MachineCertificateResult)(nil),                                          // 466: forge.MachineCertificateResult
-	(*MachineDiscoveryResult)(nil),                                            // 467: forge.MachineDiscoveryResult
-	(*MachineDiscoveryCompletedResponse)(nil),                                 // 468: forge.MachineDiscoveryCompletedResponse
-	(*MachineCleanupResult)(nil),                                              // 469: forge.MachineCleanupResult
-	(*ForgeScoutErrorReport)(nil),                                             // 470: forge.ForgeScoutErrorReport
-	(*ForgeScoutErrorReportResult)(nil),                                       // 471: forge.ForgeScoutErrorReportResult
-	(*PxeInstructionRequest)(nil),                                             // 472: forge.PxeInstructionRequest
-	(*PxeInstructions)(nil),                                                   // 473: forge.PxeInstructions
-	(*CloudInitDiscoveryInstructions)(nil),                                    // 474: forge.CloudInitDiscoveryInstructions
-	(*CloudInitMetaData)(nil),                                                 // 475: forge.CloudInitMetaData
-	(*CloudInitInstructionsRequest)(nil),                                      // 476: forge.CloudInitInstructionsRequest
-	(*CloudInitInstructions)(nil),                                             // 477: forge.CloudInitInstructions
-	(*DpuNetworkStatus)(nil),                                                  // 478: forge.DpuNetworkStatus
-	(*LastDhcpRequest)(nil),                                                   // 479: forge.LastDhcpRequest
-	(*DpuExtensionServiceStatusObservation)(nil),                              // 480: forge.DpuExtensionServiceStatusObservation
-	(*DpuExtensionServiceComponent)(nil),                                      // 481: forge.DpuExtensionServiceComponent
-	(*OptionalHealthReport)(nil),                                              // 482: forge.OptionalHealthReport
-	(*HealthReportEntry)(nil),                                                 // 483: forge.HealthReportEntry
-	(*InsertMachineHealthReportRequest)(nil),                                  // 484: forge.InsertMachineHealthReportRequest
-	(*InsertRackHealthReportRequest)(nil),                                     // 485: forge.InsertRackHealthReportRequest
-	(*RemoveRackHealthReportRequest)(nil),                                     // 486: forge.RemoveRackHealthReportRequest
-	(*ListRackHealthReportsRequest)(nil),                                      // 487: forge.ListRackHealthReportsRequest
-	(*InsertSwitchHealthReportRequest)(nil),                                   // 488: forge.InsertSwitchHealthReportRequest
-	(*RemoveSwitchHealthReportRequest)(nil),                                   // 489: forge.RemoveSwitchHealthReportRequest
-	(*ListSwitchHealthReportsRequest)(nil),                                    // 490: forge.ListSwitchHealthReportsRequest
-	(*InsertPowerShelfHealthReportRequest)(nil),                               // 491: forge.InsertPowerShelfHealthReportRequest
-	(*RemovePowerShelfHealthReportRequest)(nil),                               // 492: forge.RemovePowerShelfHealthReportRequest
-	(*ListPowerShelfHealthReportsRequest)(nil),                                // 493: forge.ListPowerShelfHealthReportsRequest
-	(*ListHealthReportResponse)(nil),                                          // 494: forge.ListHealthReportResponse
-	(*RemoveMachineHealthReportRequest)(nil),                                  // 495: forge.RemoveMachineHealthReportRequest
-	(*ListNVLinkDomainHealthReportsRequest)(nil),                              // 496: forge.ListNVLinkDomainHealthReportsRequest
-	(*InsertNVLinkDomainHealthReportRequest)(nil),                             // 497: forge.InsertNVLinkDomainHealthReportRequest
-	(*RemoveNVLinkDomainHealthReportRequest)(nil),                             // 498: forge.RemoveNVLinkDomainHealthReportRequest
-	(*InstanceInterfaceStatusObservation)(nil),                                // 499: forge.InstanceInterfaceStatusObservation
-	(*FabricInterfaceData)(nil),                                               // 500: forge.FabricInterfaceData
-	(*LinkData)(nil),                                                          // 501: forge.LinkData
-	(*Tenant)(nil),                                                            // 502: forge.Tenant
-	(*CreateTenantRequest)(nil),                                               // 503: forge.CreateTenantRequest
-	(*CreateTenantResponse)(nil),                                              // 504: forge.CreateTenantResponse
-	(*UpdateTenantRequest)(nil),                                               // 505: forge.UpdateTenantRequest
-	(*UpdateTenantResponse)(nil),                                              // 506: forge.UpdateTenantResponse
-	(*FindTenantRequest)(nil),                                                 // 507: forge.FindTenantRequest
-	(*FindTenantResponse)(nil),                                                // 508: forge.FindTenantResponse
-	(*TenantKeysetIdentifier)(nil),                                            // 509: forge.TenantKeysetIdentifier
-	(*TenantPublicKey)(nil),                                                   // 510: forge.TenantPublicKey
-	(*TenantKeysetContent)(nil),                                               // 511: forge.TenantKeysetContent
-	(*TenantKeyset)(nil),                                                      // 512: forge.TenantKeyset
-	(*CreateTenantKeysetRequest)(nil),                                         // 513: forge.CreateTenantKeysetRequest
-	(*CreateTenantKeysetResponse)(nil),                                        // 514: forge.CreateTenantKeysetResponse
-	(*TenantKeySetList)(nil),                                                  // 515: forge.TenantKeySetList
-	(*UpdateTenantKeysetRequest)(nil),                                         // 516: forge.UpdateTenantKeysetRequest
-	(*UpdateTenantKeysetResponse)(nil),                                        // 517: forge.UpdateTenantKeysetResponse
-	(*DeleteTenantKeysetRequest)(nil),                                         // 518: forge.DeleteTenantKeysetRequest
-	(*DeleteTenantKeysetResponse)(nil),                                        // 519: forge.DeleteTenantKeysetResponse
-	(*TenantKeysetSearchFilter)(nil),                                          // 520: forge.TenantKeysetSearchFilter
-	(*TenantKeysetIdList)(nil),                                                // 521: forge.TenantKeysetIdList
-	(*TenantKeysetsByIdsRequest)(nil),                                         // 522: forge.TenantKeysetsByIdsRequest
-	(*ValidateTenantPublicKeyRequest)(nil),                                    // 523: forge.ValidateTenantPublicKeyRequest
-	(*ValidateTenantPublicKeyResponse)(nil),                                   // 524: forge.ValidateTenantPublicKeyResponse
-	(*ListResourcePoolsRequest)(nil),                                          // 525: forge.ListResourcePoolsRequest
-	(*ResourcePools)(nil),                                                     // 526: forge.ResourcePools
-	(*ResourcePool)(nil),                                                      // 527: forge.ResourcePool
-	(*GrowResourcePoolRequest)(nil),                                           // 528: forge.GrowResourcePoolRequest
-	(*GrowResourcePoolResponse)(nil),                                          // 529: forge.GrowResourcePoolResponse
-	(*Range)(nil),                                                             // 530: forge.Range
-	(*MigrateVpcVniResponse)(nil),                                             // 531: forge.MigrateVpcVniResponse
-	(*MaintenanceRequest)(nil),                                                // 532: forge.MaintenanceRequest
-	(*SetDynamicConfigRequest)(nil),                                           // 533: forge.SetDynamicConfigRequest
-	(*FindIpAddressRequest)(nil),                                              // 534: forge.FindIpAddressRequest
-	(*FindIpAddressResponse)(nil),                                             // 535: forge.FindIpAddressResponse
-	(*IdentifyUuidRequest)(nil),                                               // 536: forge.IdentifyUuidRequest
-	(*IdentifyUuidResponse)(nil),                                              // 537: forge.IdentifyUuidResponse
-	(*FindBmcIpsRequest)(nil),                                                 // 538: forge.FindBmcIpsRequest
-	(*IdentifyMacRequest)(nil),                                                // 539: forge.IdentifyMacRequest
-	(*IdentifyMacResponse)(nil),                                               // 540: forge.IdentifyMacResponse
-	(*IdentifySerialRequest)(nil),                                             // 541: forge.IdentifySerialRequest
-	(*IdentifySerialResponse)(nil),                                            // 542: forge.IdentifySerialResponse
-	(*DpuReprovisioningRequest)(nil),                                          // 543: forge.DpuReprovisioningRequest
-	(*DpuReprovisioningListRequest)(nil),                                      // 544: forge.DpuReprovisioningListRequest
-	(*DpuReprovisioningListResponse)(nil),                                     // 545: forge.DpuReprovisioningListResponse
-	(*HostReprovisioningRequest)(nil),                                         // 546: forge.HostReprovisioningRequest
-	(*BmcCredentialRotationRequest)(nil),                                      // 547: forge.BmcCredentialRotationRequest
-	(*UefiCredentialRotationRequest)(nil),                                     // 548: forge.UefiCredentialRotationRequest
-	(*NicLockdownCredentialRotationRequest)(nil),                              // 549: forge.NicLockdownCredentialRotationRequest
-	(*HostReprovisioningListRequest)(nil),                                     // 550: forge.HostReprovisioningListRequest
-	(*HostReprovisioningListResponse)(nil),                                    // 551: forge.HostReprovisioningListResponse
-	(*DpuOsOperationalState)(nil),                                             // 552: forge.DpuOsOperationalState
-	(*DpuRepresentorStatus)(nil),                                              // 553: forge.DpuRepresentorStatus
-	(*DpuInfoStatusObservation)(nil),                                          // 554: forge.DpuInfoStatusObservation
-	(*DpuInfo)(nil),                                                           // 555: forge.DpuInfo
-	(*GetDpuInfoListRequest)(nil),                                             // 556: forge.GetDpuInfoListRequest
-	(*GetDpuInfoListResponse)(nil),                                            // 557: forge.GetDpuInfoListResponse
-	(*IpAddressMatch)(nil),                                                    // 558: forge.IpAddressMatch
-	(*MachineBootOverride)(nil),                                               // 559: forge.MachineBootOverride
-	(*ConnectedDevice)(nil),                                                   // 560: forge.ConnectedDevice
-	(*ConnectedDeviceList)(nil),                                               // 561: forge.ConnectedDeviceList
-	(*BmcIpList)(nil),                                                         // 562: forge.BmcIpList
-	(*BmcIp)(nil),                                                             // 563: forge.BmcIp
-	(*MacAddressBmcIp)(nil),                                                   // 564: forge.MacAddressBmcIp
-	(*MachineIdBmcIpPairs)(nil),                                               // 565: forge.MachineIdBmcIpPairs
-	(*MachineIdBmcIp)(nil),                                                    // 566: forge.MachineIdBmcIp
-	(*NetworkDevice)(nil),                                                     // 567: forge.NetworkDevice
-	(*NetworkTopologyRequest)(nil),                                            // 568: forge.NetworkTopologyRequest
-	(*NetworkDeviceIdList)(nil),                                               // 569: forge.NetworkDeviceIdList
-	(*NetworkTopologyData)(nil),                                               // 570: forge.NetworkTopologyData
-	(*RouteServers)(nil),                                                      // 571: forge.RouteServers
-	(*RouteServerEntries)(nil),                                                // 572: forge.RouteServerEntries
-	(*RouteServer)(nil),                                                       // 573: forge.RouteServer
-	(*SetHostUefiPasswordRequest)(nil),                                        // 574: forge.SetHostUefiPasswordRequest
-	(*SetHostUefiPasswordResponse)(nil),                                       // 575: forge.SetHostUefiPasswordResponse
-	(*ClearHostUefiPasswordRequest)(nil),                                      // 576: forge.ClearHostUefiPasswordRequest
-	(*ClearHostUefiPasswordResponse)(nil),                                     // 577: forge.ClearHostUefiPasswordResponse
-	(*SetDpuUefiPasswordRequest)(nil),                                         // 578: forge.SetDpuUefiPasswordRequest
-	(*SetDpuUefiPasswordResponse)(nil),                                        // 579: forge.SetDpuUefiPasswordResponse
-	(*OsImageAttributes)(nil),                                                 // 580: forge.OsImageAttributes
-	(*OsImage)(nil),                                                           // 581: forge.OsImage
-	(*ListOsImageRequest)(nil),                                                // 582: forge.ListOsImageRequest
-	(*ListOsImageResponse)(nil),                                               // 583: forge.ListOsImageResponse
-	(*DeleteOsImageRequest)(nil),                                              // 584: forge.DeleteOsImageRequest
-	(*DeleteOsImageResponse)(nil),                                             // 585: forge.DeleteOsImageResponse
-	(*GetIpxeTemplateRequest)(nil),                                            // 586: forge.GetIpxeTemplateRequest
-	(*ListIpxeTemplatesRequest)(nil),                                          // 587: forge.ListIpxeTemplatesRequest
-	(*IpxeTemplateList)(nil),                                                  // 588: forge.IpxeTemplateList
-	(*ExpectedHostNic)(nil),                                                   // 589: forge.ExpectedHostNic
-	(*HostLifecycleProfile)(nil),                                              // 590: forge.HostLifecycleProfile
-	(*ExpectedMachine)(nil),                                                   // 591: forge.ExpectedMachine
-	(*ExpectedMachineRequest)(nil),                                            // 592: forge.ExpectedMachineRequest
-	(*ExpectedMachineList)(nil),                                               // 593: forge.ExpectedMachineList
-	(*LinkedExpectedMachineList)(nil),                                         // 594: forge.LinkedExpectedMachineList
-	(*LinkedExpectedMachine)(nil),                                             // 595: forge.LinkedExpectedMachine
-	(*UnexpectedMachineList)(nil),                                             // 596: forge.UnexpectedMachineList
-	(*UnexpectedMachine)(nil),                                                 // 597: forge.UnexpectedMachine
-	(*BatchExpectedMachineOperationRequest)(nil),                              // 598: forge.BatchExpectedMachineOperationRequest
-	(*ExpectedMachineOperationResult)(nil),                                    // 599: forge.ExpectedMachineOperationResult
-	(*BatchExpectedMachineOperationResponse)(nil),                             // 600: forge.BatchExpectedMachineOperationResponse
-	(*MachineRebootCompletedResponse)(nil),                                    // 601: forge.MachineRebootCompletedResponse
-	(*MachineRebootCompletedRequest)(nil),                                     // 602: forge.MachineRebootCompletedRequest
-	(*ScoutFirmwareUpgradeStatusRequest)(nil),                                 // 603: forge.ScoutFirmwareUpgradeStatusRequest
-	(*MachineValidationCompletedRequest)(nil),                                 // 604: forge.MachineValidationCompletedRequest
-	(*MachineValidationCompletedResponse)(nil),                                // 605: forge.MachineValidationCompletedResponse
-	(*MachineValidationResult)(nil),                                           // 606: forge.MachineValidationResult
-	(*MachineValidationResultPostRequest)(nil),                                // 607: forge.MachineValidationResultPostRequest
-	(*MachineValidationResultList)(nil),                                       // 608: forge.MachineValidationResultList
-	(*MachineValidationGetRequest)(nil),                                       // 609: forge.MachineValidationGetRequest
-	(*MachineValidationStatus)(nil),                                           // 610: forge.MachineValidationStatus
-	(*MachineValidationRun)(nil),                                              // 611: forge.MachineValidationRun
-	(*MachineSetAutoUpdateRequest)(nil),                                       // 612: forge.MachineSetAutoUpdateRequest
-	(*MachineSetAutoUpdateResponse)(nil),                                      // 613: forge.MachineSetAutoUpdateResponse
-	(*GetMachineValidationExternalConfigRequest)(nil),                         // 614: forge.GetMachineValidationExternalConfigRequest
-	(*MachineValidationExternalConfig)(nil),                                   // 615: forge.MachineValidationExternalConfig
-	(*GetMachineValidationExternalConfigResponse)(nil),                        // 616: forge.GetMachineValidationExternalConfigResponse
-	(*GetMachineValidationExternalConfigsRequest)(nil),                        // 617: forge.GetMachineValidationExternalConfigsRequest
-	(*GetMachineValidationExternalConfigsResponse)(nil),                       // 618: forge.GetMachineValidationExternalConfigsResponse
-	(*AddUpdateMachineValidationExternalConfigRequest)(nil),                   // 619: forge.AddUpdateMachineValidationExternalConfigRequest
-	(*RemoveMachineValidationExternalConfigRequest)(nil),                      // 620: forge.RemoveMachineValidationExternalConfigRequest
-	(*MachineValidationOnDemandRequest)(nil),                                  // 621: forge.MachineValidationOnDemandRequest
-	(*MachineValidationOnDemandResponse)(nil),                                 // 622: forge.MachineValidationOnDemandResponse
-	(*FirmwareUpgradeActivity)(nil),                                           // 623: forge.FirmwareUpgradeActivity
-	(*NvosUpdateActivity)(nil),                                                // 624: forge.NvosUpdateActivity
-	(*ConfigureNmxClusterActivity)(nil),                                       // 625: forge.ConfigureNmxClusterActivity
-	(*PowerSequenceActivity)(nil),                                             // 626: forge.PowerSequenceActivity
-	(*MaintenanceActivityConfig)(nil),                                         // 627: forge.MaintenanceActivityConfig
-	(*RackMaintenanceScope)(nil),                                              // 628: forge.RackMaintenanceScope
-	(*RackMaintenanceOnDemandRequest)(nil),                                    // 629: forge.RackMaintenanceOnDemandRequest
-	(*RackMaintenanceOnDemandResponse)(nil),                                   // 630: forge.RackMaintenanceOnDemandResponse
-	(*RackMaintenanceTerminateRequest)(nil),                                   // 631: forge.RackMaintenanceTerminateRequest
-	(*RackMaintenanceTerminateResponse)(nil),                                  // 632: forge.RackMaintenanceTerminateResponse
-	(*AdminPowerControlRequest)(nil),                                          // 633: forge.AdminPowerControlRequest
-	(*AdminPowerControlResponse)(nil),                                         // 634: forge.AdminPowerControlResponse
-	(*AdminGpuResetRequest)(nil),                                              // 635: forge.AdminGpuResetRequest
-	(*AdminGpuResetResponse)(nil),                                             // 636: forge.AdminGpuResetResponse
-	(*GetRedfishJobStateRequest)(nil),                                         // 637: forge.GetRedfishJobStateRequest
-	(*GetRedfishJobStateResponse)(nil),                                        // 638: forge.GetRedfishJobStateResponse
-	(*MachineValidationRunList)(nil),                                          // 639: forge.MachineValidationRunList
-	(*MachineValidationRunListGetRequest)(nil),                                // 640: forge.MachineValidationRunListGetRequest
-	(*MachineValidationRunItemSearchFilter)(nil),                              // 641: forge.MachineValidationRunItemSearchFilter
-	(*MachineValidationRunItemIdList)(nil),                                    // 642: forge.MachineValidationRunItemIdList
-	(*MachineValidationRunItemsByIdsRequest)(nil),                             // 643: forge.MachineValidationRunItemsByIdsRequest
-	(*MachineValidationRunItemList)(nil),                                      // 644: forge.MachineValidationRunItemList
-	(*MachineValidationRunItem)(nil),                                          // 645: forge.MachineValidationRunItem
-	(*MachineValidationAttemptGetRequest)(nil),                                // 646: forge.MachineValidationAttemptGetRequest
-	(*MachineValidationAttempt)(nil),                                          // 647: forge.MachineValidationAttempt
-	(*MachineValidationHeartbeatRequest)(nil),                                 // 648: forge.MachineValidationHeartbeatRequest
-	(*MachineValidationHeartbeatResponse)(nil),                                // 649: forge.MachineValidationHeartbeatResponse
-	(*IsBmcInManagedHostResponse)(nil),                                        // 650: forge.IsBmcInManagedHostResponse
-	(*BmcCredentialStatusResponse)(nil),                                       // 651: forge.BmcCredentialStatusResponse
-	(*MachineValidationTestsGetRequest)(nil),                                  // 652: forge.MachineValidationTestsGetRequest
-	(*MachineValidationTestUpdateRequest)(nil),                                // 653: forge.MachineValidationTestUpdateRequest
-	(*MachineValidationTestAddRequest)(nil),                                   // 654: forge.MachineValidationTestAddRequest
-	(*MachineValidationTestAddUpdateResponse)(nil),                            // 655: forge.MachineValidationTestAddUpdateResponse
-	(*MachineValidationTestsGetResponse)(nil),                                 // 656: forge.MachineValidationTestsGetResponse
-	(*MachineValidationTestVerfiedRequest)(nil),                               // 657: forge.MachineValidationTestVerfiedRequest
-	(*MachineValidationTestVerfiedResponse)(nil),                              // 658: forge.MachineValidationTestVerfiedResponse
-	(*MachineValidationTest)(nil),                                             // 659: forge.MachineValidationTest
-	(*MachineValidationPlugin)(nil),                                           // 660: forge.MachineValidationPlugin
-	(*MachineValidationTestFullHostApprovalRequest)(nil),                      // 661: forge.MachineValidationTestFullHostApprovalRequest
-	(*MachineValidationTestFullHostApprovalResponse)(nil),                     // 662: forge.MachineValidationTestFullHostApprovalResponse
-	(*MachineValidationTestNextVersionResponse)(nil),                          // 663: forge.MachineValidationTestNextVersionResponse
-	(*MachineValidationTestNextVersionRequest)(nil),                           // 664: forge.MachineValidationTestNextVersionRequest
-	(*MachineValidationTestEnableDisableTestRequest)(nil),                     // 665: forge.MachineValidationTestEnableDisableTestRequest
-	(*MachineValidationTestEnableDisableTestResponse)(nil),                    // 666: forge.MachineValidationTestEnableDisableTestResponse
-	(*MachineValidationRunRequest)(nil),                                       // 667: forge.MachineValidationRunRequest
-	(*MachineValidationRunResponse)(nil),                                      // 668: forge.MachineValidationRunResponse
-	(*MachineCapabilityAttributesCpu)(nil),                                    // 669: forge.MachineCapabilityAttributesCpu
-	(*MachineCapabilityAttributesGpu)(nil),                                    // 670: forge.MachineCapabilityAttributesGpu
-	(*MachineCapabilityAttributesMemory)(nil),                                 // 671: forge.MachineCapabilityAttributesMemory
-	(*MachineCapabilityAttributesStorage)(nil),                                // 672: forge.MachineCapabilityAttributesStorage
-	(*MachineCapabilityAttributesNetwork)(nil),                                // 673: forge.MachineCapabilityAttributesNetwork
-	(*MachineCapabilityAttributesInfiniband)(nil),                             // 674: forge.MachineCapabilityAttributesInfiniband
-	(*MachineCapabilityAttributesDpu)(nil),                                    // 675: forge.MachineCapabilityAttributesDpu
-	(*MachineCapabilitiesSet)(nil),                                            // 676: forge.MachineCapabilitiesSet
-	(*InstanceTypeAttributes)(nil),                                            // 677: forge.InstanceTypeAttributes
-	(*InstanceType)(nil),                                                      // 678: forge.InstanceType
-	(*InstanceTypeMachineCapabilityFilterAttributes)(nil),                     // 679: forge.InstanceTypeMachineCapabilityFilterAttributes
-	(*CreateInstanceTypeRequest)(nil),                                         // 680: forge.CreateInstanceTypeRequest
-	(*CreateInstanceTypeResponse)(nil),                                        // 681: forge.CreateInstanceTypeResponse
-	(*FindInstanceTypeIdsRequest)(nil),                                        // 682: forge.FindInstanceTypeIdsRequest
-	(*FindInstanceTypeIdsResponse)(nil),                                       // 683: forge.FindInstanceTypeIdsResponse
-	(*FindInstanceTypesByIdsRequest)(nil),                                     // 684: forge.FindInstanceTypesByIdsRequest
-	(*FindInstanceTypesByIdsResponse)(nil),                                    // 685: forge.FindInstanceTypesByIdsResponse
-	(*DeleteInstanceTypeRequest)(nil),                                         // 686: forge.DeleteInstanceTypeRequest
-	(*DeleteInstanceTypeResponse)(nil),                                        // 687: forge.DeleteInstanceTypeResponse
-	(*UpdateInstanceTypeResponse)(nil),                                        // 688: forge.UpdateInstanceTypeResponse
-	(*UpdateInstanceTypeRequest)(nil),                                         // 689: forge.UpdateInstanceTypeRequest
-	(*AssociateMachinesWithInstanceTypeRequest)(nil),                          // 690: forge.AssociateMachinesWithInstanceTypeRequest
-	(*AssociateMachinesWithInstanceTypeResponse)(nil),                         // 691: forge.AssociateMachinesWithInstanceTypeResponse
-	(*RemoveMachineInstanceTypeAssociationRequest)(nil),                       // 692: forge.RemoveMachineInstanceTypeAssociationRequest
-	(*RemoveMachineInstanceTypeAssociationResponse)(nil),                      // 693: forge.RemoveMachineInstanceTypeAssociationResponse
-	(*RedfishBrowseRequest)(nil),                                              // 694: forge.RedfishBrowseRequest
-	(*RedfishBrowseResponse)(nil),                                             // 695: forge.RedfishBrowseResponse
-	(*RedfishListActionsRequest)(nil),                                         // 696: forge.RedfishListActionsRequest
-	(*RedfishListActionsResponse)(nil),                                        // 697: forge.RedfishListActionsResponse
-	(*RedfishAction)(nil),                                                     // 698: forge.RedfishAction
-	(*OptionalRedfishActionResult)(nil),                                       // 699: forge.OptionalRedfishActionResult
-	(*RedfishActionResult)(nil),                                               // 700: forge.RedfishActionResult
-	(*RedfishCreateActionRequest)(nil),                                        // 701: forge.RedfishCreateActionRequest
-	(*RedfishCreateActionResponse)(nil),                                       // 702: forge.RedfishCreateActionResponse
-	(*RedfishActionID)(nil),                                                   // 703: forge.RedfishActionID
-	(*RedfishApproveActionResponse)(nil),                                      // 704: forge.RedfishApproveActionResponse
-	(*RedfishApplyActionResponse)(nil),                                        // 705: forge.RedfishApplyActionResponse
-	(*RedfishCancelActionResponse)(nil),                                       // 706: forge.RedfishCancelActionResponse
-	(*UfmBrowseRequest)(nil),                                                  // 707: forge.UfmBrowseRequest
-	(*UfmBrowseResponse)(nil),                                                 // 708: forge.UfmBrowseResponse
-	(*NetworkSecurityGroupAttributes)(nil),                                    // 709: forge.NetworkSecurityGroupAttributes
-	(*NetworkSecurityGroup)(nil),                                              // 710: forge.NetworkSecurityGroup
-	(*CreateNetworkSecurityGroupRequest)(nil),                                 // 711: forge.CreateNetworkSecurityGroupRequest
-	(*CreateNetworkSecurityGroupResponse)(nil),                                // 712: forge.CreateNetworkSecurityGroupResponse
-	(*FindNetworkSecurityGroupIdsRequest)(nil),                                // 713: forge.FindNetworkSecurityGroupIdsRequest
-	(*FindNetworkSecurityGroupIdsResponse)(nil),                               // 714: forge.FindNetworkSecurityGroupIdsResponse
-	(*FindNetworkSecurityGroupsByIdsRequest)(nil),                             // 715: forge.FindNetworkSecurityGroupsByIdsRequest
-	(*FindNetworkSecurityGroupsByIdsResponse)(nil),                            // 716: forge.FindNetworkSecurityGroupsByIdsResponse
-	(*UpdateNetworkSecurityGroupResponse)(nil),                                // 717: forge.UpdateNetworkSecurityGroupResponse
-	(*UpdateNetworkSecurityGroupRequest)(nil),                                 // 718: forge.UpdateNetworkSecurityGroupRequest
-	(*DeleteNetworkSecurityGroupRequest)(nil),                                 // 719: forge.DeleteNetworkSecurityGroupRequest
-	(*DeleteNetworkSecurityGroupResponse)(nil),                                // 720: forge.DeleteNetworkSecurityGroupResponse
-	(*NetworkSecurityGroupStatus)(nil),                                        // 721: forge.NetworkSecurityGroupStatus
-	(*NetworkSecurityGroupPropagationObjectStatus)(nil),                       // 722: forge.NetworkSecurityGroupPropagationObjectStatus
-	(*GetNetworkSecurityGroupPropagationStatusResponse)(nil),                  // 723: forge.GetNetworkSecurityGroupPropagationStatusResponse
-	(*NetworkSecurityGroupIdList)(nil),                                        // 724: forge.NetworkSecurityGroupIdList
-	(*GetNetworkSecurityGroupPropagationStatusRequest)(nil),                   // 725: forge.GetNetworkSecurityGroupPropagationStatusRequest
-	(*NetworkSecurityGroupRuleAttributes)(nil),                                // 726: forge.NetworkSecurityGroupRuleAttributes
-	(*ResolvedNetworkSecurityGroupRule)(nil),                                  // 727: forge.ResolvedNetworkSecurityGroupRule
-	(*GetNetworkSecurityGroupAttachmentsRequest)(nil),                         // 728: forge.GetNetworkSecurityGroupAttachmentsRequest
-	(*NetworkSecurityGroupAttachments)(nil),                                   // 729: forge.NetworkSecurityGroupAttachments
-	(*GetNetworkSecurityGroupAttachmentsResponse)(nil),                        // 730: forge.GetNetworkSecurityGroupAttachmentsResponse
-	(*GetDesiredFirmwareVersionsRequest)(nil),                                 // 731: forge.GetDesiredFirmwareVersionsRequest
-	(*GetDesiredFirmwareVersionsResponse)(nil),                                // 732: forge.GetDesiredFirmwareVersionsResponse
-	(*DesiredFirmwareVersionEntry)(nil),                                       // 733: forge.DesiredFirmwareVersionEntry
-	(*SkuComponentChassis)(nil),                                               // 734: forge.SkuComponentChassis
-	(*SkuComponentCpu)(nil),                                                   // 735: forge.SkuComponentCpu
-	(*SkuComponentGpu)(nil),                                                   // 736: forge.SkuComponentGpu
-	(*SkuComponentEthernetDevices)(nil),                                       // 737: forge.SkuComponentEthernetDevices
-	(*SkuComponentInfinibandDevices)(nil),                                     // 738: forge.SkuComponentInfinibandDevices
-	(*SkuComponentStorage)(nil),                                               // 739: forge.SkuComponentStorage
-	(*SkuComponentStorageController)(nil),                                     // 740: forge.SkuComponentStorageController
-	(*SkuComponentMemory)(nil),                                                // 741: forge.SkuComponentMemory
-	(*SkuComponentTpm)(nil),                                                   // 742: forge.SkuComponentTpm
-	(*SkuComponents)(nil),                                                     // 743: forge.SkuComponents
-	(*Sku)(nil),                                                               // 744: forge.Sku
-	(*SkuMachinePair)(nil),                                                    // 745: forge.SkuMachinePair
-	(*RemoveSkuRequest)(nil),                                                  // 746: forge.RemoveSkuRequest
-	(*SkuList)(nil),                                                           // 747: forge.SkuList
-	(*SkuIdList)(nil),                                                         // 748: forge.SkuIdList
-	(*SkuStatus)(nil),                                                         // 749: forge.SkuStatus
-	(*SkusByIdsRequest)(nil),                                                  // 750: forge.SkusByIdsRequest
-	(*SkuSearchFilter)(nil),                                                   // 751: forge.SkuSearchFilter
-	(*DpaInterface)(nil),                                                      // 752: forge.DpaInterface
-	(*DpaInterfaceCreationRequest)(nil),                                       // 753: forge.DpaInterfaceCreationRequest
-	(*DpaInterfaceIdList)(nil),                                                // 754: forge.DpaInterfaceIdList
-	(*DpaInterfacesByIdsRequest)(nil),                                         // 755: forge.DpaInterfacesByIdsRequest
-	(*DpaInterfaceList)(nil),                                                  // 756: forge.DpaInterfaceList
-	(*DpaNetworkObservationSetRequest)(nil),                                   // 757: forge.DpaNetworkObservationSetRequest
-	(*DpaInterfaceDeletionRequest)(nil),                                       // 758: forge.DpaInterfaceDeletionRequest
-	(*DpaInterfaceDeletionResult)(nil),                                        // 759: forge.DpaInterfaceDeletionResult
-	(*SkuUpdateMetadataRequest)(nil),                                          // 760: forge.SkuUpdateMetadataRequest
-	(*PowerOptionRequest)(nil),                                                // 761: forge.PowerOptionRequest
-	(*PowerOptionUpdateRequest)(nil),                                          // 762: forge.PowerOptionUpdateRequest
-	(*PowerOptions)(nil),                                                      // 763: forge.PowerOptions
-	(*PowerOptionResponse)(nil),                                               // 764: forge.PowerOptionResponse
-	(*ComputeAllocationAttributes)(nil),                                       // 765: forge.ComputeAllocationAttributes
-	(*ComputeAllocation)(nil),                                                 // 766: forge.ComputeAllocation
-	(*CreateComputeAllocationRequest)(nil),                                    // 767: forge.CreateComputeAllocationRequest
-	(*CreateComputeAllocationResponse)(nil),                                   // 768: forge.CreateComputeAllocationResponse
-	(*FindComputeAllocationIdsRequest)(nil),                                   // 769: forge.FindComputeAllocationIdsRequest
-	(*FindComputeAllocationIdsResponse)(nil),                                  // 770: forge.FindComputeAllocationIdsResponse
-	(*FindComputeAllocationsByIdsRequest)(nil),                                // 771: forge.FindComputeAllocationsByIdsRequest
-	(*FindComputeAllocationsByIdsResponse)(nil),                               // 772: forge.FindComputeAllocationsByIdsResponse
-	(*UpdateComputeAllocationResponse)(nil),                                   // 773: forge.UpdateComputeAllocationResponse
-	(*UpdateComputeAllocationRequest)(nil),                                    // 774: forge.UpdateComputeAllocationRequest
-	(*DeleteComputeAllocationRequest)(nil),                                    // 775: forge.DeleteComputeAllocationRequest
-	(*DeleteComputeAllocationResponse)(nil),                                   // 776: forge.DeleteComputeAllocationResponse
-	(*InstanceTypeAllocationStats)(nil),                                       // 777: forge.InstanceTypeAllocationStats
-	(*GetRackRequest)(nil),                                                    // 778: forge.GetRackRequest
-	(*GetRackResponse)(nil),                                                   // 779: forge.GetRackResponse
-	(*RackList)(nil),                                                          // 780: forge.RackList
-	(*RackSearchFilter)(nil),                                                  // 781: forge.RackSearchFilter
-	(*RackIdList)(nil),                                                        // 782: forge.RackIdList
-	(*RacksByIdsRequest)(nil),                                                 // 783: forge.RacksByIdsRequest
-	(*Rack)(nil),                                                              // 784: forge.Rack
-	(*RackConfig)(nil),                                                        // 785: forge.RackConfig
-	(*RackStatus)(nil),                                                        // 786: forge.RackStatus
-	(*RackStateHistoriesRequest)(nil),                                         // 787: forge.RackStateHistoriesRequest
-	(*RackHealthHistoriesRequest)(nil),                                        // 788: forge.RackHealthHistoriesRequest
-	(*DeleteRackRequest)(nil),                                                 // 789: forge.DeleteRackRequest
-	(*AdminForceDeleteRackRequest)(nil),                                       // 790: forge.AdminForceDeleteRackRequest
-	(*AdminForceDeleteRackResponse)(nil),                                      // 791: forge.AdminForceDeleteRackResponse
-	(*RackCapabilityCompute)(nil),                                             // 792: forge.RackCapabilityCompute
-	(*RackCapabilitySwitch)(nil),                                              // 793: forge.RackCapabilitySwitch
-	(*RackCapabilityPowerShelf)(nil),                                          // 794: forge.RackCapabilityPowerShelf
-	(*RackCapabilitiesSet)(nil),                                               // 795: forge.RackCapabilitiesSet
-	(*RackProfile)(nil),                                                       // 796: forge.RackProfile
-	(*GetRackProfileRequest)(nil),                                             // 797: forge.GetRackProfileRequest
-	(*GetRackProfileResponse)(nil),                                            // 798: forge.GetRackProfileResponse
-	(*ConfiguredRackProfile)(nil),                                             // 799: forge.ConfiguredRackProfile
-	(*ListRackProfilesResponse)(nil),                                          // 800: forge.ListRackProfilesResponse
-	(*RackManagerForgeRequest)(nil),                                           // 801: forge.RackManagerForgeRequest
-	(*RackManagerForgeResponse)(nil),                                          // 802: forge.RackManagerForgeResponse
-	(*MachineNVLinkInfo)(nil),                                                 // 803: forge.MachineNVLinkInfo
-	(*UpdateMachineNvLinkInfoRequest)(nil),                                    // 804: forge.UpdateMachineNvLinkInfoRequest
-	(*MachineSpxStatusObservation)(nil),                                       // 805: forge.MachineSpxStatusObservation
-	(*MachineSpxAttachmentStatusObservation)(nil),                             // 806: forge.MachineSpxAttachmentStatusObservation
-	(*AstraConfig)(nil),                                                       // 807: forge.AstraConfig
-	(*AstraAttachment)(nil),                                                   // 808: forge.AstraAttachment
-	(*AstraConfigStatus)(nil),                                                 // 809: forge.AstraConfigStatus
-	(*AstraAttachmentStatus)(nil),                                             // 810: forge.AstraAttachmentStatus
-	(*AstraStatus)(nil),                                                       // 811: forge.AstraStatus
-	(*NVLinkGpu)(nil),                                                         // 812: forge.NVLinkGpu
-	(*MachineNVLinkStatusObservation)(nil),                                    // 813: forge.MachineNVLinkStatusObservation
-	(*MachineNVLinkGpuStatusObservation)(nil),                                 // 814: forge.MachineNVLinkGpuStatusObservation
-	(*NmxcBrowseRequest)(nil),                                                 // 815: forge.NmxcBrowseRequest
-	(*NmxcBrowseResponse)(nil),                                                // 816: forge.NmxcBrowseResponse
-	(*NVLinkPartition)(nil),                                                   // 817: forge.NVLinkPartition
-	(*NVLinkPartitionList)(nil),                                               // 818: forge.NVLinkPartitionList
-	(*NVLinkPartitionSearchConfig)(nil),                                       // 819: forge.NVLinkPartitionSearchConfig
-	(*NVLinkPartitionQuery)(nil),                                              // 820: forge.NVLinkPartitionQuery
-	(*NVLinkPartitionSearchFilter)(nil),                                       // 821: forge.NVLinkPartitionSearchFilter
-	(*NVLinkPartitionsByIdsRequest)(nil),                                      // 822: forge.NVLinkPartitionsByIdsRequest
-	(*NVLinkPartitionIdList)(nil),                                             // 823: forge.NVLinkPartitionIdList
-	(*NVLinkFabricSearchFilter)(nil),                                          // 824: forge.NVLinkFabricSearchFilter
-	(*NVLinkLogicalPartitionConfig)(nil),                                      // 825: forge.NVLinkLogicalPartitionConfig
-	(*NVLinkLogicalPartitionStatus)(nil),                                      // 826: forge.NVLinkLogicalPartitionStatus
-	(*NVLinkLogicalPartition)(nil),                                            // 827: forge.NVLinkLogicalPartition
-	(*NVLinkLogicalPartitionList)(nil),                                        // 828: forge.NVLinkLogicalPartitionList
-	(*NVLinkLogicalPartitionCreationRequest)(nil),                             // 829: forge.NVLinkLogicalPartitionCreationRequest
-	(*NVLinkLogicalPartitionDeletionRequest)(nil),                             // 830: forge.NVLinkLogicalPartitionDeletionRequest
-	(*NVLinkLogicalPartitionDeletionResult)(nil),                              // 831: forge.NVLinkLogicalPartitionDeletionResult
-	(*NVLinkLogicalPartitionSearchFilter)(nil),                                // 832: forge.NVLinkLogicalPartitionSearchFilter
-	(*NVLinkLogicalPartitionsByIdsRequest)(nil),                               // 833: forge.NVLinkLogicalPartitionsByIdsRequest
-	(*NVLinkLogicalPartitionIdList)(nil),                                      // 834: forge.NVLinkLogicalPartitionIdList
-	(*NVLinkLogicalPartitionUpdateRequest)(nil),                               // 835: forge.NVLinkLogicalPartitionUpdateRequest
-	(*NVLinkLogicalPartitionUpdateResult)(nil),                                // 836: forge.NVLinkLogicalPartitionUpdateResult
-	(*CreateBmcUserRequest)(nil),                                              // 837: forge.CreateBmcUserRequest
-	(*CreateBmcUserResponse)(nil),                                             // 838: forge.CreateBmcUserResponse
-	(*DeleteBmcUserRequest)(nil),                                              // 839: forge.DeleteBmcUserRequest
-	(*DeleteBmcUserResponse)(nil),                                             // 840: forge.DeleteBmcUserResponse
-	(*SetBmcRootPasswordRequest)(nil),                                         // 841: forge.SetBmcRootPasswordRequest
-	(*SetBmcRootPasswordResponse)(nil),                                        // 842: forge.SetBmcRootPasswordResponse
-	(*ProbeBmcVendorRequest)(nil),                                             // 843: forge.ProbeBmcVendorRequest
-	(*ProbeBmcVendorResponse)(nil),                                            // 844: forge.ProbeBmcVendorResponse
-	(*SetFirmwareUpdateTimeWindowRequest)(nil),                                // 845: forge.SetFirmwareUpdateTimeWindowRequest
-	(*SetFirmwareUpdateTimeWindowResponse)(nil),                               // 846: forge.SetFirmwareUpdateTimeWindowResponse
-	(*UpsertHostFirmwareConfigRequest)(nil),                                   // 847: forge.UpsertHostFirmwareConfigRequest
-	(*DeleteHostFirmwareConfigRequest)(nil),                                   // 848: forge.DeleteHostFirmwareConfigRequest
-	(*UpsertHostFirmwareComponentConfig)(nil),                                 // 849: forge.UpsertHostFirmwareComponentConfig
-	(*HostFirmwareComponentConfigResponse)(nil),                               // 850: forge.HostFirmwareComponentConfigResponse
-	(*HostFirmwareVersionConfig)(nil),                                         // 851: forge.HostFirmwareVersionConfig
-	(*HostFirmwareArtifact)(nil),                                              // 852: forge.HostFirmwareArtifact
-	(*HostFirmwareConfigResponse)(nil),                                        // 853: forge.HostFirmwareConfigResponse
-	(*ListHostFirmwareRequest)(nil),                                           // 854: forge.ListHostFirmwareRequest
-	(*ListHostFirmwareResponse)(nil),                                          // 855: forge.ListHostFirmwareResponse
-	(*AvailableHostFirmware)(nil),                                             // 856: forge.AvailableHostFirmware
-	(*TrimTableRequest)(nil),                                                  // 857: forge.TrimTableRequest
-	(*TrimTableResponse)(nil),                                                 // 858: forge.TrimTableResponse
-	(*NvlinkNmxcEndpoint)(nil),                                                // 859: forge.NvlinkNmxcEndpoint
-	(*NvlinkNmxcEndpointList)(nil),                                            // 860: forge.NvlinkNmxcEndpointList
-	(*DeleteNvlinkNmxcEndpointRequest)(nil),                                   // 861: forge.DeleteNvlinkNmxcEndpointRequest
-	(*CreateRemediationRequest)(nil),                                          // 862: forge.CreateRemediationRequest
-	(*CreateRemediationResponse)(nil),                                         // 863: forge.CreateRemediationResponse
-	(*RemediationIdList)(nil),                                                 // 864: forge.RemediationIdList
-	(*RemediationList)(nil),                                                   // 865: forge.RemediationList
-	(*Remediation)(nil),                                                       // 866: forge.Remediation
-	(*ApproveRemediationRequest)(nil),                                         // 867: forge.ApproveRemediationRequest
-	(*RevokeRemediationRequest)(nil),                                          // 868: forge.RevokeRemediationRequest
-	(*EnableRemediationRequest)(nil),                                          // 869: forge.EnableRemediationRequest
-	(*DisableRemediationRequest)(nil),                                         // 870: forge.DisableRemediationRequest
-	(*FindAppliedRemediationIdsRequest)(nil),                                  // 871: forge.FindAppliedRemediationIdsRequest
-	(*AppliedRemediationIdList)(nil),                                          // 872: forge.AppliedRemediationIdList
-	(*FindAppliedRemediationsRequest)(nil),                                    // 873: forge.FindAppliedRemediationsRequest
-	(*AppliedRemediation)(nil),                                                // 874: forge.AppliedRemediation
-	(*AppliedRemediationList)(nil),                                            // 875: forge.AppliedRemediationList
-	(*GetNextRemediationForMachineRequest)(nil),                               // 876: forge.GetNextRemediationForMachineRequest
-	(*GetNextRemediationForMachineResponse)(nil),                              // 877: forge.GetNextRemediationForMachineResponse
-	(*RemediationAppliedRequest)(nil),                                         // 878: forge.RemediationAppliedRequest
-	(*RemediationApplicationStatus)(nil),                                      // 879: forge.RemediationApplicationStatus
-	(*SetPrimaryDpuRequest)(nil),                                              // 880: forge.SetPrimaryDpuRequest
-	(*SetPrimaryInterfaceRequest)(nil),                                        // 881: forge.SetPrimaryInterfaceRequest
-	(*UsernamePassword)(nil),                                                  // 882: forge.UsernamePassword
-	(*SessionToken)(nil),                                                      // 883: forge.SessionToken
-	(*DpuExtensionServiceCredential)(nil),                                     // 884: forge.DpuExtensionServiceCredential
-	(*DpuExtensionServiceVersionInfo)(nil),                                    // 885: forge.DpuExtensionServiceVersionInfo
-	(*DpuExtensionService)(nil),                                               // 886: forge.DpuExtensionService
-	(*CreateDpuExtensionServiceRequest)(nil),                                  // 887: forge.CreateDpuExtensionServiceRequest
-	(*UpdateDpuExtensionServiceRequest)(nil),                                  // 888: forge.UpdateDpuExtensionServiceRequest
-	(*DeleteDpuExtensionServiceRequest)(nil),                                  // 889: forge.DeleteDpuExtensionServiceRequest
-	(*DeleteDpuExtensionServiceResponse)(nil),                                 // 890: forge.DeleteDpuExtensionServiceResponse
-	(*DpuExtensionServiceSearchFilter)(nil),                                   // 891: forge.DpuExtensionServiceSearchFilter
-	(*DpuExtensionServiceIdList)(nil),                                         // 892: forge.DpuExtensionServiceIdList
-	(*DpuExtensionServicesByIdsRequest)(nil),                                  // 893: forge.DpuExtensionServicesByIdsRequest
-	(*DpuExtensionServiceList)(nil),                                           // 894: forge.DpuExtensionServiceList
-	(*GetDpuExtensionServiceVersionsInfoRequest)(nil),                         // 895: forge.GetDpuExtensionServiceVersionsInfoRequest
-	(*DpuExtensionServiceVersionInfoList)(nil),                                // 896: forge.DpuExtensionServiceVersionInfoList
-	(*FindInstancesByDpuExtensionServiceRequest)(nil),                         // 897: forge.FindInstancesByDpuExtensionServiceRequest
-	(*FindInstancesByDpuExtensionServiceResponse)(nil),                        // 898: forge.FindInstancesByDpuExtensionServiceResponse
-	(*InstanceDpuExtensionServiceInfo)(nil),                                   // 899: forge.InstanceDpuExtensionServiceInfo
-	(*DpuExtensionServiceObservabilityConfigPrometheus)(nil),                  // 900: forge.DpuExtensionServiceObservabilityConfigPrometheus
-	(*DpuExtensionServiceObservabilityConfigLogging)(nil),                     // 901: forge.DpuExtensionServiceObservabilityConfigLogging
-	(*DpuExtensionServiceObservabilityConfig)(nil),                            // 902: forge.DpuExtensionServiceObservabilityConfig
-	(*DpuExtensionServiceObservability)(nil),                                  // 903: forge.DpuExtensionServiceObservability
-	(*ScoutStreamApiBoundMessage)(nil),                                        // 904: forge.ScoutStreamApiBoundMessage
-	(*ScoutStreamScoutBoundMessage)(nil),                                      // 905: forge.ScoutStreamScoutBoundMessage
-	(*ScoutStreamInitRequest)(nil),                                            // 906: forge.ScoutStreamInitRequest
-	(*ScoutStreamShowConnectionsRequest)(nil),                                 // 907: forge.ScoutStreamShowConnectionsRequest
-	(*ScoutStreamShowConnectionsResponse)(nil),                                // 908: forge.ScoutStreamShowConnectionsResponse
-	(*ScoutStreamDisconnectRequest)(nil),                                      // 909: forge.ScoutStreamDisconnectRequest
-	(*ScoutStreamDisconnectResponse)(nil),                                     // 910: forge.ScoutStreamDisconnectResponse
-	(*ScoutStreamAdminPingRequest)(nil),                                       // 911: forge.ScoutStreamAdminPingRequest
-	(*ScoutStreamAdminPingResponse)(nil),                                      // 912: forge.ScoutStreamAdminPingResponse
-	(*ScoutStreamAgentPingRequest)(nil),                                       // 913: forge.ScoutStreamAgentPingRequest
-	(*ScoutStreamAgentPingResponse)(nil),                                      // 914: forge.ScoutStreamAgentPingResponse
-	(*ScoutStreamConnectionInfo)(nil),                                         // 915: forge.ScoutStreamConnectionInfo
-	(*ScoutStreamError)(nil),                                                  // 916: forge.ScoutStreamError
-	(*PrefixFilterPolicyEntry)(nil),                                           // 917: forge.PrefixFilterPolicyEntry
-	(*RoutingProfile)(nil),                                                    // 918: forge.RoutingProfile
-	(*DomainLegacy)(nil),                                                      // 919: forge.DomainLegacy
-	(*DomainListLegacy)(nil),                                                  // 920: forge.DomainListLegacy
-	(*DomainDeletionLegacy)(nil),                                              // 921: forge.DomainDeletionLegacy
-	(*DomainDeletionResultLegacy)(nil),                                        // 922: forge.DomainDeletionResultLegacy
-	(*DomainSearchQueryLegacy)(nil),                                           // 923: forge.DomainSearchQueryLegacy
-	(*PxeDomain)(nil),                                                         // 924: forge.PxeDomain
-	(*MachinePositionQuery)(nil),                                              // 925: forge.MachinePositionQuery
-	(*MachinePositionInfoList)(nil),                                           // 926: forge.MachinePositionInfoList
-	(*MachinePositionInfo)(nil),                                               // 927: forge.MachinePositionInfo
-	(*ModifyDPFStateRequest)(nil),                                             // 928: forge.ModifyDPFStateRequest
-	(*DPFStateResponse)(nil),                                                  // 929: forge.DPFStateResponse
-	(*GetDPFStateRequest)(nil),                                                // 930: forge.GetDPFStateRequest
-	(*GetDPFHostSnapshotRequest)(nil),                                         // 931: forge.GetDPFHostSnapshotRequest
-	(*DPFHostSnapshotResponse)(nil),                                           // 932: forge.DPFHostSnapshotResponse
-	(*GetDPFServiceVersionsRequest)(nil),                                      // 933: forge.GetDPFServiceVersionsRequest
-	(*DPFServiceVersion)(nil),                                                 // 934: forge.DPFServiceVersion
-	(*DPFServiceVersionsResponse)(nil),                                        // 935: forge.DPFServiceVersionsResponse
-	(*ReleaseDPUServiceSyncHoldRequest)(nil),                                  // 936: forge.ReleaseDPUServiceSyncHoldRequest
-	(*DPUServiceSyncReleaseResult)(nil),                                       // 937: forge.DPUServiceSyncReleaseResult
-	(*ReleaseDPUServiceSyncHoldResponse)(nil),                                 // 938: forge.ReleaseDPUServiceSyncHoldResponse
-	(*FindPendingDPUServiceSyncIdsRequest)(nil),                               // 939: forge.FindPendingDPUServiceSyncIdsRequest
-	(*FindPendingDPUServiceSyncsByIdsRequest)(nil),                            // 940: forge.FindPendingDPUServiceSyncsByIdsRequest
-	(*ListDPUServiceSyncHistoryRequest)(nil),                                  // 941: forge.ListDPUServiceSyncHistoryRequest
-	(*PendingDPUServiceSync)(nil),                                             // 942: forge.PendingDPUServiceSync
-	(*ListPendingDPUServiceSyncsResponse)(nil),                                // 943: forge.ListPendingDPUServiceSyncsResponse
-	(*ComponentResult)(nil),                                                   // 944: forge.ComponentResult
-	(*SwitchIdList)(nil),                                                      // 945: forge.SwitchIdList
-	(*PowerShelfIdList)(nil),                                                  // 946: forge.PowerShelfIdList
-	(*MacAddressList)(nil),                                                    // 947: forge.MacAddressList
-	(*GetComponentInventoryRequest)(nil),                                      // 948: forge.GetComponentInventoryRequest
-	(*ComponentInventoryEntry)(nil),                                           // 949: forge.ComponentInventoryEntry
-	(*GetComponentInventoryResponse)(nil),                                     // 950: forge.GetComponentInventoryResponse
-	(*ComponentPowerControlRequest)(nil),                                      // 951: forge.ComponentPowerControlRequest
-	(*ComponentPowerControlResponse)(nil),                                     // 952: forge.ComponentPowerControlResponse
-	(*ComponentConfigureSwitchCertificateRequest)(nil),                        // 953: forge.ComponentConfigureSwitchCertificateRequest
-	(*ComponentConfigureSwitchCertificateResponse)(nil),                       // 954: forge.ComponentConfigureSwitchCertificateResponse
-	(*FirmwareUpdateStatus)(nil),                                              // 955: forge.FirmwareUpdateStatus
-	(*UpdateComputeTrayFirmwareTarget)(nil),                                   // 956: forge.UpdateComputeTrayFirmwareTarget
-	(*UpdateSwitchFirmwareTarget)(nil),                                        // 957: forge.UpdateSwitchFirmwareTarget
-	(*UpdatePowerShelfFirmwareTarget)(nil),                                    // 958: forge.UpdatePowerShelfFirmwareTarget
-	(*UpdateFirmwareObjectTarget)(nil),                                        // 959: forge.UpdateFirmwareObjectTarget
-	(*UpdateComponentFirmwareRequest)(nil),                                    // 960: forge.UpdateComponentFirmwareRequest
-	(*UpdateComponentFirmwareResponse)(nil),                                   // 961: forge.UpdateComponentFirmwareResponse
-	(*GetComponentFirmwareStatusRequest)(nil),                                 // 962: forge.GetComponentFirmwareStatusRequest
-	(*GetComponentFirmwareStatusResponse)(nil),                                // 963: forge.GetComponentFirmwareStatusResponse
-	(*ListComponentFirmwareVersionsRequest)(nil),                              // 964: forge.ListComponentFirmwareVersionsRequest
-	(*ComputeTrayFirmwareVersions)(nil),                                       // 965: forge.ComputeTrayFirmwareVersions
-	(*DeviceFirmwareVersions)(nil),                                            // 966: forge.DeviceFirmwareVersions
-	(*ListComponentFirmwareVersionsResponse)(nil),                             // 967: forge.ListComponentFirmwareVersionsResponse
-	(*SpxPartitionCreationRequest)(nil),                                       // 968: forge.SpxPartitionCreationRequest
-	(*SpxPartition)(nil),                                                      // 969: forge.SpxPartition
-	(*SpxPartitionIdList)(nil),                                                // 970: forge.SpxPartitionIdList
-	(*SpxPartitionDeletionRequest)(nil),                                       // 971: forge.SpxPartitionDeletionRequest
-	(*SpxPartitionDeletionResult)(nil),                                        // 972: forge.SpxPartitionDeletionResult
-	(*SpxPartitionSearchFilter)(nil),                                          // 973: forge.SpxPartitionSearchFilter
-	(*SpxPartitionList)(nil),                                                  // 974: forge.SpxPartitionList
-	(*SpxPartitionsByIdsRequest)(nil),                                         // 975: forge.SpxPartitionsByIdsRequest
-	(*AdminForceDeleteSwitchRequest)(nil),                                     // 976: forge.AdminForceDeleteSwitchRequest
-	(*AdminForceDeleteSwitchResponse)(nil),                                    // 977: forge.AdminForceDeleteSwitchResponse
-	(*AdminForceDeletePowerShelfRequest)(nil),                                 // 978: forge.AdminForceDeletePowerShelfRequest
-	(*AdminForceDeletePowerShelfResponse)(nil),                                // 979: forge.AdminForceDeletePowerShelfResponse
-	(*OperatingSystem)(nil),                                                   // 980: forge.OperatingSystem
-	(*CreateOperatingSystemRequest)(nil),                                      // 981: forge.CreateOperatingSystemRequest
-	(*IpxeTemplateParameters)(nil),                                            // 982: forge.IpxeTemplateParameters
-	(*IpxeTemplateArtifacts)(nil),                                             // 983: forge.IpxeTemplateArtifacts
-	(*UpdateOperatingSystemRequest)(nil),                                      // 984: forge.UpdateOperatingSystemRequest
-	(*DeleteOperatingSystemRequest)(nil),                                      // 985: forge.DeleteOperatingSystemRequest
-	(*DeleteOperatingSystemResponse)(nil),                                     // 986: forge.DeleteOperatingSystemResponse
-	(*OperatingSystemSearchFilter)(nil),                                       // 987: forge.OperatingSystemSearchFilter
-	(*OperatingSystemIdList)(nil),                                             // 988: forge.OperatingSystemIdList
-	(*OperatingSystemsByIdsRequest)(nil),                                      // 989: forge.OperatingSystemsByIdsRequest
-	(*OperatingSystemList)(nil),                                               // 990: forge.OperatingSystemList
-	(*GetOperatingSystemCachableIpxeTemplateArtifactsRequest)(nil),            // 991: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	(*IpxeTemplateArtifactList)(nil),                                          // 992: forge.IpxeTemplateArtifactList
-	(*IpxeTemplateArtifactUpdateRequest)(nil),                                 // 993: forge.IpxeTemplateArtifactUpdateRequest
-	(*UpdateOperatingSystemIpxeTemplateArtifactRequest)(nil),                  // 994: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	(*ReWrapSecretsRequest)(nil),                                              // 995: forge.ReWrapSecretsRequest
-	(*ReWrapSecretsResponse)(nil),                                             // 996: forge.ReWrapSecretsResponse
-	(*GetMachineBootInterfacesRequest)(nil),                                   // 997: forge.GetMachineBootInterfacesRequest
-	(*MachineBootInterface)(nil),                                              // 998: forge.MachineBootInterface
-	(*MachineInterfaceBootInterface)(nil),                                     // 999: forge.MachineInterfaceBootInterface
-	(*PredictedBootInterface)(nil),                                            // 1000: forge.PredictedBootInterface
-	(*ExploredBootInterface)(nil),                                             // 1001: forge.ExploredBootInterface
-	(*RetainedBootInterface)(nil),                                             // 1002: forge.RetainedBootInterface
-	(*GetMachineBootInterfacesResponse)(nil),                                  // 1003: forge.GetMachineBootInterfacesResponse
-	(*GetContainerRegistryCredentialRequest)(nil),                             // 1004: forge.GetContainerRegistryCredentialRequest
-	(*GetContainerRegistryCredentialResponse)(nil),                            // 1005: forge.GetContainerRegistryCredentialResponse
-	(*SetContainerRegistryCredentialRequest)(nil),                             // 1006: forge.SetContainerRegistryCredentialRequest
-	(*SitePrefix)(nil),                                                        // 1007: forge.SitePrefix
-	(*SitePrefixConfig)(nil),                                                  // 1008: forge.SitePrefixConfig
-	(*SitePrefixStatus)(nil),                                                  // 1009: forge.SitePrefixStatus
-	(*SitePrefixQuotaUsage)(nil),                                              // 1010: forge.SitePrefixQuotaUsage
-	(*SitePrefixCreationRequest)(nil),                                         // 1011: forge.SitePrefixCreationRequest
-	(*SitePrefixUpdateRequest)(nil),                                           // 1012: forge.SitePrefixUpdateRequest
-	(*SitePrefixDeletionRequest)(nil),                                         // 1013: forge.SitePrefixDeletionRequest
-	(*SitePrefixDeletionResult)(nil),                                          // 1014: forge.SitePrefixDeletionResult
-	(*SitePrefixStateHistoriesRequest)(nil),                                   // 1015: forge.SitePrefixStateHistoriesRequest
-	(*SitePrefixSearchFilter)(nil),                                            // 1016: forge.SitePrefixSearchFilter
-	(*SitePrefixesByIdsRequest)(nil),                                          // 1017: forge.SitePrefixesByIdsRequest
-	(*SitePrefixIdList)(nil),                                                  // 1018: forge.SitePrefixIdList
-	(*SitePrefixList)(nil),                                                    // 1019: forge.SitePrefixList
-	(*InterfaceAddressConfig)(nil),                                            // 1020: forge.InterfaceAddressConfig
-	(*VpcReleaseInactiveVniRequest)(nil),                                      // 1021: forge.VpcReleaseInactiveVniRequest
-	(*VpcReleaseInactiveVniResult)(nil),                                       // 1022: forge.VpcReleaseInactiveVniResult
-	(*VpcRoutingStateRequest)(nil),                                            // 1023: forge.VpcRoutingStateRequest
-	(*VpcRoutingState)(nil),                                                   // 1024: forge.VpcRoutingState
-	(*VpcRetainedVniAllocation)(nil),                                          // 1025: forge.VpcRetainedVniAllocation
-	(*VpcChangeRoutingProfileRequest)(nil),                                    // 1026: forge.VpcChangeRoutingProfileRequest
-	nil,                                                                       // 1027: forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
-	(*DNSMessage_DNSQuestion)(nil),                                            // 1028: forge.DNSMessage.DNSQuestion
-	(*DNSMessage_DNSResponse)(nil),                                            // 1029: forge.DNSMessage.DNSResponse
-	(*DNSMessage_DNSResponse_DNSRR)(nil),                                      // 1030: forge.DNSMessage.DNSResponse.DNSRR
-	nil,                                                                       // 1031: forge.FabricManagerConfig.ConfigMapEntry
-	nil,                                                                       // 1032: forge.StateHistories.HistoriesEntry
-	nil,                                                                       // 1033: forge.MachineStateHistories.HistoriesEntry
-	nil,                                                                       // 1034: forge.HealthHistories.HistoriesEntry
-	(*MachineCredentialsUpdateRequest_Credentials)(nil),                       // 1035: forge.MachineCredentialsUpdateRequest.Credentials
-	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo)(nil),              // 1036: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
-	(*ForgeAgentControlResponse_Noop)(nil),                                    // 1037: forge.ForgeAgentControlResponse.Noop
-	(*ForgeAgentControlResponse_Reset)(nil),                                   // 1038: forge.ForgeAgentControlResponse.Reset
-	(*ForgeAgentControlResponse_Discovery)(nil),                               // 1039: forge.ForgeAgentControlResponse.Discovery
-	(*ForgeAgentControlResponse_Rebuild)(nil),                                 // 1040: forge.ForgeAgentControlResponse.Rebuild
-	(*ForgeAgentControlResponse_Retry)(nil),                                   // 1041: forge.ForgeAgentControlResponse.Retry
-	(*ForgeAgentControlResponse_Measure)(nil),                                 // 1042: forge.ForgeAgentControlResponse.Measure
-	(*ForgeAgentControlResponse_LogError)(nil),                                // 1043: forge.ForgeAgentControlResponse.LogError
-	(*ForgeAgentControlResponse_MachineValidation)(nil),                       // 1044: forge.ForgeAgentControlResponse.MachineValidation
-	(*ForgeAgentControlResponse_MachineValidationFilter)(nil),                 // 1045: forge.ForgeAgentControlResponse.MachineValidationFilter
-	(*ForgeAgentControlResponse_MlxAction)(nil),                               // 1046: forge.ForgeAgentControlResponse.MlxAction
-	(*ForgeAgentControlResponse_MlxDeviceAction)(nil),                         // 1047: forge.ForgeAgentControlResponse.MlxDeviceAction
-	(*ForgeAgentControlResponse_MlxDeviceNoop)(nil),                           // 1048: forge.ForgeAgentControlResponse.MlxDeviceNoop
-	(*ForgeAgentControlResponse_MlxDeviceLock)(nil),                           // 1049: forge.ForgeAgentControlResponse.MlxDeviceLock
-	(*ForgeAgentControlResponse_MlxDeviceUnlock)(nil),                         // 1050: forge.ForgeAgentControlResponse.MlxDeviceUnlock
-	(*ForgeAgentControlResponse_MlxDeviceApplyProfile)(nil),                   // 1051: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
-	(*ForgeAgentControlResponse_MlxDeviceApplyFirmware)(nil),                  // 1052: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
-	(*ForgeAgentControlResponse_FirmwareUpgrade)(nil),                         // 1053: forge.ForgeAgentControlResponse.FirmwareUpgrade
-	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair)(nil), // 1054: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
-	(*MachineCleanupInfo_CleanupStepResult)(nil),                              // 1055: forge.MachineCleanupInfo.CleanupStepResult
-	(*DpuReprovisioningListResponse_DpuReprovisioningListItem)(nil),           // 1056: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
-	(*HostReprovisioningListResponse_HostReprovisioningListItem)(nil),         // 1057: forge.HostReprovisioningListResponse.HostReprovisioningListItem
-	(*MachineValidationTestUpdateRequest_Payload)(nil),                        // 1058: forge.MachineValidationTestUpdateRequest.Payload
-	nil,                               // 1059: forge.RedfishBrowseResponse.HeadersEntry
-	nil,                               // 1060: forge.RedfishActionResult.HeadersEntry
-	nil,                               // 1061: forge.UfmBrowseResponse.HeadersEntry
-	nil,                               // 1062: forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
-	nil,                               // 1063: forge.NmxcBrowseResponse.HeadersEntry
-	(*DPFStateResponse_DPFState)(nil), // 1064: forge.DPFStateResponse.DPFState
-	(*GetMachineBootInterfacesResponse_Reconciliation)(nil), // 1065: forge.GetMachineBootInterfacesResponse.Reconciliation
-	(*MachineId)(nil),                                    // 1066: common.MachineId
-	(*timestamppb.Timestamp)(nil),                        // 1067: google.protobuf.Timestamp
-	(*VpcId)(nil),                                        // 1068: common.VpcId
-	(*RouteTargets)(nil),                                 // 1069: common.RouteTargets
-	(*RouteTarget)(nil),                                  // 1070: common.RouteTarget
-	(*NVLinkLogicalPartitionId)(nil),                     // 1071: common.NVLinkLogicalPartitionId
-	(*VpcPrefixId)(nil),                                  // 1072: common.VpcPrefixId
-	(*SitePrefixId)(nil),                                 // 1073: common.SitePrefixId
-	(*VpcPeeringId)(nil),                                 // 1074: common.VpcPeeringId
-	(*IBPartitionId)(nil),                                // 1075: common.IBPartitionId
-	(*HealthReport)(nil),                                 // 1076: health.HealthReport
-	(*PowerShelfId)(nil),                                 // 1077: common.PowerShelfId
-	(*RackId)(nil),                                       // 1078: common.RackId
-	(*UUID)(nil),                                         // 1079: common.UUID
-	(*SwitchId)(nil),                                     // 1080: common.SwitchId
-	(*NVLinkDomainId)(nil),                               // 1081: common.NVLinkDomainId
-	(*RackProfileId)(nil),                                // 1082: common.RackProfileId
-	(*DomainId)(nil),                                     // 1083: common.DomainId
-	(*NetworkSegmentId)(nil),                             // 1084: common.NetworkSegmentId
-	(*NetworkPrefixId)(nil),                              // 1085: common.NetworkPrefixId
-	(*InstanceId)(nil),                                   // 1086: common.InstanceId
-	(*IpxeTemplateId)(nil),                               // 1087: common.IpxeTemplateId
-	(*OperatingSystemId)(nil),                            // 1088: common.OperatingSystemId
-	(*SpxPartitionId)(nil),                               // 1089: common.SpxPartitionId
-	(*MachineInterfaceId)(nil),                           // 1090: common.MachineInterfaceId
-	(*DiscoveryInfo)(nil),                                // 1091: machine_discovery.DiscoveryInfo
-	(*durationpb.Duration)(nil),                          // 1092: google.protobuf.Duration
-	(*StringList)(nil),                                   // 1093: common.StringList
-	(*Gpu)(nil),                                          // 1094: machine_discovery.Gpu
-	(*DeviceId)(nil),                                     // 1095: common.DeviceId
-	(*MachineValidationId)(nil),                          // 1096: common.MachineValidationId
-	(*Uint32List)(nil),                                   // 1097: common.Uint32List
-	(*DpaInterfaceId)(nil),                               // 1098: common.DpaInterfaceId
-	(*ComputeAllocationId)(nil),                          // 1099: common.ComputeAllocationId
-	(*RackHardwareType)(nil),                             // 1100: common.RackHardwareType
-	(*NVLinkPartitionId)(nil),                            // 1101: common.NVLinkPartitionId
-	(*RemediationId)(nil),                                // 1102: common.RemediationId
-	(*MlxDeviceLockdownResponse)(nil),                    // 1103: mlx_device.MlxDeviceLockdownResponse
-	(*MlxDeviceProfileSyncResponse)(nil),                 // 1104: mlx_device.MlxDeviceProfileSyncResponse
-	(*MlxDeviceProfileCompareResponse)(nil),              // 1105: mlx_device.MlxDeviceProfileCompareResponse
-	(*MlxDeviceInfoDeviceResponse)(nil),                  // 1106: mlx_device.MlxDeviceInfoDeviceResponse
-	(*MlxDeviceInfoReportResponse)(nil),                  // 1107: mlx_device.MlxDeviceInfoReportResponse
-	(*MlxDeviceRegistryListResponse)(nil),                // 1108: mlx_device.MlxDeviceRegistryListResponse
-	(*MlxDeviceRegistryShowResponse)(nil),                // 1109: mlx_device.MlxDeviceRegistryShowResponse
-	(*MlxDeviceConfigQueryResponse)(nil),                 // 1110: mlx_device.MlxDeviceConfigQueryResponse
-	(*MlxDeviceConfigSetResponse)(nil),                   // 1111: mlx_device.MlxDeviceConfigSetResponse
-	(*MlxDeviceConfigSyncResponse)(nil),                  // 1112: mlx_device.MlxDeviceConfigSyncResponse
-	(*MlxDeviceConfigCompareResponse)(nil),               // 1113: mlx_device.MlxDeviceConfigCompareResponse
-	(*MlxDeviceLockdownLockRequest)(nil),                 // 1114: mlx_device.MlxDeviceLockdownLockRequest
-	(*MlxDeviceLockdownUnlockRequest)(nil),               // 1115: mlx_device.MlxDeviceLockdownUnlockRequest
-	(*MlxDeviceLockdownStatusRequest)(nil),               // 1116: mlx_device.MlxDeviceLockdownStatusRequest
-	(*MlxDeviceProfileSyncRequest)(nil),                  // 1117: mlx_device.MlxDeviceProfileSyncRequest
-	(*MlxDeviceProfileCompareRequest)(nil),               // 1118: mlx_device.MlxDeviceProfileCompareRequest
-	(*MlxDeviceInfoDeviceRequest)(nil),                   // 1119: mlx_device.MlxDeviceInfoDeviceRequest
-	(*MlxDeviceInfoReportRequest)(nil),                   // 1120: mlx_device.MlxDeviceInfoReportRequest
-	(*MlxDeviceRegistryListRequest)(nil),                 // 1121: mlx_device.MlxDeviceRegistryListRequest
-	(*MlxDeviceRegistryShowRequest)(nil),                 // 1122: mlx_device.MlxDeviceRegistryShowRequest
-	(*MlxDeviceConfigQueryRequest)(nil),                  // 1123: mlx_device.MlxDeviceConfigQueryRequest
-	(*MlxDeviceConfigSetRequest)(nil),                    // 1124: mlx_device.MlxDeviceConfigSetRequest
-	(*MlxDeviceConfigSyncRequest)(nil),                   // 1125: mlx_device.MlxDeviceConfigSyncRequest
-	(*MlxDeviceConfigCompareRequest)(nil),                // 1126: mlx_device.MlxDeviceConfigCompareRequest
-	(*Domain)(nil),                                       // 1127: dns.Domain
-	(*MachineIdList)(nil),                                // 1128: common.MachineIdList
-	(*EndpointExplorationReport)(nil),                    // 1129: site_explorer.EndpointExplorationReport
-	(SystemPowerControl)(0),                              // 1130: common.SystemPowerControl
-	(*SerializableMlxConfigProfile)(nil),                 // 1131: mlx_device.SerializableMlxConfigProfile
-	(*FirmwareFlasherProfile)(nil),                       // 1132: mlx_device.FirmwareFlasherProfile
-	(*ScoutFirmwareUpgradeTask)(nil),                     // 1133: scout_firmware_upgrade.ScoutFirmwareUpgradeTask
-	(*CreateDomainRequest)(nil),                          // 1134: dns.CreateDomainRequest
-	(*UpdateDomainRequest)(nil),                          // 1135: dns.UpdateDomainRequest
-	(*DomainDeletionRequest)(nil),                        // 1136: dns.DomainDeletionRequest
-	(*DomainSearchQuery)(nil),                            // 1137: dns.DomainSearchQuery
-	(*DnsResourceRecordLookupRequest)(nil),               // 1138: dns.DnsResourceRecordLookupRequest
-	(*GetAllDomainsRequest)(nil),                         // 1139: dns.GetAllDomainsRequest
-	(*DomainMetadataRequest)(nil),                        // 1140: dns.DomainMetadataRequest
-	(*emptypb.Empty)(nil),                                // 1141: google.protobuf.Empty
-	(*ExploredEndpointSearchFilter)(nil),                 // 1142: site_explorer.ExploredEndpointSearchFilter
-	(*ExploredEndpointsByIdsRequest)(nil),                // 1143: site_explorer.ExploredEndpointsByIdsRequest
-	(*ExploredManagedHostSearchFilter)(nil),              // 1144: site_explorer.ExploredManagedHostSearchFilter
-	(*ExploredManagedHostsByIdsRequest)(nil),             // 1145: site_explorer.ExploredManagedHostsByIdsRequest
-	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1146: site_explorer.ExploredMlxDeviceHostSearchFilter
-	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1147: site_explorer.ExploredMlxDevicesByIdsRequest
-	(*CreateMeasurementBundleRequest)(nil),               // 1148: measured_boot.CreateMeasurementBundleRequest
-	(*DeleteMeasurementBundleRequest)(nil),               // 1149: measured_boot.DeleteMeasurementBundleRequest
-	(*RenameMeasurementBundleRequest)(nil),               // 1150: measured_boot.RenameMeasurementBundleRequest
-	(*UpdateMeasurementBundleRequest)(nil),               // 1151: measured_boot.UpdateMeasurementBundleRequest
-	(*ShowMeasurementBundleRequest)(nil),                 // 1152: measured_boot.ShowMeasurementBundleRequest
-	(*ShowMeasurementBundlesRequest)(nil),                // 1153: measured_boot.ShowMeasurementBundlesRequest
-	(*ListMeasurementBundlesRequest)(nil),                // 1154: measured_boot.ListMeasurementBundlesRequest
-	(*ListMeasurementBundleMachinesRequest)(nil),         // 1155: measured_boot.ListMeasurementBundleMachinesRequest
-	(*FindClosestBundleMatchRequest)(nil),                // 1156: measured_boot.FindClosestBundleMatchRequest
-	(*DeleteMeasurementJournalRequest)(nil),              // 1157: measured_boot.DeleteMeasurementJournalRequest
-	(*ShowMeasurementJournalRequest)(nil),                // 1158: measured_boot.ShowMeasurementJournalRequest
-	(*ShowMeasurementJournalsRequest)(nil),               // 1159: measured_boot.ShowMeasurementJournalsRequest
-	(*ListMeasurementJournalRequest)(nil),                // 1160: measured_boot.ListMeasurementJournalRequest
-	(*AttestCandidateMachineRequest)(nil),                // 1161: measured_boot.AttestCandidateMachineRequest
-	(*ShowCandidateMachineRequest)(nil),                  // 1162: measured_boot.ShowCandidateMachineRequest
-	(*ShowCandidateMachinesRequest)(nil),                 // 1163: measured_boot.ShowCandidateMachinesRequest
-	(*ListCandidateMachinesRequest)(nil),                 // 1164: measured_boot.ListCandidateMachinesRequest
-	(*CreateMeasurementSystemProfileRequest)(nil),        // 1165: measured_boot.CreateMeasurementSystemProfileRequest
-	(*DeleteMeasurementSystemProfileRequest)(nil),        // 1166: measured_boot.DeleteMeasurementSystemProfileRequest
-	(*RenameMeasurementSystemProfileRequest)(nil),        // 1167: measured_boot.RenameMeasurementSystemProfileRequest
-	(*ShowMeasurementSystemProfileRequest)(nil),          // 1168: measured_boot.ShowMeasurementSystemProfileRequest
-	(*ShowMeasurementSystemProfilesRequest)(nil),         // 1169: measured_boot.ShowMeasurementSystemProfilesRequest
-	(*ListMeasurementSystemProfilesRequest)(nil),         // 1170: measured_boot.ListMeasurementSystemProfilesRequest
-	(*ListMeasurementSystemProfileBundlesRequest)(nil),   // 1171: measured_boot.ListMeasurementSystemProfileBundlesRequest
-	(*ListMeasurementSystemProfileMachinesRequest)(nil),  // 1172: measured_boot.ListMeasurementSystemProfileMachinesRequest
-	(*CreateMeasurementReportRequest)(nil),               // 1173: measured_boot.CreateMeasurementReportRequest
-	(*DeleteMeasurementReportRequest)(nil),               // 1174: measured_boot.DeleteMeasurementReportRequest
-	(*PromoteMeasurementReportRequest)(nil),              // 1175: measured_boot.PromoteMeasurementReportRequest
-	(*RevokeMeasurementReportRequest)(nil),               // 1176: measured_boot.RevokeMeasurementReportRequest
-	(*ShowMeasurementReportForIdRequest)(nil),            // 1177: measured_boot.ShowMeasurementReportForIdRequest
-	(*ShowMeasurementReportsForMachineRequest)(nil),      // 1178: measured_boot.ShowMeasurementReportsForMachineRequest
-	(*ShowMeasurementReportsRequest)(nil),                // 1179: measured_boot.ShowMeasurementReportsRequest
-	(*ListMeasurementReportRequest)(nil),                 // 1180: measured_boot.ListMeasurementReportRequest
-	(*MatchMeasurementReportRequest)(nil),                // 1181: measured_boot.MatchMeasurementReportRequest
-	(*ImportSiteMeasurementsRequest)(nil),                // 1182: measured_boot.ImportSiteMeasurementsRequest
-	(*ExportSiteMeasurementsRequest)(nil),                // 1183: measured_boot.ExportSiteMeasurementsRequest
-	(*AddMeasurementTrustedMachineRequest)(nil),          // 1184: measured_boot.AddMeasurementTrustedMachineRequest
-	(*RemoveMeasurementTrustedMachineRequest)(nil),       // 1185: measured_boot.RemoveMeasurementTrustedMachineRequest
-	(*AddMeasurementTrustedProfileRequest)(nil),          // 1186: measured_boot.AddMeasurementTrustedProfileRequest
-	(*RemoveMeasurementTrustedProfileRequest)(nil),       // 1187: measured_boot.RemoveMeasurementTrustedProfileRequest
-	(*ListMeasurementTrustedMachinesRequest)(nil),        // 1188: measured_boot.ListMeasurementTrustedMachinesRequest
-	(*ListMeasurementTrustedProfilesRequest)(nil),        // 1189: measured_boot.ListMeasurementTrustedProfilesRequest
-	(*ListAttestationSummaryRequest)(nil),                // 1190: measured_boot.ListAttestationSummaryRequest
-	(*PublishMlxDeviceReportRequest)(nil),                // 1191: mlx_device.PublishMlxDeviceReportRequest
-	(*PublishMlxObservationReportRequest)(nil),           // 1192: mlx_device.PublishMlxObservationReportRequest
-	(*MlxAdminProfileSyncRequest)(nil),                   // 1193: mlx_device.MlxAdminProfileSyncRequest
-	(*MlxAdminProfileShowRequest)(nil),                   // 1194: mlx_device.MlxAdminProfileShowRequest
-	(*MlxAdminProfileCompareRequest)(nil),                // 1195: mlx_device.MlxAdminProfileCompareRequest
-	(*MlxAdminProfileListRequest)(nil),                   // 1196: mlx_device.MlxAdminProfileListRequest
-	(*MlxAdminLockdownLockRequest)(nil),                  // 1197: mlx_device.MlxAdminLockdownLockRequest
-	(*MlxAdminLockdownUnlockRequest)(nil),                // 1198: mlx_device.MlxAdminLockdownUnlockRequest
-	(*MlxAdminLockdownStatusRequest)(nil),                // 1199: mlx_device.MlxAdminLockdownStatusRequest
-	(*MlxAdminDeviceInfoRequest)(nil),                    // 1200: mlx_device.MlxAdminDeviceInfoRequest
-	(*MlxAdminDeviceReportRequest)(nil),                  // 1201: mlx_device.MlxAdminDeviceReportRequest
-	(*MlxAdminRegistryListRequest)(nil),                  // 1202: mlx_device.MlxAdminRegistryListRequest
-	(*MlxAdminRegistryShowRequest)(nil),                  // 1203: mlx_device.MlxAdminRegistryShowRequest
-	(*MlxAdminConfigQueryRequest)(nil),                   // 1204: mlx_device.MlxAdminConfigQueryRequest
-	(*MlxAdminConfigSetRequest)(nil),                     // 1205: mlx_device.MlxAdminConfigSetRequest
-	(*MlxAdminConfigSyncRequest)(nil),                    // 1206: mlx_device.MlxAdminConfigSyncRequest
-	(*MlxAdminConfigCompareRequest)(nil),                 // 1207: mlx_device.MlxAdminConfigCompareRequest
-	(*DomainDeletionResult)(nil),                         // 1208: dns.DomainDeletionResult
-	(*DomainList)(nil),                                   // 1209: dns.DomainList
-	(*DnsResourceRecordLookupResponse)(nil),              // 1210: dns.DnsResourceRecordLookupResponse
-	(*GetAllDomainsResponse)(nil),                        // 1211: dns.GetAllDomainsResponse
-	(*DomainMetadataResponse)(nil),                       // 1212: dns.DomainMetadataResponse
-	(*SiteExplorationReport)(nil),                        // 1213: site_explorer.SiteExplorationReport
-	(*SiteExplorerLastRunResponse)(nil),                  // 1214: site_explorer.SiteExplorerLastRunResponse
-	(*ExploredEndpoint)(nil),                             // 1215: site_explorer.ExploredEndpoint
-	(*ExploredEndpointIdList)(nil),                       // 1216: site_explorer.ExploredEndpointIdList
-	(*ExploredEndpointList)(nil),                         // 1217: site_explorer.ExploredEndpointList
-	(*ExploredManagedHostIdList)(nil),                    // 1218: site_explorer.ExploredManagedHostIdList
-	(*ExploredManagedHostList)(nil),                      // 1219: site_explorer.ExploredManagedHostList
-	(*ExploredMlxDeviceHostIdList)(nil),                  // 1220: site_explorer.ExploredMlxDeviceHostIdList
-	(*ExploredMlxDeviceList)(nil),                        // 1221: site_explorer.ExploredMlxDeviceList
-	(*CreateMeasurementBundleResponse)(nil),              // 1222: measured_boot.CreateMeasurementBundleResponse
-	(*DeleteMeasurementBundleResponse)(nil),              // 1223: measured_boot.DeleteMeasurementBundleResponse
-	(*RenameMeasurementBundleResponse)(nil),              // 1224: measured_boot.RenameMeasurementBundleResponse
-	(*UpdateMeasurementBundleResponse)(nil),              // 1225: measured_boot.UpdateMeasurementBundleResponse
-	(*ShowMeasurementBundleResponse)(nil),                // 1226: measured_boot.ShowMeasurementBundleResponse
-	(*ShowMeasurementBundlesResponse)(nil),               // 1227: measured_boot.ShowMeasurementBundlesResponse
-	(*ListMeasurementBundlesResponse)(nil),               // 1228: measured_boot.ListMeasurementBundlesResponse
-	(*ListMeasurementBundleMachinesResponse)(nil),        // 1229: measured_boot.ListMeasurementBundleMachinesResponse
-	(*DeleteMeasurementJournalResponse)(nil),             // 1230: measured_boot.DeleteMeasurementJournalResponse
-	(*ShowMeasurementJournalResponse)(nil),               // 1231: measured_boot.ShowMeasurementJournalResponse
-	(*ShowMeasurementJournalsResponse)(nil),              // 1232: measured_boot.ShowMeasurementJournalsResponse
-	(*ListMeasurementJournalResponse)(nil),               // 1233: measured_boot.ListMeasurementJournalResponse
-	(*AttestCandidateMachineResponse)(nil),               // 1234: measured_boot.AttestCandidateMachineResponse
-	(*ShowCandidateMachineResponse)(nil),                 // 1235: measured_boot.ShowCandidateMachineResponse
-	(*ShowCandidateMachinesResponse)(nil),                // 1236: measured_boot.ShowCandidateMachinesResponse
-	(*ListCandidateMachinesResponse)(nil),                // 1237: measured_boot.ListCandidateMachinesResponse
-	(*CreateMeasurementSystemProfileResponse)(nil),       // 1238: measured_boot.CreateMeasurementSystemProfileResponse
-	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1239: measured_boot.DeleteMeasurementSystemProfileResponse
-	(*RenameMeasurementSystemProfileResponse)(nil),       // 1240: measured_boot.RenameMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfileResponse)(nil),         // 1241: measured_boot.ShowMeasurementSystemProfileResponse
-	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1242: measured_boot.ShowMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfilesResponse)(nil),        // 1243: measured_boot.ListMeasurementSystemProfilesResponse
-	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1244: measured_boot.ListMeasurementSystemProfileBundlesResponse
-	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1245: measured_boot.ListMeasurementSystemProfileMachinesResponse
-	(*CreateMeasurementReportResponse)(nil),              // 1246: measured_boot.CreateMeasurementReportResponse
-	(*DeleteMeasurementReportResponse)(nil),              // 1247: measured_boot.DeleteMeasurementReportResponse
-	(*PromoteMeasurementReportResponse)(nil),             // 1248: measured_boot.PromoteMeasurementReportResponse
-	(*RevokeMeasurementReportResponse)(nil),              // 1249: measured_boot.RevokeMeasurementReportResponse
-	(*ShowMeasurementReportForIdResponse)(nil),           // 1250: measured_boot.ShowMeasurementReportForIdResponse
-	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1251: measured_boot.ShowMeasurementReportsForMachineResponse
-	(*ShowMeasurementReportsResponse)(nil),               // 1252: measured_boot.ShowMeasurementReportsResponse
-	(*ListMeasurementReportResponse)(nil),                // 1253: measured_boot.ListMeasurementReportResponse
-	(*MatchMeasurementReportResponse)(nil),               // 1254: measured_boot.MatchMeasurementReportResponse
-	(*ImportSiteMeasurementsResponse)(nil),               // 1255: measured_boot.ImportSiteMeasurementsResponse
-	(*ExportSiteMeasurementsResponse)(nil),               // 1256: measured_boot.ExportSiteMeasurementsResponse
-	(*AddMeasurementTrustedMachineResponse)(nil),         // 1257: measured_boot.AddMeasurementTrustedMachineResponse
-	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1258: measured_boot.RemoveMeasurementTrustedMachineResponse
-	(*AddMeasurementTrustedProfileResponse)(nil),         // 1259: measured_boot.AddMeasurementTrustedProfileResponse
-	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1260: measured_boot.RemoveMeasurementTrustedProfileResponse
-	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1261: measured_boot.ListMeasurementTrustedMachinesResponse
-	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1262: measured_boot.ListMeasurementTrustedProfilesResponse
-	(*ListAttestationSummaryResponse)(nil),               // 1263: measured_boot.ListAttestationSummaryResponse
-	(*LockdownStatus)(nil),                               // 1264: site_explorer.LockdownStatus
-	(*PublishMlxDeviceReportResponse)(nil),               // 1265: mlx_device.PublishMlxDeviceReportResponse
-	(*PublishMlxObservationReportResponse)(nil),          // 1266: mlx_device.PublishMlxObservationReportResponse
-	(*MlxAdminProfileSyncResponse)(nil),                  // 1267: mlx_device.MlxAdminProfileSyncResponse
-	(*MlxAdminProfileShowResponse)(nil),                  // 1268: mlx_device.MlxAdminProfileShowResponse
-	(*MlxAdminProfileCompareResponse)(nil),               // 1269: mlx_device.MlxAdminProfileCompareResponse
-	(*MlxAdminProfileListResponse)(nil),                  // 1270: mlx_device.MlxAdminProfileListResponse
-	(*MlxAdminLockdownLockResponse)(nil),                 // 1271: mlx_device.MlxAdminLockdownLockResponse
-	(*MlxAdminLockdownUnlockResponse)(nil),               // 1272: mlx_device.MlxAdminLockdownUnlockResponse
-	(*MlxAdminLockdownStatusResponse)(nil),               // 1273: mlx_device.MlxAdminLockdownStatusResponse
-	(*MlxAdminDeviceInfoResponse)(nil),                   // 1274: mlx_device.MlxAdminDeviceInfoResponse
-	(*MlxAdminDeviceReportResponse)(nil),                 // 1275: mlx_device.MlxAdminDeviceReportResponse
-	(*MlxAdminRegistryListResponse)(nil),                 // 1276: mlx_device.MlxAdminRegistryListResponse
-	(*MlxAdminRegistryShowResponse)(nil),                 // 1277: mlx_device.MlxAdminRegistryShowResponse
-	(*MlxAdminConfigQueryResponse)(nil),                  // 1278: mlx_device.MlxAdminConfigQueryResponse
-	(*MlxAdminConfigSetResponse)(nil),                    // 1279: mlx_device.MlxAdminConfigSetResponse
-	(*MlxAdminConfigSyncResponse)(nil),                   // 1280: mlx_device.MlxAdminConfigSyncResponse
-	(*MlxAdminConfigCompareResponse)(nil),                // 1281: mlx_device.MlxAdminConfigCompareResponse
+	(ManagedHostResetRequest_Mode)(0),                                         // 109: forge.ManagedHostResetRequest.Mode
+	(*LifecycleStatus)(nil),                                                   // 110: forge.LifecycleStatus
+	(*SpdmMachineAttestationStatus)(nil),                                      // 111: forge.SpdmMachineAttestationStatus
+	(*SpdmMachineAttestationTriggerResponse)(nil),                             // 112: forge.SpdmMachineAttestationTriggerResponse
+	(*SpdmAttestationDetails)(nil),                                            // 113: forge.SpdmAttestationDetails
+	(*SpdmGetAttestationMachineResponse)(nil),                                 // 114: forge.SpdmGetAttestationMachineResponse
+	(*SpdmMachineAttestationTriggerRequest)(nil),                              // 115: forge.SpdmMachineAttestationTriggerRequest
+	(*SpdmListAttestationMachinesRequest)(nil),                                // 116: forge.SpdmListAttestationMachinesRequest
+	(*SpdmListAttestationMachinesResponse)(nil),                               // 117: forge.SpdmListAttestationMachinesResponse
+	(*MachineIdentityRequest)(nil),                                            // 118: forge.MachineIdentityRequest
+	(*MachineIdentityResponse)(nil),                                           // 119: forge.MachineIdentityResponse
+	(*GetTenantIdentityConfigRequest)(nil),                                    // 120: forge.GetTenantIdentityConfigRequest
+	(*TenantIdentitySigningKey)(nil),                                          // 121: forge.TenantIdentitySigningKey
+	(*TenantIdentityConfig)(nil),                                              // 122: forge.TenantIdentityConfig
+	(*SetTenantIdentityConfigRequest)(nil),                                    // 123: forge.SetTenantIdentityConfigRequest
+	(*TenantIdentityConfigResponse)(nil),                                      // 124: forge.TenantIdentityConfigResponse
+	(*ClientSecretBasic)(nil),                                                 // 125: forge.ClientSecretBasic
+	(*ClientSecretBasicResponse)(nil),                                         // 126: forge.ClientSecretBasicResponse
+	(*TokenDelegationResponse)(nil),                                           // 127: forge.TokenDelegationResponse
+	(*GetTokenDelegationRequest)(nil),                                         // 128: forge.GetTokenDelegationRequest
+	(*TokenDelegation)(nil),                                                   // 129: forge.TokenDelegation
+	(*TokenDelegationRequest)(nil),                                            // 130: forge.TokenDelegationRequest
+	(*ReencryptTenantIdentitySecretsRequest)(nil),                             // 131: forge.ReencryptTenantIdentitySecretsRequest
+	(*ReencryptTenantIdentityFailure)(nil),                                    // 132: forge.ReencryptTenantIdentityFailure
+	(*ReencryptTenantIdentitySecretsResponse)(nil),                            // 133: forge.ReencryptTenantIdentitySecretsResponse
+	(*Jwks)(nil),                                                              // 134: forge.Jwks
+	(*OpenIdConfiguration)(nil),                                               // 135: forge.OpenIdConfiguration
+	(*JwksRequest)(nil),                                                       // 136: forge.JwksRequest
+	(*OpenIdConfigRequest)(nil),                                               // 137: forge.OpenIdConfigRequest
+	(*MachineIngestionStateResponse)(nil),                                     // 138: forge.MachineIngestionStateResponse
+	(*TpmCaAddedCaStatus)(nil),                                                // 139: forge.TpmCaAddedCaStatus
+	(*TpmCaCertId)(nil),                                                       // 140: forge.TpmCaCertId
+	(*TpmEkCertStatus)(nil),                                                   // 141: forge.TpmEkCertStatus
+	(*TpmEkCertStatusCollection)(nil),                                         // 142: forge.TpmEkCertStatusCollection
+	(*TpmCaCert)(nil),                                                         // 143: forge.TpmCaCert
+	(*TpmCaCertDetail)(nil),                                                   // 144: forge.TpmCaCertDetail
+	(*TpmCaCertDetailCollection)(nil),                                         // 145: forge.TpmCaCertDetailCollection
+	(*AttestKeyBindChallenge)(nil),                                            // 146: forge.AttestKeyBindChallenge
+	(*AttestQuoteRequest)(nil),                                                // 147: forge.AttestQuoteRequest
+	(*AttestQuoteResponse)(nil),                                               // 148: forge.AttestQuoteResponse
+	(*CredentialCreationRequest)(nil),                                         // 149: forge.CredentialCreationRequest
+	(*CredentialDeletionRequest)(nil),                                         // 150: forge.CredentialDeletionRequest
+	(*CredentialCreationResult)(nil),                                          // 151: forge.CredentialCreationResult
+	(*CredentialDeletionResult)(nil),                                          // 152: forge.CredentialDeletionResult
+	(*RotateCredentialRequest)(nil),                                           // 153: forge.RotateCredentialRequest
+	(*RotateCredentialResult)(nil),                                            // 154: forge.RotateCredentialResult
+	(*CredentialRotationStatusRequest)(nil),                                   // 155: forge.CredentialRotationStatusRequest
+	(*DeviceCredentialRotationStatus)(nil),                                    // 156: forge.DeviceCredentialRotationStatus
+	(*CredentialRotationStatusResult)(nil),                                    // 157: forge.CredentialRotationStatusResult
+	(*VersionRequest)(nil),                                                    // 158: forge.VersionRequest
+	(*BuildInfo)(nil),                                                         // 159: forge.BuildInfo
+	(*RuntimeConfig)(nil),                                                     // 160: forge.RuntimeConfig
+	(*EchoRequest)(nil),                                                       // 161: forge.EchoRequest
+	(*EchoResponse)(nil),                                                      // 162: forge.EchoResponse
+	(*DNSMessage)(nil),                                                        // 163: forge.DNSMessage
+	(*DnsRequest)(nil),                                                        // 164: forge.DnsRequest
+	(*DnsReply)(nil),                                                          // 165: forge.DnsReply
+	(*ConsoleInput)(nil),                                                      // 166: forge.ConsoleInput
+	(*ConsoleOutput)(nil),                                                     // 167: forge.ConsoleOutput
+	(*InstanceEvent)(nil),                                                     // 168: forge.InstanceEvent
+	(*VpcSearchQuery)(nil),                                                    // 169: forge.VpcSearchQuery
+	(*VpcSearchFilter)(nil),                                                   // 170: forge.VpcSearchFilter
+	(*VpcIdList)(nil),                                                         // 171: forge.VpcIdList
+	(*VpcsByIdsRequest)(nil),                                                  // 172: forge.VpcsByIdsRequest
+	(*TenantSearchQuery)(nil),                                                 // 173: forge.TenantSearchQuery
+	(*PrefixFilterPolicyEntries)(nil),                                         // 174: forge.PrefixFilterPolicyEntries
+	(*VpcRoutingProfileOverrides)(nil),                                        // 175: forge.VpcRoutingProfileOverrides
+	(*VpcEffectiveRoutingProfile)(nil),                                        // 176: forge.VpcEffectiveRoutingProfile
+	(*VpcConfig)(nil),                                                         // 177: forge.VpcConfig
+	(*VpcStatus)(nil),                                                         // 178: forge.VpcStatus
+	(*Vpc)(nil),                                                               // 179: forge.Vpc
+	(*VpcCreationRequest)(nil),                                                // 180: forge.VpcCreationRequest
+	(*VpcUpdateRequest)(nil),                                                  // 181: forge.VpcUpdateRequest
+	(*VpcUpdateResult)(nil),                                                   // 182: forge.VpcUpdateResult
+	(*VpcUpdateVirtualizationRequest)(nil),                                    // 183: forge.VpcUpdateVirtualizationRequest
+	(*VpcUpdateVirtualizationResult)(nil),                                     // 184: forge.VpcUpdateVirtualizationResult
+	(*VpcDeletionRequest)(nil),                                                // 185: forge.VpcDeletionRequest
+	(*VpcDeletionResult)(nil),                                                 // 186: forge.VpcDeletionResult
+	(*VpcList)(nil),                                                           // 187: forge.VpcList
+	(*VpcPrefix)(nil),                                                         // 188: forge.VpcPrefix
+	(*VpcPrefixConfig)(nil),                                                   // 189: forge.VpcPrefixConfig
+	(*VpcPrefixStatus)(nil),                                                   // 190: forge.VpcPrefixStatus
+	(*VpcPrefixCreationRequest)(nil),                                          // 191: forge.VpcPrefixCreationRequest
+	(*VpcPrefixSearchQuery)(nil),                                              // 192: forge.VpcPrefixSearchQuery
+	(*VpcPrefixGetRequest)(nil),                                               // 193: forge.VpcPrefixGetRequest
+	(*VpcPrefixIdList)(nil),                                                   // 194: forge.VpcPrefixIdList
+	(*VpcPrefixList)(nil),                                                     // 195: forge.VpcPrefixList
+	(*VpcPrefixUpdateRequest)(nil),                                            // 196: forge.VpcPrefixUpdateRequest
+	(*VpcPrefixDeletionRequest)(nil),                                          // 197: forge.VpcPrefixDeletionRequest
+	(*VpcPrefixDeletionResult)(nil),                                           // 198: forge.VpcPrefixDeletionResult
+	(*VpcPrefixStateHistoriesRequest)(nil),                                    // 199: forge.VpcPrefixStateHistoriesRequest
+	(*VpcPeering)(nil),                                                        // 200: forge.VpcPeering
+	(*VpcPeeringIdList)(nil),                                                  // 201: forge.VpcPeeringIdList
+	(*VpcPeeringList)(nil),                                                    // 202: forge.VpcPeeringList
+	(*VpcPeeringCreationRequest)(nil),                                         // 203: forge.VpcPeeringCreationRequest
+	(*VpcPeeringSearchFilter)(nil),                                            // 204: forge.VpcPeeringSearchFilter
+	(*VpcPeeringsByIdsRequest)(nil),                                           // 205: forge.VpcPeeringsByIdsRequest
+	(*VpcPeeringDeletionRequest)(nil),                                         // 206: forge.VpcPeeringDeletionRequest
+	(*VpcPeeringDeletionResult)(nil),                                          // 207: forge.VpcPeeringDeletionResult
+	(*IBPartitionConfig)(nil),                                                 // 208: forge.IBPartitionConfig
+	(*IBPartitionStatus)(nil),                                                 // 209: forge.IBPartitionStatus
+	(*IBPartition)(nil),                                                       // 210: forge.IBPartition
+	(*IBPartitionList)(nil),                                                   // 211: forge.IBPartitionList
+	(*IBPartitionCreationRequest)(nil),                                        // 212: forge.IBPartitionCreationRequest
+	(*IBPartitionUpdateRequest)(nil),                                          // 213: forge.IBPartitionUpdateRequest
+	(*IBPartitionDeletionRequest)(nil),                                        // 214: forge.IBPartitionDeletionRequest
+	(*IBPartitionDeletionResult)(nil),                                         // 215: forge.IBPartitionDeletionResult
+	(*IBPartitionSearchFilter)(nil),                                           // 216: forge.IBPartitionSearchFilter
+	(*IBPartitionsByIdsRequest)(nil),                                          // 217: forge.IBPartitionsByIdsRequest
+	(*IBPartitionIdList)(nil),                                                 // 218: forge.IBPartitionIdList
+	(*PowerShelfConfig)(nil),                                                  // 219: forge.PowerShelfConfig
+	(*PowerShelfStatus)(nil),                                                  // 220: forge.PowerShelfStatus
+	(*PowerShelf)(nil),                                                        // 221: forge.PowerShelf
+	(*PowerShelfList)(nil),                                                    // 222: forge.PowerShelfList
+	(*PowerShelfCreationRequest)(nil),                                         // 223: forge.PowerShelfCreationRequest
+	(*DecommissionPowerShelfRequest)(nil),                                     // 224: forge.DecommissionPowerShelfRequest
+	(*DecommissionPowerShelfResponse)(nil),                                    // 225: forge.DecommissionPowerShelfResponse
+	(*PowerShelfDeletionRequest)(nil),                                         // 226: forge.PowerShelfDeletionRequest
+	(*PowerShelfDeletionResult)(nil),                                          // 227: forge.PowerShelfDeletionResult
+	(*PowerShelfMaintenanceRequest)(nil),                                      // 228: forge.PowerShelfMaintenanceRequest
+	(*PowerShelfStateHistoriesRequest)(nil),                                   // 229: forge.PowerShelfStateHistoriesRequest
+	(*PowerShelfHealthHistoriesRequest)(nil),                                  // 230: forge.PowerShelfHealthHistoriesRequest
+	(*PowerShelfQuery)(nil),                                                   // 231: forge.PowerShelfQuery
+	(*PowerShelfSearchFilter)(nil),                                            // 232: forge.PowerShelfSearchFilter
+	(*PowerShelvesByIdsRequest)(nil),                                          // 233: forge.PowerShelvesByIdsRequest
+	(*ExpectedPowerShelf)(nil),                                                // 234: forge.ExpectedPowerShelf
+	(*ExpectedPowerShelfRequest)(nil),                                         // 235: forge.ExpectedPowerShelfRequest
+	(*ExpectedPowerShelfList)(nil),                                            // 236: forge.ExpectedPowerShelfList
+	(*LinkedExpectedPowerShelfList)(nil),                                      // 237: forge.LinkedExpectedPowerShelfList
+	(*LinkedExpectedPowerShelf)(nil),                                          // 238: forge.LinkedExpectedPowerShelf
+	(*SwitchConfig)(nil),                                                      // 239: forge.SwitchConfig
+	(*FabricManagerConfig)(nil),                                               // 240: forge.FabricManagerConfig
+	(*FabricManagerStatus)(nil),                                               // 241: forge.FabricManagerStatus
+	(*SwitchStatus)(nil),                                                      // 242: forge.SwitchStatus
+	(*PlacementInRack)(nil),                                                   // 243: forge.PlacementInRack
+	(*Switch)(nil),                                                            // 244: forge.Switch
+	(*SwitchList)(nil),                                                        // 245: forge.SwitchList
+	(*SwitchCreationRequest)(nil),                                             // 246: forge.SwitchCreationRequest
+	(*SwitchDeletionRequest)(nil),                                             // 247: forge.SwitchDeletionRequest
+	(*SwitchDeletionResult)(nil),                                              // 248: forge.SwitchDeletionResult
+	(*DecommissionSwitchRequest)(nil),                                         // 249: forge.DecommissionSwitchRequest
+	(*DecommissionSwitchResponse)(nil),                                        // 250: forge.DecommissionSwitchResponse
+	(*StateHistoryRecord)(nil),                                                // 251: forge.StateHistoryRecord
+	(*StateHistoryRecords)(nil),                                               // 252: forge.StateHistoryRecords
+	(*SwitchStateHistoriesRequest)(nil),                                       // 253: forge.SwitchStateHistoriesRequest
+	(*SwitchHealthHistoriesRequest)(nil),                                      // 254: forge.SwitchHealthHistoriesRequest
+	(*StateHistories)(nil),                                                    // 255: forge.StateHistories
+	(*SwitchQuery)(nil),                                                       // 256: forge.SwitchQuery
+	(*SwitchSearchFilter)(nil),                                                // 257: forge.SwitchSearchFilter
+	(*SwitchesByIdsRequest)(nil),                                              // 258: forge.SwitchesByIdsRequest
+	(*ExpectedSwitch)(nil),                                                    // 259: forge.ExpectedSwitch
+	(*ExpectedSwitchRequest)(nil),                                             // 260: forge.ExpectedSwitchRequest
+	(*ExpectedSwitchList)(nil),                                                // 261: forge.ExpectedSwitchList
+	(*LinkedExpectedSwitchList)(nil),                                          // 262: forge.LinkedExpectedSwitchList
+	(*LinkedExpectedSwitch)(nil),                                              // 263: forge.LinkedExpectedSwitch
+	(*ExpectedRack)(nil),                                                      // 264: forge.ExpectedRack
+	(*ExpectedRackRequest)(nil),                                               // 265: forge.ExpectedRackRequest
+	(*ExpectedRackList)(nil),                                                  // 266: forge.ExpectedRackList
+	(*IBFabricSearchFilter)(nil),                                              // 267: forge.IBFabricSearchFilter
+	(*IBFabricIdList)(nil),                                                    // 268: forge.IBFabricIdList
+	(*NetworkSegmentStateHistory)(nil),                                        // 269: forge.NetworkSegmentStateHistory
+	(*NetworkSegmentConfig)(nil),                                              // 270: forge.NetworkSegmentConfig
+	(*NetworkSegmentStatus)(nil),                                              // 271: forge.NetworkSegmentStatus
+	(*NetworkSegment)(nil),                                                    // 272: forge.NetworkSegment
+	(*NetworkSegmentCreationRequest)(nil),                                     // 273: forge.NetworkSegmentCreationRequest
+	(*NetworkSegmentDeletionRequest)(nil),                                     // 274: forge.NetworkSegmentDeletionRequest
+	(*AttachNetworkSegmentToVpcRequest)(nil),                                  // 275: forge.AttachNetworkSegmentToVpcRequest
+	(*NetworkSegmentDeletionResult)(nil),                                      // 276: forge.NetworkSegmentDeletionResult
+	(*NetworkSegmentStateHistoriesRequest)(nil),                               // 277: forge.NetworkSegmentStateHistoriesRequest
+	(*NetworkSegmentSearchConfig)(nil),                                        // 278: forge.NetworkSegmentSearchConfig
+	(*NetworkSegmentSearchFilter)(nil),                                        // 279: forge.NetworkSegmentSearchFilter
+	(*NetworkSegmentIdList)(nil),                                              // 280: forge.NetworkSegmentIdList
+	(*NetworkSegmentsByIdsRequest)(nil),                                       // 281: forge.NetworkSegmentsByIdsRequest
+	(*NetworkPrefix)(nil),                                                     // 282: forge.NetworkPrefix
+	(*MachineState)(nil),                                                      // 283: forge.MachineState
+	(*InstancePowerRequest)(nil),                                              // 284: forge.InstancePowerRequest
+	(*InstancePowerResult)(nil),                                               // 285: forge.InstancePowerResult
+	(*InstanceList)(nil),                                                      // 286: forge.InstanceList
+	(*Label)(nil),                                                             // 287: forge.Label
+	(*Metadata)(nil),                                                          // 288: forge.Metadata
+	(*InstanceSearchFilter)(nil),                                              // 289: forge.InstanceSearchFilter
+	(*InstanceIdList)(nil),                                                    // 290: forge.InstanceIdList
+	(*InstancesByIdsRequest)(nil),                                             // 291: forge.InstancesByIdsRequest
+	(*InstanceAllocationRequest)(nil),                                         // 292: forge.InstanceAllocationRequest
+	(*BatchInstanceAllocationRequest)(nil),                                    // 293: forge.BatchInstanceAllocationRequest
+	(*BatchInstanceAllocationResponse)(nil),                                   // 294: forge.BatchInstanceAllocationResponse
+	(*IpxeTemplateParameter)(nil),                                             // 295: forge.IpxeTemplateParameter
+	(*IpxeTemplateArtifact)(nil),                                              // 296: forge.IpxeTemplateArtifact
+	(*IpxeTemplate)(nil),                                                      // 297: forge.IpxeTemplate
+	(*TenantConfig)(nil),                                                      // 298: forge.TenantConfig
+	(*InstanceOperatingSystemConfig)(nil),                                     // 299: forge.InstanceOperatingSystemConfig
+	(*InlineIpxe)(nil),                                                        // 300: forge.InlineIpxe
+	(*InstanceConfig)(nil),                                                    // 301: forge.InstanceConfig
+	(*InstanceNetworkConfig)(nil),                                             // 302: forge.InstanceNetworkConfig
+	(*InstanceNetworkAutoConfig)(nil),                                         // 303: forge.InstanceNetworkAutoConfig
+	(*InstanceInfinibandConfig)(nil),                                          // 304: forge.InstanceInfinibandConfig
+	(*InstanceDpuExtensionServiceConfig)(nil),                                 // 305: forge.InstanceDpuExtensionServiceConfig
+	(*InstanceDpuExtensionServicesConfig)(nil),                                // 306: forge.InstanceDpuExtensionServicesConfig
+	(*InstanceNVLinkConfig)(nil),                                              // 307: forge.InstanceNVLinkConfig
+	(*InstanceSpxConfig)(nil),                                                 // 308: forge.InstanceSpxConfig
+	(*InstanceSpxAttachment)(nil),                                             // 309: forge.InstanceSpxAttachment
+	(*InstanceOperatingSystemUpdateRequest)(nil),                              // 310: forge.InstanceOperatingSystemUpdateRequest
+	(*InstanceConfigUpdateRequest)(nil),                                       // 311: forge.InstanceConfigUpdateRequest
+	(*InstanceStatus)(nil),                                                    // 312: forge.InstanceStatus
+	(*InstanceSpxStatus)(nil),                                                 // 313: forge.InstanceSpxStatus
+	(*InstanceSpxAttachmentStatus)(nil),                                       // 314: forge.InstanceSpxAttachmentStatus
+	(*InstanceNetworkStatus)(nil),                                             // 315: forge.InstanceNetworkStatus
+	(*InstanceInfinibandStatus)(nil),                                          // 316: forge.InstanceInfinibandStatus
+	(*DpuExtensionServiceStatus)(nil),                                         // 317: forge.DpuExtensionServiceStatus
+	(*InstanceDpuExtensionServiceStatus)(nil),                                 // 318: forge.InstanceDpuExtensionServiceStatus
+	(*InstanceDpuExtensionServicesStatus)(nil),                                // 319: forge.InstanceDpuExtensionServicesStatus
+	(*InstanceNVLinkStatus)(nil),                                              // 320: forge.InstanceNVLinkStatus
+	(*Instance)(nil),                                                          // 321: forge.Instance
+	(*InstanceUpdateStatus)(nil),                                              // 322: forge.InstanceUpdateStatus
+	(*InstanceInterfaceConfig)(nil),                                           // 323: forge.InstanceInterfaceConfig
+	(*InstanceInterfaceVpcSelection)(nil),                                     // 324: forge.InstanceInterfaceVpcSelection
+	(*InstanceInterfaceIpv6Config)(nil),                                       // 325: forge.InstanceInterfaceIpv6Config
+	(*InstanceInterfaceRoutingProfile)(nil),                                   // 326: forge.InstanceInterfaceRoutingProfile
+	(*InstanceIBInterfaceConfig)(nil),                                         // 327: forge.InstanceIBInterfaceConfig
+	(*InstanceInterfaceResolvedVpcPrefixes)(nil),                              // 328: forge.InstanceInterfaceResolvedVpcPrefixes
+	(*InstanceInterfaceStatus)(nil),                                           // 329: forge.InstanceInterfaceStatus
+	(*InstanceIBInterfaceStatus)(nil),                                         // 330: forge.InstanceIBInterfaceStatus
+	(*InstanceNVLinkGpuStatus)(nil),                                           // 331: forge.InstanceNVLinkGpuStatus
+	(*InstanceNVLinkGpuConfig)(nil),                                           // 332: forge.InstanceNVLinkGpuConfig
+	(*InstancePhoneHomeLastContactRequest)(nil),                               // 333: forge.InstancePhoneHomeLastContactRequest
+	(*InstancePhoneHomeLastContactResponse)(nil),                              // 334: forge.InstancePhoneHomeLastContactResponse
+	(*Issue)(nil),                                                             // 335: forge.Issue
+	(*DeleteInitiatedBy)(nil),                                                 // 336: forge.DeleteInitiatedBy
+	(*DeleteAttribution)(nil),                                                 // 337: forge.DeleteAttribution
+	(*InstanceReleaseRequest)(nil),                                            // 338: forge.InstanceReleaseRequest
+	(*InstanceReleaseResult)(nil),                                             // 339: forge.InstanceReleaseResult
+	(*BatchInstanceReleaseRequest)(nil),                                       // 340: forge.BatchInstanceReleaseRequest
+	(*InstanceReleaseOutcome)(nil),                                            // 341: forge.InstanceReleaseOutcome
+	(*BatchInstanceReleaseResponse)(nil),                                      // 342: forge.BatchInstanceReleaseResponse
+	(*MachinesByIdsRequest)(nil),                                              // 343: forge.MachinesByIdsRequest
+	(*MachineSearchConfig)(nil),                                               // 344: forge.MachineSearchConfig
+	(*MachineStateHistoriesRequest)(nil),                                      // 345: forge.MachineStateHistoriesRequest
+	(*MachineStateHistories)(nil),                                             // 346: forge.MachineStateHistories
+	(*MachineStateHistoryRecords)(nil),                                        // 347: forge.MachineStateHistoryRecords
+	(*MachineHealthHistoriesRequest)(nil),                                     // 348: forge.MachineHealthHistoriesRequest
+	(*HealthHistories)(nil),                                                   // 349: forge.HealthHistories
+	(*HealthHistoryRecords)(nil),                                              // 350: forge.HealthHistoryRecords
+	(*HealthHistoryRecord)(nil),                                               // 351: forge.HealthHistoryRecord
+	(*TenantByOrganizationIdsRequest)(nil),                                    // 352: forge.TenantByOrganizationIdsRequest
+	(*TenantSearchFilter)(nil),                                                // 353: forge.TenantSearchFilter
+	(*TenantList)(nil),                                                        // 354: forge.TenantList
+	(*TenantOrganizationIdList)(nil),                                          // 355: forge.TenantOrganizationIdList
+	(*InterfaceList)(nil),                                                     // 356: forge.InterfaceList
+	(*MachineList)(nil),                                                       // 357: forge.MachineList
+	(*InterfaceDeleteQuery)(nil),                                              // 358: forge.InterfaceDeleteQuery
+	(*InterfaceSearchQuery)(nil),                                              // 359: forge.InterfaceSearchQuery
+	(*AssignStaticAddressRequest)(nil),                                        // 360: forge.AssignStaticAddressRequest
+	(*AssignStaticAddressResponse)(nil),                                       // 361: forge.AssignStaticAddressResponse
+	(*RemoveStaticAddressRequest)(nil),                                        // 362: forge.RemoveStaticAddressRequest
+	(*RemoveStaticAddressResponse)(nil),                                       // 363: forge.RemoveStaticAddressResponse
+	(*FindInterfaceAddressesRequest)(nil),                                     // 364: forge.FindInterfaceAddressesRequest
+	(*InterfaceAddress)(nil),                                                  // 365: forge.InterfaceAddress
+	(*FindInterfaceAddressesResponse)(nil),                                    // 366: forge.FindInterfaceAddressesResponse
+	(*BmcInfo)(nil),                                                           // 367: forge.BmcInfo
+	(*SwitchNvosInfo)(nil),                                                    // 368: forge.SwitchNvosInfo
+	(*MachineConfig)(nil),                                                     // 369: forge.MachineConfig
+	(*MachineStatus)(nil),                                                     // 370: forge.MachineStatus
+	(*Machine)(nil),                                                           // 371: forge.Machine
+	(*DpfMachineState)(nil),                                                   // 372: forge.DpfMachineState
+	(*InstanceNetworkRestrictions)(nil),                                       // 373: forge.InstanceNetworkRestrictions
+	(*MachineMetadataUpdateRequest)(nil),                                      // 374: forge.MachineMetadataUpdateRequest
+	(*RackMetadataUpdateRequest)(nil),                                         // 375: forge.RackMetadataUpdateRequest
+	(*SwitchMetadataUpdateRequest)(nil),                                       // 376: forge.SwitchMetadataUpdateRequest
+	(*PowerShelfMetadataUpdateRequest)(nil),                                   // 377: forge.PowerShelfMetadataUpdateRequest
+	(*DpuAgentInventoryReport)(nil),                                           // 378: forge.DpuAgentInventoryReport
+	(*MachineComponentInventory)(nil),                                         // 379: forge.MachineComponentInventory
+	(*MachineInventorySoftwareComponent)(nil),                                 // 380: forge.MachineInventorySoftwareComponent
+	(*HealthSourceOrigin)(nil),                                                // 381: forge.HealthSourceOrigin
+	(*ControllerStateReason)(nil),                                             // 382: forge.ControllerStateReason
+	(*ControllerStateSourceReference)(nil),                                    // 383: forge.ControllerStateSourceReference
+	(*StateSla)(nil),                                                          // 384: forge.StateSla
+	(*InstanceTenantStatus)(nil),                                              // 385: forge.InstanceTenantStatus
+	(*MachineEvent)(nil),                                                      // 386: forge.MachineEvent
+	(*MachineInterface)(nil),                                                  // 387: forge.MachineInterface
+	(*InfinibandStatusObservation)(nil),                                       // 388: forge.InfinibandStatusObservation
+	(*MachineIbInterface)(nil),                                                // 389: forge.MachineIbInterface
+	(*DhcpDiscovery)(nil),                                                     // 390: forge.DhcpDiscovery
+	(*ExpireDhcpLeaseRequest)(nil),                                            // 391: forge.ExpireDhcpLeaseRequest
+	(*ExpireDhcpLeaseResponse)(nil),                                           // 392: forge.ExpireDhcpLeaseResponse
+	(*DhcpRecord)(nil),                                                        // 393: forge.DhcpRecord
+	(*NetworkSegmentList)(nil),                                                // 394: forge.NetworkSegmentList
+	(*SSHKeyValidationRequest)(nil),                                           // 395: forge.SSHKeyValidationRequest
+	(*SSHKeyValidationResponse)(nil),                                          // 396: forge.SSHKeyValidationResponse
+	(*GetBmcCredentialsRequest)(nil),                                          // 397: forge.GetBmcCredentialsRequest
+	(*GetSwitchNvosCredentialsRequest)(nil),                                   // 398: forge.GetSwitchNvosCredentialsRequest
+	(*GetBmcCredentialsResponse)(nil),                                         // 399: forge.GetBmcCredentialsResponse
+	(*BmcCredentials)(nil),                                                    // 400: forge.BmcCredentials
+	(*GetSiteExplorationRequest)(nil),                                         // 401: forge.GetSiteExplorationRequest
+	(*ClearSiteExplorationErrorRequest)(nil),                                  // 402: forge.ClearSiteExplorationErrorRequest
+	(*ReExploreEndpointRequest)(nil),                                          // 403: forge.ReExploreEndpointRequest
+	(*RefreshEndpointReportRequest)(nil),                                      // 404: forge.RefreshEndpointReportRequest
+	(*DeleteExploredEndpointRequest)(nil),                                     // 405: forge.DeleteExploredEndpointRequest
+	(*PauseExploredEndpointRemediationRequest)(nil),                           // 406: forge.PauseExploredEndpointRemediationRequest
+	(*DeleteExploredEndpointResponse)(nil),                                    // 407: forge.DeleteExploredEndpointResponse
+	(*BmcEndpointRequest)(nil),                                                // 408: forge.BmcEndpointRequest
+	(*SshTimeoutConfig)(nil),                                                  // 409: forge.SshTimeoutConfig
+	(*SshRequest)(nil),                                                        // 410: forge.SshRequest
+	(*CopyBfbToDpuRshimRequest)(nil),                                          // 411: forge.CopyBfbToDpuRshimRequest
+	(*UpdateMachineHardwareInfoRequest)(nil),                                  // 412: forge.UpdateMachineHardwareInfoRequest
+	(*MachineHardwareInfo)(nil),                                               // 413: forge.MachineHardwareInfo
+	(*ManagedHostNetworkConfigRequest)(nil),                                   // 414: forge.ManagedHostNetworkConfigRequest
+	(*ManagedHostNetworkConfigResponse)(nil),                                  // 415: forge.ManagedHostNetworkConfigResponse
+	(*ManagedHostDpuExtensionServiceConfig)(nil),                              // 416: forge.ManagedHostDpuExtensionServiceConfig
+	(*ManagedHostQuarantineState)(nil),                                        // 417: forge.ManagedHostQuarantineState
+	(*GetManagedHostQuarantineStateRequest)(nil),                              // 418: forge.GetManagedHostQuarantineStateRequest
+	(*GetManagedHostQuarantineStateResponse)(nil),                             // 419: forge.GetManagedHostQuarantineStateResponse
+	(*SetManagedHostQuarantineStateRequest)(nil),                              // 420: forge.SetManagedHostQuarantineStateRequest
+	(*SetManagedHostQuarantineStateResponse)(nil),                             // 421: forge.SetManagedHostQuarantineStateResponse
+	(*ClearManagedHostQuarantineStateRequest)(nil),                            // 422: forge.ClearManagedHostQuarantineStateRequest
+	(*ClearManagedHostQuarantineStateResponse)(nil),                           // 423: forge.ClearManagedHostQuarantineStateResponse
+	(*ManagedHostNetworkConfig)(nil),                                          // 424: forge.ManagedHostNetworkConfig
+	(*FlatInterfaceConfig)(nil),                                               // 425: forge.FlatInterfaceConfig
+	(*FlatInterfaceRoutingProfile)(nil),                                       // 426: forge.FlatInterfaceRoutingProfile
+	(*FlatInterfaceIpv6Config)(nil),                                           // 427: forge.FlatInterfaceIpv6Config
+	(*FlatInterfaceNetworkSecurityGroupConfig)(nil),                           // 428: forge.FlatInterfaceNetworkSecurityGroupConfig
+	(*ManagedHostNetworkStatusRequest)(nil),                                   // 429: forge.ManagedHostNetworkStatusRequest
+	(*ManagedHostNetworkStatusResponse)(nil),                                  // 430: forge.ManagedHostNetworkStatusResponse
+	(*DpuAgentUpgradeCheckRequest)(nil),                                       // 431: forge.DpuAgentUpgradeCheckRequest
+	(*DpuAgentUpgradeCheckResponse)(nil),                                      // 432: forge.DpuAgentUpgradeCheckResponse
+	(*DpuAgentUpgradePolicyRequest)(nil),                                      // 433: forge.DpuAgentUpgradePolicyRequest
+	(*DpuAgentUpgradePolicyResponse)(nil),                                     // 434: forge.DpuAgentUpgradePolicyResponse
+	(*AdminForceDeleteMachineRequest)(nil),                                    // 435: forge.AdminForceDeleteMachineRequest
+	(*DecommissionManagedHostRequest)(nil),                                    // 436: forge.DecommissionManagedHostRequest
+	(*DecommissionManagedHostResponse)(nil),                                   // 437: forge.DecommissionManagedHostResponse
+	(*AdminForceDeleteMachineResponse)(nil),                                   // 438: forge.AdminForceDeleteMachineResponse
+	(*DisableSecureBootResponse)(nil),                                         // 439: forge.DisableSecureBootResponse
+	(*LockdownRequest)(nil),                                                   // 440: forge.LockdownRequest
+	(*LockdownResponse)(nil),                                                  // 441: forge.LockdownResponse
+	(*LockdownStatusRequest)(nil),                                             // 442: forge.LockdownStatusRequest
+	(*MachineSetupStatusRequest)(nil),                                         // 443: forge.MachineSetupStatusRequest
+	(*MachineSetupRequest)(nil),                                               // 444: forge.MachineSetupRequest
+	(*MachineSetupResponse)(nil),                                              // 445: forge.MachineSetupResponse
+	(*SetDpuFirstBootOrderRequest)(nil),                                       // 446: forge.SetDpuFirstBootOrderRequest
+	(*SetDpuFirstBootOrderResponse)(nil),                                      // 447: forge.SetDpuFirstBootOrderResponse
+	(*AdminRebootRequest)(nil),                                                // 448: forge.AdminRebootRequest
+	(*AdminRebootResponse)(nil),                                               // 449: forge.AdminRebootResponse
+	(*AdminBmcResetRequest)(nil),                                              // 450: forge.AdminBmcResetRequest
+	(*AdminBmcResetResponse)(nil),                                             // 451: forge.AdminBmcResetResponse
+	(*EnableInfiniteBootRequest)(nil),                                         // 452: forge.EnableInfiniteBootRequest
+	(*EnableInfiniteBootResponse)(nil),                                        // 453: forge.EnableInfiniteBootResponse
+	(*IsInfiniteBootEnabledRequest)(nil),                                      // 454: forge.IsInfiniteBootEnabledRequest
+	(*IsInfiniteBootEnabledResponse)(nil),                                     // 455: forge.IsInfiniteBootEnabledResponse
+	(*BMCMetaDataGetRequest)(nil),                                             // 456: forge.BMCMetaDataGetRequest
+	(*BMCMetaDataGetResponse)(nil),                                            // 457: forge.BMCMetaDataGetResponse
+	(*MachineCredentialsUpdateRequest)(nil),                                   // 458: forge.MachineCredentialsUpdateRequest
+	(*MachineCredentialsUpdateResponse)(nil),                                  // 459: forge.MachineCredentialsUpdateResponse
+	(*ForgeAgentControlRequest)(nil),                                          // 460: forge.ForgeAgentControlRequest
+	(*ForgeAgentControlResponse)(nil),                                         // 461: forge.ForgeAgentControlResponse
+	(*MachineDiscoveryInfo)(nil),                                              // 462: forge.MachineDiscoveryInfo
+	(*MachineDiscoveryCompletedRequest)(nil),                                  // 463: forge.MachineDiscoveryCompletedRequest
+	(*MachineCleanupInfo)(nil),                                                // 464: forge.MachineCleanupInfo
+	(*MachineCertificate)(nil),                                                // 465: forge.MachineCertificate
+	(*MachineCertificateRenewRequest)(nil),                                    // 466: forge.MachineCertificateRenewRequest
+	(*MachineCertificateResult)(nil),                                          // 467: forge.MachineCertificateResult
+	(*MachineDiscoveryResult)(nil),                                            // 468: forge.MachineDiscoveryResult
+	(*MachineDiscoveryCompletedResponse)(nil),                                 // 469: forge.MachineDiscoveryCompletedResponse
+	(*MachineCleanupResult)(nil),                                              // 470: forge.MachineCleanupResult
+	(*ForgeScoutErrorReport)(nil),                                             // 471: forge.ForgeScoutErrorReport
+	(*ForgeScoutErrorReportResult)(nil),                                       // 472: forge.ForgeScoutErrorReportResult
+	(*PxeInstructionRequest)(nil),                                             // 473: forge.PxeInstructionRequest
+	(*PxeInstructions)(nil),                                                   // 474: forge.PxeInstructions
+	(*CloudInitDiscoveryInstructions)(nil),                                    // 475: forge.CloudInitDiscoveryInstructions
+	(*CloudInitMetaData)(nil),                                                 // 476: forge.CloudInitMetaData
+	(*CloudInitInstructionsRequest)(nil),                                      // 477: forge.CloudInitInstructionsRequest
+	(*CloudInitInstructions)(nil),                                             // 478: forge.CloudInitInstructions
+	(*DpuNetworkStatus)(nil),                                                  // 479: forge.DpuNetworkStatus
+	(*LastDhcpRequest)(nil),                                                   // 480: forge.LastDhcpRequest
+	(*DpuExtensionServiceStatusObservation)(nil),                              // 481: forge.DpuExtensionServiceStatusObservation
+	(*DpuExtensionServiceComponent)(nil),                                      // 482: forge.DpuExtensionServiceComponent
+	(*OptionalHealthReport)(nil),                                              // 483: forge.OptionalHealthReport
+	(*HealthReportEntry)(nil),                                                 // 484: forge.HealthReportEntry
+	(*InsertMachineHealthReportRequest)(nil),                                  // 485: forge.InsertMachineHealthReportRequest
+	(*InsertRackHealthReportRequest)(nil),                                     // 486: forge.InsertRackHealthReportRequest
+	(*RemoveRackHealthReportRequest)(nil),                                     // 487: forge.RemoveRackHealthReportRequest
+	(*ListRackHealthReportsRequest)(nil),                                      // 488: forge.ListRackHealthReportsRequest
+	(*InsertSwitchHealthReportRequest)(nil),                                   // 489: forge.InsertSwitchHealthReportRequest
+	(*RemoveSwitchHealthReportRequest)(nil),                                   // 490: forge.RemoveSwitchHealthReportRequest
+	(*ListSwitchHealthReportsRequest)(nil),                                    // 491: forge.ListSwitchHealthReportsRequest
+	(*InsertPowerShelfHealthReportRequest)(nil),                               // 492: forge.InsertPowerShelfHealthReportRequest
+	(*RemovePowerShelfHealthReportRequest)(nil),                               // 493: forge.RemovePowerShelfHealthReportRequest
+	(*ListPowerShelfHealthReportsRequest)(nil),                                // 494: forge.ListPowerShelfHealthReportsRequest
+	(*ListHealthReportResponse)(nil),                                          // 495: forge.ListHealthReportResponse
+	(*RemoveMachineHealthReportRequest)(nil),                                  // 496: forge.RemoveMachineHealthReportRequest
+	(*ListNVLinkDomainHealthReportsRequest)(nil),                              // 497: forge.ListNVLinkDomainHealthReportsRequest
+	(*InsertNVLinkDomainHealthReportRequest)(nil),                             // 498: forge.InsertNVLinkDomainHealthReportRequest
+	(*RemoveNVLinkDomainHealthReportRequest)(nil),                             // 499: forge.RemoveNVLinkDomainHealthReportRequest
+	(*InstanceInterfaceStatusObservation)(nil),                                // 500: forge.InstanceInterfaceStatusObservation
+	(*FabricInterfaceData)(nil),                                               // 501: forge.FabricInterfaceData
+	(*LinkData)(nil),                                                          // 502: forge.LinkData
+	(*Tenant)(nil),                                                            // 503: forge.Tenant
+	(*CreateTenantRequest)(nil),                                               // 504: forge.CreateTenantRequest
+	(*CreateTenantResponse)(nil),                                              // 505: forge.CreateTenantResponse
+	(*UpdateTenantRequest)(nil),                                               // 506: forge.UpdateTenantRequest
+	(*UpdateTenantResponse)(nil),                                              // 507: forge.UpdateTenantResponse
+	(*FindTenantRequest)(nil),                                                 // 508: forge.FindTenantRequest
+	(*FindTenantResponse)(nil),                                                // 509: forge.FindTenantResponse
+	(*TenantKeysetIdentifier)(nil),                                            // 510: forge.TenantKeysetIdentifier
+	(*TenantPublicKey)(nil),                                                   // 511: forge.TenantPublicKey
+	(*TenantKeysetContent)(nil),                                               // 512: forge.TenantKeysetContent
+	(*TenantKeyset)(nil),                                                      // 513: forge.TenantKeyset
+	(*CreateTenantKeysetRequest)(nil),                                         // 514: forge.CreateTenantKeysetRequest
+	(*CreateTenantKeysetResponse)(nil),                                        // 515: forge.CreateTenantKeysetResponse
+	(*TenantKeySetList)(nil),                                                  // 516: forge.TenantKeySetList
+	(*UpdateTenantKeysetRequest)(nil),                                         // 517: forge.UpdateTenantKeysetRequest
+	(*UpdateTenantKeysetResponse)(nil),                                        // 518: forge.UpdateTenantKeysetResponse
+	(*DeleteTenantKeysetRequest)(nil),                                         // 519: forge.DeleteTenantKeysetRequest
+	(*DeleteTenantKeysetResponse)(nil),                                        // 520: forge.DeleteTenantKeysetResponse
+	(*TenantKeysetSearchFilter)(nil),                                          // 521: forge.TenantKeysetSearchFilter
+	(*TenantKeysetIdList)(nil),                                                // 522: forge.TenantKeysetIdList
+	(*TenantKeysetsByIdsRequest)(nil),                                         // 523: forge.TenantKeysetsByIdsRequest
+	(*ValidateTenantPublicKeyRequest)(nil),                                    // 524: forge.ValidateTenantPublicKeyRequest
+	(*ValidateTenantPublicKeyResponse)(nil),                                   // 525: forge.ValidateTenantPublicKeyResponse
+	(*ListResourcePoolsRequest)(nil),                                          // 526: forge.ListResourcePoolsRequest
+	(*ResourcePools)(nil),                                                     // 527: forge.ResourcePools
+	(*ResourcePool)(nil),                                                      // 528: forge.ResourcePool
+	(*GrowResourcePoolRequest)(nil),                                           // 529: forge.GrowResourcePoolRequest
+	(*GrowResourcePoolResponse)(nil),                                          // 530: forge.GrowResourcePoolResponse
+	(*Range)(nil),                                                             // 531: forge.Range
+	(*MigrateVpcVniResponse)(nil),                                             // 532: forge.MigrateVpcVniResponse
+	(*MaintenanceRequest)(nil),                                                // 533: forge.MaintenanceRequest
+	(*SetDynamicConfigRequest)(nil),                                           // 534: forge.SetDynamicConfigRequest
+	(*FindIpAddressRequest)(nil),                                              // 535: forge.FindIpAddressRequest
+	(*FindIpAddressResponse)(nil),                                             // 536: forge.FindIpAddressResponse
+	(*IdentifyUuidRequest)(nil),                                               // 537: forge.IdentifyUuidRequest
+	(*IdentifyUuidResponse)(nil),                                              // 538: forge.IdentifyUuidResponse
+	(*FindBmcIpsRequest)(nil),                                                 // 539: forge.FindBmcIpsRequest
+	(*IdentifyMacRequest)(nil),                                                // 540: forge.IdentifyMacRequest
+	(*IdentifyMacResponse)(nil),                                               // 541: forge.IdentifyMacResponse
+	(*IdentifySerialRequest)(nil),                                             // 542: forge.IdentifySerialRequest
+	(*IdentifySerialResponse)(nil),                                            // 543: forge.IdentifySerialResponse
+	(*DpuReprovisioningRequest)(nil),                                          // 544: forge.DpuReprovisioningRequest
+	(*DpuReprovisioningListRequest)(nil),                                      // 545: forge.DpuReprovisioningListRequest
+	(*DpuReprovisioningListResponse)(nil),                                     // 546: forge.DpuReprovisioningListResponse
+	(*HostReprovisioningRequest)(nil),                                         // 547: forge.HostReprovisioningRequest
+	(*BmcCredentialRotationRequest)(nil),                                      // 548: forge.BmcCredentialRotationRequest
+	(*UefiCredentialRotationRequest)(nil),                                     // 549: forge.UefiCredentialRotationRequest
+	(*NicLockdownCredentialRotationRequest)(nil),                              // 550: forge.NicLockdownCredentialRotationRequest
+	(*HostReprovisioningListRequest)(nil),                                     // 551: forge.HostReprovisioningListRequest
+	(*HostReprovisioningListResponse)(nil),                                    // 552: forge.HostReprovisioningListResponse
+	(*DpuOsOperationalState)(nil),                                             // 553: forge.DpuOsOperationalState
+	(*DpuRepresentorStatus)(nil),                                              // 554: forge.DpuRepresentorStatus
+	(*DpuInfoStatusObservation)(nil),                                          // 555: forge.DpuInfoStatusObservation
+	(*DpuInfo)(nil),                                                           // 556: forge.DpuInfo
+	(*GetDpuInfoListRequest)(nil),                                             // 557: forge.GetDpuInfoListRequest
+	(*GetDpuInfoListResponse)(nil),                                            // 558: forge.GetDpuInfoListResponse
+	(*IpAddressMatch)(nil),                                                    // 559: forge.IpAddressMatch
+	(*MachineBootOverride)(nil),                                               // 560: forge.MachineBootOverride
+	(*ConnectedDevice)(nil),                                                   // 561: forge.ConnectedDevice
+	(*ConnectedDeviceList)(nil),                                               // 562: forge.ConnectedDeviceList
+	(*BmcIpList)(nil),                                                         // 563: forge.BmcIpList
+	(*BmcIp)(nil),                                                             // 564: forge.BmcIp
+	(*MacAddressBmcIp)(nil),                                                   // 565: forge.MacAddressBmcIp
+	(*MachineIdBmcIpPairs)(nil),                                               // 566: forge.MachineIdBmcIpPairs
+	(*MachineIdBmcIp)(nil),                                                    // 567: forge.MachineIdBmcIp
+	(*NetworkDevice)(nil),                                                     // 568: forge.NetworkDevice
+	(*NetworkTopologyRequest)(nil),                                            // 569: forge.NetworkTopologyRequest
+	(*NetworkDeviceIdList)(nil),                                               // 570: forge.NetworkDeviceIdList
+	(*NetworkTopologyData)(nil),                                               // 571: forge.NetworkTopologyData
+	(*RouteServers)(nil),                                                      // 572: forge.RouteServers
+	(*RouteServerEntries)(nil),                                                // 573: forge.RouteServerEntries
+	(*RouteServer)(nil),                                                       // 574: forge.RouteServer
+	(*SetHostUefiPasswordRequest)(nil),                                        // 575: forge.SetHostUefiPasswordRequest
+	(*SetHostUefiPasswordResponse)(nil),                                       // 576: forge.SetHostUefiPasswordResponse
+	(*ClearHostUefiPasswordRequest)(nil),                                      // 577: forge.ClearHostUefiPasswordRequest
+	(*ClearHostUefiPasswordResponse)(nil),                                     // 578: forge.ClearHostUefiPasswordResponse
+	(*SetDpuUefiPasswordRequest)(nil),                                         // 579: forge.SetDpuUefiPasswordRequest
+	(*SetDpuUefiPasswordResponse)(nil),                                        // 580: forge.SetDpuUefiPasswordResponse
+	(*OsImageAttributes)(nil),                                                 // 581: forge.OsImageAttributes
+	(*OsImage)(nil),                                                           // 582: forge.OsImage
+	(*ListOsImageRequest)(nil),                                                // 583: forge.ListOsImageRequest
+	(*ListOsImageResponse)(nil),                                               // 584: forge.ListOsImageResponse
+	(*DeleteOsImageRequest)(nil),                                              // 585: forge.DeleteOsImageRequest
+	(*DeleteOsImageResponse)(nil),                                             // 586: forge.DeleteOsImageResponse
+	(*GetIpxeTemplateRequest)(nil),                                            // 587: forge.GetIpxeTemplateRequest
+	(*ListIpxeTemplatesRequest)(nil),                                          // 588: forge.ListIpxeTemplatesRequest
+	(*IpxeTemplateList)(nil),                                                  // 589: forge.IpxeTemplateList
+	(*ExpectedHostNic)(nil),                                                   // 590: forge.ExpectedHostNic
+	(*HostLifecycleProfile)(nil),                                              // 591: forge.HostLifecycleProfile
+	(*ExpectedMachine)(nil),                                                   // 592: forge.ExpectedMachine
+	(*ExpectedMachineRequest)(nil),                                            // 593: forge.ExpectedMachineRequest
+	(*ExpectedMachineList)(nil),                                               // 594: forge.ExpectedMachineList
+	(*LinkedExpectedMachineList)(nil),                                         // 595: forge.LinkedExpectedMachineList
+	(*LinkedExpectedMachine)(nil),                                             // 596: forge.LinkedExpectedMachine
+	(*UnexpectedMachineList)(nil),                                             // 597: forge.UnexpectedMachineList
+	(*UnexpectedMachine)(nil),                                                 // 598: forge.UnexpectedMachine
+	(*BatchExpectedMachineOperationRequest)(nil),                              // 599: forge.BatchExpectedMachineOperationRequest
+	(*ExpectedMachineOperationResult)(nil),                                    // 600: forge.ExpectedMachineOperationResult
+	(*BatchExpectedMachineOperationResponse)(nil),                             // 601: forge.BatchExpectedMachineOperationResponse
+	(*MachineRebootCompletedResponse)(nil),                                    // 602: forge.MachineRebootCompletedResponse
+	(*MachineRebootCompletedRequest)(nil),                                     // 603: forge.MachineRebootCompletedRequest
+	(*ScoutFirmwareUpgradeStatusRequest)(nil),                                 // 604: forge.ScoutFirmwareUpgradeStatusRequest
+	(*MachineValidationCompletedRequest)(nil),                                 // 605: forge.MachineValidationCompletedRequest
+	(*MachineValidationCompletedResponse)(nil),                                // 606: forge.MachineValidationCompletedResponse
+	(*MachineValidationResult)(nil),                                           // 607: forge.MachineValidationResult
+	(*MachineValidationResultPostRequest)(nil),                                // 608: forge.MachineValidationResultPostRequest
+	(*MachineValidationResultList)(nil),                                       // 609: forge.MachineValidationResultList
+	(*MachineValidationGetRequest)(nil),                                       // 610: forge.MachineValidationGetRequest
+	(*MachineValidationStatus)(nil),                                           // 611: forge.MachineValidationStatus
+	(*MachineValidationRun)(nil),                                              // 612: forge.MachineValidationRun
+	(*MachineSetAutoUpdateRequest)(nil),                                       // 613: forge.MachineSetAutoUpdateRequest
+	(*MachineSetAutoUpdateResponse)(nil),                                      // 614: forge.MachineSetAutoUpdateResponse
+	(*GetMachineValidationExternalConfigRequest)(nil),                         // 615: forge.GetMachineValidationExternalConfigRequest
+	(*MachineValidationExternalConfig)(nil),                                   // 616: forge.MachineValidationExternalConfig
+	(*GetMachineValidationExternalConfigResponse)(nil),                        // 617: forge.GetMachineValidationExternalConfigResponse
+	(*GetMachineValidationExternalConfigsRequest)(nil),                        // 618: forge.GetMachineValidationExternalConfigsRequest
+	(*GetMachineValidationExternalConfigsResponse)(nil),                       // 619: forge.GetMachineValidationExternalConfigsResponse
+	(*AddUpdateMachineValidationExternalConfigRequest)(nil),                   // 620: forge.AddUpdateMachineValidationExternalConfigRequest
+	(*RemoveMachineValidationExternalConfigRequest)(nil),                      // 621: forge.RemoveMachineValidationExternalConfigRequest
+	(*MachineValidationOnDemandRequest)(nil),                                  // 622: forge.MachineValidationOnDemandRequest
+	(*MachineValidationOnDemandResponse)(nil),                                 // 623: forge.MachineValidationOnDemandResponse
+	(*FirmwareUpgradeActivity)(nil),                                           // 624: forge.FirmwareUpgradeActivity
+	(*NvosUpdateActivity)(nil),                                                // 625: forge.NvosUpdateActivity
+	(*ConfigureNmxClusterActivity)(nil),                                       // 626: forge.ConfigureNmxClusterActivity
+	(*PowerSequenceActivity)(nil),                                             // 627: forge.PowerSequenceActivity
+	(*MaintenanceActivityConfig)(nil),                                         // 628: forge.MaintenanceActivityConfig
+	(*RackMaintenanceScope)(nil),                                              // 629: forge.RackMaintenanceScope
+	(*RackMaintenanceOnDemandRequest)(nil),                                    // 630: forge.RackMaintenanceOnDemandRequest
+	(*RackMaintenanceOnDemandResponse)(nil),                                   // 631: forge.RackMaintenanceOnDemandResponse
+	(*RackMaintenanceTerminateRequest)(nil),                                   // 632: forge.RackMaintenanceTerminateRequest
+	(*RackMaintenanceTerminateResponse)(nil),                                  // 633: forge.RackMaintenanceTerminateResponse
+	(*AdminPowerControlRequest)(nil),                                          // 634: forge.AdminPowerControlRequest
+	(*AdminPowerControlResponse)(nil),                                         // 635: forge.AdminPowerControlResponse
+	(*AdminGpuResetRequest)(nil),                                              // 636: forge.AdminGpuResetRequest
+	(*AdminGpuResetResponse)(nil),                                             // 637: forge.AdminGpuResetResponse
+	(*GetRedfishJobStateRequest)(nil),                                         // 638: forge.GetRedfishJobStateRequest
+	(*GetRedfishJobStateResponse)(nil),                                        // 639: forge.GetRedfishJobStateResponse
+	(*MachineValidationRunList)(nil),                                          // 640: forge.MachineValidationRunList
+	(*MachineValidationRunListGetRequest)(nil),                                // 641: forge.MachineValidationRunListGetRequest
+	(*MachineValidationRunItemSearchFilter)(nil),                              // 642: forge.MachineValidationRunItemSearchFilter
+	(*MachineValidationRunItemIdList)(nil),                                    // 643: forge.MachineValidationRunItemIdList
+	(*MachineValidationRunItemsByIdsRequest)(nil),                             // 644: forge.MachineValidationRunItemsByIdsRequest
+	(*MachineValidationRunItemList)(nil),                                      // 645: forge.MachineValidationRunItemList
+	(*MachineValidationRunItem)(nil),                                          // 646: forge.MachineValidationRunItem
+	(*MachineValidationAttemptGetRequest)(nil),                                // 647: forge.MachineValidationAttemptGetRequest
+	(*MachineValidationAttempt)(nil),                                          // 648: forge.MachineValidationAttempt
+	(*MachineValidationHeartbeatRequest)(nil),                                 // 649: forge.MachineValidationHeartbeatRequest
+	(*MachineValidationHeartbeatResponse)(nil),                                // 650: forge.MachineValidationHeartbeatResponse
+	(*IsBmcInManagedHostResponse)(nil),                                        // 651: forge.IsBmcInManagedHostResponse
+	(*BmcCredentialStatusResponse)(nil),                                       // 652: forge.BmcCredentialStatusResponse
+	(*MachineValidationTestsGetRequest)(nil),                                  // 653: forge.MachineValidationTestsGetRequest
+	(*MachineValidationTestUpdateRequest)(nil),                                // 654: forge.MachineValidationTestUpdateRequest
+	(*MachineValidationTestAddRequest)(nil),                                   // 655: forge.MachineValidationTestAddRequest
+	(*MachineValidationTestAddUpdateResponse)(nil),                            // 656: forge.MachineValidationTestAddUpdateResponse
+	(*MachineValidationTestsGetResponse)(nil),                                 // 657: forge.MachineValidationTestsGetResponse
+	(*MachineValidationTestVerfiedRequest)(nil),                               // 658: forge.MachineValidationTestVerfiedRequest
+	(*MachineValidationTestVerfiedResponse)(nil),                              // 659: forge.MachineValidationTestVerfiedResponse
+	(*MachineValidationTest)(nil),                                             // 660: forge.MachineValidationTest
+	(*MachineValidationPlugin)(nil),                                           // 661: forge.MachineValidationPlugin
+	(*MachineValidationTestFullHostApprovalRequest)(nil),                      // 662: forge.MachineValidationTestFullHostApprovalRequest
+	(*MachineValidationTestFullHostApprovalResponse)(nil),                     // 663: forge.MachineValidationTestFullHostApprovalResponse
+	(*MachineValidationTestNextVersionResponse)(nil),                          // 664: forge.MachineValidationTestNextVersionResponse
+	(*MachineValidationTestNextVersionRequest)(nil),                           // 665: forge.MachineValidationTestNextVersionRequest
+	(*MachineValidationTestEnableDisableTestRequest)(nil),                     // 666: forge.MachineValidationTestEnableDisableTestRequest
+	(*MachineValidationTestEnableDisableTestResponse)(nil),                    // 667: forge.MachineValidationTestEnableDisableTestResponse
+	(*MachineValidationRunRequest)(nil),                                       // 668: forge.MachineValidationRunRequest
+	(*MachineValidationRunResponse)(nil),                                      // 669: forge.MachineValidationRunResponse
+	(*MachineCapabilityAttributesCpu)(nil),                                    // 670: forge.MachineCapabilityAttributesCpu
+	(*MachineCapabilityAttributesGpu)(nil),                                    // 671: forge.MachineCapabilityAttributesGpu
+	(*MachineCapabilityAttributesMemory)(nil),                                 // 672: forge.MachineCapabilityAttributesMemory
+	(*MachineCapabilityAttributesStorage)(nil),                                // 673: forge.MachineCapabilityAttributesStorage
+	(*MachineCapabilityAttributesNetwork)(nil),                                // 674: forge.MachineCapabilityAttributesNetwork
+	(*MachineCapabilityAttributesInfiniband)(nil),                             // 675: forge.MachineCapabilityAttributesInfiniband
+	(*MachineCapabilityAttributesDpu)(nil),                                    // 676: forge.MachineCapabilityAttributesDpu
+	(*MachineCapabilitiesSet)(nil),                                            // 677: forge.MachineCapabilitiesSet
+	(*InstanceTypeAttributes)(nil),                                            // 678: forge.InstanceTypeAttributes
+	(*InstanceType)(nil),                                                      // 679: forge.InstanceType
+	(*InstanceTypeMachineCapabilityFilterAttributes)(nil),                     // 680: forge.InstanceTypeMachineCapabilityFilterAttributes
+	(*CreateInstanceTypeRequest)(nil),                                         // 681: forge.CreateInstanceTypeRequest
+	(*CreateInstanceTypeResponse)(nil),                                        // 682: forge.CreateInstanceTypeResponse
+	(*FindInstanceTypeIdsRequest)(nil),                                        // 683: forge.FindInstanceTypeIdsRequest
+	(*FindInstanceTypeIdsResponse)(nil),                                       // 684: forge.FindInstanceTypeIdsResponse
+	(*FindInstanceTypesByIdsRequest)(nil),                                     // 685: forge.FindInstanceTypesByIdsRequest
+	(*FindInstanceTypesByIdsResponse)(nil),                                    // 686: forge.FindInstanceTypesByIdsResponse
+	(*DeleteInstanceTypeRequest)(nil),                                         // 687: forge.DeleteInstanceTypeRequest
+	(*DeleteInstanceTypeResponse)(nil),                                        // 688: forge.DeleteInstanceTypeResponse
+	(*UpdateInstanceTypeResponse)(nil),                                        // 689: forge.UpdateInstanceTypeResponse
+	(*UpdateInstanceTypeRequest)(nil),                                         // 690: forge.UpdateInstanceTypeRequest
+	(*AssociateMachinesWithInstanceTypeRequest)(nil),                          // 691: forge.AssociateMachinesWithInstanceTypeRequest
+	(*AssociateMachinesWithInstanceTypeResponse)(nil),                         // 692: forge.AssociateMachinesWithInstanceTypeResponse
+	(*RemoveMachineInstanceTypeAssociationRequest)(nil),                       // 693: forge.RemoveMachineInstanceTypeAssociationRequest
+	(*RemoveMachineInstanceTypeAssociationResponse)(nil),                      // 694: forge.RemoveMachineInstanceTypeAssociationResponse
+	(*RedfishBrowseRequest)(nil),                                              // 695: forge.RedfishBrowseRequest
+	(*RedfishBrowseResponse)(nil),                                             // 696: forge.RedfishBrowseResponse
+	(*RedfishListActionsRequest)(nil),                                         // 697: forge.RedfishListActionsRequest
+	(*RedfishListActionsResponse)(nil),                                        // 698: forge.RedfishListActionsResponse
+	(*RedfishAction)(nil),                                                     // 699: forge.RedfishAction
+	(*OptionalRedfishActionResult)(nil),                                       // 700: forge.OptionalRedfishActionResult
+	(*RedfishActionResult)(nil),                                               // 701: forge.RedfishActionResult
+	(*RedfishCreateActionRequest)(nil),                                        // 702: forge.RedfishCreateActionRequest
+	(*RedfishCreateActionResponse)(nil),                                       // 703: forge.RedfishCreateActionResponse
+	(*RedfishActionID)(nil),                                                   // 704: forge.RedfishActionID
+	(*RedfishApproveActionResponse)(nil),                                      // 705: forge.RedfishApproveActionResponse
+	(*RedfishApplyActionResponse)(nil),                                        // 706: forge.RedfishApplyActionResponse
+	(*RedfishCancelActionResponse)(nil),                                       // 707: forge.RedfishCancelActionResponse
+	(*UfmBrowseRequest)(nil),                                                  // 708: forge.UfmBrowseRequest
+	(*UfmBrowseResponse)(nil),                                                 // 709: forge.UfmBrowseResponse
+	(*NetworkSecurityGroupAttributes)(nil),                                    // 710: forge.NetworkSecurityGroupAttributes
+	(*NetworkSecurityGroup)(nil),                                              // 711: forge.NetworkSecurityGroup
+	(*CreateNetworkSecurityGroupRequest)(nil),                                 // 712: forge.CreateNetworkSecurityGroupRequest
+	(*CreateNetworkSecurityGroupResponse)(nil),                                // 713: forge.CreateNetworkSecurityGroupResponse
+	(*FindNetworkSecurityGroupIdsRequest)(nil),                                // 714: forge.FindNetworkSecurityGroupIdsRequest
+	(*FindNetworkSecurityGroupIdsResponse)(nil),                               // 715: forge.FindNetworkSecurityGroupIdsResponse
+	(*FindNetworkSecurityGroupsByIdsRequest)(nil),                             // 716: forge.FindNetworkSecurityGroupsByIdsRequest
+	(*FindNetworkSecurityGroupsByIdsResponse)(nil),                            // 717: forge.FindNetworkSecurityGroupsByIdsResponse
+	(*UpdateNetworkSecurityGroupResponse)(nil),                                // 718: forge.UpdateNetworkSecurityGroupResponse
+	(*UpdateNetworkSecurityGroupRequest)(nil),                                 // 719: forge.UpdateNetworkSecurityGroupRequest
+	(*DeleteNetworkSecurityGroupRequest)(nil),                                 // 720: forge.DeleteNetworkSecurityGroupRequest
+	(*DeleteNetworkSecurityGroupResponse)(nil),                                // 721: forge.DeleteNetworkSecurityGroupResponse
+	(*NetworkSecurityGroupStatus)(nil),                                        // 722: forge.NetworkSecurityGroupStatus
+	(*NetworkSecurityGroupPropagationObjectStatus)(nil),                       // 723: forge.NetworkSecurityGroupPropagationObjectStatus
+	(*GetNetworkSecurityGroupPropagationStatusResponse)(nil),                  // 724: forge.GetNetworkSecurityGroupPropagationStatusResponse
+	(*NetworkSecurityGroupIdList)(nil),                                        // 725: forge.NetworkSecurityGroupIdList
+	(*GetNetworkSecurityGroupPropagationStatusRequest)(nil),                   // 726: forge.GetNetworkSecurityGroupPropagationStatusRequest
+	(*NetworkSecurityGroupRuleAttributes)(nil),                                // 727: forge.NetworkSecurityGroupRuleAttributes
+	(*ResolvedNetworkSecurityGroupRule)(nil),                                  // 728: forge.ResolvedNetworkSecurityGroupRule
+	(*GetNetworkSecurityGroupAttachmentsRequest)(nil),                         // 729: forge.GetNetworkSecurityGroupAttachmentsRequest
+	(*NetworkSecurityGroupAttachments)(nil),                                   // 730: forge.NetworkSecurityGroupAttachments
+	(*GetNetworkSecurityGroupAttachmentsResponse)(nil),                        // 731: forge.GetNetworkSecurityGroupAttachmentsResponse
+	(*GetDesiredFirmwareVersionsRequest)(nil),                                 // 732: forge.GetDesiredFirmwareVersionsRequest
+	(*GetDesiredFirmwareVersionsResponse)(nil),                                // 733: forge.GetDesiredFirmwareVersionsResponse
+	(*DesiredFirmwareVersionEntry)(nil),                                       // 734: forge.DesiredFirmwareVersionEntry
+	(*SkuComponentChassis)(nil),                                               // 735: forge.SkuComponentChassis
+	(*SkuComponentCpu)(nil),                                                   // 736: forge.SkuComponentCpu
+	(*SkuComponentGpu)(nil),                                                   // 737: forge.SkuComponentGpu
+	(*SkuComponentEthernetDevices)(nil),                                       // 738: forge.SkuComponentEthernetDevices
+	(*SkuComponentInfinibandDevices)(nil),                                     // 739: forge.SkuComponentInfinibandDevices
+	(*SkuComponentStorage)(nil),                                               // 740: forge.SkuComponentStorage
+	(*SkuComponentStorageController)(nil),                                     // 741: forge.SkuComponentStorageController
+	(*SkuComponentMemory)(nil),                                                // 742: forge.SkuComponentMemory
+	(*SkuComponentTpm)(nil),                                                   // 743: forge.SkuComponentTpm
+	(*SkuComponents)(nil),                                                     // 744: forge.SkuComponents
+	(*Sku)(nil),                                                               // 745: forge.Sku
+	(*SkuMachinePair)(nil),                                                    // 746: forge.SkuMachinePair
+	(*RemoveSkuRequest)(nil),                                                  // 747: forge.RemoveSkuRequest
+	(*SkuList)(nil),                                                           // 748: forge.SkuList
+	(*SkuIdList)(nil),                                                         // 749: forge.SkuIdList
+	(*SkuStatus)(nil),                                                         // 750: forge.SkuStatus
+	(*SkusByIdsRequest)(nil),                                                  // 751: forge.SkusByIdsRequest
+	(*SkuSearchFilter)(nil),                                                   // 752: forge.SkuSearchFilter
+	(*DpaInterface)(nil),                                                      // 753: forge.DpaInterface
+	(*DpaInterfaceCreationRequest)(nil),                                       // 754: forge.DpaInterfaceCreationRequest
+	(*DpaInterfaceIdList)(nil),                                                // 755: forge.DpaInterfaceIdList
+	(*DpaInterfacesByIdsRequest)(nil),                                         // 756: forge.DpaInterfacesByIdsRequest
+	(*DpaInterfaceList)(nil),                                                  // 757: forge.DpaInterfaceList
+	(*DpaNetworkObservationSetRequest)(nil),                                   // 758: forge.DpaNetworkObservationSetRequest
+	(*DpaInterfaceDeletionRequest)(nil),                                       // 759: forge.DpaInterfaceDeletionRequest
+	(*DpaInterfaceDeletionResult)(nil),                                        // 760: forge.DpaInterfaceDeletionResult
+	(*SkuUpdateMetadataRequest)(nil),                                          // 761: forge.SkuUpdateMetadataRequest
+	(*PowerOptionRequest)(nil),                                                // 762: forge.PowerOptionRequest
+	(*PowerOptionUpdateRequest)(nil),                                          // 763: forge.PowerOptionUpdateRequest
+	(*PowerOptions)(nil),                                                      // 764: forge.PowerOptions
+	(*PowerOptionResponse)(nil),                                               // 765: forge.PowerOptionResponse
+	(*ComputeAllocationAttributes)(nil),                                       // 766: forge.ComputeAllocationAttributes
+	(*ComputeAllocation)(nil),                                                 // 767: forge.ComputeAllocation
+	(*CreateComputeAllocationRequest)(nil),                                    // 768: forge.CreateComputeAllocationRequest
+	(*CreateComputeAllocationResponse)(nil),                                   // 769: forge.CreateComputeAllocationResponse
+	(*FindComputeAllocationIdsRequest)(nil),                                   // 770: forge.FindComputeAllocationIdsRequest
+	(*FindComputeAllocationIdsResponse)(nil),                                  // 771: forge.FindComputeAllocationIdsResponse
+	(*FindComputeAllocationsByIdsRequest)(nil),                                // 772: forge.FindComputeAllocationsByIdsRequest
+	(*FindComputeAllocationsByIdsResponse)(nil),                               // 773: forge.FindComputeAllocationsByIdsResponse
+	(*UpdateComputeAllocationResponse)(nil),                                   // 774: forge.UpdateComputeAllocationResponse
+	(*UpdateComputeAllocationRequest)(nil),                                    // 775: forge.UpdateComputeAllocationRequest
+	(*DeleteComputeAllocationRequest)(nil),                                    // 776: forge.DeleteComputeAllocationRequest
+	(*DeleteComputeAllocationResponse)(nil),                                   // 777: forge.DeleteComputeAllocationResponse
+	(*InstanceTypeAllocationStats)(nil),                                       // 778: forge.InstanceTypeAllocationStats
+	(*GetRackRequest)(nil),                                                    // 779: forge.GetRackRequest
+	(*GetRackResponse)(nil),                                                   // 780: forge.GetRackResponse
+	(*RackList)(nil),                                                          // 781: forge.RackList
+	(*RackSearchFilter)(nil),                                                  // 782: forge.RackSearchFilter
+	(*RackIdList)(nil),                                                        // 783: forge.RackIdList
+	(*RacksByIdsRequest)(nil),                                                 // 784: forge.RacksByIdsRequest
+	(*Rack)(nil),                                                              // 785: forge.Rack
+	(*RackConfig)(nil),                                                        // 786: forge.RackConfig
+	(*RackStatus)(nil),                                                        // 787: forge.RackStatus
+	(*RackStateHistoriesRequest)(nil),                                         // 788: forge.RackStateHistoriesRequest
+	(*RackHealthHistoriesRequest)(nil),                                        // 789: forge.RackHealthHistoriesRequest
+	(*DeleteRackRequest)(nil),                                                 // 790: forge.DeleteRackRequest
+	(*AdminForceDeleteRackRequest)(nil),                                       // 791: forge.AdminForceDeleteRackRequest
+	(*AdminForceDeleteRackResponse)(nil),                                      // 792: forge.AdminForceDeleteRackResponse
+	(*RackCapabilityCompute)(nil),                                             // 793: forge.RackCapabilityCompute
+	(*RackCapabilitySwitch)(nil),                                              // 794: forge.RackCapabilitySwitch
+	(*RackCapabilityPowerShelf)(nil),                                          // 795: forge.RackCapabilityPowerShelf
+	(*RackCapabilitiesSet)(nil),                                               // 796: forge.RackCapabilitiesSet
+	(*RackProfile)(nil),                                                       // 797: forge.RackProfile
+	(*GetRackProfileRequest)(nil),                                             // 798: forge.GetRackProfileRequest
+	(*GetRackProfileResponse)(nil),                                            // 799: forge.GetRackProfileResponse
+	(*ConfiguredRackProfile)(nil),                                             // 800: forge.ConfiguredRackProfile
+	(*ListRackProfilesResponse)(nil),                                          // 801: forge.ListRackProfilesResponse
+	(*RackManagerForgeRequest)(nil),                                           // 802: forge.RackManagerForgeRequest
+	(*RackManagerForgeResponse)(nil),                                          // 803: forge.RackManagerForgeResponse
+	(*MachineNVLinkInfo)(nil),                                                 // 804: forge.MachineNVLinkInfo
+	(*UpdateMachineNvLinkInfoRequest)(nil),                                    // 805: forge.UpdateMachineNvLinkInfoRequest
+	(*MachineSpxStatusObservation)(nil),                                       // 806: forge.MachineSpxStatusObservation
+	(*MachineSpxAttachmentStatusObservation)(nil),                             // 807: forge.MachineSpxAttachmentStatusObservation
+	(*AstraConfig)(nil),                                                       // 808: forge.AstraConfig
+	(*AstraAttachment)(nil),                                                   // 809: forge.AstraAttachment
+	(*AstraConfigStatus)(nil),                                                 // 810: forge.AstraConfigStatus
+	(*AstraAttachmentStatus)(nil),                                             // 811: forge.AstraAttachmentStatus
+	(*AstraStatus)(nil),                                                       // 812: forge.AstraStatus
+	(*NVLinkGpu)(nil),                                                         // 813: forge.NVLinkGpu
+	(*MachineNVLinkStatusObservation)(nil),                                    // 814: forge.MachineNVLinkStatusObservation
+	(*MachineNVLinkGpuStatusObservation)(nil),                                 // 815: forge.MachineNVLinkGpuStatusObservation
+	(*NmxcBrowseRequest)(nil),                                                 // 816: forge.NmxcBrowseRequest
+	(*NmxcBrowseResponse)(nil),                                                // 817: forge.NmxcBrowseResponse
+	(*NVLinkPartition)(nil),                                                   // 818: forge.NVLinkPartition
+	(*NVLinkPartitionList)(nil),                                               // 819: forge.NVLinkPartitionList
+	(*NVLinkPartitionSearchConfig)(nil),                                       // 820: forge.NVLinkPartitionSearchConfig
+	(*NVLinkPartitionQuery)(nil),                                              // 821: forge.NVLinkPartitionQuery
+	(*NVLinkPartitionSearchFilter)(nil),                                       // 822: forge.NVLinkPartitionSearchFilter
+	(*NVLinkPartitionsByIdsRequest)(nil),                                      // 823: forge.NVLinkPartitionsByIdsRequest
+	(*NVLinkPartitionIdList)(nil),                                             // 824: forge.NVLinkPartitionIdList
+	(*NVLinkFabricSearchFilter)(nil),                                          // 825: forge.NVLinkFabricSearchFilter
+	(*NVLinkLogicalPartitionConfig)(nil),                                      // 826: forge.NVLinkLogicalPartitionConfig
+	(*NVLinkLogicalPartitionStatus)(nil),                                      // 827: forge.NVLinkLogicalPartitionStatus
+	(*NVLinkLogicalPartition)(nil),                                            // 828: forge.NVLinkLogicalPartition
+	(*NVLinkLogicalPartitionList)(nil),                                        // 829: forge.NVLinkLogicalPartitionList
+	(*NVLinkLogicalPartitionCreationRequest)(nil),                             // 830: forge.NVLinkLogicalPartitionCreationRequest
+	(*NVLinkLogicalPartitionDeletionRequest)(nil),                             // 831: forge.NVLinkLogicalPartitionDeletionRequest
+	(*NVLinkLogicalPartitionDeletionResult)(nil),                              // 832: forge.NVLinkLogicalPartitionDeletionResult
+	(*NVLinkLogicalPartitionSearchFilter)(nil),                                // 833: forge.NVLinkLogicalPartitionSearchFilter
+	(*NVLinkLogicalPartitionsByIdsRequest)(nil),                               // 834: forge.NVLinkLogicalPartitionsByIdsRequest
+	(*NVLinkLogicalPartitionIdList)(nil),                                      // 835: forge.NVLinkLogicalPartitionIdList
+	(*NVLinkLogicalPartitionUpdateRequest)(nil),                               // 836: forge.NVLinkLogicalPartitionUpdateRequest
+	(*NVLinkLogicalPartitionUpdateResult)(nil),                                // 837: forge.NVLinkLogicalPartitionUpdateResult
+	(*CreateBmcUserRequest)(nil),                                              // 838: forge.CreateBmcUserRequest
+	(*CreateBmcUserResponse)(nil),                                             // 839: forge.CreateBmcUserResponse
+	(*DeleteBmcUserRequest)(nil),                                              // 840: forge.DeleteBmcUserRequest
+	(*DeleteBmcUserResponse)(nil),                                             // 841: forge.DeleteBmcUserResponse
+	(*SetBmcRootPasswordRequest)(nil),                                         // 842: forge.SetBmcRootPasswordRequest
+	(*SetBmcRootPasswordResponse)(nil),                                        // 843: forge.SetBmcRootPasswordResponse
+	(*ProbeBmcVendorRequest)(nil),                                             // 844: forge.ProbeBmcVendorRequest
+	(*ProbeBmcVendorResponse)(nil),                                            // 845: forge.ProbeBmcVendorResponse
+	(*SetFirmwareUpdateTimeWindowRequest)(nil),                                // 846: forge.SetFirmwareUpdateTimeWindowRequest
+	(*SetFirmwareUpdateTimeWindowResponse)(nil),                               // 847: forge.SetFirmwareUpdateTimeWindowResponse
+	(*UpsertHostFirmwareConfigRequest)(nil),                                   // 848: forge.UpsertHostFirmwareConfigRequest
+	(*DeleteHostFirmwareConfigRequest)(nil),                                   // 849: forge.DeleteHostFirmwareConfigRequest
+	(*UpsertHostFirmwareComponentConfig)(nil),                                 // 850: forge.UpsertHostFirmwareComponentConfig
+	(*HostFirmwareComponentConfigResponse)(nil),                               // 851: forge.HostFirmwareComponentConfigResponse
+	(*HostFirmwareVersionConfig)(nil),                                         // 852: forge.HostFirmwareVersionConfig
+	(*HostFirmwareArtifact)(nil),                                              // 853: forge.HostFirmwareArtifact
+	(*HostFirmwareConfigResponse)(nil),                                        // 854: forge.HostFirmwareConfigResponse
+	(*ListHostFirmwareRequest)(nil),                                           // 855: forge.ListHostFirmwareRequest
+	(*ListHostFirmwareResponse)(nil),                                          // 856: forge.ListHostFirmwareResponse
+	(*AvailableHostFirmware)(nil),                                             // 857: forge.AvailableHostFirmware
+	(*TrimTableRequest)(nil),                                                  // 858: forge.TrimTableRequest
+	(*TrimTableResponse)(nil),                                                 // 859: forge.TrimTableResponse
+	(*NvlinkNmxcEndpoint)(nil),                                                // 860: forge.NvlinkNmxcEndpoint
+	(*NvlinkNmxcEndpointList)(nil),                                            // 861: forge.NvlinkNmxcEndpointList
+	(*DeleteNvlinkNmxcEndpointRequest)(nil),                                   // 862: forge.DeleteNvlinkNmxcEndpointRequest
+	(*CreateRemediationRequest)(nil),                                          // 863: forge.CreateRemediationRequest
+	(*CreateRemediationResponse)(nil),                                         // 864: forge.CreateRemediationResponse
+	(*RemediationIdList)(nil),                                                 // 865: forge.RemediationIdList
+	(*RemediationList)(nil),                                                   // 866: forge.RemediationList
+	(*Remediation)(nil),                                                       // 867: forge.Remediation
+	(*ApproveRemediationRequest)(nil),                                         // 868: forge.ApproveRemediationRequest
+	(*RevokeRemediationRequest)(nil),                                          // 869: forge.RevokeRemediationRequest
+	(*EnableRemediationRequest)(nil),                                          // 870: forge.EnableRemediationRequest
+	(*DisableRemediationRequest)(nil),                                         // 871: forge.DisableRemediationRequest
+	(*FindAppliedRemediationIdsRequest)(nil),                                  // 872: forge.FindAppliedRemediationIdsRequest
+	(*AppliedRemediationIdList)(nil),                                          // 873: forge.AppliedRemediationIdList
+	(*FindAppliedRemediationsRequest)(nil),                                    // 874: forge.FindAppliedRemediationsRequest
+	(*AppliedRemediation)(nil),                                                // 875: forge.AppliedRemediation
+	(*AppliedRemediationList)(nil),                                            // 876: forge.AppliedRemediationList
+	(*GetNextRemediationForMachineRequest)(nil),                               // 877: forge.GetNextRemediationForMachineRequest
+	(*GetNextRemediationForMachineResponse)(nil),                              // 878: forge.GetNextRemediationForMachineResponse
+	(*RemediationAppliedRequest)(nil),                                         // 879: forge.RemediationAppliedRequest
+	(*RemediationApplicationStatus)(nil),                                      // 880: forge.RemediationApplicationStatus
+	(*SetPrimaryDpuRequest)(nil),                                              // 881: forge.SetPrimaryDpuRequest
+	(*SetPrimaryInterfaceRequest)(nil),                                        // 882: forge.SetPrimaryInterfaceRequest
+	(*UsernamePassword)(nil),                                                  // 883: forge.UsernamePassword
+	(*SessionToken)(nil),                                                      // 884: forge.SessionToken
+	(*DpuExtensionServiceCredential)(nil),                                     // 885: forge.DpuExtensionServiceCredential
+	(*DpuExtensionServiceVersionInfo)(nil),                                    // 886: forge.DpuExtensionServiceVersionInfo
+	(*DpuExtensionService)(nil),                                               // 887: forge.DpuExtensionService
+	(*CreateDpuExtensionServiceRequest)(nil),                                  // 888: forge.CreateDpuExtensionServiceRequest
+	(*UpdateDpuExtensionServiceRequest)(nil),                                  // 889: forge.UpdateDpuExtensionServiceRequest
+	(*DeleteDpuExtensionServiceRequest)(nil),                                  // 890: forge.DeleteDpuExtensionServiceRequest
+	(*DeleteDpuExtensionServiceResponse)(nil),                                 // 891: forge.DeleteDpuExtensionServiceResponse
+	(*DpuExtensionServiceSearchFilter)(nil),                                   // 892: forge.DpuExtensionServiceSearchFilter
+	(*DpuExtensionServiceIdList)(nil),                                         // 893: forge.DpuExtensionServiceIdList
+	(*DpuExtensionServicesByIdsRequest)(nil),                                  // 894: forge.DpuExtensionServicesByIdsRequest
+	(*DpuExtensionServiceList)(nil),                                           // 895: forge.DpuExtensionServiceList
+	(*GetDpuExtensionServiceVersionsInfoRequest)(nil),                         // 896: forge.GetDpuExtensionServiceVersionsInfoRequest
+	(*DpuExtensionServiceVersionInfoList)(nil),                                // 897: forge.DpuExtensionServiceVersionInfoList
+	(*FindInstancesByDpuExtensionServiceRequest)(nil),                         // 898: forge.FindInstancesByDpuExtensionServiceRequest
+	(*FindInstancesByDpuExtensionServiceResponse)(nil),                        // 899: forge.FindInstancesByDpuExtensionServiceResponse
+	(*InstanceDpuExtensionServiceInfo)(nil),                                   // 900: forge.InstanceDpuExtensionServiceInfo
+	(*DpuExtensionServiceObservabilityConfigPrometheus)(nil),                  // 901: forge.DpuExtensionServiceObservabilityConfigPrometheus
+	(*DpuExtensionServiceObservabilityConfigLogging)(nil),                     // 902: forge.DpuExtensionServiceObservabilityConfigLogging
+	(*DpuExtensionServiceObservabilityConfig)(nil),                            // 903: forge.DpuExtensionServiceObservabilityConfig
+	(*DpuExtensionServiceObservability)(nil),                                  // 904: forge.DpuExtensionServiceObservability
+	(*ScoutStreamApiBoundMessage)(nil),                                        // 905: forge.ScoutStreamApiBoundMessage
+	(*ScoutStreamScoutBoundMessage)(nil),                                      // 906: forge.ScoutStreamScoutBoundMessage
+	(*ScoutStreamInitRequest)(nil),                                            // 907: forge.ScoutStreamInitRequest
+	(*ScoutStreamShowConnectionsRequest)(nil),                                 // 908: forge.ScoutStreamShowConnectionsRequest
+	(*ScoutStreamShowConnectionsResponse)(nil),                                // 909: forge.ScoutStreamShowConnectionsResponse
+	(*ScoutStreamDisconnectRequest)(nil),                                      // 910: forge.ScoutStreamDisconnectRequest
+	(*ScoutStreamDisconnectResponse)(nil),                                     // 911: forge.ScoutStreamDisconnectResponse
+	(*ScoutStreamAdminPingRequest)(nil),                                       // 912: forge.ScoutStreamAdminPingRequest
+	(*ScoutStreamAdminPingResponse)(nil),                                      // 913: forge.ScoutStreamAdminPingResponse
+	(*ScoutStreamAgentPingRequest)(nil),                                       // 914: forge.ScoutStreamAgentPingRequest
+	(*ScoutStreamAgentPingResponse)(nil),                                      // 915: forge.ScoutStreamAgentPingResponse
+	(*ScoutStreamConnectionInfo)(nil),                                         // 916: forge.ScoutStreamConnectionInfo
+	(*ScoutStreamError)(nil),                                                  // 917: forge.ScoutStreamError
+	(*PrefixFilterPolicyEntry)(nil),                                           // 918: forge.PrefixFilterPolicyEntry
+	(*RoutingProfile)(nil),                                                    // 919: forge.RoutingProfile
+	(*DomainLegacy)(nil),                                                      // 920: forge.DomainLegacy
+	(*DomainListLegacy)(nil),                                                  // 921: forge.DomainListLegacy
+	(*DomainDeletionLegacy)(nil),                                              // 922: forge.DomainDeletionLegacy
+	(*DomainDeletionResultLegacy)(nil),                                        // 923: forge.DomainDeletionResultLegacy
+	(*DomainSearchQueryLegacy)(nil),                                           // 924: forge.DomainSearchQueryLegacy
+	(*PxeDomain)(nil),                                                         // 925: forge.PxeDomain
+	(*MachinePositionQuery)(nil),                                              // 926: forge.MachinePositionQuery
+	(*MachinePositionInfoList)(nil),                                           // 927: forge.MachinePositionInfoList
+	(*MachinePositionInfo)(nil),                                               // 928: forge.MachinePositionInfo
+	(*ModifyDPFStateRequest)(nil),                                             // 929: forge.ModifyDPFStateRequest
+	(*DPFStateResponse)(nil),                                                  // 930: forge.DPFStateResponse
+	(*GetDPFStateRequest)(nil),                                                // 931: forge.GetDPFStateRequest
+	(*GetDPFHostSnapshotRequest)(nil),                                         // 932: forge.GetDPFHostSnapshotRequest
+	(*DPFHostSnapshotResponse)(nil),                                           // 933: forge.DPFHostSnapshotResponse
+	(*GetDPFServiceVersionsRequest)(nil),                                      // 934: forge.GetDPFServiceVersionsRequest
+	(*DPFServiceVersion)(nil),                                                 // 935: forge.DPFServiceVersion
+	(*DPFServiceVersionsResponse)(nil),                                        // 936: forge.DPFServiceVersionsResponse
+	(*ReleaseDPUServiceSyncHoldRequest)(nil),                                  // 937: forge.ReleaseDPUServiceSyncHoldRequest
+	(*DPUServiceSyncReleaseResult)(nil),                                       // 938: forge.DPUServiceSyncReleaseResult
+	(*ReleaseDPUServiceSyncHoldResponse)(nil),                                 // 939: forge.ReleaseDPUServiceSyncHoldResponse
+	(*FindPendingDPUServiceSyncIdsRequest)(nil),                               // 940: forge.FindPendingDPUServiceSyncIdsRequest
+	(*FindPendingDPUServiceSyncsByIdsRequest)(nil),                            // 941: forge.FindPendingDPUServiceSyncsByIdsRequest
+	(*ListDPUServiceSyncHistoryRequest)(nil),                                  // 942: forge.ListDPUServiceSyncHistoryRequest
+	(*PendingDPUServiceSync)(nil),                                             // 943: forge.PendingDPUServiceSync
+	(*ListPendingDPUServiceSyncsResponse)(nil),                                // 944: forge.ListPendingDPUServiceSyncsResponse
+	(*ComponentResult)(nil),                                                   // 945: forge.ComponentResult
+	(*SwitchIdList)(nil),                                                      // 946: forge.SwitchIdList
+	(*PowerShelfIdList)(nil),                                                  // 947: forge.PowerShelfIdList
+	(*MacAddressList)(nil),                                                    // 948: forge.MacAddressList
+	(*GetComponentInventoryRequest)(nil),                                      // 949: forge.GetComponentInventoryRequest
+	(*ComponentInventoryEntry)(nil),                                           // 950: forge.ComponentInventoryEntry
+	(*GetComponentInventoryResponse)(nil),                                     // 951: forge.GetComponentInventoryResponse
+	(*ComponentPowerControlRequest)(nil),                                      // 952: forge.ComponentPowerControlRequest
+	(*ComponentPowerControlResponse)(nil),                                     // 953: forge.ComponentPowerControlResponse
+	(*ComponentConfigureSwitchCertificateRequest)(nil),                        // 954: forge.ComponentConfigureSwitchCertificateRequest
+	(*ComponentConfigureSwitchCertificateResponse)(nil),                       // 955: forge.ComponentConfigureSwitchCertificateResponse
+	(*FirmwareUpdateStatus)(nil),                                              // 956: forge.FirmwareUpdateStatus
+	(*UpdateComputeTrayFirmwareTarget)(nil),                                   // 957: forge.UpdateComputeTrayFirmwareTarget
+	(*UpdateSwitchFirmwareTarget)(nil),                                        // 958: forge.UpdateSwitchFirmwareTarget
+	(*UpdatePowerShelfFirmwareTarget)(nil),                                    // 959: forge.UpdatePowerShelfFirmwareTarget
+	(*UpdateFirmwareObjectTarget)(nil),                                        // 960: forge.UpdateFirmwareObjectTarget
+	(*UpdateComponentFirmwareRequest)(nil),                                    // 961: forge.UpdateComponentFirmwareRequest
+	(*UpdateComponentFirmwareResponse)(nil),                                   // 962: forge.UpdateComponentFirmwareResponse
+	(*GetComponentFirmwareStatusRequest)(nil),                                 // 963: forge.GetComponentFirmwareStatusRequest
+	(*GetComponentFirmwareStatusResponse)(nil),                                // 964: forge.GetComponentFirmwareStatusResponse
+	(*ListComponentFirmwareVersionsRequest)(nil),                              // 965: forge.ListComponentFirmwareVersionsRequest
+	(*ComputeTrayFirmwareVersions)(nil),                                       // 966: forge.ComputeTrayFirmwareVersions
+	(*DeviceFirmwareVersions)(nil),                                            // 967: forge.DeviceFirmwareVersions
+	(*ListComponentFirmwareVersionsResponse)(nil),                             // 968: forge.ListComponentFirmwareVersionsResponse
+	(*SpxPartitionCreationRequest)(nil),                                       // 969: forge.SpxPartitionCreationRequest
+	(*SpxPartition)(nil),                                                      // 970: forge.SpxPartition
+	(*SpxPartitionIdList)(nil),                                                // 971: forge.SpxPartitionIdList
+	(*SpxPartitionDeletionRequest)(nil),                                       // 972: forge.SpxPartitionDeletionRequest
+	(*SpxPartitionDeletionResult)(nil),                                        // 973: forge.SpxPartitionDeletionResult
+	(*SpxPartitionSearchFilter)(nil),                                          // 974: forge.SpxPartitionSearchFilter
+	(*SpxPartitionList)(nil),                                                  // 975: forge.SpxPartitionList
+	(*SpxPartitionsByIdsRequest)(nil),                                         // 976: forge.SpxPartitionsByIdsRequest
+	(*AdminForceDeleteSwitchRequest)(nil),                                     // 977: forge.AdminForceDeleteSwitchRequest
+	(*AdminForceDeleteSwitchResponse)(nil),                                    // 978: forge.AdminForceDeleteSwitchResponse
+	(*AdminForceDeletePowerShelfRequest)(nil),                                 // 979: forge.AdminForceDeletePowerShelfRequest
+	(*AdminForceDeletePowerShelfResponse)(nil),                                // 980: forge.AdminForceDeletePowerShelfResponse
+	(*OperatingSystem)(nil),                                                   // 981: forge.OperatingSystem
+	(*CreateOperatingSystemRequest)(nil),                                      // 982: forge.CreateOperatingSystemRequest
+	(*IpxeTemplateParameters)(nil),                                            // 983: forge.IpxeTemplateParameters
+	(*IpxeTemplateArtifacts)(nil),                                             // 984: forge.IpxeTemplateArtifacts
+	(*UpdateOperatingSystemRequest)(nil),                                      // 985: forge.UpdateOperatingSystemRequest
+	(*DeleteOperatingSystemRequest)(nil),                                      // 986: forge.DeleteOperatingSystemRequest
+	(*DeleteOperatingSystemResponse)(nil),                                     // 987: forge.DeleteOperatingSystemResponse
+	(*OperatingSystemSearchFilter)(nil),                                       // 988: forge.OperatingSystemSearchFilter
+	(*OperatingSystemIdList)(nil),                                             // 989: forge.OperatingSystemIdList
+	(*OperatingSystemsByIdsRequest)(nil),                                      // 990: forge.OperatingSystemsByIdsRequest
+	(*OperatingSystemList)(nil),                                               // 991: forge.OperatingSystemList
+	(*GetOperatingSystemCachableIpxeTemplateArtifactsRequest)(nil),            // 992: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	(*IpxeTemplateArtifactList)(nil),                                          // 993: forge.IpxeTemplateArtifactList
+	(*IpxeTemplateArtifactUpdateRequest)(nil),                                 // 994: forge.IpxeTemplateArtifactUpdateRequest
+	(*UpdateOperatingSystemIpxeTemplateArtifactRequest)(nil),                  // 995: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	(*ReWrapSecretsRequest)(nil),                                              // 996: forge.ReWrapSecretsRequest
+	(*ReWrapSecretsResponse)(nil),                                             // 997: forge.ReWrapSecretsResponse
+	(*GetMachineBootInterfacesRequest)(nil),                                   // 998: forge.GetMachineBootInterfacesRequest
+	(*MachineBootInterface)(nil),                                              // 999: forge.MachineBootInterface
+	(*MachineInterfaceBootInterface)(nil),                                     // 1000: forge.MachineInterfaceBootInterface
+	(*PredictedBootInterface)(nil),                                            // 1001: forge.PredictedBootInterface
+	(*ExploredBootInterface)(nil),                                             // 1002: forge.ExploredBootInterface
+	(*RetainedBootInterface)(nil),                                             // 1003: forge.RetainedBootInterface
+	(*GetMachineBootInterfacesResponse)(nil),                                  // 1004: forge.GetMachineBootInterfacesResponse
+	(*GetContainerRegistryCredentialRequest)(nil),                             // 1005: forge.GetContainerRegistryCredentialRequest
+	(*GetContainerRegistryCredentialResponse)(nil),                            // 1006: forge.GetContainerRegistryCredentialResponse
+	(*SetContainerRegistryCredentialRequest)(nil),                             // 1007: forge.SetContainerRegistryCredentialRequest
+	(*SitePrefix)(nil),                                                        // 1008: forge.SitePrefix
+	(*SitePrefixConfig)(nil),                                                  // 1009: forge.SitePrefixConfig
+	(*SitePrefixStatus)(nil),                                                  // 1010: forge.SitePrefixStatus
+	(*SitePrefixQuotaUsage)(nil),                                              // 1011: forge.SitePrefixQuotaUsage
+	(*SitePrefixCreationRequest)(nil),                                         // 1012: forge.SitePrefixCreationRequest
+	(*SitePrefixUpdateRequest)(nil),                                           // 1013: forge.SitePrefixUpdateRequest
+	(*SitePrefixDeletionRequest)(nil),                                         // 1014: forge.SitePrefixDeletionRequest
+	(*SitePrefixDeletionResult)(nil),                                          // 1015: forge.SitePrefixDeletionResult
+	(*SitePrefixStateHistoriesRequest)(nil),                                   // 1016: forge.SitePrefixStateHistoriesRequest
+	(*SitePrefixSearchFilter)(nil),                                            // 1017: forge.SitePrefixSearchFilter
+	(*SitePrefixesByIdsRequest)(nil),                                          // 1018: forge.SitePrefixesByIdsRequest
+	(*SitePrefixIdList)(nil),                                                  // 1019: forge.SitePrefixIdList
+	(*SitePrefixList)(nil),                                                    // 1020: forge.SitePrefixList
+	(*InterfaceAddressConfig)(nil),                                            // 1021: forge.InterfaceAddressConfig
+	(*ManagedHostResetRequest)(nil),                                           // 1022: forge.ManagedHostResetRequest
+	(*ManagedHostResetListRequest)(nil),                                       // 1023: forge.ManagedHostResetListRequest
+	(*ManagedHostResetListResponse)(nil),                                      // 1024: forge.ManagedHostResetListResponse
+	(*VpcReleaseInactiveVniRequest)(nil),                                      // 1025: forge.VpcReleaseInactiveVniRequest
+	(*VpcReleaseInactiveVniResult)(nil),                                       // 1026: forge.VpcReleaseInactiveVniResult
+	(*VpcRoutingStateRequest)(nil),                                            // 1027: forge.VpcRoutingStateRequest
+	(*VpcRoutingState)(nil),                                                   // 1028: forge.VpcRoutingState
+	(*VpcRetainedVniAllocation)(nil),                                          // 1029: forge.VpcRetainedVniAllocation
+	(*VpcChangeRoutingProfileRequest)(nil),                                    // 1030: forge.VpcChangeRoutingProfileRequest
+	nil,                                                                       // 1031: forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
+	(*DNSMessage_DNSQuestion)(nil),                                            // 1032: forge.DNSMessage.DNSQuestion
+	(*DNSMessage_DNSResponse)(nil),                                            // 1033: forge.DNSMessage.DNSResponse
+	(*DNSMessage_DNSResponse_DNSRR)(nil),                                      // 1034: forge.DNSMessage.DNSResponse.DNSRR
+	nil,                                                                       // 1035: forge.FabricManagerConfig.ConfigMapEntry
+	nil,                                                                       // 1036: forge.StateHistories.HistoriesEntry
+	nil,                                                                       // 1037: forge.MachineStateHistories.HistoriesEntry
+	nil,                                                                       // 1038: forge.HealthHistories.HistoriesEntry
+	(*MachineCredentialsUpdateRequest_Credentials)(nil),                       // 1039: forge.MachineCredentialsUpdateRequest.Credentials
+	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo)(nil),              // 1040: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
+	(*ForgeAgentControlResponse_Noop)(nil),                                    // 1041: forge.ForgeAgentControlResponse.Noop
+	(*ForgeAgentControlResponse_Reset)(nil),                                   // 1042: forge.ForgeAgentControlResponse.Reset
+	(*ForgeAgentControlResponse_Discovery)(nil),                               // 1043: forge.ForgeAgentControlResponse.Discovery
+	(*ForgeAgentControlResponse_Rebuild)(nil),                                 // 1044: forge.ForgeAgentControlResponse.Rebuild
+	(*ForgeAgentControlResponse_Retry)(nil),                                   // 1045: forge.ForgeAgentControlResponse.Retry
+	(*ForgeAgentControlResponse_Measure)(nil),                                 // 1046: forge.ForgeAgentControlResponse.Measure
+	(*ForgeAgentControlResponse_LogError)(nil),                                // 1047: forge.ForgeAgentControlResponse.LogError
+	(*ForgeAgentControlResponse_MachineValidation)(nil),                       // 1048: forge.ForgeAgentControlResponse.MachineValidation
+	(*ForgeAgentControlResponse_MachineValidationFilter)(nil),                 // 1049: forge.ForgeAgentControlResponse.MachineValidationFilter
+	(*ForgeAgentControlResponse_MlxAction)(nil),                               // 1050: forge.ForgeAgentControlResponse.MlxAction
+	(*ForgeAgentControlResponse_MlxDeviceAction)(nil),                         // 1051: forge.ForgeAgentControlResponse.MlxDeviceAction
+	(*ForgeAgentControlResponse_MlxDeviceNoop)(nil),                           // 1052: forge.ForgeAgentControlResponse.MlxDeviceNoop
+	(*ForgeAgentControlResponse_MlxDeviceLock)(nil),                           // 1053: forge.ForgeAgentControlResponse.MlxDeviceLock
+	(*ForgeAgentControlResponse_MlxDeviceUnlock)(nil),                         // 1054: forge.ForgeAgentControlResponse.MlxDeviceUnlock
+	(*ForgeAgentControlResponse_MlxDeviceApplyProfile)(nil),                   // 1055: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
+	(*ForgeAgentControlResponse_MlxDeviceApplyFirmware)(nil),                  // 1056: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
+	(*ForgeAgentControlResponse_FirmwareUpgrade)(nil),                         // 1057: forge.ForgeAgentControlResponse.FirmwareUpgrade
+	(*ForgeAgentControlResponse_ForgeAgentControlExtraInfo_KeyValuePair)(nil), // 1058: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
+	(*MachineCleanupInfo_CleanupStepResult)(nil),                              // 1059: forge.MachineCleanupInfo.CleanupStepResult
+	(*DpuReprovisioningListResponse_DpuReprovisioningListItem)(nil),           // 1060: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
+	(*HostReprovisioningListResponse_HostReprovisioningListItem)(nil),         // 1061: forge.HostReprovisioningListResponse.HostReprovisioningListItem
+	(*MachineValidationTestUpdateRequest_Payload)(nil),                        // 1062: forge.MachineValidationTestUpdateRequest.Payload
+	nil,                               // 1063: forge.RedfishBrowseResponse.HeadersEntry
+	nil,                               // 1064: forge.RedfishActionResult.HeadersEntry
+	nil,                               // 1065: forge.UfmBrowseResponse.HeadersEntry
+	nil,                               // 1066: forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
+	nil,                               // 1067: forge.NmxcBrowseResponse.HeadersEntry
+	(*DPFStateResponse_DPFState)(nil), // 1068: forge.DPFStateResponse.DPFState
+	(*GetMachineBootInterfacesResponse_Reconciliation)(nil),       // 1069: forge.GetMachineBootInterfacesResponse.Reconciliation
+	(*ManagedHostResetListResponse_ManagedHostResetListItem)(nil), // 1070: forge.ManagedHostResetListResponse.ManagedHostResetListItem
+	(*MachineId)(nil),                                    // 1071: common.MachineId
+	(*timestamppb.Timestamp)(nil),                        // 1072: google.protobuf.Timestamp
+	(*VpcId)(nil),                                        // 1073: common.VpcId
+	(*RouteTargets)(nil),                                 // 1074: common.RouteTargets
+	(*RouteTarget)(nil),                                  // 1075: common.RouteTarget
+	(*NVLinkLogicalPartitionId)(nil),                     // 1076: common.NVLinkLogicalPartitionId
+	(*VpcPrefixId)(nil),                                  // 1077: common.VpcPrefixId
+	(*SitePrefixId)(nil),                                 // 1078: common.SitePrefixId
+	(*VpcPeeringId)(nil),                                 // 1079: common.VpcPeeringId
+	(*IBPartitionId)(nil),                                // 1080: common.IBPartitionId
+	(*HealthReport)(nil),                                 // 1081: health.HealthReport
+	(*PowerShelfId)(nil),                                 // 1082: common.PowerShelfId
+	(*RackId)(nil),                                       // 1083: common.RackId
+	(*UUID)(nil),                                         // 1084: common.UUID
+	(*SwitchId)(nil),                                     // 1085: common.SwitchId
+	(*NVLinkDomainId)(nil),                               // 1086: common.NVLinkDomainId
+	(*RackProfileId)(nil),                                // 1087: common.RackProfileId
+	(*DomainId)(nil),                                     // 1088: common.DomainId
+	(*NetworkSegmentId)(nil),                             // 1089: common.NetworkSegmentId
+	(*NetworkPrefixId)(nil),                              // 1090: common.NetworkPrefixId
+	(*InstanceId)(nil),                                   // 1091: common.InstanceId
+	(*IpxeTemplateId)(nil),                               // 1092: common.IpxeTemplateId
+	(*OperatingSystemId)(nil),                            // 1093: common.OperatingSystemId
+	(*SpxPartitionId)(nil),                               // 1094: common.SpxPartitionId
+	(*MachineInterfaceId)(nil),                           // 1095: common.MachineInterfaceId
+	(*DiscoveryInfo)(nil),                                // 1096: machine_discovery.DiscoveryInfo
+	(*durationpb.Duration)(nil),                          // 1097: google.protobuf.Duration
+	(*StringList)(nil),                                   // 1098: common.StringList
+	(*Gpu)(nil),                                          // 1099: machine_discovery.Gpu
+	(*DeviceId)(nil),                                     // 1100: common.DeviceId
+	(*MachineValidationId)(nil),                          // 1101: common.MachineValidationId
+	(*Uint32List)(nil),                                   // 1102: common.Uint32List
+	(*DpaInterfaceId)(nil),                               // 1103: common.DpaInterfaceId
+	(*ComputeAllocationId)(nil),                          // 1104: common.ComputeAllocationId
+	(*RackHardwareType)(nil),                             // 1105: common.RackHardwareType
+	(*NVLinkPartitionId)(nil),                            // 1106: common.NVLinkPartitionId
+	(*RemediationId)(nil),                                // 1107: common.RemediationId
+	(*MlxDeviceLockdownResponse)(nil),                    // 1108: mlx_device.MlxDeviceLockdownResponse
+	(*MlxDeviceProfileSyncResponse)(nil),                 // 1109: mlx_device.MlxDeviceProfileSyncResponse
+	(*MlxDeviceProfileCompareResponse)(nil),              // 1110: mlx_device.MlxDeviceProfileCompareResponse
+	(*MlxDeviceInfoDeviceResponse)(nil),                  // 1111: mlx_device.MlxDeviceInfoDeviceResponse
+	(*MlxDeviceInfoReportResponse)(nil),                  // 1112: mlx_device.MlxDeviceInfoReportResponse
+	(*MlxDeviceRegistryListResponse)(nil),                // 1113: mlx_device.MlxDeviceRegistryListResponse
+	(*MlxDeviceRegistryShowResponse)(nil),                // 1114: mlx_device.MlxDeviceRegistryShowResponse
+	(*MlxDeviceConfigQueryResponse)(nil),                 // 1115: mlx_device.MlxDeviceConfigQueryResponse
+	(*MlxDeviceConfigSetResponse)(nil),                   // 1116: mlx_device.MlxDeviceConfigSetResponse
+	(*MlxDeviceConfigSyncResponse)(nil),                  // 1117: mlx_device.MlxDeviceConfigSyncResponse
+	(*MlxDeviceConfigCompareResponse)(nil),               // 1118: mlx_device.MlxDeviceConfigCompareResponse
+	(*MlxDeviceLockdownLockRequest)(nil),                 // 1119: mlx_device.MlxDeviceLockdownLockRequest
+	(*MlxDeviceLockdownUnlockRequest)(nil),               // 1120: mlx_device.MlxDeviceLockdownUnlockRequest
+	(*MlxDeviceLockdownStatusRequest)(nil),               // 1121: mlx_device.MlxDeviceLockdownStatusRequest
+	(*MlxDeviceProfileSyncRequest)(nil),                  // 1122: mlx_device.MlxDeviceProfileSyncRequest
+	(*MlxDeviceProfileCompareRequest)(nil),               // 1123: mlx_device.MlxDeviceProfileCompareRequest
+	(*MlxDeviceInfoDeviceRequest)(nil),                   // 1124: mlx_device.MlxDeviceInfoDeviceRequest
+	(*MlxDeviceInfoReportRequest)(nil),                   // 1125: mlx_device.MlxDeviceInfoReportRequest
+	(*MlxDeviceRegistryListRequest)(nil),                 // 1126: mlx_device.MlxDeviceRegistryListRequest
+	(*MlxDeviceRegistryShowRequest)(nil),                 // 1127: mlx_device.MlxDeviceRegistryShowRequest
+	(*MlxDeviceConfigQueryRequest)(nil),                  // 1128: mlx_device.MlxDeviceConfigQueryRequest
+	(*MlxDeviceConfigSetRequest)(nil),                    // 1129: mlx_device.MlxDeviceConfigSetRequest
+	(*MlxDeviceConfigSyncRequest)(nil),                   // 1130: mlx_device.MlxDeviceConfigSyncRequest
+	(*MlxDeviceConfigCompareRequest)(nil),                // 1131: mlx_device.MlxDeviceConfigCompareRequest
+	(*Domain)(nil),                                       // 1132: dns.Domain
+	(*MachineIdList)(nil),                                // 1133: common.MachineIdList
+	(*EndpointExplorationReport)(nil),                    // 1134: site_explorer.EndpointExplorationReport
+	(SystemPowerControl)(0),                              // 1135: common.SystemPowerControl
+	(*SerializableMlxConfigProfile)(nil),                 // 1136: mlx_device.SerializableMlxConfigProfile
+	(*FirmwareFlasherProfile)(nil),                       // 1137: mlx_device.FirmwareFlasherProfile
+	(*ScoutFirmwareUpgradeTask)(nil),                     // 1138: scout_firmware_upgrade.ScoutFirmwareUpgradeTask
+	(*CreateDomainRequest)(nil),                          // 1139: dns.CreateDomainRequest
+	(*UpdateDomainRequest)(nil),                          // 1140: dns.UpdateDomainRequest
+	(*DomainDeletionRequest)(nil),                        // 1141: dns.DomainDeletionRequest
+	(*DomainSearchQuery)(nil),                            // 1142: dns.DomainSearchQuery
+	(*DnsResourceRecordLookupRequest)(nil),               // 1143: dns.DnsResourceRecordLookupRequest
+	(*GetAllDomainsRequest)(nil),                         // 1144: dns.GetAllDomainsRequest
+	(*DomainMetadataRequest)(nil),                        // 1145: dns.DomainMetadataRequest
+	(*emptypb.Empty)(nil),                                // 1146: google.protobuf.Empty
+	(*ExploredEndpointSearchFilter)(nil),                 // 1147: site_explorer.ExploredEndpointSearchFilter
+	(*ExploredEndpointsByIdsRequest)(nil),                // 1148: site_explorer.ExploredEndpointsByIdsRequest
+	(*ExploredManagedHostSearchFilter)(nil),              // 1149: site_explorer.ExploredManagedHostSearchFilter
+	(*ExploredManagedHostsByIdsRequest)(nil),             // 1150: site_explorer.ExploredManagedHostsByIdsRequest
+	(*ExploredMlxDeviceHostSearchFilter)(nil),            // 1151: site_explorer.ExploredMlxDeviceHostSearchFilter
+	(*ExploredMlxDevicesByIdsRequest)(nil),               // 1152: site_explorer.ExploredMlxDevicesByIdsRequest
+	(*CreateMeasurementBundleRequest)(nil),               // 1153: measured_boot.CreateMeasurementBundleRequest
+	(*DeleteMeasurementBundleRequest)(nil),               // 1154: measured_boot.DeleteMeasurementBundleRequest
+	(*RenameMeasurementBundleRequest)(nil),               // 1155: measured_boot.RenameMeasurementBundleRequest
+	(*UpdateMeasurementBundleRequest)(nil),               // 1156: measured_boot.UpdateMeasurementBundleRequest
+	(*ShowMeasurementBundleRequest)(nil),                 // 1157: measured_boot.ShowMeasurementBundleRequest
+	(*ShowMeasurementBundlesRequest)(nil),                // 1158: measured_boot.ShowMeasurementBundlesRequest
+	(*ListMeasurementBundlesRequest)(nil),                // 1159: measured_boot.ListMeasurementBundlesRequest
+	(*ListMeasurementBundleMachinesRequest)(nil),         // 1160: measured_boot.ListMeasurementBundleMachinesRequest
+	(*FindClosestBundleMatchRequest)(nil),                // 1161: measured_boot.FindClosestBundleMatchRequest
+	(*DeleteMeasurementJournalRequest)(nil),              // 1162: measured_boot.DeleteMeasurementJournalRequest
+	(*ShowMeasurementJournalRequest)(nil),                // 1163: measured_boot.ShowMeasurementJournalRequest
+	(*ShowMeasurementJournalsRequest)(nil),               // 1164: measured_boot.ShowMeasurementJournalsRequest
+	(*ListMeasurementJournalRequest)(nil),                // 1165: measured_boot.ListMeasurementJournalRequest
+	(*AttestCandidateMachineRequest)(nil),                // 1166: measured_boot.AttestCandidateMachineRequest
+	(*ShowCandidateMachineRequest)(nil),                  // 1167: measured_boot.ShowCandidateMachineRequest
+	(*ShowCandidateMachinesRequest)(nil),                 // 1168: measured_boot.ShowCandidateMachinesRequest
+	(*ListCandidateMachinesRequest)(nil),                 // 1169: measured_boot.ListCandidateMachinesRequest
+	(*CreateMeasurementSystemProfileRequest)(nil),        // 1170: measured_boot.CreateMeasurementSystemProfileRequest
+	(*DeleteMeasurementSystemProfileRequest)(nil),        // 1171: measured_boot.DeleteMeasurementSystemProfileRequest
+	(*RenameMeasurementSystemProfileRequest)(nil),        // 1172: measured_boot.RenameMeasurementSystemProfileRequest
+	(*ShowMeasurementSystemProfileRequest)(nil),          // 1173: measured_boot.ShowMeasurementSystemProfileRequest
+	(*ShowMeasurementSystemProfilesRequest)(nil),         // 1174: measured_boot.ShowMeasurementSystemProfilesRequest
+	(*ListMeasurementSystemProfilesRequest)(nil),         // 1175: measured_boot.ListMeasurementSystemProfilesRequest
+	(*ListMeasurementSystemProfileBundlesRequest)(nil),   // 1176: measured_boot.ListMeasurementSystemProfileBundlesRequest
+	(*ListMeasurementSystemProfileMachinesRequest)(nil),  // 1177: measured_boot.ListMeasurementSystemProfileMachinesRequest
+	(*CreateMeasurementReportRequest)(nil),               // 1178: measured_boot.CreateMeasurementReportRequest
+	(*DeleteMeasurementReportRequest)(nil),               // 1179: measured_boot.DeleteMeasurementReportRequest
+	(*PromoteMeasurementReportRequest)(nil),              // 1180: measured_boot.PromoteMeasurementReportRequest
+	(*RevokeMeasurementReportRequest)(nil),               // 1181: measured_boot.RevokeMeasurementReportRequest
+	(*ShowMeasurementReportForIdRequest)(nil),            // 1182: measured_boot.ShowMeasurementReportForIdRequest
+	(*ShowMeasurementReportsForMachineRequest)(nil),      // 1183: measured_boot.ShowMeasurementReportsForMachineRequest
+	(*ShowMeasurementReportsRequest)(nil),                // 1184: measured_boot.ShowMeasurementReportsRequest
+	(*ListMeasurementReportRequest)(nil),                 // 1185: measured_boot.ListMeasurementReportRequest
+	(*MatchMeasurementReportRequest)(nil),                // 1186: measured_boot.MatchMeasurementReportRequest
+	(*ImportSiteMeasurementsRequest)(nil),                // 1187: measured_boot.ImportSiteMeasurementsRequest
+	(*ExportSiteMeasurementsRequest)(nil),                // 1188: measured_boot.ExportSiteMeasurementsRequest
+	(*AddMeasurementTrustedMachineRequest)(nil),          // 1189: measured_boot.AddMeasurementTrustedMachineRequest
+	(*RemoveMeasurementTrustedMachineRequest)(nil),       // 1190: measured_boot.RemoveMeasurementTrustedMachineRequest
+	(*AddMeasurementTrustedProfileRequest)(nil),          // 1191: measured_boot.AddMeasurementTrustedProfileRequest
+	(*RemoveMeasurementTrustedProfileRequest)(nil),       // 1192: measured_boot.RemoveMeasurementTrustedProfileRequest
+	(*ListMeasurementTrustedMachinesRequest)(nil),        // 1193: measured_boot.ListMeasurementTrustedMachinesRequest
+	(*ListMeasurementTrustedProfilesRequest)(nil),        // 1194: measured_boot.ListMeasurementTrustedProfilesRequest
+	(*ListAttestationSummaryRequest)(nil),                // 1195: measured_boot.ListAttestationSummaryRequest
+	(*PublishMlxDeviceReportRequest)(nil),                // 1196: mlx_device.PublishMlxDeviceReportRequest
+	(*PublishMlxObservationReportRequest)(nil),           // 1197: mlx_device.PublishMlxObservationReportRequest
+	(*MlxAdminProfileSyncRequest)(nil),                   // 1198: mlx_device.MlxAdminProfileSyncRequest
+	(*MlxAdminProfileShowRequest)(nil),                   // 1199: mlx_device.MlxAdminProfileShowRequest
+	(*MlxAdminProfileCompareRequest)(nil),                // 1200: mlx_device.MlxAdminProfileCompareRequest
+	(*MlxAdminProfileListRequest)(nil),                   // 1201: mlx_device.MlxAdminProfileListRequest
+	(*MlxAdminLockdownLockRequest)(nil),                  // 1202: mlx_device.MlxAdminLockdownLockRequest
+	(*MlxAdminLockdownUnlockRequest)(nil),                // 1203: mlx_device.MlxAdminLockdownUnlockRequest
+	(*MlxAdminLockdownStatusRequest)(nil),                // 1204: mlx_device.MlxAdminLockdownStatusRequest
+	(*MlxAdminDeviceInfoRequest)(nil),                    // 1205: mlx_device.MlxAdminDeviceInfoRequest
+	(*MlxAdminDeviceReportRequest)(nil),                  // 1206: mlx_device.MlxAdminDeviceReportRequest
+	(*MlxAdminRegistryListRequest)(nil),                  // 1207: mlx_device.MlxAdminRegistryListRequest
+	(*MlxAdminRegistryShowRequest)(nil),                  // 1208: mlx_device.MlxAdminRegistryShowRequest
+	(*MlxAdminConfigQueryRequest)(nil),                   // 1209: mlx_device.MlxAdminConfigQueryRequest
+	(*MlxAdminConfigSetRequest)(nil),                     // 1210: mlx_device.MlxAdminConfigSetRequest
+	(*MlxAdminConfigSyncRequest)(nil),                    // 1211: mlx_device.MlxAdminConfigSyncRequest
+	(*MlxAdminConfigCompareRequest)(nil),                 // 1212: mlx_device.MlxAdminConfigCompareRequest
+	(*DomainDeletionResult)(nil),                         // 1213: dns.DomainDeletionResult
+	(*DomainList)(nil),                                   // 1214: dns.DomainList
+	(*DnsResourceRecordLookupResponse)(nil),              // 1215: dns.DnsResourceRecordLookupResponse
+	(*GetAllDomainsResponse)(nil),                        // 1216: dns.GetAllDomainsResponse
+	(*DomainMetadataResponse)(nil),                       // 1217: dns.DomainMetadataResponse
+	(*SiteExplorationReport)(nil),                        // 1218: site_explorer.SiteExplorationReport
+	(*SiteExplorerLastRunResponse)(nil),                  // 1219: site_explorer.SiteExplorerLastRunResponse
+	(*ExploredEndpoint)(nil),                             // 1220: site_explorer.ExploredEndpoint
+	(*ExploredEndpointIdList)(nil),                       // 1221: site_explorer.ExploredEndpointIdList
+	(*ExploredEndpointList)(nil),                         // 1222: site_explorer.ExploredEndpointList
+	(*ExploredManagedHostIdList)(nil),                    // 1223: site_explorer.ExploredManagedHostIdList
+	(*ExploredManagedHostList)(nil),                      // 1224: site_explorer.ExploredManagedHostList
+	(*ExploredMlxDeviceHostIdList)(nil),                  // 1225: site_explorer.ExploredMlxDeviceHostIdList
+	(*ExploredMlxDeviceList)(nil),                        // 1226: site_explorer.ExploredMlxDeviceList
+	(*CreateMeasurementBundleResponse)(nil),              // 1227: measured_boot.CreateMeasurementBundleResponse
+	(*DeleteMeasurementBundleResponse)(nil),              // 1228: measured_boot.DeleteMeasurementBundleResponse
+	(*RenameMeasurementBundleResponse)(nil),              // 1229: measured_boot.RenameMeasurementBundleResponse
+	(*UpdateMeasurementBundleResponse)(nil),              // 1230: measured_boot.UpdateMeasurementBundleResponse
+	(*ShowMeasurementBundleResponse)(nil),                // 1231: measured_boot.ShowMeasurementBundleResponse
+	(*ShowMeasurementBundlesResponse)(nil),               // 1232: measured_boot.ShowMeasurementBundlesResponse
+	(*ListMeasurementBundlesResponse)(nil),               // 1233: measured_boot.ListMeasurementBundlesResponse
+	(*ListMeasurementBundleMachinesResponse)(nil),        // 1234: measured_boot.ListMeasurementBundleMachinesResponse
+	(*DeleteMeasurementJournalResponse)(nil),             // 1235: measured_boot.DeleteMeasurementJournalResponse
+	(*ShowMeasurementJournalResponse)(nil),               // 1236: measured_boot.ShowMeasurementJournalResponse
+	(*ShowMeasurementJournalsResponse)(nil),              // 1237: measured_boot.ShowMeasurementJournalsResponse
+	(*ListMeasurementJournalResponse)(nil),               // 1238: measured_boot.ListMeasurementJournalResponse
+	(*AttestCandidateMachineResponse)(nil),               // 1239: measured_boot.AttestCandidateMachineResponse
+	(*ShowCandidateMachineResponse)(nil),                 // 1240: measured_boot.ShowCandidateMachineResponse
+	(*ShowCandidateMachinesResponse)(nil),                // 1241: measured_boot.ShowCandidateMachinesResponse
+	(*ListCandidateMachinesResponse)(nil),                // 1242: measured_boot.ListCandidateMachinesResponse
+	(*CreateMeasurementSystemProfileResponse)(nil),       // 1243: measured_boot.CreateMeasurementSystemProfileResponse
+	(*DeleteMeasurementSystemProfileResponse)(nil),       // 1244: measured_boot.DeleteMeasurementSystemProfileResponse
+	(*RenameMeasurementSystemProfileResponse)(nil),       // 1245: measured_boot.RenameMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfileResponse)(nil),         // 1246: measured_boot.ShowMeasurementSystemProfileResponse
+	(*ShowMeasurementSystemProfilesResponse)(nil),        // 1247: measured_boot.ShowMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfilesResponse)(nil),        // 1248: measured_boot.ListMeasurementSystemProfilesResponse
+	(*ListMeasurementSystemProfileBundlesResponse)(nil),  // 1249: measured_boot.ListMeasurementSystemProfileBundlesResponse
+	(*ListMeasurementSystemProfileMachinesResponse)(nil), // 1250: measured_boot.ListMeasurementSystemProfileMachinesResponse
+	(*CreateMeasurementReportResponse)(nil),              // 1251: measured_boot.CreateMeasurementReportResponse
+	(*DeleteMeasurementReportResponse)(nil),              // 1252: measured_boot.DeleteMeasurementReportResponse
+	(*PromoteMeasurementReportResponse)(nil),             // 1253: measured_boot.PromoteMeasurementReportResponse
+	(*RevokeMeasurementReportResponse)(nil),              // 1254: measured_boot.RevokeMeasurementReportResponse
+	(*ShowMeasurementReportForIdResponse)(nil),           // 1255: measured_boot.ShowMeasurementReportForIdResponse
+	(*ShowMeasurementReportsForMachineResponse)(nil),     // 1256: measured_boot.ShowMeasurementReportsForMachineResponse
+	(*ShowMeasurementReportsResponse)(nil),               // 1257: measured_boot.ShowMeasurementReportsResponse
+	(*ListMeasurementReportResponse)(nil),                // 1258: measured_boot.ListMeasurementReportResponse
+	(*MatchMeasurementReportResponse)(nil),               // 1259: measured_boot.MatchMeasurementReportResponse
+	(*ImportSiteMeasurementsResponse)(nil),               // 1260: measured_boot.ImportSiteMeasurementsResponse
+	(*ExportSiteMeasurementsResponse)(nil),               // 1261: measured_boot.ExportSiteMeasurementsResponse
+	(*AddMeasurementTrustedMachineResponse)(nil),         // 1262: measured_boot.AddMeasurementTrustedMachineResponse
+	(*RemoveMeasurementTrustedMachineResponse)(nil),      // 1263: measured_boot.RemoveMeasurementTrustedMachineResponse
+	(*AddMeasurementTrustedProfileResponse)(nil),         // 1264: measured_boot.AddMeasurementTrustedProfileResponse
+	(*RemoveMeasurementTrustedProfileResponse)(nil),      // 1265: measured_boot.RemoveMeasurementTrustedProfileResponse
+	(*ListMeasurementTrustedMachinesResponse)(nil),       // 1266: measured_boot.ListMeasurementTrustedMachinesResponse
+	(*ListMeasurementTrustedProfilesResponse)(nil),       // 1267: measured_boot.ListMeasurementTrustedProfilesResponse
+	(*ListAttestationSummaryResponse)(nil),               // 1268: measured_boot.ListAttestationSummaryResponse
+	(*LockdownStatus)(nil),                               // 1269: site_explorer.LockdownStatus
+	(*PublishMlxDeviceReportResponse)(nil),               // 1270: mlx_device.PublishMlxDeviceReportResponse
+	(*PublishMlxObservationReportResponse)(nil),          // 1271: mlx_device.PublishMlxObservationReportResponse
+	(*MlxAdminProfileSyncResponse)(nil),                  // 1272: mlx_device.MlxAdminProfileSyncResponse
+	(*MlxAdminProfileShowResponse)(nil),                  // 1273: mlx_device.MlxAdminProfileShowResponse
+	(*MlxAdminProfileCompareResponse)(nil),               // 1274: mlx_device.MlxAdminProfileCompareResponse
+	(*MlxAdminProfileListResponse)(nil),                  // 1275: mlx_device.MlxAdminProfileListResponse
+	(*MlxAdminLockdownLockResponse)(nil),                 // 1276: mlx_device.MlxAdminLockdownLockResponse
+	(*MlxAdminLockdownUnlockResponse)(nil),               // 1277: mlx_device.MlxAdminLockdownUnlockResponse
+	(*MlxAdminLockdownStatusResponse)(nil),               // 1278: mlx_device.MlxAdminLockdownStatusResponse
+	(*MlxAdminDeviceInfoResponse)(nil),                   // 1279: mlx_device.MlxAdminDeviceInfoResponse
+	(*MlxAdminDeviceReportResponse)(nil),                 // 1280: mlx_device.MlxAdminDeviceReportResponse
+	(*MlxAdminRegistryListResponse)(nil),                 // 1281: mlx_device.MlxAdminRegistryListResponse
+	(*MlxAdminRegistryShowResponse)(nil),                 // 1282: mlx_device.MlxAdminRegistryShowResponse
+	(*MlxAdminConfigQueryResponse)(nil),                  // 1283: mlx_device.MlxAdminConfigQueryResponse
+	(*MlxAdminConfigSetResponse)(nil),                    // 1284: mlx_device.MlxAdminConfigSetResponse
+	(*MlxAdminConfigSyncResponse)(nil),                   // 1285: mlx_device.MlxAdminConfigSyncResponse
+	(*MlxAdminConfigCompareResponse)(nil),                // 1286: mlx_device.MlxAdminConfigCompareResponse
 }
 var file_nico_nico_proto_depIdxs = []int32{
-	381,  // 0: forge.LifecycleStatus.state_reason:type_name -> forge.ControllerStateReason
-	383,  // 1: forge.LifecycleStatus.sla:type_name -> forge.StateSla
-	1066, // 2: forge.SpdmMachineAttestationStatus.machine_id:type_name -> common.MachineId
+	382,  // 0: forge.LifecycleStatus.state_reason:type_name -> forge.ControllerStateReason
+	384,  // 1: forge.LifecycleStatus.sla:type_name -> forge.StateSla
+	1071, // 2: forge.SpdmMachineAttestationStatus.machine_id:type_name -> common.MachineId
 	0,    // 3: forge.SpdmMachineAttestationStatus.attestation_status:type_name -> forge.SpdmAttestationStatus
-	1066, // 4: forge.SpdmMachineAttestationTriggerResponse.machine_id:type_name -> common.MachineId
-	1066, // 5: forge.SpdmAttestationDetails.machine_id:type_name -> common.MachineId
-	1067, // 6: forge.SpdmAttestationDetails.started_at:type_name -> google.protobuf.Timestamp
-	1067, // 7: forge.SpdmAttestationDetails.cancelled_at:type_name -> google.protobuf.Timestamp
-	1067, // 8: forge.SpdmAttestationDetails.completed_at:type_name -> google.protobuf.Timestamp
-	112,  // 9: forge.SpdmGetAttestationMachineResponse.attestations_details:type_name -> forge.SpdmAttestationDetails
-	1066, // 10: forge.SpdmMachineAttestationTriggerRequest.machine_id:type_name -> common.MachineId
-	1066, // 11: forge.SpdmListAttestationMachinesRequest.machine_id:type_name -> common.MachineId
+	1071, // 4: forge.SpdmMachineAttestationTriggerResponse.machine_id:type_name -> common.MachineId
+	1071, // 5: forge.SpdmAttestationDetails.machine_id:type_name -> common.MachineId
+	1072, // 6: forge.SpdmAttestationDetails.started_at:type_name -> google.protobuf.Timestamp
+	1072, // 7: forge.SpdmAttestationDetails.cancelled_at:type_name -> google.protobuf.Timestamp
+	1072, // 8: forge.SpdmAttestationDetails.completed_at:type_name -> google.protobuf.Timestamp
+	113,  // 9: forge.SpdmGetAttestationMachineResponse.attestations_details:type_name -> forge.SpdmAttestationDetails
+	1071, // 10: forge.SpdmMachineAttestationTriggerRequest.machine_id:type_name -> common.MachineId
+	1071, // 11: forge.SpdmListAttestationMachinesRequest.machine_id:type_name -> common.MachineId
 	1,    // 12: forge.SpdmListAttestationMachinesRequest.selector:type_name -> forge.SpdmListAttestationMachinesRequestSelector
-	110,  // 13: forge.SpdmListAttestationMachinesResponse.statuses:type_name -> forge.SpdmMachineAttestationStatus
-	1067, // 14: forge.TenantIdentitySigningKey.expire_at:type_name -> google.protobuf.Timestamp
-	121,  // 15: forge.SetTenantIdentityConfigRequest.config:type_name -> forge.TenantIdentityConfig
-	121,  // 16: forge.TenantIdentityConfigResponse.config:type_name -> forge.TenantIdentityConfig
-	1067, // 17: forge.TenantIdentityConfigResponse.created_at:type_name -> google.protobuf.Timestamp
-	1067, // 18: forge.TenantIdentityConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
-	120,  // 19: forge.TenantIdentityConfigResponse.signing_keys:type_name -> forge.TenantIdentitySigningKey
-	125,  // 20: forge.TokenDelegationResponse.client_secret_basic:type_name -> forge.ClientSecretBasicResponse
-	1067, // 21: forge.TokenDelegationResponse.created_at:type_name -> google.protobuf.Timestamp
-	1067, // 22: forge.TokenDelegationResponse.updated_at:type_name -> google.protobuf.Timestamp
-	124,  // 23: forge.TokenDelegation.client_secret_basic:type_name -> forge.ClientSecretBasic
-	128,  // 24: forge.TokenDelegationRequest.config:type_name -> forge.TokenDelegation
-	131,  // 25: forge.ReencryptTenantIdentitySecretsResponse.failures:type_name -> forge.ReencryptTenantIdentityFailure
+	111,  // 13: forge.SpdmListAttestationMachinesResponse.statuses:type_name -> forge.SpdmMachineAttestationStatus
+	1072, // 14: forge.TenantIdentitySigningKey.expire_at:type_name -> google.protobuf.Timestamp
+	122,  // 15: forge.SetTenantIdentityConfigRequest.config:type_name -> forge.TenantIdentityConfig
+	122,  // 16: forge.TenantIdentityConfigResponse.config:type_name -> forge.TenantIdentityConfig
+	1072, // 17: forge.TenantIdentityConfigResponse.created_at:type_name -> google.protobuf.Timestamp
+	1072, // 18: forge.TenantIdentityConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
+	121,  // 19: forge.TenantIdentityConfigResponse.signing_keys:type_name -> forge.TenantIdentitySigningKey
+	126,  // 20: forge.TokenDelegationResponse.client_secret_basic:type_name -> forge.ClientSecretBasicResponse
+	1072, // 21: forge.TokenDelegationResponse.created_at:type_name -> google.protobuf.Timestamp
+	1072, // 22: forge.TokenDelegationResponse.updated_at:type_name -> google.protobuf.Timestamp
+	125,  // 23: forge.TokenDelegation.client_secret_basic:type_name -> forge.ClientSecretBasic
+	129,  // 24: forge.TokenDelegationRequest.config:type_name -> forge.TokenDelegation
+	132,  // 25: forge.ReencryptTenantIdentitySecretsResponse.failures:type_name -> forge.ReencryptTenantIdentityFailure
 	2,    // 26: forge.JwksRequest.kind:type_name -> forge.JwksKind
 	3,    // 27: forge.MachineIngestionStateResponse.machine_ingestion_state:type_name -> forge.MachineIngestionState
-	139,  // 28: forge.TpmCaAddedCaStatus.id:type_name -> forge.TpmCaCertId
-	1066, // 29: forge.TpmEkCertStatus.machine_id:type_name -> common.MachineId
-	140,  // 30: forge.TpmEkCertStatusCollection.tpm_ek_cert_statuses:type_name -> forge.TpmEkCertStatus
-	143,  // 31: forge.TpmCaCertDetailCollection.tpm_ca_cert_details:type_name -> forge.TpmCaCertDetail
-	1066, // 32: forge.AttestQuoteRequest.machine_id:type_name -> common.MachineId
-	464,  // 33: forge.AttestQuoteResponse.machine_certificate:type_name -> forge.MachineCertificate
+	140,  // 28: forge.TpmCaAddedCaStatus.id:type_name -> forge.TpmCaCertId
+	1071, // 29: forge.TpmEkCertStatus.machine_id:type_name -> common.MachineId
+	141,  // 30: forge.TpmEkCertStatusCollection.tpm_ek_cert_statuses:type_name -> forge.TpmEkCertStatus
+	144,  // 31: forge.TpmCaCertDetailCollection.tpm_ca_cert_details:type_name -> forge.TpmCaCertDetail
+	1071, // 32: forge.AttestQuoteRequest.machine_id:type_name -> common.MachineId
+	465,  // 33: forge.AttestQuoteResponse.machine_certificate:type_name -> forge.MachineCertificate
 	4,    // 34: forge.CredentialCreationRequest.credential_type:type_name -> forge.CredentialType
 	4,    // 35: forge.CredentialDeletionRequest.credential_type:type_name -> forge.CredentialType
 	5,    // 36: forge.RotateCredentialRequest.credential_type:type_name -> forge.RotationCredentialType
 	5,    // 37: forge.RotateCredentialResult.credential_type:type_name -> forge.RotationCredentialType
-	1067, // 38: forge.RotateCredentialResult.started_at:type_name -> google.protobuf.Timestamp
+	1072, // 38: forge.RotateCredentialResult.started_at:type_name -> google.protobuf.Timestamp
 	5,    // 39: forge.CredentialRotationStatusRequest.credential_type:type_name -> forge.RotationCredentialType
-	1067, // 40: forge.DeviceCredentialRotationStatus.quarantined_until:type_name -> google.protobuf.Timestamp
-	1067, // 41: forge.DeviceCredentialRotationStatus.last_attempt_at:type_name -> google.protobuf.Timestamp
-	1067, // 42: forge.CredentialRotationStatusResult.started_at:type_name -> google.protobuf.Timestamp
-	155,  // 43: forge.CredentialRotationStatusResult.device:type_name -> forge.DeviceCredentialRotationStatus
+	1072, // 40: forge.DeviceCredentialRotationStatus.quarantined_until:type_name -> google.protobuf.Timestamp
+	1072, // 41: forge.DeviceCredentialRotationStatus.last_attempt_at:type_name -> google.protobuf.Timestamp
+	1072, // 42: forge.CredentialRotationStatusResult.started_at:type_name -> google.protobuf.Timestamp
+	156,  // 43: forge.CredentialRotationStatusResult.device:type_name -> forge.DeviceCredentialRotationStatus
 	6,    // 44: forge.BuildInfo.capabilities:type_name -> forge.BuildCapability
-	159,  // 45: forge.BuildInfo.runtime_config:type_name -> forge.RuntimeConfig
-	1027, // 46: forge.RuntimeConfig.dpu_nic_firmware_update_version:type_name -> forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
-	1028, // 47: forge.DNSMessage.question:type_name -> forge.DNSMessage.DNSQuestion
-	1029, // 48: forge.DNSMessage.response:type_name -> forge.DNSMessage.DNSResponse
-	1068, // 49: forge.VpcSearchQuery.id:type_name -> common.VpcId
-	286,  // 50: forge.VpcSearchFilter.label:type_name -> forge.Label
-	1068, // 51: forge.VpcIdList.vpc_ids:type_name -> common.VpcId
-	1068, // 52: forge.VpcsByIdsRequest.vpc_ids:type_name -> common.VpcId
-	917,  // 53: forge.PrefixFilterPolicyEntries.values:type_name -> forge.PrefixFilterPolicyEntry
-	1069, // 54: forge.VpcRoutingProfileOverrides.route_target_imports:type_name -> common.RouteTargets
-	1069, // 55: forge.VpcRoutingProfileOverrides.route_targets_on_exports:type_name -> common.RouteTargets
-	173,  // 56: forge.VpcRoutingProfileOverrides.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntries
-	173,  // 57: forge.VpcRoutingProfileOverrides.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntries
-	1070, // 58: forge.VpcEffectiveRoutingProfile.route_target_imports:type_name -> common.RouteTarget
-	1070, // 59: forge.VpcEffectiveRoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
-	917,  // 60: forge.VpcEffectiveRoutingProfile.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntry
-	917,  // 61: forge.VpcEffectiveRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
+	160,  // 45: forge.BuildInfo.runtime_config:type_name -> forge.RuntimeConfig
+	1031, // 46: forge.RuntimeConfig.dpu_nic_firmware_update_version:type_name -> forge.RuntimeConfig.DpuNicFirmwareUpdateVersionEntry
+	1032, // 47: forge.DNSMessage.question:type_name -> forge.DNSMessage.DNSQuestion
+	1033, // 48: forge.DNSMessage.response:type_name -> forge.DNSMessage.DNSResponse
+	1073, // 49: forge.VpcSearchQuery.id:type_name -> common.VpcId
+	287,  // 50: forge.VpcSearchFilter.label:type_name -> forge.Label
+	1073, // 51: forge.VpcIdList.vpc_ids:type_name -> common.VpcId
+	1073, // 52: forge.VpcsByIdsRequest.vpc_ids:type_name -> common.VpcId
+	918,  // 53: forge.PrefixFilterPolicyEntries.values:type_name -> forge.PrefixFilterPolicyEntry
+	1074, // 54: forge.VpcRoutingProfileOverrides.route_target_imports:type_name -> common.RouteTargets
+	1074, // 55: forge.VpcRoutingProfileOverrides.route_targets_on_exports:type_name -> common.RouteTargets
+	174,  // 56: forge.VpcRoutingProfileOverrides.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntries
+	174,  // 57: forge.VpcRoutingProfileOverrides.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntries
+	1075, // 58: forge.VpcEffectiveRoutingProfile.route_target_imports:type_name -> common.RouteTarget
+	1075, // 59: forge.VpcEffectiveRoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
+	918,  // 60: forge.VpcEffectiveRoutingProfile.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntry
+	918,  // 61: forge.VpcEffectiveRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
 	7,    // 62: forge.VpcConfig.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1071, // 63: forge.VpcConfig.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	174,  // 64: forge.VpcConfig.routing_profile_overrides:type_name -> forge.VpcRoutingProfileOverrides
-	175,  // 65: forge.VpcStatus.effective_routing_profile:type_name -> forge.VpcEffectiveRoutingProfile
-	1068, // 66: forge.Vpc.id:type_name -> common.VpcId
-	1067, // 67: forge.Vpc.created:type_name -> google.protobuf.Timestamp
-	1067, // 68: forge.Vpc.updated:type_name -> google.protobuf.Timestamp
-	1067, // 69: forge.Vpc.deleted:type_name -> google.protobuf.Timestamp
-	287,  // 70: forge.Vpc.metadata:type_name -> forge.Metadata
-	177,  // 71: forge.Vpc.status:type_name -> forge.VpcStatus
-	176,  // 72: forge.Vpc.config:type_name -> forge.VpcConfig
+	1076, // 63: forge.VpcConfig.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	175,  // 64: forge.VpcConfig.routing_profile_overrides:type_name -> forge.VpcRoutingProfileOverrides
+	176,  // 65: forge.VpcStatus.effective_routing_profile:type_name -> forge.VpcEffectiveRoutingProfile
+	1073, // 66: forge.Vpc.id:type_name -> common.VpcId
+	1072, // 67: forge.Vpc.created:type_name -> google.protobuf.Timestamp
+	1072, // 68: forge.Vpc.updated:type_name -> google.protobuf.Timestamp
+	1072, // 69: forge.Vpc.deleted:type_name -> google.protobuf.Timestamp
+	288,  // 70: forge.Vpc.metadata:type_name -> forge.Metadata
+	178,  // 71: forge.Vpc.status:type_name -> forge.VpcStatus
+	177,  // 72: forge.Vpc.config:type_name -> forge.VpcConfig
 	7,    // 73: forge.VpcCreationRequest.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1068, // 74: forge.VpcCreationRequest.id:type_name -> common.VpcId
-	287,  // 75: forge.VpcCreationRequest.metadata:type_name -> forge.Metadata
-	1071, // 76: forge.VpcCreationRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	174,  // 77: forge.VpcCreationRequest.routing_profile_overrides:type_name -> forge.VpcRoutingProfileOverrides
-	1068, // 78: forge.VpcUpdateRequest.id:type_name -> common.VpcId
-	287,  // 79: forge.VpcUpdateRequest.metadata:type_name -> forge.Metadata
-	1071, // 80: forge.VpcUpdateRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	174,  // 81: forge.VpcUpdateRequest.routing_profile_overrides:type_name -> forge.VpcRoutingProfileOverrides
-	178,  // 82: forge.VpcUpdateResult.vpc:type_name -> forge.Vpc
-	1068, // 83: forge.VpcUpdateVirtualizationRequest.id:type_name -> common.VpcId
+	1073, // 74: forge.VpcCreationRequest.id:type_name -> common.VpcId
+	288,  // 75: forge.VpcCreationRequest.metadata:type_name -> forge.Metadata
+	1076, // 76: forge.VpcCreationRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	175,  // 77: forge.VpcCreationRequest.routing_profile_overrides:type_name -> forge.VpcRoutingProfileOverrides
+	1073, // 78: forge.VpcUpdateRequest.id:type_name -> common.VpcId
+	288,  // 79: forge.VpcUpdateRequest.metadata:type_name -> forge.Metadata
+	1076, // 80: forge.VpcUpdateRequest.default_nvlink_logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	175,  // 81: forge.VpcUpdateRequest.routing_profile_overrides:type_name -> forge.VpcRoutingProfileOverrides
+	179,  // 82: forge.VpcUpdateResult.vpc:type_name -> forge.Vpc
+	1073, // 83: forge.VpcUpdateVirtualizationRequest.id:type_name -> common.VpcId
 	7,    // 84: forge.VpcUpdateVirtualizationRequest.network_virtualization_type:type_name -> forge.VpcVirtualizationType
-	1068, // 85: forge.VpcDeletionRequest.id:type_name -> common.VpcId
-	178,  // 86: forge.VpcList.vpcs:type_name -> forge.Vpc
-	1072, // 87: forge.VpcPrefix.id:type_name -> common.VpcPrefixId
-	1068, // 88: forge.VpcPrefix.vpc_id:type_name -> common.VpcId
-	188,  // 89: forge.VpcPrefix.config:type_name -> forge.VpcPrefixConfig
-	189,  // 90: forge.VpcPrefix.status:type_name -> forge.VpcPrefixStatus
-	287,  // 91: forge.VpcPrefix.metadata:type_name -> forge.Metadata
-	1073, // 92: forge.VpcPrefix.site_prefix_id:type_name -> common.SitePrefixId
-	109,  // 93: forge.VpcPrefixStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1073, // 85: forge.VpcDeletionRequest.id:type_name -> common.VpcId
+	179,  // 86: forge.VpcList.vpcs:type_name -> forge.Vpc
+	1077, // 87: forge.VpcPrefix.id:type_name -> common.VpcPrefixId
+	1073, // 88: forge.VpcPrefix.vpc_id:type_name -> common.VpcId
+	189,  // 89: forge.VpcPrefix.config:type_name -> forge.VpcPrefixConfig
+	190,  // 90: forge.VpcPrefix.status:type_name -> forge.VpcPrefixStatus
+	288,  // 91: forge.VpcPrefix.metadata:type_name -> forge.Metadata
+	1078, // 92: forge.VpcPrefix.site_prefix_id:type_name -> common.SitePrefixId
+	110,  // 93: forge.VpcPrefixStatus.lifecycle:type_name -> forge.LifecycleStatus
 	9,    // 94: forge.VpcPrefixStatus.tenant_state:type_name -> forge.TenantState
-	1072, // 95: forge.VpcPrefixCreationRequest.id:type_name -> common.VpcPrefixId
-	1068, // 96: forge.VpcPrefixCreationRequest.vpc_id:type_name -> common.VpcId
-	188,  // 97: forge.VpcPrefixCreationRequest.config:type_name -> forge.VpcPrefixConfig
-	287,  // 98: forge.VpcPrefixCreationRequest.metadata:type_name -> forge.Metadata
-	1073, // 99: forge.VpcPrefixCreationRequest.site_prefix_id:type_name -> common.SitePrefixId
-	1068, // 100: forge.VpcPrefixSearchQuery.vpc_id:type_name -> common.VpcId
-	1072, // 101: forge.VpcPrefixSearchQuery.tenant_prefix_id:type_name -> common.VpcPrefixId
+	1077, // 95: forge.VpcPrefixCreationRequest.id:type_name -> common.VpcPrefixId
+	1073, // 96: forge.VpcPrefixCreationRequest.vpc_id:type_name -> common.VpcId
+	189,  // 97: forge.VpcPrefixCreationRequest.config:type_name -> forge.VpcPrefixConfig
+	288,  // 98: forge.VpcPrefixCreationRequest.metadata:type_name -> forge.Metadata
+	1078, // 99: forge.VpcPrefixCreationRequest.site_prefix_id:type_name -> common.SitePrefixId
+	1073, // 100: forge.VpcPrefixSearchQuery.vpc_id:type_name -> common.VpcId
+	1077, // 101: forge.VpcPrefixSearchQuery.tenant_prefix_id:type_name -> common.VpcPrefixId
 	8,    // 102: forge.VpcPrefixSearchQuery.prefix_match_type:type_name -> forge.PrefixMatchType
 	11,   // 103: forge.VpcPrefixSearchQuery.deleted:type_name -> forge.DeletedFilter
-	1073, // 104: forge.VpcPrefixSearchQuery.site_prefix_id:type_name -> common.SitePrefixId
-	1072, // 105: forge.VpcPrefixGetRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	1078, // 104: forge.VpcPrefixSearchQuery.site_prefix_id:type_name -> common.SitePrefixId
+	1077, // 105: forge.VpcPrefixGetRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
 	11,   // 106: forge.VpcPrefixGetRequest.deleted:type_name -> forge.DeletedFilter
-	1072, // 107: forge.VpcPrefixIdList.vpc_prefix_ids:type_name -> common.VpcPrefixId
-	187,  // 108: forge.VpcPrefixList.vpc_prefixes:type_name -> forge.VpcPrefix
-	1072, // 109: forge.VpcPrefixUpdateRequest.id:type_name -> common.VpcPrefixId
-	188,  // 110: forge.VpcPrefixUpdateRequest.config:type_name -> forge.VpcPrefixConfig
-	287,  // 111: forge.VpcPrefixUpdateRequest.metadata:type_name -> forge.Metadata
-	1072, // 112: forge.VpcPrefixDeletionRequest.id:type_name -> common.VpcPrefixId
-	1072, // 113: forge.VpcPrefixStateHistoriesRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
-	1074, // 114: forge.VpcPeering.id:type_name -> common.VpcPeeringId
-	1068, // 115: forge.VpcPeering.vpc_id:type_name -> common.VpcId
-	1068, // 116: forge.VpcPeering.peer_vpc_id:type_name -> common.VpcId
-	1074, // 117: forge.VpcPeeringIdList.vpc_peering_ids:type_name -> common.VpcPeeringId
-	199,  // 118: forge.VpcPeeringList.vpc_peerings:type_name -> forge.VpcPeering
-	1068, // 119: forge.VpcPeeringCreationRequest.vpc_id:type_name -> common.VpcId
-	1068, // 120: forge.VpcPeeringCreationRequest.peer_vpc_id:type_name -> common.VpcId
-	1074, // 121: forge.VpcPeeringCreationRequest.id:type_name -> common.VpcPeeringId
-	1068, // 122: forge.VpcPeeringSearchFilter.vpc_id:type_name -> common.VpcId
-	1074, // 123: forge.VpcPeeringsByIdsRequest.vpc_peering_ids:type_name -> common.VpcPeeringId
-	1074, // 124: forge.VpcPeeringDeletionRequest.id:type_name -> common.VpcPeeringId
+	1077, // 107: forge.VpcPrefixIdList.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	188,  // 108: forge.VpcPrefixList.vpc_prefixes:type_name -> forge.VpcPrefix
+	1077, // 109: forge.VpcPrefixUpdateRequest.id:type_name -> common.VpcPrefixId
+	189,  // 110: forge.VpcPrefixUpdateRequest.config:type_name -> forge.VpcPrefixConfig
+	288,  // 111: forge.VpcPrefixUpdateRequest.metadata:type_name -> forge.Metadata
+	1077, // 112: forge.VpcPrefixDeletionRequest.id:type_name -> common.VpcPrefixId
+	1077, // 113: forge.VpcPrefixStateHistoriesRequest.vpc_prefix_ids:type_name -> common.VpcPrefixId
+	1079, // 114: forge.VpcPeering.id:type_name -> common.VpcPeeringId
+	1073, // 115: forge.VpcPeering.vpc_id:type_name -> common.VpcId
+	1073, // 116: forge.VpcPeering.peer_vpc_id:type_name -> common.VpcId
+	1079, // 117: forge.VpcPeeringIdList.vpc_peering_ids:type_name -> common.VpcPeeringId
+	200,  // 118: forge.VpcPeeringList.vpc_peerings:type_name -> forge.VpcPeering
+	1073, // 119: forge.VpcPeeringCreationRequest.vpc_id:type_name -> common.VpcId
+	1073, // 120: forge.VpcPeeringCreationRequest.peer_vpc_id:type_name -> common.VpcId
+	1079, // 121: forge.VpcPeeringCreationRequest.id:type_name -> common.VpcPeeringId
+	1073, // 122: forge.VpcPeeringSearchFilter.vpc_id:type_name -> common.VpcId
+	1079, // 123: forge.VpcPeeringsByIdsRequest.vpc_peering_ids:type_name -> common.VpcPeeringId
+	1079, // 124: forge.VpcPeeringDeletionRequest.id:type_name -> common.VpcPeeringId
 	9,    // 125: forge.IBPartitionStatus.state:type_name -> forge.TenantState
-	381,  // 126: forge.IBPartitionStatus.state_reason:type_name -> forge.ControllerStateReason
-	383,  // 127: forge.IBPartitionStatus.state_sla:type_name -> forge.StateSla
-	1075, // 128: forge.IBPartition.id:type_name -> common.IBPartitionId
-	207,  // 129: forge.IBPartition.config:type_name -> forge.IBPartitionConfig
-	208,  // 130: forge.IBPartition.status:type_name -> forge.IBPartitionStatus
-	287,  // 131: forge.IBPartition.metadata:type_name -> forge.Metadata
-	209,  // 132: forge.IBPartitionList.ib_partitions:type_name -> forge.IBPartition
-	207,  // 133: forge.IBPartitionCreationRequest.config:type_name -> forge.IBPartitionConfig
-	1075, // 134: forge.IBPartitionCreationRequest.id:type_name -> common.IBPartitionId
-	287,  // 135: forge.IBPartitionCreationRequest.metadata:type_name -> forge.Metadata
-	1075, // 136: forge.IBPartitionUpdateRequest.id:type_name -> common.IBPartitionId
-	207,  // 137: forge.IBPartitionUpdateRequest.config:type_name -> forge.IBPartitionConfig
-	287,  // 138: forge.IBPartitionUpdateRequest.metadata:type_name -> forge.Metadata
-	1075, // 139: forge.IBPartitionDeletionRequest.id:type_name -> common.IBPartitionId
-	1075, // 140: forge.IBPartitionsByIdsRequest.ib_partition_ids:type_name -> common.IBPartitionId
-	1075, // 141: forge.IBPartitionIdList.ib_partition_ids:type_name -> common.IBPartitionId
-	381,  // 142: forge.PowerShelfStatus.state_reason:type_name -> forge.ControllerStateReason
-	383,  // 143: forge.PowerShelfStatus.state_sla:type_name -> forge.StateSla
-	1076, // 144: forge.PowerShelfStatus.health:type_name -> health.HealthReport
-	380,  // 145: forge.PowerShelfStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	109,  // 146: forge.PowerShelfStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1077, // 147: forge.PowerShelf.id:type_name -> common.PowerShelfId
-	218,  // 148: forge.PowerShelf.config:type_name -> forge.PowerShelfConfig
-	219,  // 149: forge.PowerShelf.status:type_name -> forge.PowerShelfStatus
-	1067, // 150: forge.PowerShelf.deleted:type_name -> google.protobuf.Timestamp
-	287,  // 151: forge.PowerShelf.metadata:type_name -> forge.Metadata
-	366,  // 152: forge.PowerShelf.bmc_info:type_name -> forge.BmcInfo
-	1078, // 153: forge.PowerShelf.rack_id:type_name -> common.RackId
-	220,  // 154: forge.PowerShelfList.power_shelves:type_name -> forge.PowerShelf
-	218,  // 155: forge.PowerShelfCreationRequest.config:type_name -> forge.PowerShelfConfig
-	1077, // 156: forge.PowerShelfCreationRequest.id:type_name -> common.PowerShelfId
-	1077, // 157: forge.DecommissionPowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1077, // 158: forge.PowerShelfDeletionRequest.id:type_name -> common.PowerShelfId
-	1077, // 159: forge.PowerShelfMaintenanceRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	382,  // 126: forge.IBPartitionStatus.state_reason:type_name -> forge.ControllerStateReason
+	384,  // 127: forge.IBPartitionStatus.state_sla:type_name -> forge.StateSla
+	1080, // 128: forge.IBPartition.id:type_name -> common.IBPartitionId
+	208,  // 129: forge.IBPartition.config:type_name -> forge.IBPartitionConfig
+	209,  // 130: forge.IBPartition.status:type_name -> forge.IBPartitionStatus
+	288,  // 131: forge.IBPartition.metadata:type_name -> forge.Metadata
+	210,  // 132: forge.IBPartitionList.ib_partitions:type_name -> forge.IBPartition
+	208,  // 133: forge.IBPartitionCreationRequest.config:type_name -> forge.IBPartitionConfig
+	1080, // 134: forge.IBPartitionCreationRequest.id:type_name -> common.IBPartitionId
+	288,  // 135: forge.IBPartitionCreationRequest.metadata:type_name -> forge.Metadata
+	1080, // 136: forge.IBPartitionUpdateRequest.id:type_name -> common.IBPartitionId
+	208,  // 137: forge.IBPartitionUpdateRequest.config:type_name -> forge.IBPartitionConfig
+	288,  // 138: forge.IBPartitionUpdateRequest.metadata:type_name -> forge.Metadata
+	1080, // 139: forge.IBPartitionDeletionRequest.id:type_name -> common.IBPartitionId
+	1080, // 140: forge.IBPartitionsByIdsRequest.ib_partition_ids:type_name -> common.IBPartitionId
+	1080, // 141: forge.IBPartitionIdList.ib_partition_ids:type_name -> common.IBPartitionId
+	382,  // 142: forge.PowerShelfStatus.state_reason:type_name -> forge.ControllerStateReason
+	384,  // 143: forge.PowerShelfStatus.state_sla:type_name -> forge.StateSla
+	1081, // 144: forge.PowerShelfStatus.health:type_name -> health.HealthReport
+	381,  // 145: forge.PowerShelfStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	110,  // 146: forge.PowerShelfStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1082, // 147: forge.PowerShelf.id:type_name -> common.PowerShelfId
+	219,  // 148: forge.PowerShelf.config:type_name -> forge.PowerShelfConfig
+	220,  // 149: forge.PowerShelf.status:type_name -> forge.PowerShelfStatus
+	1072, // 150: forge.PowerShelf.deleted:type_name -> google.protobuf.Timestamp
+	288,  // 151: forge.PowerShelf.metadata:type_name -> forge.Metadata
+	367,  // 152: forge.PowerShelf.bmc_info:type_name -> forge.BmcInfo
+	1083, // 153: forge.PowerShelf.rack_id:type_name -> common.RackId
+	221,  // 154: forge.PowerShelfList.power_shelves:type_name -> forge.PowerShelf
+	219,  // 155: forge.PowerShelfCreationRequest.config:type_name -> forge.PowerShelfConfig
+	1082, // 156: forge.PowerShelfCreationRequest.id:type_name -> common.PowerShelfId
+	1082, // 157: forge.DecommissionPowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1082, // 158: forge.PowerShelfDeletionRequest.id:type_name -> common.PowerShelfId
+	1082, // 159: forge.PowerShelfMaintenanceRequest.power_shelf_ids:type_name -> common.PowerShelfId
 	10,   // 160: forge.PowerShelfMaintenanceRequest.operation:type_name -> forge.PowerShelfMaintenanceOperation
-	1077, // 161: forge.PowerShelfStateHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
-	1077, // 162: forge.PowerShelfHealthHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
-	1067, // 163: forge.PowerShelfHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	1067, // 164: forge.PowerShelfHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	1077, // 165: forge.PowerShelfQuery.power_shelf_id:type_name -> common.PowerShelfId
-	1078, // 166: forge.PowerShelfSearchFilter.rack_id:type_name -> common.RackId
+	1082, // 161: forge.PowerShelfStateHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	1082, // 162: forge.PowerShelfHealthHistoriesRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	1072, // 163: forge.PowerShelfHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	1072, // 164: forge.PowerShelfHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	1082, // 165: forge.PowerShelfQuery.power_shelf_id:type_name -> common.PowerShelfId
+	1083, // 166: forge.PowerShelfSearchFilter.rack_id:type_name -> common.RackId
 	11,   // 167: forge.PowerShelfSearchFilter.deleted:type_name -> forge.DeletedFilter
-	1077, // 168: forge.PowerShelvesByIdsRequest.power_shelf_ids:type_name -> common.PowerShelfId
-	287,  // 169: forge.ExpectedPowerShelf.metadata:type_name -> forge.Metadata
-	1078, // 170: forge.ExpectedPowerShelf.rack_id:type_name -> common.RackId
-	1079, // 171: forge.ExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
-	1079, // 172: forge.ExpectedPowerShelfRequest.expected_power_shelf_id:type_name -> common.UUID
-	233,  // 173: forge.ExpectedPowerShelfList.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
-	237,  // 174: forge.LinkedExpectedPowerShelfList.expected_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
-	1077, // 175: forge.LinkedExpectedPowerShelf.power_shelf_id:type_name -> common.PowerShelfId
-	1079, // 176: forge.LinkedExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
-	1078, // 177: forge.LinkedExpectedPowerShelf.rack_id:type_name -> common.RackId
-	239,  // 178: forge.SwitchConfig.fabric_manager_config:type_name -> forge.FabricManagerConfig
-	1031, // 179: forge.FabricManagerConfig.config_map:type_name -> forge.FabricManagerConfig.ConfigMapEntry
+	1082, // 168: forge.PowerShelvesByIdsRequest.power_shelf_ids:type_name -> common.PowerShelfId
+	288,  // 169: forge.ExpectedPowerShelf.metadata:type_name -> forge.Metadata
+	1083, // 170: forge.ExpectedPowerShelf.rack_id:type_name -> common.RackId
+	1084, // 171: forge.ExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
+	1084, // 172: forge.ExpectedPowerShelfRequest.expected_power_shelf_id:type_name -> common.UUID
+	234,  // 173: forge.ExpectedPowerShelfList.expected_power_shelves:type_name -> forge.ExpectedPowerShelf
+	238,  // 174: forge.LinkedExpectedPowerShelfList.expected_power_shelves:type_name -> forge.LinkedExpectedPowerShelf
+	1082, // 175: forge.LinkedExpectedPowerShelf.power_shelf_id:type_name -> common.PowerShelfId
+	1084, // 176: forge.LinkedExpectedPowerShelf.expected_power_shelf_id:type_name -> common.UUID
+	1083, // 177: forge.LinkedExpectedPowerShelf.rack_id:type_name -> common.RackId
+	240,  // 178: forge.SwitchConfig.fabric_manager_config:type_name -> forge.FabricManagerConfig
+	1035, // 179: forge.FabricManagerConfig.config_map:type_name -> forge.FabricManagerConfig.ConfigMapEntry
 	12,   // 180: forge.FabricManagerStatus.fabric_manager_state:type_name -> forge.FabricManagerState
-	381,  // 181: forge.SwitchStatus.state_reason:type_name -> forge.ControllerStateReason
-	383,  // 182: forge.SwitchStatus.state_sla:type_name -> forge.StateSla
-	1076, // 183: forge.SwitchStatus.health:type_name -> health.HealthReport
-	380,  // 184: forge.SwitchStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	109,  // 185: forge.SwitchStatus.lifecycle:type_name -> forge.LifecycleStatus
-	240,  // 186: forge.SwitchStatus.fabric_manager_status_details:type_name -> forge.FabricManagerStatus
-	1080, // 187: forge.Switch.id:type_name -> common.SwitchId
-	238,  // 188: forge.Switch.config:type_name -> forge.SwitchConfig
-	241,  // 189: forge.Switch.status:type_name -> forge.SwitchStatus
-	1067, // 190: forge.Switch.deleted:type_name -> google.protobuf.Timestamp
-	366,  // 191: forge.Switch.bmc_info:type_name -> forge.BmcInfo
-	287,  // 192: forge.Switch.metadata:type_name -> forge.Metadata
-	1078, // 193: forge.Switch.rack_id:type_name -> common.RackId
-	242,  // 194: forge.Switch.placement_in_rack:type_name -> forge.PlacementInRack
-	367,  // 195: forge.Switch.nvos_info:type_name -> forge.SwitchNvosInfo
-	1081, // 196: forge.Switch.nvlink_domain_uuid:type_name -> common.NVLinkDomainId
-	243,  // 197: forge.SwitchList.switches:type_name -> forge.Switch
-	238,  // 198: forge.SwitchCreationRequest.config:type_name -> forge.SwitchConfig
-	1079, // 199: forge.SwitchCreationRequest.id:type_name -> common.UUID
-	242,  // 200: forge.SwitchCreationRequest.placement_in_rack:type_name -> forge.PlacementInRack
-	1080, // 201: forge.SwitchDeletionRequest.id:type_name -> common.SwitchId
-	1080, // 202: forge.DecommissionSwitchRequest.switch_id:type_name -> common.SwitchId
-	1067, // 203: forge.StateHistoryRecord.time:type_name -> google.protobuf.Timestamp
-	250,  // 204: forge.StateHistoryRecords.records:type_name -> forge.StateHistoryRecord
-	1080, // 205: forge.SwitchStateHistoriesRequest.switch_ids:type_name -> common.SwitchId
-	1080, // 206: forge.SwitchHealthHistoriesRequest.switch_ids:type_name -> common.SwitchId
-	1067, // 207: forge.SwitchHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	1067, // 208: forge.SwitchHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	1032, // 209: forge.StateHistories.histories:type_name -> forge.StateHistories.HistoriesEntry
-	1080, // 210: forge.SwitchQuery.switch_id:type_name -> common.SwitchId
-	1078, // 211: forge.SwitchSearchFilter.rack_id:type_name -> common.RackId
+	382,  // 181: forge.SwitchStatus.state_reason:type_name -> forge.ControllerStateReason
+	384,  // 182: forge.SwitchStatus.state_sla:type_name -> forge.StateSla
+	1081, // 183: forge.SwitchStatus.health:type_name -> health.HealthReport
+	381,  // 184: forge.SwitchStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	110,  // 185: forge.SwitchStatus.lifecycle:type_name -> forge.LifecycleStatus
+	241,  // 186: forge.SwitchStatus.fabric_manager_status_details:type_name -> forge.FabricManagerStatus
+	1085, // 187: forge.Switch.id:type_name -> common.SwitchId
+	239,  // 188: forge.Switch.config:type_name -> forge.SwitchConfig
+	242,  // 189: forge.Switch.status:type_name -> forge.SwitchStatus
+	1072, // 190: forge.Switch.deleted:type_name -> google.protobuf.Timestamp
+	367,  // 191: forge.Switch.bmc_info:type_name -> forge.BmcInfo
+	288,  // 192: forge.Switch.metadata:type_name -> forge.Metadata
+	1083, // 193: forge.Switch.rack_id:type_name -> common.RackId
+	243,  // 194: forge.Switch.placement_in_rack:type_name -> forge.PlacementInRack
+	368,  // 195: forge.Switch.nvos_info:type_name -> forge.SwitchNvosInfo
+	1086, // 196: forge.Switch.nvlink_domain_uuid:type_name -> common.NVLinkDomainId
+	244,  // 197: forge.SwitchList.switches:type_name -> forge.Switch
+	239,  // 198: forge.SwitchCreationRequest.config:type_name -> forge.SwitchConfig
+	1084, // 199: forge.SwitchCreationRequest.id:type_name -> common.UUID
+	243,  // 200: forge.SwitchCreationRequest.placement_in_rack:type_name -> forge.PlacementInRack
+	1085, // 201: forge.SwitchDeletionRequest.id:type_name -> common.SwitchId
+	1085, // 202: forge.DecommissionSwitchRequest.switch_id:type_name -> common.SwitchId
+	1072, // 203: forge.StateHistoryRecord.time:type_name -> google.protobuf.Timestamp
+	251,  // 204: forge.StateHistoryRecords.records:type_name -> forge.StateHistoryRecord
+	1085, // 205: forge.SwitchStateHistoriesRequest.switch_ids:type_name -> common.SwitchId
+	1085, // 206: forge.SwitchHealthHistoriesRequest.switch_ids:type_name -> common.SwitchId
+	1072, // 207: forge.SwitchHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	1072, // 208: forge.SwitchHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	1036, // 209: forge.StateHistories.histories:type_name -> forge.StateHistories.HistoriesEntry
+	1085, // 210: forge.SwitchQuery.switch_id:type_name -> common.SwitchId
+	1083, // 211: forge.SwitchSearchFilter.rack_id:type_name -> common.RackId
 	11,   // 212: forge.SwitchSearchFilter.deleted:type_name -> forge.DeletedFilter
-	1080, // 213: forge.SwitchesByIdsRequest.switch_ids:type_name -> common.SwitchId
-	287,  // 214: forge.ExpectedSwitch.metadata:type_name -> forge.Metadata
-	1078, // 215: forge.ExpectedSwitch.rack_id:type_name -> common.RackId
-	1079, // 216: forge.ExpectedSwitch.expected_switch_id:type_name -> common.UUID
-	1079, // 217: forge.ExpectedSwitchRequest.expected_switch_id:type_name -> common.UUID
-	258,  // 218: forge.ExpectedSwitchList.expected_switches:type_name -> forge.ExpectedSwitch
-	262,  // 219: forge.LinkedExpectedSwitchList.expected_switches:type_name -> forge.LinkedExpectedSwitch
-	1080, // 220: forge.LinkedExpectedSwitch.switch_id:type_name -> common.SwitchId
-	1079, // 221: forge.LinkedExpectedSwitch.expected_switch_id:type_name -> common.UUID
-	1078, // 222: forge.LinkedExpectedSwitch.rack_id:type_name -> common.RackId
-	1078, // 223: forge.ExpectedRack.rack_id:type_name -> common.RackId
-	1082, // 224: forge.ExpectedRack.rack_profile_id:type_name -> common.RackProfileId
-	287,  // 225: forge.ExpectedRack.metadata:type_name -> forge.Metadata
-	263,  // 226: forge.ExpectedRackList.expected_racks:type_name -> forge.ExpectedRack
-	1067, // 227: forge.NetworkSegmentStateHistory.time:type_name -> google.protobuf.Timestamp
-	1068, // 228: forge.NetworkSegmentConfig.vpc_id:type_name -> common.VpcId
-	1083, // 229: forge.NetworkSegmentConfig.subdomain_id:type_name -> common.DomainId
+	1085, // 213: forge.SwitchesByIdsRequest.switch_ids:type_name -> common.SwitchId
+	288,  // 214: forge.ExpectedSwitch.metadata:type_name -> forge.Metadata
+	1083, // 215: forge.ExpectedSwitch.rack_id:type_name -> common.RackId
+	1084, // 216: forge.ExpectedSwitch.expected_switch_id:type_name -> common.UUID
+	1084, // 217: forge.ExpectedSwitchRequest.expected_switch_id:type_name -> common.UUID
+	259,  // 218: forge.ExpectedSwitchList.expected_switches:type_name -> forge.ExpectedSwitch
+	263,  // 219: forge.LinkedExpectedSwitchList.expected_switches:type_name -> forge.LinkedExpectedSwitch
+	1085, // 220: forge.LinkedExpectedSwitch.switch_id:type_name -> common.SwitchId
+	1084, // 221: forge.LinkedExpectedSwitch.expected_switch_id:type_name -> common.UUID
+	1083, // 222: forge.LinkedExpectedSwitch.rack_id:type_name -> common.RackId
+	1083, // 223: forge.ExpectedRack.rack_id:type_name -> common.RackId
+	1087, // 224: forge.ExpectedRack.rack_profile_id:type_name -> common.RackProfileId
+	288,  // 225: forge.ExpectedRack.metadata:type_name -> forge.Metadata
+	264,  // 226: forge.ExpectedRackList.expected_racks:type_name -> forge.ExpectedRack
+	1072, // 227: forge.NetworkSegmentStateHistory.time:type_name -> google.protobuf.Timestamp
+	1073, // 228: forge.NetworkSegmentConfig.vpc_id:type_name -> common.VpcId
+	1088, // 229: forge.NetworkSegmentConfig.subdomain_id:type_name -> common.DomainId
 	13,   // 230: forge.NetworkSegmentConfig.segment_type:type_name -> forge.NetworkSegmentType
-	281,  // 231: forge.NetworkSegmentConfig.prefixes:type_name -> forge.NetworkPrefix
+	282,  // 231: forge.NetworkSegmentConfig.prefixes:type_name -> forge.NetworkPrefix
 	14,   // 232: forge.NetworkSegmentStatus.flags:type_name -> forge.NetworkSegmentFlag
-	109,  // 233: forge.NetworkSegmentStatus.lifecycle:type_name -> forge.LifecycleStatus
+	110,  // 233: forge.NetworkSegmentStatus.lifecycle:type_name -> forge.LifecycleStatus
 	9,    // 234: forge.NetworkSegmentStatus.tenant_state:type_name -> forge.TenantState
-	1084, // 235: forge.NetworkSegment.id:type_name -> common.NetworkSegmentId
-	1068, // 236: forge.NetworkSegment.vpc_id:type_name -> common.VpcId
-	1083, // 237: forge.NetworkSegment.subdomain_id:type_name -> common.DomainId
-	281,  // 238: forge.NetworkSegment.prefixes:type_name -> forge.NetworkPrefix
-	1067, // 239: forge.NetworkSegment.created:type_name -> google.protobuf.Timestamp
-	1067, // 240: forge.NetworkSegment.updated:type_name -> google.protobuf.Timestamp
-	1067, // 241: forge.NetworkSegment.deleted:type_name -> google.protobuf.Timestamp
+	1089, // 235: forge.NetworkSegment.id:type_name -> common.NetworkSegmentId
+	1073, // 236: forge.NetworkSegment.vpc_id:type_name -> common.VpcId
+	1088, // 237: forge.NetworkSegment.subdomain_id:type_name -> common.DomainId
+	282,  // 238: forge.NetworkSegment.prefixes:type_name -> forge.NetworkPrefix
+	1072, // 239: forge.NetworkSegment.created:type_name -> google.protobuf.Timestamp
+	1072, // 240: forge.NetworkSegment.updated:type_name -> google.protobuf.Timestamp
+	1072, // 241: forge.NetworkSegment.deleted:type_name -> google.protobuf.Timestamp
 	13,   // 242: forge.NetworkSegment.segment_type:type_name -> forge.NetworkSegmentType
 	14,   // 243: forge.NetworkSegment.flags:type_name -> forge.NetworkSegmentFlag
-	269,  // 244: forge.NetworkSegment.config:type_name -> forge.NetworkSegmentConfig
-	270,  // 245: forge.NetworkSegment.status:type_name -> forge.NetworkSegmentStatus
-	287,  // 246: forge.NetworkSegment.metadata:type_name -> forge.Metadata
+	270,  // 244: forge.NetworkSegment.config:type_name -> forge.NetworkSegmentConfig
+	271,  // 245: forge.NetworkSegment.status:type_name -> forge.NetworkSegmentStatus
+	288,  // 246: forge.NetworkSegment.metadata:type_name -> forge.Metadata
 	9,    // 247: forge.NetworkSegment.state:type_name -> forge.TenantState
-	268,  // 248: forge.NetworkSegment.history:type_name -> forge.NetworkSegmentStateHistory
-	381,  // 249: forge.NetworkSegment.state_reason:type_name -> forge.ControllerStateReason
-	383,  // 250: forge.NetworkSegment.state_sla:type_name -> forge.StateSla
-	1068, // 251: forge.NetworkSegmentCreationRequest.vpc_id:type_name -> common.VpcId
-	1083, // 252: forge.NetworkSegmentCreationRequest.subdomain_id:type_name -> common.DomainId
-	281,  // 253: forge.NetworkSegmentCreationRequest.prefixes:type_name -> forge.NetworkPrefix
+	269,  // 248: forge.NetworkSegment.history:type_name -> forge.NetworkSegmentStateHistory
+	382,  // 249: forge.NetworkSegment.state_reason:type_name -> forge.ControllerStateReason
+	384,  // 250: forge.NetworkSegment.state_sla:type_name -> forge.StateSla
+	1073, // 251: forge.NetworkSegmentCreationRequest.vpc_id:type_name -> common.VpcId
+	1088, // 252: forge.NetworkSegmentCreationRequest.subdomain_id:type_name -> common.DomainId
+	282,  // 253: forge.NetworkSegmentCreationRequest.prefixes:type_name -> forge.NetworkPrefix
 	13,   // 254: forge.NetworkSegmentCreationRequest.segment_type:type_name -> forge.NetworkSegmentType
-	1084, // 255: forge.NetworkSegmentCreationRequest.id:type_name -> common.NetworkSegmentId
-	1084, // 256: forge.NetworkSegmentDeletionRequest.id:type_name -> common.NetworkSegmentId
-	1084, // 257: forge.AttachNetworkSegmentToVpcRequest.network_segment_id:type_name -> common.NetworkSegmentId
-	1068, // 258: forge.AttachNetworkSegmentToVpcRequest.vpc_id:type_name -> common.VpcId
-	1084, // 259: forge.NetworkSegmentStateHistoriesRequest.network_segment_ids:type_name -> common.NetworkSegmentId
-	1084, // 260: forge.NetworkSegmentIdList.network_segments_ids:type_name -> common.NetworkSegmentId
-	1084, // 261: forge.NetworkSegmentsByIdsRequest.network_segments_ids:type_name -> common.NetworkSegmentId
-	1085, // 262: forge.NetworkPrefix.id:type_name -> common.NetworkPrefixId
+	1089, // 255: forge.NetworkSegmentCreationRequest.id:type_name -> common.NetworkSegmentId
+	1089, // 256: forge.NetworkSegmentDeletionRequest.id:type_name -> common.NetworkSegmentId
+	1089, // 257: forge.AttachNetworkSegmentToVpcRequest.network_segment_id:type_name -> common.NetworkSegmentId
+	1073, // 258: forge.AttachNetworkSegmentToVpcRequest.vpc_id:type_name -> common.VpcId
+	1089, // 259: forge.NetworkSegmentStateHistoriesRequest.network_segment_ids:type_name -> common.NetworkSegmentId
+	1089, // 260: forge.NetworkSegmentIdList.network_segments_ids:type_name -> common.NetworkSegmentId
+	1089, // 261: forge.NetworkSegmentsByIdsRequest.network_segments_ids:type_name -> common.NetworkSegmentId
+	1090, // 262: forge.NetworkPrefix.id:type_name -> common.NetworkPrefixId
 	93,   // 263: forge.InstancePowerRequest.operation:type_name -> forge.InstancePowerRequest.Operation
-	1086, // 264: forge.InstancePowerRequest.instance_id:type_name -> common.InstanceId
-	320,  // 265: forge.InstanceList.instances:type_name -> forge.Instance
-	286,  // 266: forge.Metadata.labels:type_name -> forge.Label
-	286,  // 267: forge.InstanceSearchFilter.label:type_name -> forge.Label
-	1086, // 268: forge.InstanceIdList.instance_ids:type_name -> common.InstanceId
-	1086, // 269: forge.InstancesByIdsRequest.instance_ids:type_name -> common.InstanceId
-	1066, // 270: forge.InstanceAllocationRequest.machine_id:type_name -> common.MachineId
-	300,  // 271: forge.InstanceAllocationRequest.config:type_name -> forge.InstanceConfig
-	1086, // 272: forge.InstanceAllocationRequest.instance_id:type_name -> common.InstanceId
-	287,  // 273: forge.InstanceAllocationRequest.metadata:type_name -> forge.Metadata
-	291,  // 274: forge.BatchInstanceAllocationRequest.instance_requests:type_name -> forge.InstanceAllocationRequest
-	320,  // 275: forge.BatchInstanceAllocationResponse.instances:type_name -> forge.Instance
+	1091, // 264: forge.InstancePowerRequest.instance_id:type_name -> common.InstanceId
+	321,  // 265: forge.InstanceList.instances:type_name -> forge.Instance
+	287,  // 266: forge.Metadata.labels:type_name -> forge.Label
+	287,  // 267: forge.InstanceSearchFilter.label:type_name -> forge.Label
+	1091, // 268: forge.InstanceIdList.instance_ids:type_name -> common.InstanceId
+	1091, // 269: forge.InstancesByIdsRequest.instance_ids:type_name -> common.InstanceId
+	1071, // 270: forge.InstanceAllocationRequest.machine_id:type_name -> common.MachineId
+	301,  // 271: forge.InstanceAllocationRequest.config:type_name -> forge.InstanceConfig
+	1091, // 272: forge.InstanceAllocationRequest.instance_id:type_name -> common.InstanceId
+	288,  // 273: forge.InstanceAllocationRequest.metadata:type_name -> forge.Metadata
+	292,  // 274: forge.BatchInstanceAllocationRequest.instance_requests:type_name -> forge.InstanceAllocationRequest
+	321,  // 275: forge.BatchInstanceAllocationResponse.instances:type_name -> forge.Instance
 	15,   // 276: forge.IpxeTemplateArtifact.cache_strategy:type_name -> forge.IpxeTemplateArtifactCacheStrategy
-	1087, // 277: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
+	1092, // 277: forge.IpxeTemplate.id:type_name -> common.IpxeTemplateId
 	16,   // 278: forge.IpxeTemplate.visibility:type_name -> forge.IpxeTemplateVisibility
-	299,  // 279: forge.InstanceOperatingSystemConfig.ipxe:type_name -> forge.InlineIpxe
-	1079, // 280: forge.InstanceOperatingSystemConfig.os_image_id:type_name -> common.UUID
-	1088, // 281: forge.InstanceOperatingSystemConfig.operating_system_id:type_name -> common.OperatingSystemId
-	297,  // 282: forge.InstanceConfig.tenant:type_name -> forge.TenantConfig
-	298,  // 283: forge.InstanceConfig.os:type_name -> forge.InstanceOperatingSystemConfig
-	301,  // 284: forge.InstanceConfig.network:type_name -> forge.InstanceNetworkConfig
-	303,  // 285: forge.InstanceConfig.infiniband:type_name -> forge.InstanceInfinibandConfig
-	305,  // 286: forge.InstanceConfig.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesConfig
-	306,  // 287: forge.InstanceConfig.nvlink:type_name -> forge.InstanceNVLinkConfig
-	307,  // 288: forge.InstanceConfig.spxconfig:type_name -> forge.InstanceSpxConfig
-	322,  // 289: forge.InstanceNetworkConfig.interfaces:type_name -> forge.InstanceInterfaceConfig
-	302,  // 290: forge.InstanceNetworkConfig.auto_config:type_name -> forge.InstanceNetworkAutoConfig
-	1068, // 291: forge.InstanceNetworkAutoConfig.vpc_id:type_name -> common.VpcId
-	326,  // 292: forge.InstanceInfinibandConfig.ib_interfaces:type_name -> forge.InstanceIBInterfaceConfig
-	304,  // 293: forge.InstanceDpuExtensionServicesConfig.service_configs:type_name -> forge.InstanceDpuExtensionServiceConfig
-	331,  // 294: forge.InstanceNVLinkConfig.gpu_configs:type_name -> forge.InstanceNVLinkGpuConfig
-	308,  // 295: forge.InstanceSpxConfig.spx_attachments:type_name -> forge.InstanceSpxAttachment
-	1089, // 296: forge.InstanceSpxAttachment.spx_partition_id:type_name -> common.SpxPartitionId
+	300,  // 279: forge.InstanceOperatingSystemConfig.ipxe:type_name -> forge.InlineIpxe
+	1084, // 280: forge.InstanceOperatingSystemConfig.os_image_id:type_name -> common.UUID
+	1093, // 281: forge.InstanceOperatingSystemConfig.operating_system_id:type_name -> common.OperatingSystemId
+	298,  // 282: forge.InstanceConfig.tenant:type_name -> forge.TenantConfig
+	299,  // 283: forge.InstanceConfig.os:type_name -> forge.InstanceOperatingSystemConfig
+	302,  // 284: forge.InstanceConfig.network:type_name -> forge.InstanceNetworkConfig
+	304,  // 285: forge.InstanceConfig.infiniband:type_name -> forge.InstanceInfinibandConfig
+	306,  // 286: forge.InstanceConfig.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesConfig
+	307,  // 287: forge.InstanceConfig.nvlink:type_name -> forge.InstanceNVLinkConfig
+	308,  // 288: forge.InstanceConfig.spxconfig:type_name -> forge.InstanceSpxConfig
+	323,  // 289: forge.InstanceNetworkConfig.interfaces:type_name -> forge.InstanceInterfaceConfig
+	303,  // 290: forge.InstanceNetworkConfig.auto_config:type_name -> forge.InstanceNetworkAutoConfig
+	1073, // 291: forge.InstanceNetworkAutoConfig.vpc_id:type_name -> common.VpcId
+	327,  // 292: forge.InstanceInfinibandConfig.ib_interfaces:type_name -> forge.InstanceIBInterfaceConfig
+	305,  // 293: forge.InstanceDpuExtensionServicesConfig.service_configs:type_name -> forge.InstanceDpuExtensionServiceConfig
+	332,  // 294: forge.InstanceNVLinkConfig.gpu_configs:type_name -> forge.InstanceNVLinkGpuConfig
+	309,  // 295: forge.InstanceSpxConfig.spx_attachments:type_name -> forge.InstanceSpxAttachment
+	1094, // 296: forge.InstanceSpxAttachment.spx_partition_id:type_name -> common.SpxPartitionId
 	17,   // 297: forge.InstanceSpxAttachment.attachment_type:type_name -> forge.SpxAttachmentType
-	1086, // 298: forge.InstanceOperatingSystemUpdateRequest.instance_id:type_name -> common.InstanceId
-	298,  // 299: forge.InstanceOperatingSystemUpdateRequest.os:type_name -> forge.InstanceOperatingSystemConfig
-	1086, // 300: forge.InstanceConfigUpdateRequest.instance_id:type_name -> common.InstanceId
-	300,  // 301: forge.InstanceConfigUpdateRequest.config:type_name -> forge.InstanceConfig
-	287,  // 302: forge.InstanceConfigUpdateRequest.metadata:type_name -> forge.Metadata
-	384,  // 303: forge.InstanceStatus.tenant:type_name -> forge.InstanceTenantStatus
-	314,  // 304: forge.InstanceStatus.network:type_name -> forge.InstanceNetworkStatus
-	315,  // 305: forge.InstanceStatus.infiniband:type_name -> forge.InstanceInfinibandStatus
-	318,  // 306: forge.InstanceStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesStatus
+	1091, // 298: forge.InstanceOperatingSystemUpdateRequest.instance_id:type_name -> common.InstanceId
+	299,  // 299: forge.InstanceOperatingSystemUpdateRequest.os:type_name -> forge.InstanceOperatingSystemConfig
+	1091, // 300: forge.InstanceConfigUpdateRequest.instance_id:type_name -> common.InstanceId
+	301,  // 301: forge.InstanceConfigUpdateRequest.config:type_name -> forge.InstanceConfig
+	288,  // 302: forge.InstanceConfigUpdateRequest.metadata:type_name -> forge.Metadata
+	385,  // 303: forge.InstanceStatus.tenant:type_name -> forge.InstanceTenantStatus
+	315,  // 304: forge.InstanceStatus.network:type_name -> forge.InstanceNetworkStatus
+	316,  // 305: forge.InstanceStatus.infiniband:type_name -> forge.InstanceInfinibandStatus
+	319,  // 306: forge.InstanceStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServicesStatus
 	26,   // 307: forge.InstanceStatus.configs_synced:type_name -> forge.SyncState
-	321,  // 308: forge.InstanceStatus.update:type_name -> forge.InstanceUpdateStatus
-	319,  // 309: forge.InstanceStatus.nvlink:type_name -> forge.InstanceNVLinkStatus
-	312,  // 310: forge.InstanceStatus.spx_status:type_name -> forge.InstanceSpxStatus
-	313,  // 311: forge.InstanceSpxStatus.attachment_statuses:type_name -> forge.InstanceSpxAttachmentStatus
+	322,  // 308: forge.InstanceStatus.update:type_name -> forge.InstanceUpdateStatus
+	320,  // 309: forge.InstanceStatus.nvlink:type_name -> forge.InstanceNVLinkStatus
+	313,  // 310: forge.InstanceStatus.spx_status:type_name -> forge.InstanceSpxStatus
+	314,  // 311: forge.InstanceSpxStatus.attachment_statuses:type_name -> forge.InstanceSpxAttachmentStatus
 	26,   // 312: forge.InstanceSpxStatus.configs_synced:type_name -> forge.SyncState
 	17,   // 313: forge.InstanceSpxAttachmentStatus.attachment_type:type_name -> forge.SpxAttachmentType
-	1089, // 314: forge.InstanceSpxAttachmentStatus.spx_partition_id:type_name -> common.SpxPartitionId
-	328,  // 315: forge.InstanceNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatus
+	1094, // 314: forge.InstanceSpxAttachmentStatus.spx_partition_id:type_name -> common.SpxPartitionId
+	329,  // 315: forge.InstanceNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatus
 	26,   // 316: forge.InstanceNetworkStatus.configs_synced:type_name -> forge.SyncState
-	329,  // 317: forge.InstanceInfinibandStatus.ib_interfaces:type_name -> forge.InstanceIBInterfaceStatus
+	330,  // 317: forge.InstanceInfinibandStatus.ib_interfaces:type_name -> forge.InstanceIBInterfaceStatus
 	26,   // 318: forge.InstanceInfinibandStatus.configs_synced:type_name -> forge.SyncState
-	1066, // 319: forge.DpuExtensionServiceStatus.dpu_machine_id:type_name -> common.MachineId
+	1071, // 319: forge.DpuExtensionServiceStatus.dpu_machine_id:type_name -> common.MachineId
 	77,   // 320: forge.DpuExtensionServiceStatus.status:type_name -> forge.DpuExtensionServiceDeploymentStatus
-	481,  // 321: forge.DpuExtensionServiceStatus.components:type_name -> forge.DpuExtensionServiceComponent
+	482,  // 321: forge.DpuExtensionServiceStatus.components:type_name -> forge.DpuExtensionServiceComponent
 	77,   // 322: forge.InstanceDpuExtensionServiceStatus.deployment_status:type_name -> forge.DpuExtensionServiceDeploymentStatus
-	316,  // 323: forge.InstanceDpuExtensionServiceStatus.dpu_statuses:type_name -> forge.DpuExtensionServiceStatus
-	317,  // 324: forge.InstanceDpuExtensionServicesStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServiceStatus
+	317,  // 323: forge.InstanceDpuExtensionServiceStatus.dpu_statuses:type_name -> forge.DpuExtensionServiceStatus
+	318,  // 324: forge.InstanceDpuExtensionServicesStatus.dpu_extension_services:type_name -> forge.InstanceDpuExtensionServiceStatus
 	26,   // 325: forge.InstanceDpuExtensionServicesStatus.configs_synced:type_name -> forge.SyncState
-	330,  // 326: forge.InstanceNVLinkStatus.gpu_statuses:type_name -> forge.InstanceNVLinkGpuStatus
+	331,  // 326: forge.InstanceNVLinkStatus.gpu_statuses:type_name -> forge.InstanceNVLinkGpuStatus
 	26,   // 327: forge.InstanceNVLinkStatus.configs_synced:type_name -> forge.SyncState
-	1086, // 328: forge.Instance.id:type_name -> common.InstanceId
-	1066, // 329: forge.Instance.machine_id:type_name -> common.MachineId
-	287,  // 330: forge.Instance.metadata:type_name -> forge.Metadata
-	300,  // 331: forge.Instance.config:type_name -> forge.InstanceConfig
-	311,  // 332: forge.Instance.status:type_name -> forge.InstanceStatus
+	1091, // 328: forge.Instance.id:type_name -> common.InstanceId
+	1071, // 329: forge.Instance.machine_id:type_name -> common.MachineId
+	288,  // 330: forge.Instance.metadata:type_name -> forge.Metadata
+	301,  // 331: forge.Instance.config:type_name -> forge.InstanceConfig
+	312,  // 332: forge.Instance.status:type_name -> forge.InstanceStatus
 	94,   // 333: forge.InstanceUpdateStatus.module:type_name -> forge.InstanceUpdateStatus.Module
-	1067, // 334: forge.InstanceUpdateStatus.trigger_received_at:type_name -> google.protobuf.Timestamp
-	1067, // 335: forge.InstanceUpdateStatus.update_triggered_at:type_name -> google.protobuf.Timestamp
+	1072, // 334: forge.InstanceUpdateStatus.trigger_received_at:type_name -> google.protobuf.Timestamp
+	1072, // 335: forge.InstanceUpdateStatus.update_triggered_at:type_name -> google.protobuf.Timestamp
 	42,   // 336: forge.InstanceInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	1084, // 337: forge.InstanceInterfaceConfig.network_segment_id:type_name -> common.NetworkSegmentId
-	1084, // 338: forge.InstanceInterfaceConfig.segment_id:type_name -> common.NetworkSegmentId
-	1072, // 339: forge.InstanceInterfaceConfig.vpc_prefix_id:type_name -> common.VpcPrefixId
-	323,  // 340: forge.InstanceInterfaceConfig.vpc:type_name -> forge.InstanceInterfaceVpcSelection
-	324,  // 341: forge.InstanceInterfaceConfig.ipv6_interface_config:type_name -> forge.InstanceInterfaceIpv6Config
-	325,  // 342: forge.InstanceInterfaceConfig.routing_profile:type_name -> forge.InstanceInterfaceRoutingProfile
-	1068, // 343: forge.InstanceInterfaceVpcSelection.vpc_id:type_name -> common.VpcId
+	1089, // 337: forge.InstanceInterfaceConfig.network_segment_id:type_name -> common.NetworkSegmentId
+	1089, // 338: forge.InstanceInterfaceConfig.segment_id:type_name -> common.NetworkSegmentId
+	1077, // 339: forge.InstanceInterfaceConfig.vpc_prefix_id:type_name -> common.VpcPrefixId
+	324,  // 340: forge.InstanceInterfaceConfig.vpc:type_name -> forge.InstanceInterfaceVpcSelection
+	325,  // 341: forge.InstanceInterfaceConfig.ipv6_interface_config:type_name -> forge.InstanceInterfaceIpv6Config
+	326,  // 342: forge.InstanceInterfaceConfig.routing_profile:type_name -> forge.InstanceInterfaceRoutingProfile
+	1073, // 343: forge.InstanceInterfaceVpcSelection.vpc_id:type_name -> common.VpcId
 	18,   // 344: forge.InstanceInterfaceVpcSelection.family_mode:type_name -> forge.InstanceInterfaceIpFamilyMode
-	1072, // 345: forge.InstanceInterfaceIpv6Config.vpc_prefix_id:type_name -> common.VpcPrefixId
-	917,  // 346: forge.InstanceInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
+	1077, // 345: forge.InstanceInterfaceIpv6Config.vpc_prefix_id:type_name -> common.VpcPrefixId
+	918,  // 346: forge.InstanceInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
 	42,   // 347: forge.InstanceIBInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	1075, // 348: forge.InstanceIBInterfaceConfig.ib_partition_id:type_name -> common.IBPartitionId
-	1072, // 349: forge.InstanceInterfaceResolvedVpcPrefixes.ipv4_vpc_prefix_id:type_name -> common.VpcPrefixId
-	1072, // 350: forge.InstanceInterfaceResolvedVpcPrefixes.ipv6_vpc_prefix_id:type_name -> common.VpcPrefixId
-	1068, // 351: forge.InstanceInterfaceStatus.vpc_id:type_name -> common.VpcId
-	327,  // 352: forge.InstanceInterfaceStatus.resolved_vpc_prefixes:type_name -> forge.InstanceInterfaceResolvedVpcPrefixes
-	1081, // 353: forge.InstanceNVLinkGpuStatus.domain_id:type_name -> common.NVLinkDomainId
-	1071, // 354: forge.InstanceNVLinkGpuStatus.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1071, // 355: forge.InstanceNVLinkGpuConfig.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1086, // 356: forge.InstancePhoneHomeLastContactRequest.instance_id:type_name -> common.InstanceId
-	1067, // 357: forge.InstancePhoneHomeLastContactResponse.timestamp:type_name -> google.protobuf.Timestamp
+	1080, // 348: forge.InstanceIBInterfaceConfig.ib_partition_id:type_name -> common.IBPartitionId
+	1077, // 349: forge.InstanceInterfaceResolvedVpcPrefixes.ipv4_vpc_prefix_id:type_name -> common.VpcPrefixId
+	1077, // 350: forge.InstanceInterfaceResolvedVpcPrefixes.ipv6_vpc_prefix_id:type_name -> common.VpcPrefixId
+	1073, // 351: forge.InstanceInterfaceStatus.vpc_id:type_name -> common.VpcId
+	328,  // 352: forge.InstanceInterfaceStatus.resolved_vpc_prefixes:type_name -> forge.InstanceInterfaceResolvedVpcPrefixes
+	1086, // 353: forge.InstanceNVLinkGpuStatus.domain_id:type_name -> common.NVLinkDomainId
+	1076, // 354: forge.InstanceNVLinkGpuStatus.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1076, // 355: forge.InstanceNVLinkGpuConfig.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1091, // 356: forge.InstancePhoneHomeLastContactRequest.instance_id:type_name -> common.InstanceId
+	1072, // 357: forge.InstancePhoneHomeLastContactResponse.timestamp:type_name -> google.protobuf.Timestamp
 	19,   // 358: forge.Issue.category:type_name -> forge.IssueCategory
-	335,  // 359: forge.DeleteAttribution.initiated_by:type_name -> forge.DeleteInitiatedBy
-	1086, // 360: forge.InstanceReleaseRequest.id:type_name -> common.InstanceId
-	334,  // 361: forge.InstanceReleaseRequest.issue:type_name -> forge.Issue
-	336,  // 362: forge.InstanceReleaseRequest.delete_attribution:type_name -> forge.DeleteAttribution
-	337,  // 363: forge.BatchInstanceReleaseRequest.release_requests:type_name -> forge.InstanceReleaseRequest
-	1086, // 364: forge.InstanceReleaseOutcome.id:type_name -> common.InstanceId
+	336,  // 359: forge.DeleteAttribution.initiated_by:type_name -> forge.DeleteInitiatedBy
+	1091, // 360: forge.InstanceReleaseRequest.id:type_name -> common.InstanceId
+	335,  // 361: forge.InstanceReleaseRequest.issue:type_name -> forge.Issue
+	337,  // 362: forge.InstanceReleaseRequest.delete_attribution:type_name -> forge.DeleteAttribution
+	338,  // 363: forge.BatchInstanceReleaseRequest.release_requests:type_name -> forge.InstanceReleaseRequest
+	1091, // 364: forge.InstanceReleaseOutcome.id:type_name -> common.InstanceId
 	20,   // 365: forge.InstanceReleaseOutcome.status:type_name -> forge.InstanceReleaseStatusCode
-	340,  // 366: forge.BatchInstanceReleaseResponse.results:type_name -> forge.InstanceReleaseOutcome
-	1066, // 367: forge.MachinesByIdsRequest.machine_ids:type_name -> common.MachineId
-	1078, // 368: forge.MachineSearchConfig.rack_id:type_name -> common.RackId
-	1066, // 369: forge.MachineStateHistoriesRequest.machine_ids:type_name -> common.MachineId
-	1033, // 370: forge.MachineStateHistories.histories:type_name -> forge.MachineStateHistories.HistoriesEntry
-	385,  // 371: forge.MachineStateHistoryRecords.records:type_name -> forge.MachineEvent
-	1066, // 372: forge.MachineHealthHistoriesRequest.machine_ids:type_name -> common.MachineId
-	1067, // 373: forge.MachineHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	1067, // 374: forge.MachineHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	1034, // 375: forge.HealthHistories.histories:type_name -> forge.HealthHistories.HistoriesEntry
-	350,  // 376: forge.HealthHistoryRecords.records:type_name -> forge.HealthHistoryRecord
-	1076, // 377: forge.HealthHistoryRecord.health:type_name -> health.HealthReport
-	1067, // 378: forge.HealthHistoryRecord.time:type_name -> google.protobuf.Timestamp
-	502,  // 379: forge.TenantList.tenants:type_name -> forge.Tenant
-	386,  // 380: forge.InterfaceList.interfaces:type_name -> forge.MachineInterface
-	370,  // 381: forge.MachineList.machines:type_name -> forge.Machine
-	1090, // 382: forge.InterfaceDeleteQuery.id:type_name -> common.MachineInterfaceId
-	1090, // 383: forge.InterfaceSearchQuery.id:type_name -> common.MachineInterfaceId
-	1090, // 384: forge.AssignStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
-	1090, // 385: forge.AssignStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
+	341,  // 366: forge.BatchInstanceReleaseResponse.results:type_name -> forge.InstanceReleaseOutcome
+	1071, // 367: forge.MachinesByIdsRequest.machine_ids:type_name -> common.MachineId
+	1083, // 368: forge.MachineSearchConfig.rack_id:type_name -> common.RackId
+	1071, // 369: forge.MachineStateHistoriesRequest.machine_ids:type_name -> common.MachineId
+	1037, // 370: forge.MachineStateHistories.histories:type_name -> forge.MachineStateHistories.HistoriesEntry
+	386,  // 371: forge.MachineStateHistoryRecords.records:type_name -> forge.MachineEvent
+	1071, // 372: forge.MachineHealthHistoriesRequest.machine_ids:type_name -> common.MachineId
+	1072, // 373: forge.MachineHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	1072, // 374: forge.MachineHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	1038, // 375: forge.HealthHistories.histories:type_name -> forge.HealthHistories.HistoriesEntry
+	351,  // 376: forge.HealthHistoryRecords.records:type_name -> forge.HealthHistoryRecord
+	1081, // 377: forge.HealthHistoryRecord.health:type_name -> health.HealthReport
+	1072, // 378: forge.HealthHistoryRecord.time:type_name -> google.protobuf.Timestamp
+	503,  // 379: forge.TenantList.tenants:type_name -> forge.Tenant
+	387,  // 380: forge.InterfaceList.interfaces:type_name -> forge.MachineInterface
+	371,  // 381: forge.MachineList.machines:type_name -> forge.Machine
+	1095, // 382: forge.InterfaceDeleteQuery.id:type_name -> common.MachineInterfaceId
+	1095, // 383: forge.InterfaceSearchQuery.id:type_name -> common.MachineInterfaceId
+	1095, // 384: forge.AssignStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
+	1095, // 385: forge.AssignStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
 	21,   // 386: forge.AssignStaticAddressResponse.status:type_name -> forge.AssignStaticAddressStatus
-	1090, // 387: forge.RemoveStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
-	1090, // 388: forge.RemoveStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
+	1095, // 387: forge.RemoveStaticAddressRequest.interface_id:type_name -> common.MachineInterfaceId
+	1095, // 388: forge.RemoveStaticAddressResponse.interface_id:type_name -> common.MachineInterfaceId
 	22,   // 389: forge.RemoveStaticAddressResponse.status:type_name -> forge.RemoveStaticAddressStatus
-	1090, // 390: forge.FindInterfaceAddressesRequest.interface_id:type_name -> common.MachineInterfaceId
-	1090, // 391: forge.FindInterfaceAddressesResponse.interface_id:type_name -> common.MachineInterfaceId
-	364,  // 392: forge.FindInterfaceAddressesResponse.addresses:type_name -> forge.InterfaceAddress
-	1090, // 393: forge.BmcInfo.machine_interface_id:type_name -> common.MachineInterfaceId
-	1067, // 394: forge.MachineConfig.maintenance_start_time:type_name -> google.protobuf.Timestamp
-	371,  // 395: forge.MachineConfig.dpf:type_name -> forge.DpfMachineState
-	386,  // 396: forge.MachineStatus.interfaces:type_name -> forge.MachineInterface
-	1091, // 397: forge.MachineStatus.discovery_info:type_name -> machine_discovery.DiscoveryInfo
-	1067, // 398: forge.MachineStatus.last_reboot_time:type_name -> google.protobuf.Timestamp
-	1067, // 399: forge.MachineStatus.last_observation_time:type_name -> google.protobuf.Timestamp
-	1066, // 400: forge.MachineStatus.associated_host_machine_id:type_name -> common.MachineId
-	1066, // 401: forge.MachineStatus.associated_dpu_machine_ids:type_name -> common.MachineId
-	1067, // 402: forge.MachineStatus.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
-	1076, // 403: forge.MachineStatus.health:type_name -> health.HealthReport
-	380,  // 404: forge.MachineStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	387,  // 405: forge.MachineStatus.infiniband:type_name -> forge.InfinibandStatusObservation
-	676,  // 406: forge.MachineStatus.capabilities:type_name -> forge.MachineCapabilitiesSet
-	749,  // 407: forge.MachineStatus.hw_sku:type_name -> forge.SkuStatus
-	416,  // 408: forge.MachineStatus.quarantine:type_name -> forge.ManagedHostQuarantineState
-	803,  // 409: forge.MachineStatus.nvlink_info:type_name -> forge.MachineNVLinkInfo
-	813,  // 410: forge.MachineStatus.nvlink:type_name -> forge.MachineNVLinkStatusObservation
-	805,  // 411: forge.MachineStatus.spx:type_name -> forge.MachineSpxStatusObservation
-	372,  // 412: forge.MachineStatus.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
-	109,  // 413: forge.MachineStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1066, // 414: forge.Machine.id:type_name -> common.MachineId
-	381,  // 415: forge.Machine.state_reason:type_name -> forge.ControllerStateReason
-	383,  // 416: forge.Machine.state_sla:type_name -> forge.StateSla
-	385,  // 417: forge.Machine.events:type_name -> forge.MachineEvent
-	386,  // 418: forge.Machine.interfaces:type_name -> forge.MachineInterface
-	1091, // 419: forge.Machine.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	1095, // 390: forge.FindInterfaceAddressesRequest.interface_id:type_name -> common.MachineInterfaceId
+	1095, // 391: forge.FindInterfaceAddressesResponse.interface_id:type_name -> common.MachineInterfaceId
+	365,  // 392: forge.FindInterfaceAddressesResponse.addresses:type_name -> forge.InterfaceAddress
+	1095, // 393: forge.BmcInfo.machine_interface_id:type_name -> common.MachineInterfaceId
+	1072, // 394: forge.MachineConfig.maintenance_start_time:type_name -> google.protobuf.Timestamp
+	372,  // 395: forge.MachineConfig.dpf:type_name -> forge.DpfMachineState
+	387,  // 396: forge.MachineStatus.interfaces:type_name -> forge.MachineInterface
+	1096, // 397: forge.MachineStatus.discovery_info:type_name -> machine_discovery.DiscoveryInfo
+	1072, // 398: forge.MachineStatus.last_reboot_time:type_name -> google.protobuf.Timestamp
+	1072, // 399: forge.MachineStatus.last_observation_time:type_name -> google.protobuf.Timestamp
+	1071, // 400: forge.MachineStatus.associated_host_machine_id:type_name -> common.MachineId
+	1071, // 401: forge.MachineStatus.associated_dpu_machine_ids:type_name -> common.MachineId
+	1072, // 402: forge.MachineStatus.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
+	1081, // 403: forge.MachineStatus.health:type_name -> health.HealthReport
+	381,  // 404: forge.MachineStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	388,  // 405: forge.MachineStatus.infiniband:type_name -> forge.InfinibandStatusObservation
+	677,  // 406: forge.MachineStatus.capabilities:type_name -> forge.MachineCapabilitiesSet
+	750,  // 407: forge.MachineStatus.hw_sku:type_name -> forge.SkuStatus
+	417,  // 408: forge.MachineStatus.quarantine:type_name -> forge.ManagedHostQuarantineState
+	804,  // 409: forge.MachineStatus.nvlink_info:type_name -> forge.MachineNVLinkInfo
+	814,  // 410: forge.MachineStatus.nvlink:type_name -> forge.MachineNVLinkStatusObservation
+	806,  // 411: forge.MachineStatus.spx:type_name -> forge.MachineSpxStatusObservation
+	373,  // 412: forge.MachineStatus.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
+	110,  // 413: forge.MachineStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1071, // 414: forge.Machine.id:type_name -> common.MachineId
+	382,  // 415: forge.Machine.state_reason:type_name -> forge.ControllerStateReason
+	384,  // 416: forge.Machine.state_sla:type_name -> forge.StateSla
+	386,  // 417: forge.Machine.events:type_name -> forge.MachineEvent
+	387,  // 418: forge.Machine.interfaces:type_name -> forge.MachineInterface
+	1096, // 419: forge.Machine.discovery_info:type_name -> machine_discovery.DiscoveryInfo
 	23,   // 420: forge.Machine.machine_type:type_name -> forge.MachineType
-	366,  // 421: forge.Machine.bmc_info:type_name -> forge.BmcInfo
-	1067, // 422: forge.Machine.last_reboot_time:type_name -> google.protobuf.Timestamp
-	1067, // 423: forge.Machine.last_observation_time:type_name -> google.protobuf.Timestamp
-	1067, // 424: forge.Machine.maintenance_start_time:type_name -> google.protobuf.Timestamp
-	1066, // 425: forge.Machine.associated_host_machine_id:type_name -> common.MachineId
-	378,  // 426: forge.Machine.inventory:type_name -> forge.MachineComponentInventory
-	1067, // 427: forge.Machine.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
-	1066, // 428: forge.Machine.associated_dpu_machine_ids:type_name -> common.MachineId
-	1076, // 429: forge.Machine.health:type_name -> health.HealthReport
-	380,  // 430: forge.Machine.health_sources:type_name -> forge.HealthSourceOrigin
-	387,  // 431: forge.Machine.ib_status:type_name -> forge.InfinibandStatusObservation
-	287,  // 432: forge.Machine.metadata:type_name -> forge.Metadata
-	372,  // 433: forge.Machine.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
-	676,  // 434: forge.Machine.capabilities:type_name -> forge.MachineCapabilitiesSet
-	749,  // 435: forge.Machine.hw_sku_status:type_name -> forge.SkuStatus
-	416,  // 436: forge.Machine.quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	803,  // 437: forge.Machine.nvlink_info:type_name -> forge.MachineNVLinkInfo
-	813,  // 438: forge.Machine.nvlink_status_observation:type_name -> forge.MachineNVLinkStatusObservation
-	1078, // 439: forge.Machine.rack_id:type_name -> common.RackId
-	242,  // 440: forge.Machine.placement_in_rack:type_name -> forge.PlacementInRack
-	805,  // 441: forge.Machine.spx_status_observation:type_name -> forge.MachineSpxStatusObservation
-	371,  // 442: forge.Machine.dpf:type_name -> forge.DpfMachineState
-	368,  // 443: forge.Machine.config:type_name -> forge.MachineConfig
-	369,  // 444: forge.Machine.status:type_name -> forge.MachineStatus
+	367,  // 421: forge.Machine.bmc_info:type_name -> forge.BmcInfo
+	1072, // 422: forge.Machine.last_reboot_time:type_name -> google.protobuf.Timestamp
+	1072, // 423: forge.Machine.last_observation_time:type_name -> google.protobuf.Timestamp
+	1072, // 424: forge.Machine.maintenance_start_time:type_name -> google.protobuf.Timestamp
+	1071, // 425: forge.Machine.associated_host_machine_id:type_name -> common.MachineId
+	379,  // 426: forge.Machine.inventory:type_name -> forge.MachineComponentInventory
+	1072, // 427: forge.Machine.last_reboot_requested_time:type_name -> google.protobuf.Timestamp
+	1071, // 428: forge.Machine.associated_dpu_machine_ids:type_name -> common.MachineId
+	1081, // 429: forge.Machine.health:type_name -> health.HealthReport
+	381,  // 430: forge.Machine.health_sources:type_name -> forge.HealthSourceOrigin
+	388,  // 431: forge.Machine.ib_status:type_name -> forge.InfinibandStatusObservation
+	288,  // 432: forge.Machine.metadata:type_name -> forge.Metadata
+	373,  // 433: forge.Machine.instance_network_restrictions:type_name -> forge.InstanceNetworkRestrictions
+	677,  // 434: forge.Machine.capabilities:type_name -> forge.MachineCapabilitiesSet
+	750,  // 435: forge.Machine.hw_sku_status:type_name -> forge.SkuStatus
+	417,  // 436: forge.Machine.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	804,  // 437: forge.Machine.nvlink_info:type_name -> forge.MachineNVLinkInfo
+	814,  // 438: forge.Machine.nvlink_status_observation:type_name -> forge.MachineNVLinkStatusObservation
+	1083, // 439: forge.Machine.rack_id:type_name -> common.RackId
+	243,  // 440: forge.Machine.placement_in_rack:type_name -> forge.PlacementInRack
+	806,  // 441: forge.Machine.spx_status_observation:type_name -> forge.MachineSpxStatusObservation
+	372,  // 442: forge.Machine.dpf:type_name -> forge.DpfMachineState
+	369,  // 443: forge.Machine.config:type_name -> forge.MachineConfig
+	370,  // 444: forge.Machine.status:type_name -> forge.MachineStatus
 	24,   // 445: forge.InstanceNetworkRestrictions.network_segment_membership_type:type_name -> forge.InstanceNetworkSegmentMembershipType
-	1084, // 446: forge.InstanceNetworkRestrictions.network_segment_ids:type_name -> common.NetworkSegmentId
-	1066, // 447: forge.MachineMetadataUpdateRequest.machine_id:type_name -> common.MachineId
-	287,  // 448: forge.MachineMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1078, // 449: forge.RackMetadataUpdateRequest.rack_id:type_name -> common.RackId
-	287,  // 450: forge.RackMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1080, // 451: forge.SwitchMetadataUpdateRequest.switch_id:type_name -> common.SwitchId
-	287,  // 452: forge.SwitchMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1077, // 453: forge.PowerShelfMetadataUpdateRequest.power_shelf_id:type_name -> common.PowerShelfId
-	287,  // 454: forge.PowerShelfMetadataUpdateRequest.metadata:type_name -> forge.Metadata
-	1066, // 455: forge.DpuAgentInventoryReport.machine_id:type_name -> common.MachineId
-	378,  // 456: forge.DpuAgentInventoryReport.inventory:type_name -> forge.MachineComponentInventory
-	379,  // 457: forge.MachineComponentInventory.components:type_name -> forge.MachineInventorySoftwareComponent
+	1089, // 446: forge.InstanceNetworkRestrictions.network_segment_ids:type_name -> common.NetworkSegmentId
+	1071, // 447: forge.MachineMetadataUpdateRequest.machine_id:type_name -> common.MachineId
+	288,  // 448: forge.MachineMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1083, // 449: forge.RackMetadataUpdateRequest.rack_id:type_name -> common.RackId
+	288,  // 450: forge.RackMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1085, // 451: forge.SwitchMetadataUpdateRequest.switch_id:type_name -> common.SwitchId
+	288,  // 452: forge.SwitchMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1082, // 453: forge.PowerShelfMetadataUpdateRequest.power_shelf_id:type_name -> common.PowerShelfId
+	288,  // 454: forge.PowerShelfMetadataUpdateRequest.metadata:type_name -> forge.Metadata
+	1071, // 455: forge.DpuAgentInventoryReport.machine_id:type_name -> common.MachineId
+	379,  // 456: forge.DpuAgentInventoryReport.inventory:type_name -> forge.MachineComponentInventory
+	380,  // 457: forge.MachineComponentInventory.components:type_name -> forge.MachineInventorySoftwareComponent
 	43,   // 458: forge.HealthSourceOrigin.mode:type_name -> forge.HealthReportApplyMode
 	25,   // 459: forge.ControllerStateReason.outcome:type_name -> forge.ControllerStateOutcome
-	382,  // 460: forge.ControllerStateReason.source_ref:type_name -> forge.ControllerStateSourceReference
-	1092, // 461: forge.StateSla.sla:type_name -> google.protobuf.Duration
+	383,  // 460: forge.ControllerStateReason.source_ref:type_name -> forge.ControllerStateSourceReference
+	1097, // 461: forge.StateSla.sla:type_name -> google.protobuf.Duration
 	9,    // 462: forge.InstanceTenantStatus.state:type_name -> forge.TenantState
-	1067, // 463: forge.MachineEvent.time:type_name -> google.protobuf.Timestamp
-	1090, // 464: forge.MachineInterface.id:type_name -> common.MachineInterfaceId
-	1066, // 465: forge.MachineInterface.attached_dpu_machine_id:type_name -> common.MachineId
-	1066, // 466: forge.MachineInterface.machine_id:type_name -> common.MachineId
-	1084, // 467: forge.MachineInterface.segment_id:type_name -> common.NetworkSegmentId
-	1083, // 468: forge.MachineInterface.domain_id:type_name -> common.DomainId
-	1067, // 469: forge.MachineInterface.created:type_name -> google.protobuf.Timestamp
-	1067, // 470: forge.MachineInterface.last_dhcp:type_name -> google.protobuf.Timestamp
-	1077, // 471: forge.MachineInterface.power_shelf_id:type_name -> common.PowerShelfId
-	1080, // 472: forge.MachineInterface.switch_id:type_name -> common.SwitchId
+	1072, // 463: forge.MachineEvent.time:type_name -> google.protobuf.Timestamp
+	1095, // 464: forge.MachineInterface.id:type_name -> common.MachineInterfaceId
+	1071, // 465: forge.MachineInterface.attached_dpu_machine_id:type_name -> common.MachineId
+	1071, // 466: forge.MachineInterface.machine_id:type_name -> common.MachineId
+	1089, // 467: forge.MachineInterface.segment_id:type_name -> common.NetworkSegmentId
+	1088, // 468: forge.MachineInterface.domain_id:type_name -> common.DomainId
+	1072, // 469: forge.MachineInterface.created:type_name -> google.protobuf.Timestamp
+	1072, // 470: forge.MachineInterface.last_dhcp:type_name -> google.protobuf.Timestamp
+	1082, // 471: forge.MachineInterface.power_shelf_id:type_name -> common.PowerShelfId
+	1085, // 472: forge.MachineInterface.switch_id:type_name -> common.SwitchId
 	28,   // 473: forge.MachineInterface.association_type:type_name -> forge.InterfaceAssociationType
 	29,   // 474: forge.MachineInterface.interface_type:type_name -> forge.InterfaceType
-	388,  // 475: forge.InfinibandStatusObservation.ib_interfaces:type_name -> forge.MachineIbInterface
-	1067, // 476: forge.InfinibandStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	1093, // 477: forge.MachineIbInterface.associated_pkeys:type_name -> common.StringList
-	1093, // 478: forge.MachineIbInterface.associated_partition_ids:type_name -> common.StringList
+	389,  // 475: forge.InfinibandStatusObservation.ib_interfaces:type_name -> forge.MachineIbInterface
+	1072, // 476: forge.InfinibandStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	1098, // 477: forge.MachineIbInterface.associated_pkeys:type_name -> common.StringList
+	1098, // 478: forge.MachineIbInterface.associated_partition_ids:type_name -> common.StringList
 	30,   // 479: forge.DhcpDiscovery.address_family:type_name -> forge.AddressFamily
 	31,   // 480: forge.DhcpDiscovery.message_kind:type_name -> forge.MessageKind
 	32,   // 481: forge.ExpireDhcpLeaseResponse.status:type_name -> forge.ExpireDhcpLeaseStatus
-	1066, // 482: forge.DhcpRecord.machine_id:type_name -> common.MachineId
-	1090, // 483: forge.DhcpRecord.machine_interface_id:type_name -> common.MachineInterfaceId
-	1084, // 484: forge.DhcpRecord.segment_id:type_name -> common.NetworkSegmentId
-	1083, // 485: forge.DhcpRecord.subdomain_id:type_name -> common.DomainId
-	1067, // 486: forge.DhcpRecord.last_invalidation_time:type_name -> google.protobuf.Timestamp
-	271,  // 487: forge.NetworkSegmentList.network_segments:type_name -> forge.NetworkSegment
+	1071, // 482: forge.DhcpRecord.machine_id:type_name -> common.MachineId
+	1095, // 483: forge.DhcpRecord.machine_interface_id:type_name -> common.MachineInterfaceId
+	1089, // 484: forge.DhcpRecord.segment_id:type_name -> common.NetworkSegmentId
+	1088, // 485: forge.DhcpRecord.subdomain_id:type_name -> common.DomainId
+	1072, // 486: forge.DhcpRecord.last_invalidation_time:type_name -> google.protobuf.Timestamp
+	272,  // 487: forge.NetworkSegmentList.network_segments:type_name -> forge.NetworkSegment
 	33,   // 488: forge.SSHKeyValidationResponse.role:type_name -> forge.UserRoles
-	1080, // 489: forge.GetSwitchNvosCredentialsRequest.switch_id:type_name -> common.SwitchId
-	399,  // 490: forge.GetBmcCredentialsResponse.credentials:type_name -> forge.BmcCredentials
-	882,  // 491: forge.BmcCredentials.username_password:type_name -> forge.UsernamePassword
-	883,  // 492: forge.BmcCredentials.session_token:type_name -> forge.SessionToken
-	407,  // 493: forge.SshRequest.endpoint_request:type_name -> forge.BmcEndpointRequest
-	409,  // 494: forge.CopyBfbToDpuRshimRequest.ssh_request:type_name -> forge.SshRequest
-	1066, // 495: forge.UpdateMachineHardwareInfoRequest.machine_id:type_name -> common.MachineId
-	412,  // 496: forge.UpdateMachineHardwareInfoRequest.info:type_name -> forge.MachineHardwareInfo
+	1085, // 489: forge.GetSwitchNvosCredentialsRequest.switch_id:type_name -> common.SwitchId
+	400,  // 490: forge.GetBmcCredentialsResponse.credentials:type_name -> forge.BmcCredentials
+	883,  // 491: forge.BmcCredentials.username_password:type_name -> forge.UsernamePassword
+	884,  // 492: forge.BmcCredentials.session_token:type_name -> forge.SessionToken
+	408,  // 493: forge.SshRequest.endpoint_request:type_name -> forge.BmcEndpointRequest
+	410,  // 494: forge.CopyBfbToDpuRshimRequest.ssh_request:type_name -> forge.SshRequest
+	1071, // 495: forge.UpdateMachineHardwareInfoRequest.machine_id:type_name -> common.MachineId
+	413,  // 496: forge.UpdateMachineHardwareInfoRequest.info:type_name -> forge.MachineHardwareInfo
 	34,   // 497: forge.UpdateMachineHardwareInfoRequest.update_type:type_name -> forge.MachineHardwareInfoUpdateType
-	1094, // 498: forge.MachineHardwareInfo.gpus:type_name -> machine_discovery.Gpu
-	1066, // 499: forge.ManagedHostNetworkConfigRequest.dpu_machine_id:type_name -> common.MachineId
-	423,  // 500: forge.ManagedHostNetworkConfigResponse.managed_host_config:type_name -> forge.ManagedHostNetworkConfig
-	424,  // 501: forge.ManagedHostNetworkConfigResponse.admin_interface:type_name -> forge.FlatInterfaceConfig
-	424,  // 502: forge.ManagedHostNetworkConfigResponse.tenant_interfaces:type_name -> forge.FlatInterfaceConfig
-	1086, // 503: forge.ManagedHostNetworkConfigResponse.instance_id:type_name -> common.InstanceId
+	1099, // 498: forge.MachineHardwareInfo.gpus:type_name -> machine_discovery.Gpu
+	1071, // 499: forge.ManagedHostNetworkConfigRequest.dpu_machine_id:type_name -> common.MachineId
+	424,  // 500: forge.ManagedHostNetworkConfigResponse.managed_host_config:type_name -> forge.ManagedHostNetworkConfig
+	425,  // 501: forge.ManagedHostNetworkConfigResponse.admin_interface:type_name -> forge.FlatInterfaceConfig
+	425,  // 502: forge.ManagedHostNetworkConfigResponse.tenant_interfaces:type_name -> forge.FlatInterfaceConfig
+	1091, // 503: forge.ManagedHostNetworkConfigResponse.instance_id:type_name -> common.InstanceId
 	7,    // 504: forge.ManagedHostNetworkConfigResponse.network_virtualization_type:type_name -> forge.VpcVirtualizationType
 	36,   // 505: forge.ManagedHostNetworkConfigResponse.vpc_isolation_behavior:type_name -> forge.VpcIsolationBehaviorType
-	320,  // 506: forge.ManagedHostNetworkConfigResponse.instance:type_name -> forge.Instance
-	1070, // 507: forge.ManagedHostNetworkConfigResponse.common_internal_route_target:type_name -> common.RouteTarget
-	1070, // 508: forge.ManagedHostNetworkConfigResponse.additional_route_target_imports:type_name -> common.RouteTarget
-	727,  // 509: forge.ManagedHostNetworkConfigResponse.network_security_policy_overrides:type_name -> forge.ResolvedNetworkSecurityGroupRule
-	415,  // 510: forge.ManagedHostNetworkConfigResponse.dpu_extension_services:type_name -> forge.ManagedHostDpuExtensionServiceConfig
-	918,  // 511: forge.ManagedHostNetworkConfigResponse.routing_profile:type_name -> forge.RoutingProfile
-	807,  // 512: forge.ManagedHostNetworkConfigResponse.astra_config:type_name -> forge.AstraConfig
+	321,  // 506: forge.ManagedHostNetworkConfigResponse.instance:type_name -> forge.Instance
+	1075, // 507: forge.ManagedHostNetworkConfigResponse.common_internal_route_target:type_name -> common.RouteTarget
+	1075, // 508: forge.ManagedHostNetworkConfigResponse.additional_route_target_imports:type_name -> common.RouteTarget
+	728,  // 509: forge.ManagedHostNetworkConfigResponse.network_security_policy_overrides:type_name -> forge.ResolvedNetworkSecurityGroupRule
+	416,  // 510: forge.ManagedHostNetworkConfigResponse.dpu_extension_services:type_name -> forge.ManagedHostDpuExtensionServiceConfig
+	919,  // 511: forge.ManagedHostNetworkConfigResponse.routing_profile:type_name -> forge.RoutingProfile
+	808,  // 512: forge.ManagedHostNetworkConfigResponse.astra_config:type_name -> forge.AstraConfig
 	75,   // 513: forge.ManagedHostDpuExtensionServiceConfig.service_type:type_name -> forge.DpuExtensionServiceType
-	884,  // 514: forge.ManagedHostDpuExtensionServiceConfig.credential:type_name -> forge.DpuExtensionServiceCredential
-	903,  // 515: forge.ManagedHostDpuExtensionServiceConfig.observability:type_name -> forge.DpuExtensionServiceObservability
+	885,  // 514: forge.ManagedHostDpuExtensionServiceConfig.credential:type_name -> forge.DpuExtensionServiceCredential
+	904,  // 515: forge.ManagedHostDpuExtensionServiceConfig.observability:type_name -> forge.DpuExtensionServiceObservability
 	35,   // 516: forge.ManagedHostQuarantineState.mode:type_name -> forge.ManagedHostQuarantineMode
-	1066, // 517: forge.GetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
-	416,  // 518: forge.GetManagedHostQuarantineStateResponse.quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	1066, // 519: forge.SetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
-	416,  // 520: forge.SetManagedHostQuarantineStateRequest.quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	416,  // 521: forge.SetManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	1066, // 522: forge.ClearManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
-	416,  // 523: forge.ClearManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
-	416,  // 524: forge.ManagedHostNetworkConfig.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	1071, // 517: forge.GetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	417,  // 518: forge.GetManagedHostQuarantineStateResponse.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	1071, // 519: forge.SetManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	417,  // 520: forge.SetManagedHostQuarantineStateRequest.quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	417,  // 521: forge.SetManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	1071, // 522: forge.ClearManagedHostQuarantineStateRequest.machine_id:type_name -> common.MachineId
+	417,  // 523: forge.ClearManagedHostQuarantineStateResponse.prior_quarantine_state:type_name -> forge.ManagedHostQuarantineState
+	417,  // 524: forge.ManagedHostNetworkConfig.quarantine_state:type_name -> forge.ManagedHostQuarantineState
 	42,   // 525: forge.FlatInterfaceConfig.function_type:type_name -> forge.InterfaceFunctionType
-	426,  // 526: forge.FlatInterfaceConfig.ipv6_interface_config:type_name -> forge.FlatInterfaceIpv6Config
-	918,  // 527: forge.FlatInterfaceConfig.vpc_routing_profile:type_name -> forge.RoutingProfile
-	425,  // 528: forge.FlatInterfaceConfig.interface_routing_profile:type_name -> forge.FlatInterfaceRoutingProfile
-	1020, // 529: forge.FlatInterfaceConfig.addresses:type_name -> forge.InterfaceAddressConfig
-	427,  // 530: forge.FlatInterfaceConfig.network_security_group:type_name -> forge.FlatInterfaceNetworkSecurityGroupConfig
-	1079, // 531: forge.FlatInterfaceConfig.internal_uuid:type_name -> common.UUID
-	917,  // 532: forge.FlatInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
+	427,  // 526: forge.FlatInterfaceConfig.ipv6_interface_config:type_name -> forge.FlatInterfaceIpv6Config
+	919,  // 527: forge.FlatInterfaceConfig.vpc_routing_profile:type_name -> forge.RoutingProfile
+	426,  // 528: forge.FlatInterfaceConfig.interface_routing_profile:type_name -> forge.FlatInterfaceRoutingProfile
+	1021, // 529: forge.FlatInterfaceConfig.addresses:type_name -> forge.InterfaceAddressConfig
+	428,  // 530: forge.FlatInterfaceConfig.network_security_group:type_name -> forge.FlatInterfaceNetworkSecurityGroupConfig
+	1084, // 531: forge.FlatInterfaceConfig.internal_uuid:type_name -> common.UUID
+	918,  // 532: forge.FlatInterfaceRoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
 	60,   // 533: forge.FlatInterfaceNetworkSecurityGroupConfig.source:type_name -> forge.NetworkSecurityGroupSource
-	727,  // 534: forge.FlatInterfaceNetworkSecurityGroupConfig.rules:type_name -> forge.ResolvedNetworkSecurityGroupRule
-	478,  // 535: forge.ManagedHostNetworkStatusResponse.all:type_name -> forge.DpuNetworkStatus
-	1067, // 536: forge.DpuAgentUpgradeCheckRequest.binary_mtime:type_name -> google.protobuf.Timestamp
+	728,  // 534: forge.FlatInterfaceNetworkSecurityGroupConfig.rules:type_name -> forge.ResolvedNetworkSecurityGroupRule
+	479,  // 535: forge.ManagedHostNetworkStatusResponse.all:type_name -> forge.DpuNetworkStatus
+	1072, // 536: forge.DpuAgentUpgradeCheckRequest.binary_mtime:type_name -> google.protobuf.Timestamp
 	37,   // 537: forge.DpuAgentUpgradePolicyRequest.new_policy:type_name -> forge.AgentUpgradePolicy
 	37,   // 538: forge.DpuAgentUpgradePolicyResponse.active_policy:type_name -> forge.AgentUpgradePolicy
-	1066, // 539: forge.DecommissionManagedHostRequest.machine_id:type_name -> common.MachineId
-	407,  // 540: forge.LockdownRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1066, // 541: forge.LockdownRequest.machine_id:type_name -> common.MachineId
+	1071, // 539: forge.DecommissionManagedHostRequest.machine_id:type_name -> common.MachineId
+	408,  // 540: forge.LockdownRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1071, // 541: forge.LockdownRequest.machine_id:type_name -> common.MachineId
 	38,   // 542: forge.LockdownRequest.action:type_name -> forge.LockdownAction
-	407,  // 543: forge.LockdownStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1066, // 544: forge.LockdownStatusRequest.machine_id:type_name -> common.MachineId
-	407,  // 545: forge.MachineSetupStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 546: forge.MachineSetupRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 547: forge.SetDpuFirstBootOrderRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 548: forge.AdminRebootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 549: forge.AdminBmcResetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1095, // 550: forge.AdminBmcResetRequest.device_id:type_name -> common.DeviceId
+	408,  // 543: forge.LockdownStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1071, // 544: forge.LockdownStatusRequest.machine_id:type_name -> common.MachineId
+	408,  // 545: forge.MachineSetupStatusRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 546: forge.MachineSetupRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 547: forge.SetDpuFirstBootOrderRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 548: forge.AdminRebootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 549: forge.AdminBmcResetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1100, // 550: forge.AdminBmcResetRequest.device_id:type_name -> common.DeviceId
 	95,   // 551: forge.AdminBmcResetRequest.reset_type:type_name -> forge.AdminBmcResetRequest.ResetType
-	407,  // 552: forge.EnableInfiniteBootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 553: forge.IsInfiniteBootEnabledRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1066, // 554: forge.BMCMetaDataGetRequest.machine_id:type_name -> common.MachineId
+	408,  // 552: forge.EnableInfiniteBootRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 553: forge.IsInfiniteBootEnabledRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1071, // 554: forge.BMCMetaDataGetRequest.machine_id:type_name -> common.MachineId
 	33,   // 555: forge.BMCMetaDataGetRequest.role:type_name -> forge.UserRoles
 	39,   // 556: forge.BMCMetaDataGetRequest.request_type:type_name -> forge.BMCRequestType
-	407,  // 557: forge.BMCMetaDataGetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1066, // 558: forge.MachineCredentialsUpdateRequest.machine_id:type_name -> common.MachineId
-	1035, // 559: forge.MachineCredentialsUpdateRequest.credentials:type_name -> forge.MachineCredentialsUpdateRequest.Credentials
-	1066, // 560: forge.ForgeAgentControlRequest.machine_id:type_name -> common.MachineId
+	408,  // 557: forge.BMCMetaDataGetRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1071, // 558: forge.MachineCredentialsUpdateRequest.machine_id:type_name -> common.MachineId
+	1039, // 559: forge.MachineCredentialsUpdateRequest.credentials:type_name -> forge.MachineCredentialsUpdateRequest.Credentials
+	1071, // 560: forge.ForgeAgentControlRequest.machine_id:type_name -> common.MachineId
 	97,   // 561: forge.ForgeAgentControlResponse.legacy_action:type_name -> forge.ForgeAgentControlResponse.LegacyAction
-	1036, // 562: forge.ForgeAgentControlResponse.data:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
-	1037, // 563: forge.ForgeAgentControlResponse.noop:type_name -> forge.ForgeAgentControlResponse.Noop
-	1038, // 564: forge.ForgeAgentControlResponse.reset:type_name -> forge.ForgeAgentControlResponse.Reset
-	1039, // 565: forge.ForgeAgentControlResponse.discovery:type_name -> forge.ForgeAgentControlResponse.Discovery
-	1040, // 566: forge.ForgeAgentControlResponse.rebuild:type_name -> forge.ForgeAgentControlResponse.Rebuild
-	1041, // 567: forge.ForgeAgentControlResponse.retry:type_name -> forge.ForgeAgentControlResponse.Retry
-	1042, // 568: forge.ForgeAgentControlResponse.measure:type_name -> forge.ForgeAgentControlResponse.Measure
-	1043, // 569: forge.ForgeAgentControlResponse.log_error:type_name -> forge.ForgeAgentControlResponse.LogError
-	1044, // 570: forge.ForgeAgentControlResponse.machine_validation:type_name -> forge.ForgeAgentControlResponse.MachineValidation
-	1046, // 571: forge.ForgeAgentControlResponse.mlx_action:type_name -> forge.ForgeAgentControlResponse.MlxAction
-	1053, // 572: forge.ForgeAgentControlResponse.firmware_upgrade:type_name -> forge.ForgeAgentControlResponse.FirmwareUpgrade
-	1090, // 573: forge.MachineDiscoveryInfo.machine_interface_id:type_name -> common.MachineInterfaceId
-	1091, // 574: forge.MachineDiscoveryInfo.info:type_name -> machine_discovery.DiscoveryInfo
+	1040, // 562: forge.ForgeAgentControlResponse.data:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo
+	1041, // 563: forge.ForgeAgentControlResponse.noop:type_name -> forge.ForgeAgentControlResponse.Noop
+	1042, // 564: forge.ForgeAgentControlResponse.reset:type_name -> forge.ForgeAgentControlResponse.Reset
+	1043, // 565: forge.ForgeAgentControlResponse.discovery:type_name -> forge.ForgeAgentControlResponse.Discovery
+	1044, // 566: forge.ForgeAgentControlResponse.rebuild:type_name -> forge.ForgeAgentControlResponse.Rebuild
+	1045, // 567: forge.ForgeAgentControlResponse.retry:type_name -> forge.ForgeAgentControlResponse.Retry
+	1046, // 568: forge.ForgeAgentControlResponse.measure:type_name -> forge.ForgeAgentControlResponse.Measure
+	1047, // 569: forge.ForgeAgentControlResponse.log_error:type_name -> forge.ForgeAgentControlResponse.LogError
+	1048, // 570: forge.ForgeAgentControlResponse.machine_validation:type_name -> forge.ForgeAgentControlResponse.MachineValidation
+	1050, // 571: forge.ForgeAgentControlResponse.mlx_action:type_name -> forge.ForgeAgentControlResponse.MlxAction
+	1057, // 572: forge.ForgeAgentControlResponse.firmware_upgrade:type_name -> forge.ForgeAgentControlResponse.FirmwareUpgrade
+	1095, // 573: forge.MachineDiscoveryInfo.machine_interface_id:type_name -> common.MachineInterfaceId
+	1096, // 574: forge.MachineDiscoveryInfo.info:type_name -> machine_discovery.DiscoveryInfo
 	40,   // 575: forge.MachineDiscoveryInfo.discovery_reporter:type_name -> forge.MachineDiscoveryReporter
-	1066, // 576: forge.MachineDiscoveryCompletedRequest.machine_id:type_name -> common.MachineId
-	1066, // 577: forge.MachineCleanupInfo.machine_id:type_name -> common.MachineId
-	1055, // 578: forge.MachineCleanupInfo.nvme:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	1055, // 579: forge.MachineCleanupInfo.ram:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	1055, // 580: forge.MachineCleanupInfo.mem_overwrite:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	1055, // 581: forge.MachineCleanupInfo.ib:type_name -> forge.MachineCleanupInfo.CleanupStepResult
-	1055, // 582: forge.MachineCleanupInfo.hdd:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	1071, // 576: forge.MachineDiscoveryCompletedRequest.machine_id:type_name -> common.MachineId
+	1071, // 577: forge.MachineCleanupInfo.machine_id:type_name -> common.MachineId
+	1059, // 578: forge.MachineCleanupInfo.nvme:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	1059, // 579: forge.MachineCleanupInfo.ram:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	1059, // 580: forge.MachineCleanupInfo.mem_overwrite:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	1059, // 581: forge.MachineCleanupInfo.ib:type_name -> forge.MachineCleanupInfo.CleanupStepResult
+	1059, // 582: forge.MachineCleanupInfo.hdd:type_name -> forge.MachineCleanupInfo.CleanupStepResult
 	98,   // 583: forge.MachineCleanupInfo.result:type_name -> forge.MachineCleanupInfo.CleanupResult
-	464,  // 584: forge.MachineCertificateResult.machine_certificate:type_name -> forge.MachineCertificate
-	1066, // 585: forge.MachineDiscoveryResult.machine_id:type_name -> common.MachineId
-	464,  // 586: forge.MachineDiscoveryResult.machine_certificate:type_name -> forge.MachineCertificate
-	145,  // 587: forge.MachineDiscoveryResult.attest_key_challenge:type_name -> forge.AttestKeyBindChallenge
-	1090, // 588: forge.MachineDiscoveryResult.machine_interface_id:type_name -> common.MachineInterfaceId
-	1066, // 589: forge.ForgeScoutErrorReport.machine_id:type_name -> common.MachineId
-	1090, // 590: forge.ForgeScoutErrorReport.machine_interface_id:type_name -> common.MachineInterfaceId
+	465,  // 584: forge.MachineCertificateResult.machine_certificate:type_name -> forge.MachineCertificate
+	1071, // 585: forge.MachineDiscoveryResult.machine_id:type_name -> common.MachineId
+	465,  // 586: forge.MachineDiscoveryResult.machine_certificate:type_name -> forge.MachineCertificate
+	146,  // 587: forge.MachineDiscoveryResult.attest_key_challenge:type_name -> forge.AttestKeyBindChallenge
+	1095, // 588: forge.MachineDiscoveryResult.machine_interface_id:type_name -> common.MachineInterfaceId
+	1071, // 589: forge.ForgeScoutErrorReport.machine_id:type_name -> common.MachineId
+	1095, // 590: forge.ForgeScoutErrorReport.machine_interface_id:type_name -> common.MachineInterfaceId
 	27,   // 591: forge.PxeInstructionRequest.arch:type_name -> forge.MachineArchitecture
-	1090, // 592: forge.PxeInstructionRequest.interface_id:type_name -> common.MachineInterfaceId
-	386,  // 593: forge.CloudInitDiscoveryInstructions.machine_interface:type_name -> forge.MachineInterface
-	924,  // 594: forge.CloudInitDiscoveryInstructions.domain:type_name -> forge.PxeDomain
+	1095, // 592: forge.PxeInstructionRequest.interface_id:type_name -> common.MachineInterfaceId
+	387,  // 593: forge.CloudInitDiscoveryInstructions.machine_interface:type_name -> forge.MachineInterface
+	925,  // 594: forge.CloudInitDiscoveryInstructions.domain:type_name -> forge.PxeDomain
 	41,   // 595: forge.CloudInitDiscoveryInstructions.bootstrap_ca_source:type_name -> forge.BootstrapCaSource
 	92,   // 596: forge.CloudInitDiscoveryInstructions.dpu_nvconfig_profile:type_name -> forge.DpuNvConfigProfile
-	474,  // 597: forge.CloudInitInstructions.discovery_instructions:type_name -> forge.CloudInitDiscoveryInstructions
-	475,  // 598: forge.CloudInitInstructions.metadata:type_name -> forge.CloudInitMetaData
-	1066, // 599: forge.DpuNetworkStatus.dpu_machine_id:type_name -> common.MachineId
-	1067, // 600: forge.DpuNetworkStatus.observed_at:type_name -> google.protobuf.Timestamp
-	499,  // 601: forge.DpuNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatusObservation
-	1086, // 602: forge.DpuNetworkStatus.instance_id:type_name -> common.InstanceId
-	1076, // 603: forge.DpuNetworkStatus.dpu_health:type_name -> health.HealthReport
-	500,  // 604: forge.DpuNetworkStatus.fabric_interfaces:type_name -> forge.FabricInterfaceData
-	479,  // 605: forge.DpuNetworkStatus.last_dhcp_requests:type_name -> forge.LastDhcpRequest
-	480,  // 606: forge.DpuNetworkStatus.dpu_extension_services:type_name -> forge.DpuExtensionServiceStatusObservation
-	809,  // 607: forge.DpuNetworkStatus.astra_config_status:type_name -> forge.AstraConfigStatus
-	1090, // 608: forge.LastDhcpRequest.host_interface_id:type_name -> common.MachineInterfaceId
+	475,  // 597: forge.CloudInitInstructions.discovery_instructions:type_name -> forge.CloudInitDiscoveryInstructions
+	476,  // 598: forge.CloudInitInstructions.metadata:type_name -> forge.CloudInitMetaData
+	1071, // 599: forge.DpuNetworkStatus.dpu_machine_id:type_name -> common.MachineId
+	1072, // 600: forge.DpuNetworkStatus.observed_at:type_name -> google.protobuf.Timestamp
+	500,  // 601: forge.DpuNetworkStatus.interfaces:type_name -> forge.InstanceInterfaceStatusObservation
+	1091, // 602: forge.DpuNetworkStatus.instance_id:type_name -> common.InstanceId
+	1081, // 603: forge.DpuNetworkStatus.dpu_health:type_name -> health.HealthReport
+	501,  // 604: forge.DpuNetworkStatus.fabric_interfaces:type_name -> forge.FabricInterfaceData
+	480,  // 605: forge.DpuNetworkStatus.last_dhcp_requests:type_name -> forge.LastDhcpRequest
+	481,  // 606: forge.DpuNetworkStatus.dpu_extension_services:type_name -> forge.DpuExtensionServiceStatusObservation
+	810,  // 607: forge.DpuNetworkStatus.astra_config_status:type_name -> forge.AstraConfigStatus
+	1095, // 608: forge.LastDhcpRequest.host_interface_id:type_name -> common.MachineInterfaceId
 	75,   // 609: forge.DpuExtensionServiceStatusObservation.service_type:type_name -> forge.DpuExtensionServiceType
 	77,   // 610: forge.DpuExtensionServiceStatusObservation.state:type_name -> forge.DpuExtensionServiceDeploymentStatus
-	481,  // 611: forge.DpuExtensionServiceStatusObservation.components:type_name -> forge.DpuExtensionServiceComponent
-	1076, // 612: forge.OptionalHealthReport.report:type_name -> health.HealthReport
-	1076, // 613: forge.HealthReportEntry.report:type_name -> health.HealthReport
+	482,  // 611: forge.DpuExtensionServiceStatusObservation.components:type_name -> forge.DpuExtensionServiceComponent
+	1081, // 612: forge.OptionalHealthReport.report:type_name -> health.HealthReport
+	1081, // 613: forge.HealthReportEntry.report:type_name -> health.HealthReport
 	43,   // 614: forge.HealthReportEntry.mode:type_name -> forge.HealthReportApplyMode
-	1066, // 615: forge.InsertMachineHealthReportRequest.machine_id:type_name -> common.MachineId
-	483,  // 616: forge.InsertMachineHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1078, // 617: forge.InsertRackHealthReportRequest.rack_id:type_name -> common.RackId
-	483,  // 618: forge.InsertRackHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1078, // 619: forge.RemoveRackHealthReportRequest.rack_id:type_name -> common.RackId
-	1078, // 620: forge.ListRackHealthReportsRequest.rack_id:type_name -> common.RackId
-	1080, // 621: forge.InsertSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
-	483,  // 622: forge.InsertSwitchHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1080, // 623: forge.RemoveSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
-	1080, // 624: forge.ListSwitchHealthReportsRequest.switch_id:type_name -> common.SwitchId
-	1077, // 625: forge.InsertPowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
-	483,  // 626: forge.InsertPowerShelfHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1077, // 627: forge.RemovePowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1077, // 628: forge.ListPowerShelfHealthReportsRequest.power_shelf_id:type_name -> common.PowerShelfId
-	483,  // 629: forge.ListHealthReportResponse.health_report_entries:type_name -> forge.HealthReportEntry
-	1066, // 630: forge.RemoveMachineHealthReportRequest.machine_id:type_name -> common.MachineId
-	1081, // 631: forge.ListNVLinkDomainHealthReportsRequest.domain_id:type_name -> common.NVLinkDomainId
-	1081, // 632: forge.InsertNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
-	483,  // 633: forge.InsertNVLinkDomainHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
-	1081, // 634: forge.RemoveNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
+	1071, // 615: forge.InsertMachineHealthReportRequest.machine_id:type_name -> common.MachineId
+	484,  // 616: forge.InsertMachineHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1083, // 617: forge.InsertRackHealthReportRequest.rack_id:type_name -> common.RackId
+	484,  // 618: forge.InsertRackHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1083, // 619: forge.RemoveRackHealthReportRequest.rack_id:type_name -> common.RackId
+	1083, // 620: forge.ListRackHealthReportsRequest.rack_id:type_name -> common.RackId
+	1085, // 621: forge.InsertSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
+	484,  // 622: forge.InsertSwitchHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1085, // 623: forge.RemoveSwitchHealthReportRequest.switch_id:type_name -> common.SwitchId
+	1085, // 624: forge.ListSwitchHealthReportsRequest.switch_id:type_name -> common.SwitchId
+	1082, // 625: forge.InsertPowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
+	484,  // 626: forge.InsertPowerShelfHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1082, // 627: forge.RemovePowerShelfHealthReportRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1082, // 628: forge.ListPowerShelfHealthReportsRequest.power_shelf_id:type_name -> common.PowerShelfId
+	484,  // 629: forge.ListHealthReportResponse.health_report_entries:type_name -> forge.HealthReportEntry
+	1071, // 630: forge.RemoveMachineHealthReportRequest.machine_id:type_name -> common.MachineId
+	1086, // 631: forge.ListNVLinkDomainHealthReportsRequest.domain_id:type_name -> common.NVLinkDomainId
+	1086, // 632: forge.InsertNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
+	484,  // 633: forge.InsertNVLinkDomainHealthReportRequest.health_report_entry:type_name -> forge.HealthReportEntry
+	1086, // 634: forge.RemoveNVLinkDomainHealthReportRequest.domain_id:type_name -> common.NVLinkDomainId
 	42,   // 635: forge.InstanceInterfaceStatusObservation.function_type:type_name -> forge.InterfaceFunctionType
-	721,  // 636: forge.InstanceInterfaceStatusObservation.network_security_group:type_name -> forge.NetworkSecurityGroupStatus
-	1079, // 637: forge.InstanceInterfaceStatusObservation.internal_uuid:type_name -> common.UUID
-	501,  // 638: forge.FabricInterfaceData.link_data:type_name -> forge.LinkData
-	287,  // 639: forge.Tenant.metadata:type_name -> forge.Metadata
-	287,  // 640: forge.CreateTenantRequest.metadata:type_name -> forge.Metadata
-	502,  // 641: forge.CreateTenantResponse.tenant:type_name -> forge.Tenant
-	287,  // 642: forge.UpdateTenantRequest.metadata:type_name -> forge.Metadata
-	502,  // 643: forge.UpdateTenantResponse.tenant:type_name -> forge.Tenant
-	502,  // 644: forge.FindTenantResponse.tenant:type_name -> forge.Tenant
-	510,  // 645: forge.TenantKeysetContent.public_keys:type_name -> forge.TenantPublicKey
-	509,  // 646: forge.TenantKeyset.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	511,  // 647: forge.TenantKeyset.keyset_content:type_name -> forge.TenantKeysetContent
-	509,  // 648: forge.CreateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	511,  // 649: forge.CreateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
-	512,  // 650: forge.CreateTenantKeysetResponse.keyset:type_name -> forge.TenantKeyset
-	512,  // 651: forge.TenantKeySetList.keyset:type_name -> forge.TenantKeyset
-	509,  // 652: forge.UpdateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	511,  // 653: forge.UpdateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
-	509,  // 654: forge.DeleteTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
-	509,  // 655: forge.TenantKeysetIdList.keyset_ids:type_name -> forge.TenantKeysetIdentifier
-	509,  // 656: forge.TenantKeysetsByIdsRequest.keyset_ids:type_name -> forge.TenantKeysetIdentifier
-	527,  // 657: forge.ResourcePools.pools:type_name -> forge.ResourcePool
+	722,  // 636: forge.InstanceInterfaceStatusObservation.network_security_group:type_name -> forge.NetworkSecurityGroupStatus
+	1084, // 637: forge.InstanceInterfaceStatusObservation.internal_uuid:type_name -> common.UUID
+	502,  // 638: forge.FabricInterfaceData.link_data:type_name -> forge.LinkData
+	288,  // 639: forge.Tenant.metadata:type_name -> forge.Metadata
+	288,  // 640: forge.CreateTenantRequest.metadata:type_name -> forge.Metadata
+	503,  // 641: forge.CreateTenantResponse.tenant:type_name -> forge.Tenant
+	288,  // 642: forge.UpdateTenantRequest.metadata:type_name -> forge.Metadata
+	503,  // 643: forge.UpdateTenantResponse.tenant:type_name -> forge.Tenant
+	503,  // 644: forge.FindTenantResponse.tenant:type_name -> forge.Tenant
+	511,  // 645: forge.TenantKeysetContent.public_keys:type_name -> forge.TenantPublicKey
+	510,  // 646: forge.TenantKeyset.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	512,  // 647: forge.TenantKeyset.keyset_content:type_name -> forge.TenantKeysetContent
+	510,  // 648: forge.CreateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	512,  // 649: forge.CreateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
+	513,  // 650: forge.CreateTenantKeysetResponse.keyset:type_name -> forge.TenantKeyset
+	513,  // 651: forge.TenantKeySetList.keyset:type_name -> forge.TenantKeyset
+	510,  // 652: forge.UpdateTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	512,  // 653: forge.UpdateTenantKeysetRequest.keyset_content:type_name -> forge.TenantKeysetContent
+	510,  // 654: forge.DeleteTenantKeysetRequest.keyset_identifier:type_name -> forge.TenantKeysetIdentifier
+	510,  // 655: forge.TenantKeysetIdList.keyset_ids:type_name -> forge.TenantKeysetIdentifier
+	510,  // 656: forge.TenantKeysetsByIdsRequest.keyset_ids:type_name -> forge.TenantKeysetIdentifier
+	528,  // 657: forge.ResourcePools.pools:type_name -> forge.ResourcePool
 	45,   // 658: forge.MaintenanceRequest.operation:type_name -> forge.MaintenanceOperation
-	1066, // 659: forge.MaintenanceRequest.host_id:type_name -> common.MachineId
+	1071, // 659: forge.MaintenanceRequest.host_id:type_name -> common.MachineId
 	46,   // 660: forge.SetDynamicConfigRequest.setting:type_name -> forge.ConfigSetting
-	558,  // 661: forge.FindIpAddressResponse.matches:type_name -> forge.IpAddressMatch
-	1079, // 662: forge.IdentifyUuidRequest.uuid:type_name -> common.UUID
-	1079, // 663: forge.IdentifyUuidResponse.uuid:type_name -> common.UUID
+	559,  // 661: forge.FindIpAddressResponse.matches:type_name -> forge.IpAddressMatch
+	1084, // 662: forge.IdentifyUuidRequest.uuid:type_name -> common.UUID
+	1084, // 663: forge.IdentifyUuidResponse.uuid:type_name -> common.UUID
 	47,   // 664: forge.IdentifyUuidResponse.object_type:type_name -> forge.UuidType
 	48,   // 665: forge.IdentifyMacResponse.object_type:type_name -> forge.MacOwner
-	1066, // 666: forge.IdentifySerialResponse.machine_id:type_name -> common.MachineId
-	1066, // 667: forge.DpuReprovisioningRequest.dpu_id:type_name -> common.MachineId
+	1071, // 666: forge.IdentifySerialResponse.machine_id:type_name -> common.MachineId
+	1071, // 667: forge.DpuReprovisioningRequest.dpu_id:type_name -> common.MachineId
 	99,   // 668: forge.DpuReprovisioningRequest.mode:type_name -> forge.DpuReprovisioningRequest.Mode
 	49,   // 669: forge.DpuReprovisioningRequest.initiator:type_name -> forge.UpdateInitiator
-	1066, // 670: forge.DpuReprovisioningRequest.machine_id:type_name -> common.MachineId
-	1056, // 671: forge.DpuReprovisioningListResponse.dpus:type_name -> forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
-	1066, // 672: forge.HostReprovisioningRequest.machine_id:type_name -> common.MachineId
+	1071, // 670: forge.DpuReprovisioningRequest.machine_id:type_name -> common.MachineId
+	1060, // 671: forge.DpuReprovisioningListResponse.dpus:type_name -> forge.DpuReprovisioningListResponse.DpuReprovisioningListItem
+	1071, // 672: forge.HostReprovisioningRequest.machine_id:type_name -> common.MachineId
 	100,  // 673: forge.HostReprovisioningRequest.mode:type_name -> forge.HostReprovisioningRequest.Mode
 	49,   // 674: forge.HostReprovisioningRequest.initiator:type_name -> forge.UpdateInitiator
 	101,  // 675: forge.BmcCredentialRotationRequest.mode:type_name -> forge.BmcCredentialRotationRequest.Mode
-	1095, // 676: forge.BmcCredentialRotationRequest.device_id:type_name -> common.DeviceId
+	1100, // 676: forge.BmcCredentialRotationRequest.device_id:type_name -> common.DeviceId
 	102,  // 677: forge.UefiCredentialRotationRequest.mode:type_name -> forge.UefiCredentialRotationRequest.Mode
-	1066, // 678: forge.UefiCredentialRotationRequest.machine_id:type_name -> common.MachineId
+	1071, // 678: forge.UefiCredentialRotationRequest.machine_id:type_name -> common.MachineId
 	103,  // 679: forge.NicLockdownCredentialRotationRequest.mode:type_name -> forge.NicLockdownCredentialRotationRequest.Mode
-	1066, // 680: forge.NicLockdownCredentialRotationRequest.machine_id:type_name -> common.MachineId
-	1057, // 681: forge.HostReprovisioningListResponse.hosts:type_name -> forge.HostReprovisioningListResponse.HostReprovisioningListItem
-	552,  // 682: forge.DpuInfoStatusObservation.os_operational_state:type_name -> forge.DpuOsOperationalState
-	553,  // 683: forge.DpuInfoStatusObservation.representors:type_name -> forge.DpuRepresentorStatus
-	1067, // 684: forge.DpuInfoStatusObservation.last_heartbeat:type_name -> google.protobuf.Timestamp
-	554,  // 685: forge.DpuInfo.observed_status:type_name -> forge.DpuInfoStatusObservation
-	555,  // 686: forge.GetDpuInfoListResponse.dpu_list:type_name -> forge.DpuInfo
+	1071, // 680: forge.NicLockdownCredentialRotationRequest.machine_id:type_name -> common.MachineId
+	1061, // 681: forge.HostReprovisioningListResponse.hosts:type_name -> forge.HostReprovisioningListResponse.HostReprovisioningListItem
+	553,  // 682: forge.DpuInfoStatusObservation.os_operational_state:type_name -> forge.DpuOsOperationalState
+	554,  // 683: forge.DpuInfoStatusObservation.representors:type_name -> forge.DpuRepresentorStatus
+	1072, // 684: forge.DpuInfoStatusObservation.last_heartbeat:type_name -> google.protobuf.Timestamp
+	555,  // 685: forge.DpuInfo.observed_status:type_name -> forge.DpuInfoStatusObservation
+	556,  // 686: forge.GetDpuInfoListResponse.dpu_list:type_name -> forge.DpuInfo
 	50,   // 687: forge.IpAddressMatch.ip_type:type_name -> forge.IpType
-	1090, // 688: forge.MachineBootOverride.machine_interface_id:type_name -> common.MachineInterfaceId
-	1066, // 689: forge.ConnectedDevice.id:type_name -> common.MachineId
-	560,  // 690: forge.ConnectedDeviceList.connected_devices:type_name -> forge.ConnectedDevice
-	566,  // 691: forge.MachineIdBmcIpPairs.pairs:type_name -> forge.MachineIdBmcIp
-	1066, // 692: forge.MachineIdBmcIp.machine_id:type_name -> common.MachineId
-	560,  // 693: forge.NetworkDevice.devices:type_name -> forge.ConnectedDevice
-	567,  // 694: forge.NetworkTopologyData.network_devices:type_name -> forge.NetworkDevice
+	1095, // 688: forge.MachineBootOverride.machine_interface_id:type_name -> common.MachineInterfaceId
+	1071, // 689: forge.ConnectedDevice.id:type_name -> common.MachineId
+	561,  // 690: forge.ConnectedDeviceList.connected_devices:type_name -> forge.ConnectedDevice
+	567,  // 691: forge.MachineIdBmcIpPairs.pairs:type_name -> forge.MachineIdBmcIp
+	1071, // 692: forge.MachineIdBmcIp.machine_id:type_name -> common.MachineId
+	561,  // 693: forge.NetworkDevice.devices:type_name -> forge.ConnectedDevice
+	568,  // 694: forge.NetworkTopologyData.network_devices:type_name -> forge.NetworkDevice
 	51,   // 695: forge.RouteServers.source_type:type_name -> forge.RouteServerSourceType
-	573,  // 696: forge.RouteServerEntries.route_servers:type_name -> forge.RouteServer
+	574,  // 696: forge.RouteServerEntries.route_servers:type_name -> forge.RouteServer
 	51,   // 697: forge.RouteServer.source_type:type_name -> forge.RouteServerSourceType
-	1066, // 698: forge.SetHostUefiPasswordRequest.host_id:type_name -> common.MachineId
-	1066, // 699: forge.ClearHostUefiPasswordRequest.host_id:type_name -> common.MachineId
-	1066, // 700: forge.SetDpuUefiPasswordRequest.dpu_id:type_name -> common.MachineId
-	1079, // 701: forge.OsImageAttributes.id:type_name -> common.UUID
-	580,  // 702: forge.OsImage.attributes:type_name -> forge.OsImageAttributes
+	1071, // 698: forge.SetHostUefiPasswordRequest.host_id:type_name -> common.MachineId
+	1071, // 699: forge.ClearHostUefiPasswordRequest.host_id:type_name -> common.MachineId
+	1071, // 700: forge.SetDpuUefiPasswordRequest.dpu_id:type_name -> common.MachineId
+	1084, // 701: forge.OsImageAttributes.id:type_name -> common.UUID
+	581,  // 702: forge.OsImage.attributes:type_name -> forge.OsImageAttributes
 	52,   // 703: forge.OsImage.status:type_name -> forge.OsImageStatus
-	581,  // 704: forge.ListOsImageResponse.images:type_name -> forge.OsImage
-	1079, // 705: forge.DeleteOsImageRequest.id:type_name -> common.UUID
-	1087, // 706: forge.GetIpxeTemplateRequest.id:type_name -> common.IpxeTemplateId
-	296,  // 707: forge.IpxeTemplateList.templates:type_name -> forge.IpxeTemplate
+	582,  // 704: forge.ListOsImageResponse.images:type_name -> forge.OsImage
+	1084, // 705: forge.DeleteOsImageRequest.id:type_name -> common.UUID
+	1092, // 706: forge.GetIpxeTemplateRequest.id:type_name -> common.IpxeTemplateId
+	297,  // 707: forge.IpxeTemplateList.templates:type_name -> forge.IpxeTemplate
 	13,   // 708: forge.ExpectedHostNic.network_segment_type:type_name -> forge.NetworkSegmentType
 	86,   // 709: forge.ExpectedHostNic.role:type_name -> forge.ExpectedInterfaceRole
 	87,   // 710: forge.ExpectedHostNic.ip_allocation:type_name -> forge.ExpectedInterfaceIpAllocation
-	287,  // 711: forge.ExpectedMachine.metadata:type_name -> forge.Metadata
-	1079, // 712: forge.ExpectedMachine.id:type_name -> common.UUID
-	589,  // 713: forge.ExpectedMachine.host_nics:type_name -> forge.ExpectedHostNic
-	1078, // 714: forge.ExpectedMachine.rack_id:type_name -> common.RackId
+	288,  // 711: forge.ExpectedMachine.metadata:type_name -> forge.Metadata
+	1084, // 712: forge.ExpectedMachine.id:type_name -> common.UUID
+	590,  // 713: forge.ExpectedMachine.host_nics:type_name -> forge.ExpectedHostNic
+	1083, // 714: forge.ExpectedMachine.rack_id:type_name -> common.RackId
 	53,   // 715: forge.ExpectedMachine.dpu_mode:type_name -> forge.DpuMode
-	590,  // 716: forge.ExpectedMachine.host_lifecycle_profile:type_name -> forge.HostLifecycleProfile
+	591,  // 716: forge.ExpectedMachine.host_lifecycle_profile:type_name -> forge.HostLifecycleProfile
 	54,   // 717: forge.ExpectedMachine.bmc_ip_allocation:type_name -> forge.BmcIpAllocationType
-	1079, // 718: forge.ExpectedMachineRequest.id:type_name -> common.UUID
-	591,  // 719: forge.ExpectedMachineList.expected_machines:type_name -> forge.ExpectedMachine
-	595,  // 720: forge.LinkedExpectedMachineList.expected_machines:type_name -> forge.LinkedExpectedMachine
-	1066, // 721: forge.LinkedExpectedMachine.machine_id:type_name -> common.MachineId
-	1079, // 722: forge.LinkedExpectedMachine.expected_machine_id:type_name -> common.UUID
-	597,  // 723: forge.UnexpectedMachineList.unexpected_machines:type_name -> forge.UnexpectedMachine
-	1066, // 724: forge.UnexpectedMachine.machine_id:type_name -> common.MachineId
-	593,  // 725: forge.BatchExpectedMachineOperationRequest.expected_machines:type_name -> forge.ExpectedMachineList
-	1079, // 726: forge.ExpectedMachineOperationResult.id:type_name -> common.UUID
-	591,  // 727: forge.ExpectedMachineOperationResult.expected_machine:type_name -> forge.ExpectedMachine
-	599,  // 728: forge.BatchExpectedMachineOperationResponse.results:type_name -> forge.ExpectedMachineOperationResult
-	1066, // 729: forge.MachineRebootCompletedRequest.machine_id:type_name -> common.MachineId
-	1066, // 730: forge.ScoutFirmwareUpgradeStatusRequest.machine_id:type_name -> common.MachineId
-	1066, // 731: forge.MachineValidationCompletedRequest.machine_id:type_name -> common.MachineId
-	1096, // 732: forge.MachineValidationCompletedRequest.validation_id:type_name -> common.MachineValidationId
-	1067, // 733: forge.MachineValidationResult.start_time:type_name -> google.protobuf.Timestamp
-	1067, // 734: forge.MachineValidationResult.end_time:type_name -> google.protobuf.Timestamp
-	1096, // 735: forge.MachineValidationResult.validation_id:type_name -> common.MachineValidationId
-	606,  // 736: forge.MachineValidationResultPostRequest.result:type_name -> forge.MachineValidationResult
-	606,  // 737: forge.MachineValidationResultList.results:type_name -> forge.MachineValidationResult
-	1066, // 738: forge.MachineValidationGetRequest.machine_id:type_name -> common.MachineId
-	1096, // 739: forge.MachineValidationGetRequest.validation_id:type_name -> common.MachineValidationId
+	1084, // 718: forge.ExpectedMachineRequest.id:type_name -> common.UUID
+	592,  // 719: forge.ExpectedMachineList.expected_machines:type_name -> forge.ExpectedMachine
+	596,  // 720: forge.LinkedExpectedMachineList.expected_machines:type_name -> forge.LinkedExpectedMachine
+	1071, // 721: forge.LinkedExpectedMachine.machine_id:type_name -> common.MachineId
+	1084, // 722: forge.LinkedExpectedMachine.expected_machine_id:type_name -> common.UUID
+	598,  // 723: forge.UnexpectedMachineList.unexpected_machines:type_name -> forge.UnexpectedMachine
+	1071, // 724: forge.UnexpectedMachine.machine_id:type_name -> common.MachineId
+	594,  // 725: forge.BatchExpectedMachineOperationRequest.expected_machines:type_name -> forge.ExpectedMachineList
+	1084, // 726: forge.ExpectedMachineOperationResult.id:type_name -> common.UUID
+	592,  // 727: forge.ExpectedMachineOperationResult.expected_machine:type_name -> forge.ExpectedMachine
+	600,  // 728: forge.BatchExpectedMachineOperationResponse.results:type_name -> forge.ExpectedMachineOperationResult
+	1071, // 729: forge.MachineRebootCompletedRequest.machine_id:type_name -> common.MachineId
+	1071, // 730: forge.ScoutFirmwareUpgradeStatusRequest.machine_id:type_name -> common.MachineId
+	1071, // 731: forge.MachineValidationCompletedRequest.machine_id:type_name -> common.MachineId
+	1101, // 732: forge.MachineValidationCompletedRequest.validation_id:type_name -> common.MachineValidationId
+	1072, // 733: forge.MachineValidationResult.start_time:type_name -> google.protobuf.Timestamp
+	1072, // 734: forge.MachineValidationResult.end_time:type_name -> google.protobuf.Timestamp
+	1101, // 735: forge.MachineValidationResult.validation_id:type_name -> common.MachineValidationId
+	607,  // 736: forge.MachineValidationResultPostRequest.result:type_name -> forge.MachineValidationResult
+	607,  // 737: forge.MachineValidationResultList.results:type_name -> forge.MachineValidationResult
+	1071, // 738: forge.MachineValidationGetRequest.machine_id:type_name -> common.MachineId
+	1101, // 739: forge.MachineValidationGetRequest.validation_id:type_name -> common.MachineValidationId
 	55,   // 740: forge.MachineValidationStatus.started:type_name -> forge.MachineValidationStarted
 	56,   // 741: forge.MachineValidationStatus.in_progress:type_name -> forge.MachineValidationInProgress
 	57,   // 742: forge.MachineValidationStatus.completed:type_name -> forge.MachineValidationCompleted
-	1096, // 743: forge.MachineValidationRun.validation_id:type_name -> common.MachineValidationId
-	1066, // 744: forge.MachineValidationRun.machine_id:type_name -> common.MachineId
-	1067, // 745: forge.MachineValidationRun.start_time:type_name -> google.protobuf.Timestamp
-	1067, // 746: forge.MachineValidationRun.end_time:type_name -> google.protobuf.Timestamp
-	610,  // 747: forge.MachineValidationRun.status:type_name -> forge.MachineValidationStatus
-	1092, // 748: forge.MachineValidationRun.duration_to_complete:type_name -> google.protobuf.Duration
-	1067, // 749: forge.MachineValidationRun.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1066, // 750: forge.MachineSetAutoUpdateRequest.machine_id:type_name -> common.MachineId
+	1101, // 743: forge.MachineValidationRun.validation_id:type_name -> common.MachineValidationId
+	1071, // 744: forge.MachineValidationRun.machine_id:type_name -> common.MachineId
+	1072, // 745: forge.MachineValidationRun.start_time:type_name -> google.protobuf.Timestamp
+	1072, // 746: forge.MachineValidationRun.end_time:type_name -> google.protobuf.Timestamp
+	611,  // 747: forge.MachineValidationRun.status:type_name -> forge.MachineValidationStatus
+	1097, // 748: forge.MachineValidationRun.duration_to_complete:type_name -> google.protobuf.Duration
+	1072, // 749: forge.MachineValidationRun.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1071, // 750: forge.MachineSetAutoUpdateRequest.machine_id:type_name -> common.MachineId
 	104,  // 751: forge.MachineSetAutoUpdateRequest.action:type_name -> forge.MachineSetAutoUpdateRequest.SetAutoupdateAction
-	1067, // 752: forge.MachineValidationExternalConfig.timestamp:type_name -> google.protobuf.Timestamp
-	615,  // 753: forge.GetMachineValidationExternalConfigResponse.config:type_name -> forge.MachineValidationExternalConfig
-	615,  // 754: forge.GetMachineValidationExternalConfigsResponse.configs:type_name -> forge.MachineValidationExternalConfig
-	1066, // 755: forge.MachineValidationOnDemandRequest.machine_id:type_name -> common.MachineId
+	1072, // 752: forge.MachineValidationExternalConfig.timestamp:type_name -> google.protobuf.Timestamp
+	616,  // 753: forge.GetMachineValidationExternalConfigResponse.config:type_name -> forge.MachineValidationExternalConfig
+	616,  // 754: forge.GetMachineValidationExternalConfigsResponse.configs:type_name -> forge.MachineValidationExternalConfig
+	1071, // 755: forge.MachineValidationOnDemandRequest.machine_id:type_name -> common.MachineId
 	105,  // 756: forge.MachineValidationOnDemandRequest.action:type_name -> forge.MachineValidationOnDemandRequest.Action
-	1096, // 757: forge.MachineValidationOnDemandResponse.validation_id:type_name -> common.MachineValidationId
-	611,  // 758: forge.MachineValidationOnDemandResponse.run:type_name -> forge.MachineValidationRun
-	623,  // 759: forge.MaintenanceActivityConfig.firmware_upgrade:type_name -> forge.FirmwareUpgradeActivity
-	625,  // 760: forge.MaintenanceActivityConfig.configure_nmx_cluster:type_name -> forge.ConfigureNmxClusterActivity
-	626,  // 761: forge.MaintenanceActivityConfig.power_sequence:type_name -> forge.PowerSequenceActivity
-	624,  // 762: forge.MaintenanceActivityConfig.nvos_update:type_name -> forge.NvosUpdateActivity
-	627,  // 763: forge.RackMaintenanceScope.activities:type_name -> forge.MaintenanceActivityConfig
-	1078, // 764: forge.RackMaintenanceOnDemandRequest.rack_id:type_name -> common.RackId
-	628,  // 765: forge.RackMaintenanceOnDemandRequest.scope:type_name -> forge.RackMaintenanceScope
-	1078, // 766: forge.RackMaintenanceTerminateRequest.rack_id:type_name -> common.RackId
-	407,  // 767: forge.AdminPowerControlRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1101, // 757: forge.MachineValidationOnDemandResponse.validation_id:type_name -> common.MachineValidationId
+	612,  // 758: forge.MachineValidationOnDemandResponse.run:type_name -> forge.MachineValidationRun
+	624,  // 759: forge.MaintenanceActivityConfig.firmware_upgrade:type_name -> forge.FirmwareUpgradeActivity
+	626,  // 760: forge.MaintenanceActivityConfig.configure_nmx_cluster:type_name -> forge.ConfigureNmxClusterActivity
+	627,  // 761: forge.MaintenanceActivityConfig.power_sequence:type_name -> forge.PowerSequenceActivity
+	625,  // 762: forge.MaintenanceActivityConfig.nvos_update:type_name -> forge.NvosUpdateActivity
+	628,  // 763: forge.RackMaintenanceScope.activities:type_name -> forge.MaintenanceActivityConfig
+	1083, // 764: forge.RackMaintenanceOnDemandRequest.rack_id:type_name -> common.RackId
+	629,  // 765: forge.RackMaintenanceOnDemandRequest.scope:type_name -> forge.RackMaintenanceScope
+	1083, // 766: forge.RackMaintenanceTerminateRequest.rack_id:type_name -> common.RackId
+	408,  // 767: forge.AdminPowerControlRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
 	106,  // 768: forge.AdminPowerControlRequest.action:type_name -> forge.AdminPowerControlRequest.SystemPowerControl
-	1066, // 769: forge.AdminGpuResetRequest.machine_id:type_name -> common.MachineId
+	1071, // 769: forge.AdminGpuResetRequest.machine_id:type_name -> common.MachineId
 	106,  // 770: forge.AdminGpuResetRequest.action:type_name -> forge.AdminPowerControlRequest.SystemPowerControl
-	1066, // 771: forge.GetRedfishJobStateRequest.machine_id:type_name -> common.MachineId
+	1071, // 771: forge.GetRedfishJobStateRequest.machine_id:type_name -> common.MachineId
 	107,  // 772: forge.GetRedfishJobStateResponse.job_state:type_name -> forge.GetRedfishJobStateResponse.RedfishJobState
-	611,  // 773: forge.MachineValidationRunList.runs:type_name -> forge.MachineValidationRun
-	1066, // 774: forge.MachineValidationRunListGetRequest.machine_id:type_name -> common.MachineId
-	1096, // 775: forge.MachineValidationRunItemSearchFilter.validation_id:type_name -> common.MachineValidationId
-	1079, // 776: forge.MachineValidationRunItemIdList.run_item_ids:type_name -> common.UUID
-	1079, // 777: forge.MachineValidationRunItemsByIdsRequest.run_item_ids:type_name -> common.UUID
-	645,  // 778: forge.MachineValidationRunItemList.run_items:type_name -> forge.MachineValidationRunItem
-	1079, // 779: forge.MachineValidationRunItem.run_item_id:type_name -> common.UUID
-	1096, // 780: forge.MachineValidationRunItem.validation_id:type_name -> common.MachineValidationId
-	1092, // 781: forge.MachineValidationRunItem.timeout:type_name -> google.protobuf.Duration
-	1067, // 782: forge.MachineValidationRunItem.started_at:type_name -> google.protobuf.Timestamp
-	1067, // 783: forge.MachineValidationRunItem.ended_at:type_name -> google.protobuf.Timestamp
-	1067, // 784: forge.MachineValidationRunItem.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1079, // 785: forge.MachineValidationRunItem.current_attempt_id:type_name -> common.UUID
-	1079, // 786: forge.MachineValidationAttemptGetRequest.attempt_id:type_name -> common.UUID
-	1079, // 787: forge.MachineValidationAttempt.attempt_id:type_name -> common.UUID
-	1079, // 788: forge.MachineValidationAttempt.run_item_id:type_name -> common.UUID
-	1067, // 789: forge.MachineValidationAttempt.started_at:type_name -> google.protobuf.Timestamp
-	1067, // 790: forge.MachineValidationAttempt.ended_at:type_name -> google.protobuf.Timestamp
-	1067, // 791: forge.MachineValidationAttempt.last_heartbeat_at:type_name -> google.protobuf.Timestamp
-	1096, // 792: forge.MachineValidationHeartbeatRequest.validation_id:type_name -> common.MachineValidationId
-	1079, // 793: forge.MachineValidationHeartbeatRequest.run_item_id:type_name -> common.UUID
-	1079, // 794: forge.MachineValidationHeartbeatRequest.attempt_id:type_name -> common.UUID
-	1058, // 795: forge.MachineValidationTestUpdateRequest.payload:type_name -> forge.MachineValidationTestUpdateRequest.Payload
-	660,  // 796: forge.MachineValidationTestAddRequest.plugin:type_name -> forge.MachineValidationPlugin
-	659,  // 797: forge.MachineValidationTestsGetResponse.tests:type_name -> forge.MachineValidationTest
-	660,  // 798: forge.MachineValidationTest.plugin:type_name -> forge.MachineValidationPlugin
-	1096, // 799: forge.MachineValidationRunRequest.validation_id:type_name -> common.MachineValidationId
-	1092, // 800: forge.MachineValidationRunRequest.duration_to_complete:type_name -> google.protobuf.Duration
-	659,  // 801: forge.MachineValidationRunRequest.selected_tests:type_name -> forge.MachineValidationTest
+	612,  // 773: forge.MachineValidationRunList.runs:type_name -> forge.MachineValidationRun
+	1071, // 774: forge.MachineValidationRunListGetRequest.machine_id:type_name -> common.MachineId
+	1101, // 775: forge.MachineValidationRunItemSearchFilter.validation_id:type_name -> common.MachineValidationId
+	1084, // 776: forge.MachineValidationRunItemIdList.run_item_ids:type_name -> common.UUID
+	1084, // 777: forge.MachineValidationRunItemsByIdsRequest.run_item_ids:type_name -> common.UUID
+	646,  // 778: forge.MachineValidationRunItemList.run_items:type_name -> forge.MachineValidationRunItem
+	1084, // 779: forge.MachineValidationRunItem.run_item_id:type_name -> common.UUID
+	1101, // 780: forge.MachineValidationRunItem.validation_id:type_name -> common.MachineValidationId
+	1097, // 781: forge.MachineValidationRunItem.timeout:type_name -> google.protobuf.Duration
+	1072, // 782: forge.MachineValidationRunItem.started_at:type_name -> google.protobuf.Timestamp
+	1072, // 783: forge.MachineValidationRunItem.ended_at:type_name -> google.protobuf.Timestamp
+	1072, // 784: forge.MachineValidationRunItem.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1084, // 785: forge.MachineValidationRunItem.current_attempt_id:type_name -> common.UUID
+	1084, // 786: forge.MachineValidationAttemptGetRequest.attempt_id:type_name -> common.UUID
+	1084, // 787: forge.MachineValidationAttempt.attempt_id:type_name -> common.UUID
+	1084, // 788: forge.MachineValidationAttempt.run_item_id:type_name -> common.UUID
+	1072, // 789: forge.MachineValidationAttempt.started_at:type_name -> google.protobuf.Timestamp
+	1072, // 790: forge.MachineValidationAttempt.ended_at:type_name -> google.protobuf.Timestamp
+	1072, // 791: forge.MachineValidationAttempt.last_heartbeat_at:type_name -> google.protobuf.Timestamp
+	1101, // 792: forge.MachineValidationHeartbeatRequest.validation_id:type_name -> common.MachineValidationId
+	1084, // 793: forge.MachineValidationHeartbeatRequest.run_item_id:type_name -> common.UUID
+	1084, // 794: forge.MachineValidationHeartbeatRequest.attempt_id:type_name -> common.UUID
+	1062, // 795: forge.MachineValidationTestUpdateRequest.payload:type_name -> forge.MachineValidationTestUpdateRequest.Payload
+	661,  // 796: forge.MachineValidationTestAddRequest.plugin:type_name -> forge.MachineValidationPlugin
+	660,  // 797: forge.MachineValidationTestsGetResponse.tests:type_name -> forge.MachineValidationTest
+	661,  // 798: forge.MachineValidationTest.plugin:type_name -> forge.MachineValidationPlugin
+	1101, // 799: forge.MachineValidationRunRequest.validation_id:type_name -> common.MachineValidationId
+	1097, // 800: forge.MachineValidationRunRequest.duration_to_complete:type_name -> google.protobuf.Duration
+	660,  // 801: forge.MachineValidationRunRequest.selected_tests:type_name -> forge.MachineValidationTest
 	58,   // 802: forge.MachineCapabilityAttributesGpu.device_type:type_name -> forge.MachineCapabilityDeviceType
 	58,   // 803: forge.MachineCapabilityAttributesNetwork.device_type:type_name -> forge.MachineCapabilityDeviceType
-	669,  // 804: forge.MachineCapabilitiesSet.cpu:type_name -> forge.MachineCapabilityAttributesCpu
-	670,  // 805: forge.MachineCapabilitiesSet.gpu:type_name -> forge.MachineCapabilityAttributesGpu
-	671,  // 806: forge.MachineCapabilitiesSet.memory:type_name -> forge.MachineCapabilityAttributesMemory
-	672,  // 807: forge.MachineCapabilitiesSet.storage:type_name -> forge.MachineCapabilityAttributesStorage
-	673,  // 808: forge.MachineCapabilitiesSet.network:type_name -> forge.MachineCapabilityAttributesNetwork
-	674,  // 809: forge.MachineCapabilitiesSet.infiniband:type_name -> forge.MachineCapabilityAttributesInfiniband
-	675,  // 810: forge.MachineCapabilitiesSet.dpu:type_name -> forge.MachineCapabilityAttributesDpu
-	679,  // 811: forge.InstanceTypeAttributes.desired_capabilities:type_name -> forge.InstanceTypeMachineCapabilityFilterAttributes
-	677,  // 812: forge.InstanceType.attributes:type_name -> forge.InstanceTypeAttributes
-	287,  // 813: forge.InstanceType.metadata:type_name -> forge.Metadata
-	777,  // 814: forge.InstanceType.allocation_stats:type_name -> forge.InstanceTypeAllocationStats
+	670,  // 804: forge.MachineCapabilitiesSet.cpu:type_name -> forge.MachineCapabilityAttributesCpu
+	671,  // 805: forge.MachineCapabilitiesSet.gpu:type_name -> forge.MachineCapabilityAttributesGpu
+	672,  // 806: forge.MachineCapabilitiesSet.memory:type_name -> forge.MachineCapabilityAttributesMemory
+	673,  // 807: forge.MachineCapabilitiesSet.storage:type_name -> forge.MachineCapabilityAttributesStorage
+	674,  // 808: forge.MachineCapabilitiesSet.network:type_name -> forge.MachineCapabilityAttributesNetwork
+	675,  // 809: forge.MachineCapabilitiesSet.infiniband:type_name -> forge.MachineCapabilityAttributesInfiniband
+	676,  // 810: forge.MachineCapabilitiesSet.dpu:type_name -> forge.MachineCapabilityAttributesDpu
+	680,  // 811: forge.InstanceTypeAttributes.desired_capabilities:type_name -> forge.InstanceTypeMachineCapabilityFilterAttributes
+	678,  // 812: forge.InstanceType.attributes:type_name -> forge.InstanceTypeAttributes
+	288,  // 813: forge.InstanceType.metadata:type_name -> forge.Metadata
+	778,  // 814: forge.InstanceType.allocation_stats:type_name -> forge.InstanceTypeAllocationStats
 	59,   // 815: forge.InstanceTypeMachineCapabilityFilterAttributes.capability_type:type_name -> forge.MachineCapabilityType
-	1097, // 816: forge.InstanceTypeMachineCapabilityFilterAttributes.inactive_devices:type_name -> common.Uint32List
+	1102, // 816: forge.InstanceTypeMachineCapabilityFilterAttributes.inactive_devices:type_name -> common.Uint32List
 	58,   // 817: forge.InstanceTypeMachineCapabilityFilterAttributes.device_type:type_name -> forge.MachineCapabilityDeviceType
-	287,  // 818: forge.CreateInstanceTypeRequest.metadata:type_name -> forge.Metadata
-	677,  // 819: forge.CreateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
-	678,  // 820: forge.CreateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
-	678,  // 821: forge.FindInstanceTypesByIdsResponse.instance_types:type_name -> forge.InstanceType
-	678,  // 822: forge.UpdateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
-	287,  // 823: forge.UpdateInstanceTypeRequest.metadata:type_name -> forge.Metadata
-	677,  // 824: forge.UpdateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
-	1059, // 825: forge.RedfishBrowseResponse.headers:type_name -> forge.RedfishBrowseResponse.HeadersEntry
-	698,  // 826: forge.RedfishListActionsResponse.actions:type_name -> forge.RedfishAction
-	1067, // 827: forge.RedfishAction.approver_dates:type_name -> google.protobuf.Timestamp
-	1067, // 828: forge.RedfishAction.applied_at:type_name -> google.protobuf.Timestamp
-	699,  // 829: forge.RedfishAction.results:type_name -> forge.OptionalRedfishActionResult
-	700,  // 830: forge.OptionalRedfishActionResult.result:type_name -> forge.RedfishActionResult
-	1060, // 831: forge.RedfishActionResult.headers:type_name -> forge.RedfishActionResult.HeadersEntry
-	1067, // 832: forge.RedfishActionResult.completed_at:type_name -> google.protobuf.Timestamp
-	1061, // 833: forge.UfmBrowseResponse.headers:type_name -> forge.UfmBrowseResponse.HeadersEntry
-	726,  // 834: forge.NetworkSecurityGroupAttributes.rules:type_name -> forge.NetworkSecurityGroupRuleAttributes
-	287,  // 835: forge.NetworkSecurityGroup.metadata:type_name -> forge.Metadata
-	709,  // 836: forge.NetworkSecurityGroup.attributes:type_name -> forge.NetworkSecurityGroupAttributes
-	287,  // 837: forge.CreateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
-	709,  // 838: forge.CreateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
-	710,  // 839: forge.CreateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
-	710,  // 840: forge.FindNetworkSecurityGroupsByIdsResponse.network_security_groups:type_name -> forge.NetworkSecurityGroup
-	710,  // 841: forge.UpdateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
-	287,  // 842: forge.UpdateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
-	709,  // 843: forge.UpdateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
+	288,  // 818: forge.CreateInstanceTypeRequest.metadata:type_name -> forge.Metadata
+	678,  // 819: forge.CreateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
+	679,  // 820: forge.CreateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
+	679,  // 821: forge.FindInstanceTypesByIdsResponse.instance_types:type_name -> forge.InstanceType
+	679,  // 822: forge.UpdateInstanceTypeResponse.instance_type:type_name -> forge.InstanceType
+	288,  // 823: forge.UpdateInstanceTypeRequest.metadata:type_name -> forge.Metadata
+	678,  // 824: forge.UpdateInstanceTypeRequest.instance_type_attributes:type_name -> forge.InstanceTypeAttributes
+	1063, // 825: forge.RedfishBrowseResponse.headers:type_name -> forge.RedfishBrowseResponse.HeadersEntry
+	699,  // 826: forge.RedfishListActionsResponse.actions:type_name -> forge.RedfishAction
+	1072, // 827: forge.RedfishAction.approver_dates:type_name -> google.protobuf.Timestamp
+	1072, // 828: forge.RedfishAction.applied_at:type_name -> google.protobuf.Timestamp
+	700,  // 829: forge.RedfishAction.results:type_name -> forge.OptionalRedfishActionResult
+	701,  // 830: forge.OptionalRedfishActionResult.result:type_name -> forge.RedfishActionResult
+	1064, // 831: forge.RedfishActionResult.headers:type_name -> forge.RedfishActionResult.HeadersEntry
+	1072, // 832: forge.RedfishActionResult.completed_at:type_name -> google.protobuf.Timestamp
+	1065, // 833: forge.UfmBrowseResponse.headers:type_name -> forge.UfmBrowseResponse.HeadersEntry
+	727,  // 834: forge.NetworkSecurityGroupAttributes.rules:type_name -> forge.NetworkSecurityGroupRuleAttributes
+	288,  // 835: forge.NetworkSecurityGroup.metadata:type_name -> forge.Metadata
+	710,  // 836: forge.NetworkSecurityGroup.attributes:type_name -> forge.NetworkSecurityGroupAttributes
+	288,  // 837: forge.CreateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
+	710,  // 838: forge.CreateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
+	711,  // 839: forge.CreateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
+	711,  // 840: forge.FindNetworkSecurityGroupsByIdsResponse.network_security_groups:type_name -> forge.NetworkSecurityGroup
+	711,  // 841: forge.UpdateNetworkSecurityGroupResponse.network_security_group:type_name -> forge.NetworkSecurityGroup
+	288,  // 842: forge.UpdateNetworkSecurityGroupRequest.metadata:type_name -> forge.Metadata
+	710,  // 843: forge.UpdateNetworkSecurityGroupRequest.network_security_group_attributes:type_name -> forge.NetworkSecurityGroupAttributes
 	60,   // 844: forge.NetworkSecurityGroupStatus.source:type_name -> forge.NetworkSecurityGroupSource
 	61,   // 845: forge.NetworkSecurityGroupPropagationObjectStatus.status:type_name -> forge.NetworkSecurityGroupPropagationStatus
-	722,  // 846: forge.GetNetworkSecurityGroupPropagationStatusResponse.vpcs:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	722,  // 847: forge.GetNetworkSecurityGroupPropagationStatusResponse.instances:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
-	724,  // 848: forge.GetNetworkSecurityGroupPropagationStatusRequest.network_security_group_ids:type_name -> forge.NetworkSecurityGroupIdList
+	723,  // 846: forge.GetNetworkSecurityGroupPropagationStatusResponse.vpcs:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	723,  // 847: forge.GetNetworkSecurityGroupPropagationStatusResponse.instances:type_name -> forge.NetworkSecurityGroupPropagationObjectStatus
+	725,  // 848: forge.GetNetworkSecurityGroupPropagationStatusRequest.network_security_group_ids:type_name -> forge.NetworkSecurityGroupIdList
 	62,   // 849: forge.NetworkSecurityGroupRuleAttributes.direction:type_name -> forge.NetworkSecurityGroupRuleDirection
 	63,   // 850: forge.NetworkSecurityGroupRuleAttributes.protocol:type_name -> forge.NetworkSecurityGroupRuleProtocol
 	64,   // 851: forge.NetworkSecurityGroupRuleAttributes.action:type_name -> forge.NetworkSecurityGroupRuleAction
-	726,  // 852: forge.ResolvedNetworkSecurityGroupRule.rule:type_name -> forge.NetworkSecurityGroupRuleAttributes
-	729,  // 853: forge.GetNetworkSecurityGroupAttachmentsResponse.attachments:type_name -> forge.NetworkSecurityGroupAttachments
-	733,  // 854: forge.GetDesiredFirmwareVersionsResponse.entries:type_name -> forge.DesiredFirmwareVersionEntry
-	1062, // 855: forge.DesiredFirmwareVersionEntry.component_versions:type_name -> forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
-	734,  // 856: forge.SkuComponents.chassis:type_name -> forge.SkuComponentChassis
-	735,  // 857: forge.SkuComponents.cpus:type_name -> forge.SkuComponentCpu
-	736,  // 858: forge.SkuComponents.gpus:type_name -> forge.SkuComponentGpu
-	737,  // 859: forge.SkuComponents.ethernet_devices:type_name -> forge.SkuComponentEthernetDevices
-	738,  // 860: forge.SkuComponents.infiniband_devices:type_name -> forge.SkuComponentInfinibandDevices
-	739,  // 861: forge.SkuComponents.storage:type_name -> forge.SkuComponentStorage
-	741,  // 862: forge.SkuComponents.memory:type_name -> forge.SkuComponentMemory
-	742,  // 863: forge.SkuComponents.tpm:type_name -> forge.SkuComponentTpm
-	1067, // 864: forge.Sku.created:type_name -> google.protobuf.Timestamp
-	743,  // 865: forge.Sku.components:type_name -> forge.SkuComponents
-	1066, // 866: forge.Sku.associated_machine_ids:type_name -> common.MachineId
-	1066, // 867: forge.SkuMachinePair.machine_id:type_name -> common.MachineId
-	1066, // 868: forge.RemoveSkuRequest.machine_id:type_name -> common.MachineId
-	744,  // 869: forge.SkuList.skus:type_name -> forge.Sku
-	1067, // 870: forge.SkuStatus.verify_request_time:type_name -> google.protobuf.Timestamp
-	1067, // 871: forge.SkuStatus.last_match_attempt:type_name -> google.protobuf.Timestamp
-	1067, // 872: forge.SkuStatus.last_generate_attempt:type_name -> google.protobuf.Timestamp
-	1098, // 873: forge.DpaInterface.id:type_name -> common.DpaInterfaceId
-	1066, // 874: forge.DpaInterface.machine_id:type_name -> common.MachineId
-	1067, // 875: forge.DpaInterface.created:type_name -> google.protobuf.Timestamp
-	1067, // 876: forge.DpaInterface.updated:type_name -> google.protobuf.Timestamp
-	1067, // 877: forge.DpaInterface.deleted:type_name -> google.protobuf.Timestamp
-	250,  // 878: forge.DpaInterface.history:type_name -> forge.StateHistoryRecord
-	1067, // 879: forge.DpaInterface.last_hb_time:type_name -> google.protobuf.Timestamp
+	727,  // 852: forge.ResolvedNetworkSecurityGroupRule.rule:type_name -> forge.NetworkSecurityGroupRuleAttributes
+	730,  // 853: forge.GetNetworkSecurityGroupAttachmentsResponse.attachments:type_name -> forge.NetworkSecurityGroupAttachments
+	734,  // 854: forge.GetDesiredFirmwareVersionsResponse.entries:type_name -> forge.DesiredFirmwareVersionEntry
+	1066, // 855: forge.DesiredFirmwareVersionEntry.component_versions:type_name -> forge.DesiredFirmwareVersionEntry.ComponentVersionsEntry
+	735,  // 856: forge.SkuComponents.chassis:type_name -> forge.SkuComponentChassis
+	736,  // 857: forge.SkuComponents.cpus:type_name -> forge.SkuComponentCpu
+	737,  // 858: forge.SkuComponents.gpus:type_name -> forge.SkuComponentGpu
+	738,  // 859: forge.SkuComponents.ethernet_devices:type_name -> forge.SkuComponentEthernetDevices
+	739,  // 860: forge.SkuComponents.infiniband_devices:type_name -> forge.SkuComponentInfinibandDevices
+	740,  // 861: forge.SkuComponents.storage:type_name -> forge.SkuComponentStorage
+	742,  // 862: forge.SkuComponents.memory:type_name -> forge.SkuComponentMemory
+	743,  // 863: forge.SkuComponents.tpm:type_name -> forge.SkuComponentTpm
+	1072, // 864: forge.Sku.created:type_name -> google.protobuf.Timestamp
+	744,  // 865: forge.Sku.components:type_name -> forge.SkuComponents
+	1071, // 866: forge.Sku.associated_machine_ids:type_name -> common.MachineId
+	1071, // 867: forge.SkuMachinePair.machine_id:type_name -> common.MachineId
+	1071, // 868: forge.RemoveSkuRequest.machine_id:type_name -> common.MachineId
+	745,  // 869: forge.SkuList.skus:type_name -> forge.Sku
+	1072, // 870: forge.SkuStatus.verify_request_time:type_name -> google.protobuf.Timestamp
+	1072, // 871: forge.SkuStatus.last_match_attempt:type_name -> google.protobuf.Timestamp
+	1072, // 872: forge.SkuStatus.last_generate_attempt:type_name -> google.protobuf.Timestamp
+	1103, // 873: forge.DpaInterface.id:type_name -> common.DpaInterfaceId
+	1071, // 874: forge.DpaInterface.machine_id:type_name -> common.MachineId
+	1072, // 875: forge.DpaInterface.created:type_name -> google.protobuf.Timestamp
+	1072, // 876: forge.DpaInterface.updated:type_name -> google.protobuf.Timestamp
+	1072, // 877: forge.DpaInterface.deleted:type_name -> google.protobuf.Timestamp
+	251,  // 878: forge.DpaInterface.history:type_name -> forge.StateHistoryRecord
+	1072, // 879: forge.DpaInterface.last_hb_time:type_name -> google.protobuf.Timestamp
 	65,   // 880: forge.DpaInterface.interface_type:type_name -> forge.DpaInterfaceType
-	1066, // 881: forge.DpaInterfaceCreationRequest.machine_id:type_name -> common.MachineId
+	1071, // 881: forge.DpaInterfaceCreationRequest.machine_id:type_name -> common.MachineId
 	65,   // 882: forge.DpaInterfaceCreationRequest.interface_type:type_name -> forge.DpaInterfaceType
-	1098, // 883: forge.DpaInterfaceIdList.ids:type_name -> common.DpaInterfaceId
-	1098, // 884: forge.DpaInterfacesByIdsRequest.ids:type_name -> common.DpaInterfaceId
-	752,  // 885: forge.DpaInterfaceList.interfaces:type_name -> forge.DpaInterface
-	1098, // 886: forge.DpaNetworkObservationSetRequest.id:type_name -> common.DpaInterfaceId
-	1098, // 887: forge.DpaInterfaceDeletionRequest.id:type_name -> common.DpaInterfaceId
-	1066, // 888: forge.PowerOptionRequest.machine_id:type_name -> common.MachineId
-	1066, // 889: forge.PowerOptionUpdateRequest.machine_id:type_name -> common.MachineId
+	1103, // 883: forge.DpaInterfaceIdList.ids:type_name -> common.DpaInterfaceId
+	1103, // 884: forge.DpaInterfacesByIdsRequest.ids:type_name -> common.DpaInterfaceId
+	753,  // 885: forge.DpaInterfaceList.interfaces:type_name -> forge.DpaInterface
+	1103, // 886: forge.DpaNetworkObservationSetRequest.id:type_name -> common.DpaInterfaceId
+	1103, // 887: forge.DpaInterfaceDeletionRequest.id:type_name -> common.DpaInterfaceId
+	1071, // 888: forge.PowerOptionRequest.machine_id:type_name -> common.MachineId
+	1071, // 889: forge.PowerOptionUpdateRequest.machine_id:type_name -> common.MachineId
 	66,   // 890: forge.PowerOptionUpdateRequest.power_state:type_name -> forge.PowerState
 	66,   // 891: forge.PowerOptions.desired_state:type_name -> forge.PowerState
-	1067, // 892: forge.PowerOptions.desired_state_updated_at:type_name -> google.protobuf.Timestamp
+	1072, // 892: forge.PowerOptions.desired_state_updated_at:type_name -> google.protobuf.Timestamp
 	66,   // 893: forge.PowerOptions.actual_state:type_name -> forge.PowerState
-	1067, // 894: forge.PowerOptions.actual_state_updated_at:type_name -> google.protobuf.Timestamp
-	1066, // 895: forge.PowerOptions.host_id:type_name -> common.MachineId
-	1067, // 896: forge.PowerOptions.next_power_state_fetch_at:type_name -> google.protobuf.Timestamp
-	1067, // 897: forge.PowerOptions.tried_triggering_on_at:type_name -> google.protobuf.Timestamp
-	1067, // 898: forge.PowerOptions.wait_until_time_before_performing_next_power_action:type_name -> google.protobuf.Timestamp
-	763,  // 899: forge.PowerOptionResponse.response:type_name -> forge.PowerOptions
-	1099, // 900: forge.ComputeAllocation.id:type_name -> common.ComputeAllocationId
-	765,  // 901: forge.ComputeAllocation.attributes:type_name -> forge.ComputeAllocationAttributes
-	287,  // 902: forge.ComputeAllocation.metadata:type_name -> forge.Metadata
-	1099, // 903: forge.CreateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
-	287,  // 904: forge.CreateComputeAllocationRequest.metadata:type_name -> forge.Metadata
-	765,  // 905: forge.CreateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
-	766,  // 906: forge.CreateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
-	1099, // 907: forge.FindComputeAllocationIdsResponse.ids:type_name -> common.ComputeAllocationId
-	1099, // 908: forge.FindComputeAllocationsByIdsRequest.ids:type_name -> common.ComputeAllocationId
-	766,  // 909: forge.FindComputeAllocationsByIdsResponse.allocations:type_name -> forge.ComputeAllocation
-	766,  // 910: forge.UpdateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
-	1099, // 911: forge.UpdateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
-	287,  // 912: forge.UpdateComputeAllocationRequest.metadata:type_name -> forge.Metadata
-	765,  // 913: forge.UpdateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
-	1099, // 914: forge.DeleteComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
-	784,  // 915: forge.GetRackResponse.rack:type_name -> forge.Rack
-	784,  // 916: forge.RackList.racks:type_name -> forge.Rack
-	286,  // 917: forge.RackSearchFilter.label:type_name -> forge.Label
-	1078, // 918: forge.RackIdList.rack_ids:type_name -> common.RackId
-	1078, // 919: forge.RacksByIdsRequest.rack_ids:type_name -> common.RackId
-	1078, // 920: forge.Rack.id:type_name -> common.RackId
-	1067, // 921: forge.Rack.created:type_name -> google.protobuf.Timestamp
-	1067, // 922: forge.Rack.updated:type_name -> google.protobuf.Timestamp
-	1067, // 923: forge.Rack.deleted:type_name -> google.protobuf.Timestamp
-	287,  // 924: forge.Rack.metadata:type_name -> forge.Metadata
-	785,  // 925: forge.Rack.config:type_name -> forge.RackConfig
-	786,  // 926: forge.Rack.status:type_name -> forge.RackStatus
-	1076, // 927: forge.RackStatus.health:type_name -> health.HealthReport
-	380,  // 928: forge.RackStatus.health_sources:type_name -> forge.HealthSourceOrigin
-	109,  // 929: forge.RackStatus.lifecycle:type_name -> forge.LifecycleStatus
-	1078, // 930: forge.RackStateHistoriesRequest.rack_ids:type_name -> common.RackId
-	1078, // 931: forge.RackHealthHistoriesRequest.rack_ids:type_name -> common.RackId
-	1067, // 932: forge.RackHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
-	1067, // 933: forge.RackHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
-	1078, // 934: forge.AdminForceDeleteRackRequest.rack_id:type_name -> common.RackId
-	792,  // 935: forge.RackCapabilitiesSet.compute:type_name -> forge.RackCapabilityCompute
-	793,  // 936: forge.RackCapabilitiesSet.switch:type_name -> forge.RackCapabilitySwitch
-	794,  // 937: forge.RackCapabilitiesSet.power_shelf:type_name -> forge.RackCapabilityPowerShelf
-	1100, // 938: forge.RackProfile.rack_hardware_type:type_name -> common.RackHardwareType
+	1072, // 894: forge.PowerOptions.actual_state_updated_at:type_name -> google.protobuf.Timestamp
+	1071, // 895: forge.PowerOptions.host_id:type_name -> common.MachineId
+	1072, // 896: forge.PowerOptions.next_power_state_fetch_at:type_name -> google.protobuf.Timestamp
+	1072, // 897: forge.PowerOptions.tried_triggering_on_at:type_name -> google.protobuf.Timestamp
+	1072, // 898: forge.PowerOptions.wait_until_time_before_performing_next_power_action:type_name -> google.protobuf.Timestamp
+	764,  // 899: forge.PowerOptionResponse.response:type_name -> forge.PowerOptions
+	1104, // 900: forge.ComputeAllocation.id:type_name -> common.ComputeAllocationId
+	766,  // 901: forge.ComputeAllocation.attributes:type_name -> forge.ComputeAllocationAttributes
+	288,  // 902: forge.ComputeAllocation.metadata:type_name -> forge.Metadata
+	1104, // 903: forge.CreateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	288,  // 904: forge.CreateComputeAllocationRequest.metadata:type_name -> forge.Metadata
+	766,  // 905: forge.CreateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
+	767,  // 906: forge.CreateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
+	1104, // 907: forge.FindComputeAllocationIdsResponse.ids:type_name -> common.ComputeAllocationId
+	1104, // 908: forge.FindComputeAllocationsByIdsRequest.ids:type_name -> common.ComputeAllocationId
+	767,  // 909: forge.FindComputeAllocationsByIdsResponse.allocations:type_name -> forge.ComputeAllocation
+	767,  // 910: forge.UpdateComputeAllocationResponse.allocation:type_name -> forge.ComputeAllocation
+	1104, // 911: forge.UpdateComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	288,  // 912: forge.UpdateComputeAllocationRequest.metadata:type_name -> forge.Metadata
+	766,  // 913: forge.UpdateComputeAllocationRequest.attributes:type_name -> forge.ComputeAllocationAttributes
+	1104, // 914: forge.DeleteComputeAllocationRequest.id:type_name -> common.ComputeAllocationId
+	785,  // 915: forge.GetRackResponse.rack:type_name -> forge.Rack
+	785,  // 916: forge.RackList.racks:type_name -> forge.Rack
+	287,  // 917: forge.RackSearchFilter.label:type_name -> forge.Label
+	1083, // 918: forge.RackIdList.rack_ids:type_name -> common.RackId
+	1083, // 919: forge.RacksByIdsRequest.rack_ids:type_name -> common.RackId
+	1083, // 920: forge.Rack.id:type_name -> common.RackId
+	1072, // 921: forge.Rack.created:type_name -> google.protobuf.Timestamp
+	1072, // 922: forge.Rack.updated:type_name -> google.protobuf.Timestamp
+	1072, // 923: forge.Rack.deleted:type_name -> google.protobuf.Timestamp
+	288,  // 924: forge.Rack.metadata:type_name -> forge.Metadata
+	786,  // 925: forge.Rack.config:type_name -> forge.RackConfig
+	787,  // 926: forge.Rack.status:type_name -> forge.RackStatus
+	1081, // 927: forge.RackStatus.health:type_name -> health.HealthReport
+	381,  // 928: forge.RackStatus.health_sources:type_name -> forge.HealthSourceOrigin
+	110,  // 929: forge.RackStatus.lifecycle:type_name -> forge.LifecycleStatus
+	1083, // 930: forge.RackStateHistoriesRequest.rack_ids:type_name -> common.RackId
+	1083, // 931: forge.RackHealthHistoriesRequest.rack_ids:type_name -> common.RackId
+	1072, // 932: forge.RackHealthHistoriesRequest.start_time:type_name -> google.protobuf.Timestamp
+	1072, // 933: forge.RackHealthHistoriesRequest.end_time:type_name -> google.protobuf.Timestamp
+	1083, // 934: forge.AdminForceDeleteRackRequest.rack_id:type_name -> common.RackId
+	793,  // 935: forge.RackCapabilitiesSet.compute:type_name -> forge.RackCapabilityCompute
+	794,  // 936: forge.RackCapabilitiesSet.switch:type_name -> forge.RackCapabilitySwitch
+	795,  // 937: forge.RackCapabilitiesSet.power_shelf:type_name -> forge.RackCapabilityPowerShelf
+	1105, // 938: forge.RackProfile.rack_hardware_type:type_name -> common.RackHardwareType
 	67,   // 939: forge.RackProfile.rack_hardware_topology:type_name -> forge.RackHardwareTopology
 	69,   // 940: forge.RackProfile.rack_hardware_class:type_name -> forge.RackHardwareClass
-	795,  // 941: forge.RackProfile.capabilities:type_name -> forge.RackCapabilitiesSet
+	796,  // 941: forge.RackProfile.capabilities:type_name -> forge.RackCapabilitiesSet
 	68,   // 942: forge.RackProfile.product_family:type_name -> forge.RackProductFamily
-	1078, // 943: forge.GetRackProfileRequest.rack_id:type_name -> common.RackId
-	1078, // 944: forge.GetRackProfileResponse.rack_id:type_name -> common.RackId
-	1082, // 945: forge.GetRackProfileResponse.rack_profile_id:type_name -> common.RackProfileId
-	796,  // 946: forge.GetRackProfileResponse.profile:type_name -> forge.RackProfile
-	1082, // 947: forge.ConfiguredRackProfile.rack_profile_id:type_name -> common.RackProfileId
-	796,  // 948: forge.ConfiguredRackProfile.profile:type_name -> forge.RackProfile
-	799,  // 949: forge.ListRackProfilesResponse.rack_profiles:type_name -> forge.ConfiguredRackProfile
+	1083, // 943: forge.GetRackProfileRequest.rack_id:type_name -> common.RackId
+	1083, // 944: forge.GetRackProfileResponse.rack_id:type_name -> common.RackId
+	1087, // 945: forge.GetRackProfileResponse.rack_profile_id:type_name -> common.RackProfileId
+	797,  // 946: forge.GetRackProfileResponse.profile:type_name -> forge.RackProfile
+	1087, // 947: forge.ConfiguredRackProfile.rack_profile_id:type_name -> common.RackProfileId
+	797,  // 948: forge.ConfiguredRackProfile.profile:type_name -> forge.RackProfile
+	800,  // 949: forge.ListRackProfilesResponse.rack_profiles:type_name -> forge.ConfiguredRackProfile
 	70,   // 950: forge.RackManagerForgeRequest.cmd:type_name -> forge.RackManagerForgeCmd
-	1081, // 951: forge.MachineNVLinkInfo.domain_uuid:type_name -> common.NVLinkDomainId
-	812,  // 952: forge.MachineNVLinkInfo.gpus:type_name -> forge.NVLinkGpu
-	1066, // 953: forge.UpdateMachineNvLinkInfoRequest.machine_id:type_name -> common.MachineId
-	803,  // 954: forge.UpdateMachineNvLinkInfoRequest.nvlink_info:type_name -> forge.MachineNVLinkInfo
-	806,  // 955: forge.MachineSpxStatusObservation.attachment_status:type_name -> forge.MachineSpxAttachmentStatusObservation
-	1067, // 956: forge.MachineSpxStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	1089, // 957: forge.MachineSpxAttachmentStatusObservation.partition_id:type_name -> common.SpxPartitionId
+	1086, // 951: forge.MachineNVLinkInfo.domain_uuid:type_name -> common.NVLinkDomainId
+	813,  // 952: forge.MachineNVLinkInfo.gpus:type_name -> forge.NVLinkGpu
+	1071, // 953: forge.UpdateMachineNvLinkInfoRequest.machine_id:type_name -> common.MachineId
+	804,  // 954: forge.UpdateMachineNvLinkInfoRequest.nvlink_info:type_name -> forge.MachineNVLinkInfo
+	807,  // 955: forge.MachineSpxStatusObservation.attachment_status:type_name -> forge.MachineSpxAttachmentStatusObservation
+	1072, // 956: forge.MachineSpxStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	1094, // 957: forge.MachineSpxAttachmentStatusObservation.partition_id:type_name -> common.SpxPartitionId
 	17,   // 958: forge.MachineSpxAttachmentStatusObservation.attachment_type:type_name -> forge.SpxAttachmentType
-	1067, // 959: forge.MachineSpxAttachmentStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
-	808,  // 960: forge.AstraConfig.astra_attachments:type_name -> forge.AstraAttachment
+	1072, // 959: forge.MachineSpxAttachmentStatusObservation.observed_at:type_name -> google.protobuf.Timestamp
+	809,  // 960: forge.AstraConfig.astra_attachments:type_name -> forge.AstraAttachment
 	17,   // 961: forge.AstraAttachment.attachment_type:type_name -> forge.SpxAttachmentType
-	810,  // 962: forge.AstraConfigStatus.astra_attachments_status:type_name -> forge.AstraAttachmentStatus
+	811,  // 962: forge.AstraConfigStatus.astra_attachments_status:type_name -> forge.AstraAttachmentStatus
 	17,   // 963: forge.AstraAttachmentStatus.attachment_type:type_name -> forge.SpxAttachmentType
-	811,  // 964: forge.AstraAttachmentStatus.status:type_name -> forge.AstraStatus
+	812,  // 964: forge.AstraAttachmentStatus.status:type_name -> forge.AstraStatus
 	71,   // 965: forge.AstraStatus.phase:type_name -> forge.AstraPhase
-	814,  // 966: forge.MachineNVLinkStatusObservation.gpu_status:type_name -> forge.MachineNVLinkGpuStatusObservation
-	1101, // 967: forge.MachineNVLinkGpuStatusObservation.partition_id:type_name -> common.NVLinkPartitionId
-	1071, // 968: forge.MachineNVLinkGpuStatusObservation.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	1081, // 969: forge.MachineNVLinkGpuStatusObservation.domain_id:type_name -> common.NVLinkDomainId
+	815,  // 966: forge.MachineNVLinkStatusObservation.gpu_status:type_name -> forge.MachineNVLinkGpuStatusObservation
+	1106, // 967: forge.MachineNVLinkGpuStatusObservation.partition_id:type_name -> common.NVLinkPartitionId
+	1076, // 968: forge.MachineNVLinkGpuStatusObservation.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	1086, // 969: forge.MachineNVLinkGpuStatusObservation.domain_id:type_name -> common.NVLinkDomainId
 	72,   // 970: forge.NmxcBrowseRequest.operation:type_name -> forge.NmxcBrowseOperation
-	1078, // 971: forge.NmxcBrowseRequest.rack_id:type_name -> common.RackId
-	1063, // 972: forge.NmxcBrowseResponse.headers:type_name -> forge.NmxcBrowseResponse.HeadersEntry
-	1101, // 973: forge.NVLinkPartition.id:type_name -> common.NVLinkPartitionId
-	1081, // 974: forge.NVLinkPartition.domain_uuid:type_name -> common.NVLinkDomainId
-	1071, // 975: forge.NVLinkPartition.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
-	817,  // 976: forge.NVLinkPartitionList.partitions:type_name -> forge.NVLinkPartition
-	1079, // 977: forge.NVLinkPartitionQuery.id:type_name -> common.UUID
-	819,  // 978: forge.NVLinkPartitionQuery.search_config:type_name -> forge.NVLinkPartitionSearchConfig
-	1101, // 979: forge.NVLinkPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkPartitionId
-	1101, // 980: forge.NVLinkPartitionIdList.partition_ids:type_name -> common.NVLinkPartitionId
-	287,  // 981: forge.NVLinkLogicalPartitionConfig.metadata:type_name -> forge.Metadata
+	1083, // 971: forge.NmxcBrowseRequest.rack_id:type_name -> common.RackId
+	1067, // 972: forge.NmxcBrowseResponse.headers:type_name -> forge.NmxcBrowseResponse.HeadersEntry
+	1106, // 973: forge.NVLinkPartition.id:type_name -> common.NVLinkPartitionId
+	1086, // 974: forge.NVLinkPartition.domain_uuid:type_name -> common.NVLinkDomainId
+	1076, // 975: forge.NVLinkPartition.logical_partition_id:type_name -> common.NVLinkLogicalPartitionId
+	818,  // 976: forge.NVLinkPartitionList.partitions:type_name -> forge.NVLinkPartition
+	1084, // 977: forge.NVLinkPartitionQuery.id:type_name -> common.UUID
+	820,  // 978: forge.NVLinkPartitionQuery.search_config:type_name -> forge.NVLinkPartitionSearchConfig
+	1106, // 979: forge.NVLinkPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkPartitionId
+	1106, // 980: forge.NVLinkPartitionIdList.partition_ids:type_name -> common.NVLinkPartitionId
+	288,  // 981: forge.NVLinkLogicalPartitionConfig.metadata:type_name -> forge.Metadata
 	9,    // 982: forge.NVLinkLogicalPartitionStatus.state:type_name -> forge.TenantState
-	1071, // 983: forge.NVLinkLogicalPartition.id:type_name -> common.NVLinkLogicalPartitionId
-	825,  // 984: forge.NVLinkLogicalPartition.config:type_name -> forge.NVLinkLogicalPartitionConfig
-	826,  // 985: forge.NVLinkLogicalPartition.status:type_name -> forge.NVLinkLogicalPartitionStatus
-	1067, // 986: forge.NVLinkLogicalPartition.created:type_name -> google.protobuf.Timestamp
-	827,  // 987: forge.NVLinkLogicalPartitionList.partitions:type_name -> forge.NVLinkLogicalPartition
-	825,  // 988: forge.NVLinkLogicalPartitionCreationRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
-	1071, // 989: forge.NVLinkLogicalPartitionCreationRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	1071, // 990: forge.NVLinkLogicalPartitionDeletionRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	1071, // 991: forge.NVLinkLogicalPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkLogicalPartitionId
-	1071, // 992: forge.NVLinkLogicalPartitionIdList.partition_ids:type_name -> common.NVLinkLogicalPartitionId
-	1071, // 993: forge.NVLinkLogicalPartitionUpdateRequest.id:type_name -> common.NVLinkLogicalPartitionId
-	825,  // 994: forge.NVLinkLogicalPartitionUpdateRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
-	407,  // 995: forge.CreateBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 996: forge.DeleteBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 997: forge.SetBmcRootPasswordRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	407,  // 998: forge.ProbeBmcVendorRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
-	1066, // 999: forge.SetFirmwareUpdateTimeWindowRequest.machine_ids:type_name -> common.MachineId
-	1067, // 1000: forge.SetFirmwareUpdateTimeWindowRequest.start_timestamp:type_name -> google.protobuf.Timestamp
-	1067, // 1001: forge.SetFirmwareUpdateTimeWindowRequest.end_timestamp:type_name -> google.protobuf.Timestamp
-	849,  // 1002: forge.UpsertHostFirmwareConfigRequest.components:type_name -> forge.UpsertHostFirmwareComponentConfig
+	1076, // 983: forge.NVLinkLogicalPartition.id:type_name -> common.NVLinkLogicalPartitionId
+	826,  // 984: forge.NVLinkLogicalPartition.config:type_name -> forge.NVLinkLogicalPartitionConfig
+	827,  // 985: forge.NVLinkLogicalPartition.status:type_name -> forge.NVLinkLogicalPartitionStatus
+	1072, // 986: forge.NVLinkLogicalPartition.created:type_name -> google.protobuf.Timestamp
+	828,  // 987: forge.NVLinkLogicalPartitionList.partitions:type_name -> forge.NVLinkLogicalPartition
+	826,  // 988: forge.NVLinkLogicalPartitionCreationRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
+	1076, // 989: forge.NVLinkLogicalPartitionCreationRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	1076, // 990: forge.NVLinkLogicalPartitionDeletionRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	1076, // 991: forge.NVLinkLogicalPartitionsByIdsRequest.partition_ids:type_name -> common.NVLinkLogicalPartitionId
+	1076, // 992: forge.NVLinkLogicalPartitionIdList.partition_ids:type_name -> common.NVLinkLogicalPartitionId
+	1076, // 993: forge.NVLinkLogicalPartitionUpdateRequest.id:type_name -> common.NVLinkLogicalPartitionId
+	826,  // 994: forge.NVLinkLogicalPartitionUpdateRequest.config:type_name -> forge.NVLinkLogicalPartitionConfig
+	408,  // 995: forge.CreateBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 996: forge.DeleteBmcUserRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 997: forge.SetBmcRootPasswordRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	408,  // 998: forge.ProbeBmcVendorRequest.bmc_endpoint_request:type_name -> forge.BmcEndpointRequest
+	1071, // 999: forge.SetFirmwareUpdateTimeWindowRequest.machine_ids:type_name -> common.MachineId
+	1072, // 1000: forge.SetFirmwareUpdateTimeWindowRequest.start_timestamp:type_name -> google.protobuf.Timestamp
+	1072, // 1001: forge.SetFirmwareUpdateTimeWindowRequest.end_timestamp:type_name -> google.protobuf.Timestamp
+	850,  // 1002: forge.UpsertHostFirmwareConfigRequest.components:type_name -> forge.UpsertHostFirmwareComponentConfig
 	73,   // 1003: forge.UpsertHostFirmwareConfigRequest.ordering:type_name -> forge.HostFirmwareComponentType
 	73,   // 1004: forge.UpsertHostFirmwareComponentConfig.type:type_name -> forge.HostFirmwareComponentType
-	851,  // 1005: forge.UpsertHostFirmwareComponentConfig.firmware:type_name -> forge.HostFirmwareVersionConfig
+	852,  // 1005: forge.UpsertHostFirmwareComponentConfig.firmware:type_name -> forge.HostFirmwareVersionConfig
 	73,   // 1006: forge.HostFirmwareComponentConfigResponse.type:type_name -> forge.HostFirmwareComponentType
-	851,  // 1007: forge.HostFirmwareComponentConfigResponse.firmware:type_name -> forge.HostFirmwareVersionConfig
-	852,  // 1008: forge.HostFirmwareVersionConfig.artifacts:type_name -> forge.HostFirmwareArtifact
-	850,  // 1009: forge.HostFirmwareConfigResponse.components:type_name -> forge.HostFirmwareComponentConfigResponse
+	852,  // 1007: forge.HostFirmwareComponentConfigResponse.firmware:type_name -> forge.HostFirmwareVersionConfig
+	853,  // 1008: forge.HostFirmwareVersionConfig.artifacts:type_name -> forge.HostFirmwareArtifact
+	851,  // 1009: forge.HostFirmwareConfigResponse.components:type_name -> forge.HostFirmwareComponentConfigResponse
 	73,   // 1010: forge.HostFirmwareConfigResponse.ordering:type_name -> forge.HostFirmwareComponentType
-	1067, // 1011: forge.HostFirmwareConfigResponse.created_at:type_name -> google.protobuf.Timestamp
-	1067, // 1012: forge.HostFirmwareConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
-	856,  // 1013: forge.ListHostFirmwareResponse.available:type_name -> forge.AvailableHostFirmware
+	1072, // 1011: forge.HostFirmwareConfigResponse.created_at:type_name -> google.protobuf.Timestamp
+	1072, // 1012: forge.HostFirmwareConfigResponse.updated_at:type_name -> google.protobuf.Timestamp
+	857,  // 1013: forge.ListHostFirmwareResponse.available:type_name -> forge.AvailableHostFirmware
 	74,   // 1014: forge.TrimTableRequest.target:type_name -> forge.TrimTableTarget
-	859,  // 1015: forge.NvlinkNmxcEndpointList.entries:type_name -> forge.NvlinkNmxcEndpoint
-	287,  // 1016: forge.CreateRemediationRequest.metadata:type_name -> forge.Metadata
-	1102, // 1017: forge.CreateRemediationResponse.remediation_id:type_name -> common.RemediationId
-	1102, // 1018: forge.RemediationIdList.remediation_ids:type_name -> common.RemediationId
-	866,  // 1019: forge.RemediationList.remediations:type_name -> forge.Remediation
-	1102, // 1020: forge.Remediation.id:type_name -> common.RemediationId
-	287,  // 1021: forge.Remediation.metadata:type_name -> forge.Metadata
-	1067, // 1022: forge.Remediation.creation_time:type_name -> google.protobuf.Timestamp
-	1102, // 1023: forge.ApproveRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1102, // 1024: forge.RevokeRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1102, // 1025: forge.EnableRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1102, // 1026: forge.DisableRemediationRequest.remediation_id:type_name -> common.RemediationId
-	1102, // 1027: forge.FindAppliedRemediationIdsRequest.remediation_id:type_name -> common.RemediationId
-	1066, // 1028: forge.FindAppliedRemediationIdsRequest.dpu_machine_id:type_name -> common.MachineId
-	1102, // 1029: forge.AppliedRemediationIdList.remediation_ids:type_name -> common.RemediationId
-	1066, // 1030: forge.AppliedRemediationIdList.dpu_machine_ids:type_name -> common.MachineId
-	1102, // 1031: forge.FindAppliedRemediationsRequest.remediation_id:type_name -> common.RemediationId
-	1066, // 1032: forge.FindAppliedRemediationsRequest.dpu_machine_id:type_name -> common.MachineId
-	1102, // 1033: forge.AppliedRemediation.remediation_id:type_name -> common.RemediationId
-	1066, // 1034: forge.AppliedRemediation.dpu_machine_id:type_name -> common.MachineId
-	1067, // 1035: forge.AppliedRemediation.applied_time:type_name -> google.protobuf.Timestamp
-	287,  // 1036: forge.AppliedRemediation.metadata:type_name -> forge.Metadata
-	874,  // 1037: forge.AppliedRemediationList.applied_remediations:type_name -> forge.AppliedRemediation
-	1066, // 1038: forge.GetNextRemediationForMachineRequest.dpu_machine_id:type_name -> common.MachineId
-	1102, // 1039: forge.GetNextRemediationForMachineResponse.remediation_id:type_name -> common.RemediationId
-	1102, // 1040: forge.RemediationAppliedRequest.remediation_id:type_name -> common.RemediationId
-	1066, // 1041: forge.RemediationAppliedRequest.dpu_machine_id:type_name -> common.MachineId
-	879,  // 1042: forge.RemediationAppliedRequest.status:type_name -> forge.RemediationApplicationStatus
-	287,  // 1043: forge.RemediationApplicationStatus.metadata:type_name -> forge.Metadata
-	1066, // 1044: forge.SetPrimaryDpuRequest.host_machine_id:type_name -> common.MachineId
-	1066, // 1045: forge.SetPrimaryDpuRequest.dpu_machine_id:type_name -> common.MachineId
-	1066, // 1046: forge.SetPrimaryInterfaceRequest.host_machine_id:type_name -> common.MachineId
-	1090, // 1047: forge.SetPrimaryInterfaceRequest.interface_id:type_name -> common.MachineInterfaceId
-	882,  // 1048: forge.DpuExtensionServiceCredential.username_password:type_name -> forge.UsernamePassword
-	903,  // 1049: forge.DpuExtensionServiceVersionInfo.observability:type_name -> forge.DpuExtensionServiceObservability
+	860,  // 1015: forge.NvlinkNmxcEndpointList.entries:type_name -> forge.NvlinkNmxcEndpoint
+	288,  // 1016: forge.CreateRemediationRequest.metadata:type_name -> forge.Metadata
+	1107, // 1017: forge.CreateRemediationResponse.remediation_id:type_name -> common.RemediationId
+	1107, // 1018: forge.RemediationIdList.remediation_ids:type_name -> common.RemediationId
+	867,  // 1019: forge.RemediationList.remediations:type_name -> forge.Remediation
+	1107, // 1020: forge.Remediation.id:type_name -> common.RemediationId
+	288,  // 1021: forge.Remediation.metadata:type_name -> forge.Metadata
+	1072, // 1022: forge.Remediation.creation_time:type_name -> google.protobuf.Timestamp
+	1107, // 1023: forge.ApproveRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1107, // 1024: forge.RevokeRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1107, // 1025: forge.EnableRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1107, // 1026: forge.DisableRemediationRequest.remediation_id:type_name -> common.RemediationId
+	1107, // 1027: forge.FindAppliedRemediationIdsRequest.remediation_id:type_name -> common.RemediationId
+	1071, // 1028: forge.FindAppliedRemediationIdsRequest.dpu_machine_id:type_name -> common.MachineId
+	1107, // 1029: forge.AppliedRemediationIdList.remediation_ids:type_name -> common.RemediationId
+	1071, // 1030: forge.AppliedRemediationIdList.dpu_machine_ids:type_name -> common.MachineId
+	1107, // 1031: forge.FindAppliedRemediationsRequest.remediation_id:type_name -> common.RemediationId
+	1071, // 1032: forge.FindAppliedRemediationsRequest.dpu_machine_id:type_name -> common.MachineId
+	1107, // 1033: forge.AppliedRemediation.remediation_id:type_name -> common.RemediationId
+	1071, // 1034: forge.AppliedRemediation.dpu_machine_id:type_name -> common.MachineId
+	1072, // 1035: forge.AppliedRemediation.applied_time:type_name -> google.protobuf.Timestamp
+	288,  // 1036: forge.AppliedRemediation.metadata:type_name -> forge.Metadata
+	875,  // 1037: forge.AppliedRemediationList.applied_remediations:type_name -> forge.AppliedRemediation
+	1071, // 1038: forge.GetNextRemediationForMachineRequest.dpu_machine_id:type_name -> common.MachineId
+	1107, // 1039: forge.GetNextRemediationForMachineResponse.remediation_id:type_name -> common.RemediationId
+	1107, // 1040: forge.RemediationAppliedRequest.remediation_id:type_name -> common.RemediationId
+	1071, // 1041: forge.RemediationAppliedRequest.dpu_machine_id:type_name -> common.MachineId
+	880,  // 1042: forge.RemediationAppliedRequest.status:type_name -> forge.RemediationApplicationStatus
+	288,  // 1043: forge.RemediationApplicationStatus.metadata:type_name -> forge.Metadata
+	1071, // 1044: forge.SetPrimaryDpuRequest.host_machine_id:type_name -> common.MachineId
+	1071, // 1045: forge.SetPrimaryDpuRequest.dpu_machine_id:type_name -> common.MachineId
+	1071, // 1046: forge.SetPrimaryInterfaceRequest.host_machine_id:type_name -> common.MachineId
+	1095, // 1047: forge.SetPrimaryInterfaceRequest.interface_id:type_name -> common.MachineInterfaceId
+	883,  // 1048: forge.DpuExtensionServiceCredential.username_password:type_name -> forge.UsernamePassword
+	904,  // 1049: forge.DpuExtensionServiceVersionInfo.observability:type_name -> forge.DpuExtensionServiceObservability
 	75,   // 1050: forge.DpuExtensionService.service_type:type_name -> forge.DpuExtensionServiceType
-	885,  // 1051: forge.DpuExtensionService.latest_version_info:type_name -> forge.DpuExtensionServiceVersionInfo
-	109,  // 1052: forge.DpuExtensionService.lifecycle_status:type_name -> forge.LifecycleStatus
+	886,  // 1051: forge.DpuExtensionService.latest_version_info:type_name -> forge.DpuExtensionServiceVersionInfo
+	110,  // 1052: forge.DpuExtensionService.lifecycle_status:type_name -> forge.LifecycleStatus
 	75,   // 1053: forge.CreateDpuExtensionServiceRequest.service_type:type_name -> forge.DpuExtensionServiceType
-	884,  // 1054: forge.CreateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
-	903,  // 1055: forge.CreateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
-	884,  // 1056: forge.UpdateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
-	903,  // 1057: forge.UpdateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
+	885,  // 1054: forge.CreateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
+	904,  // 1055: forge.CreateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
+	885,  // 1056: forge.UpdateDpuExtensionServiceRequest.credential:type_name -> forge.DpuExtensionServiceCredential
+	904,  // 1057: forge.UpdateDpuExtensionServiceRequest.observability:type_name -> forge.DpuExtensionServiceObservability
 	75,   // 1058: forge.DpuExtensionServiceSearchFilter.service_type:type_name -> forge.DpuExtensionServiceType
-	886,  // 1059: forge.DpuExtensionServiceList.services:type_name -> forge.DpuExtensionService
-	885,  // 1060: forge.DpuExtensionServiceVersionInfoList.version_infos:type_name -> forge.DpuExtensionServiceVersionInfo
-	899,  // 1061: forge.FindInstancesByDpuExtensionServiceResponse.instances:type_name -> forge.InstanceDpuExtensionServiceInfo
-	900,  // 1062: forge.DpuExtensionServiceObservabilityConfig.prometheus:type_name -> forge.DpuExtensionServiceObservabilityConfigPrometheus
-	901,  // 1063: forge.DpuExtensionServiceObservabilityConfig.logging:type_name -> forge.DpuExtensionServiceObservabilityConfigLogging
-	902,  // 1064: forge.DpuExtensionServiceObservability.configs:type_name -> forge.DpuExtensionServiceObservabilityConfig
-	1079, // 1065: forge.ScoutStreamApiBoundMessage.flow_uuid:type_name -> common.UUID
-	906,  // 1066: forge.ScoutStreamApiBoundMessage.init:type_name -> forge.ScoutStreamInitRequest
-	1103, // 1067: forge.ScoutStreamApiBoundMessage.mlx_device_lockdown_response:type_name -> mlx_device.MlxDeviceLockdownResponse
-	1104, // 1068: forge.ScoutStreamApiBoundMessage.mlx_device_profile_sync_response:type_name -> mlx_device.MlxDeviceProfileSyncResponse
-	1105, // 1069: forge.ScoutStreamApiBoundMessage.mlx_device_profile_compare_response:type_name -> mlx_device.MlxDeviceProfileCompareResponse
-	1106, // 1070: forge.ScoutStreamApiBoundMessage.mlx_device_info_device_response:type_name -> mlx_device.MlxDeviceInfoDeviceResponse
-	1107, // 1071: forge.ScoutStreamApiBoundMessage.mlx_device_info_report_response:type_name -> mlx_device.MlxDeviceInfoReportResponse
-	1108, // 1072: forge.ScoutStreamApiBoundMessage.mlx_device_registry_list_response:type_name -> mlx_device.MlxDeviceRegistryListResponse
-	1109, // 1073: forge.ScoutStreamApiBoundMessage.mlx_device_registry_show_response:type_name -> mlx_device.MlxDeviceRegistryShowResponse
-	1110, // 1074: forge.ScoutStreamApiBoundMessage.mlx_device_config_query_response:type_name -> mlx_device.MlxDeviceConfigQueryResponse
-	1111, // 1075: forge.ScoutStreamApiBoundMessage.mlx_device_config_set_response:type_name -> mlx_device.MlxDeviceConfigSetResponse
-	1112, // 1076: forge.ScoutStreamApiBoundMessage.mlx_device_config_sync_response:type_name -> mlx_device.MlxDeviceConfigSyncResponse
-	1113, // 1077: forge.ScoutStreamApiBoundMessage.mlx_device_config_compare_response:type_name -> mlx_device.MlxDeviceConfigCompareResponse
-	914,  // 1078: forge.ScoutStreamApiBoundMessage.scout_stream_agent_ping_response:type_name -> forge.ScoutStreamAgentPingResponse
-	1079, // 1079: forge.ScoutStreamScoutBoundMessage.flow_uuid:type_name -> common.UUID
-	1114, // 1080: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_lock_request:type_name -> mlx_device.MlxDeviceLockdownLockRequest
-	1115, // 1081: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_unlock_request:type_name -> mlx_device.MlxDeviceLockdownUnlockRequest
-	1116, // 1082: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_status_request:type_name -> mlx_device.MlxDeviceLockdownStatusRequest
-	1117, // 1083: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_sync_request:type_name -> mlx_device.MlxDeviceProfileSyncRequest
-	1118, // 1084: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_compare_request:type_name -> mlx_device.MlxDeviceProfileCompareRequest
-	1119, // 1085: forge.ScoutStreamScoutBoundMessage.mlx_device_info_device_request:type_name -> mlx_device.MlxDeviceInfoDeviceRequest
-	1120, // 1086: forge.ScoutStreamScoutBoundMessage.mlx_device_info_report_request:type_name -> mlx_device.MlxDeviceInfoReportRequest
-	1121, // 1087: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_list_request:type_name -> mlx_device.MlxDeviceRegistryListRequest
-	1122, // 1088: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_show_request:type_name -> mlx_device.MlxDeviceRegistryShowRequest
-	1123, // 1089: forge.ScoutStreamScoutBoundMessage.mlx_device_config_query_request:type_name -> mlx_device.MlxDeviceConfigQueryRequest
-	1124, // 1090: forge.ScoutStreamScoutBoundMessage.mlx_device_config_set_request:type_name -> mlx_device.MlxDeviceConfigSetRequest
-	1125, // 1091: forge.ScoutStreamScoutBoundMessage.mlx_device_config_sync_request:type_name -> mlx_device.MlxDeviceConfigSyncRequest
-	1126, // 1092: forge.ScoutStreamScoutBoundMessage.mlx_device_config_compare_request:type_name -> mlx_device.MlxDeviceConfigCompareRequest
-	913,  // 1093: forge.ScoutStreamScoutBoundMessage.scout_stream_agent_ping_request:type_name -> forge.ScoutStreamAgentPingRequest
-	1066, // 1094: forge.ScoutStreamInitRequest.machine_id:type_name -> common.MachineId
-	915,  // 1095: forge.ScoutStreamShowConnectionsResponse.scout_stream_connections:type_name -> forge.ScoutStreamConnectionInfo
-	1066, // 1096: forge.ScoutStreamDisconnectRequest.machine_id:type_name -> common.MachineId
-	1066, // 1097: forge.ScoutStreamDisconnectResponse.machine_id:type_name -> common.MachineId
-	1066, // 1098: forge.ScoutStreamAdminPingRequest.machine_id:type_name -> common.MachineId
-	916,  // 1099: forge.ScoutStreamAgentPingResponse.error:type_name -> forge.ScoutStreamError
-	1066, // 1100: forge.ScoutStreamConnectionInfo.machine_id:type_name -> common.MachineId
+	887,  // 1059: forge.DpuExtensionServiceList.services:type_name -> forge.DpuExtensionService
+	886,  // 1060: forge.DpuExtensionServiceVersionInfoList.version_infos:type_name -> forge.DpuExtensionServiceVersionInfo
+	900,  // 1061: forge.FindInstancesByDpuExtensionServiceResponse.instances:type_name -> forge.InstanceDpuExtensionServiceInfo
+	901,  // 1062: forge.DpuExtensionServiceObservabilityConfig.prometheus:type_name -> forge.DpuExtensionServiceObservabilityConfigPrometheus
+	902,  // 1063: forge.DpuExtensionServiceObservabilityConfig.logging:type_name -> forge.DpuExtensionServiceObservabilityConfigLogging
+	903,  // 1064: forge.DpuExtensionServiceObservability.configs:type_name -> forge.DpuExtensionServiceObservabilityConfig
+	1084, // 1065: forge.ScoutStreamApiBoundMessage.flow_uuid:type_name -> common.UUID
+	907,  // 1066: forge.ScoutStreamApiBoundMessage.init:type_name -> forge.ScoutStreamInitRequest
+	1108, // 1067: forge.ScoutStreamApiBoundMessage.mlx_device_lockdown_response:type_name -> mlx_device.MlxDeviceLockdownResponse
+	1109, // 1068: forge.ScoutStreamApiBoundMessage.mlx_device_profile_sync_response:type_name -> mlx_device.MlxDeviceProfileSyncResponse
+	1110, // 1069: forge.ScoutStreamApiBoundMessage.mlx_device_profile_compare_response:type_name -> mlx_device.MlxDeviceProfileCompareResponse
+	1111, // 1070: forge.ScoutStreamApiBoundMessage.mlx_device_info_device_response:type_name -> mlx_device.MlxDeviceInfoDeviceResponse
+	1112, // 1071: forge.ScoutStreamApiBoundMessage.mlx_device_info_report_response:type_name -> mlx_device.MlxDeviceInfoReportResponse
+	1113, // 1072: forge.ScoutStreamApiBoundMessage.mlx_device_registry_list_response:type_name -> mlx_device.MlxDeviceRegistryListResponse
+	1114, // 1073: forge.ScoutStreamApiBoundMessage.mlx_device_registry_show_response:type_name -> mlx_device.MlxDeviceRegistryShowResponse
+	1115, // 1074: forge.ScoutStreamApiBoundMessage.mlx_device_config_query_response:type_name -> mlx_device.MlxDeviceConfigQueryResponse
+	1116, // 1075: forge.ScoutStreamApiBoundMessage.mlx_device_config_set_response:type_name -> mlx_device.MlxDeviceConfigSetResponse
+	1117, // 1076: forge.ScoutStreamApiBoundMessage.mlx_device_config_sync_response:type_name -> mlx_device.MlxDeviceConfigSyncResponse
+	1118, // 1077: forge.ScoutStreamApiBoundMessage.mlx_device_config_compare_response:type_name -> mlx_device.MlxDeviceConfigCompareResponse
+	915,  // 1078: forge.ScoutStreamApiBoundMessage.scout_stream_agent_ping_response:type_name -> forge.ScoutStreamAgentPingResponse
+	1084, // 1079: forge.ScoutStreamScoutBoundMessage.flow_uuid:type_name -> common.UUID
+	1119, // 1080: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_lock_request:type_name -> mlx_device.MlxDeviceLockdownLockRequest
+	1120, // 1081: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_unlock_request:type_name -> mlx_device.MlxDeviceLockdownUnlockRequest
+	1121, // 1082: forge.ScoutStreamScoutBoundMessage.mlx_device_lockdown_status_request:type_name -> mlx_device.MlxDeviceLockdownStatusRequest
+	1122, // 1083: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_sync_request:type_name -> mlx_device.MlxDeviceProfileSyncRequest
+	1123, // 1084: forge.ScoutStreamScoutBoundMessage.mlx_device_profile_compare_request:type_name -> mlx_device.MlxDeviceProfileCompareRequest
+	1124, // 1085: forge.ScoutStreamScoutBoundMessage.mlx_device_info_device_request:type_name -> mlx_device.MlxDeviceInfoDeviceRequest
+	1125, // 1086: forge.ScoutStreamScoutBoundMessage.mlx_device_info_report_request:type_name -> mlx_device.MlxDeviceInfoReportRequest
+	1126, // 1087: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_list_request:type_name -> mlx_device.MlxDeviceRegistryListRequest
+	1127, // 1088: forge.ScoutStreamScoutBoundMessage.mlx_device_registry_show_request:type_name -> mlx_device.MlxDeviceRegistryShowRequest
+	1128, // 1089: forge.ScoutStreamScoutBoundMessage.mlx_device_config_query_request:type_name -> mlx_device.MlxDeviceConfigQueryRequest
+	1129, // 1090: forge.ScoutStreamScoutBoundMessage.mlx_device_config_set_request:type_name -> mlx_device.MlxDeviceConfigSetRequest
+	1130, // 1091: forge.ScoutStreamScoutBoundMessage.mlx_device_config_sync_request:type_name -> mlx_device.MlxDeviceConfigSyncRequest
+	1131, // 1092: forge.ScoutStreamScoutBoundMessage.mlx_device_config_compare_request:type_name -> mlx_device.MlxDeviceConfigCompareRequest
+	914,  // 1093: forge.ScoutStreamScoutBoundMessage.scout_stream_agent_ping_request:type_name -> forge.ScoutStreamAgentPingRequest
+	1071, // 1094: forge.ScoutStreamInitRequest.machine_id:type_name -> common.MachineId
+	916,  // 1095: forge.ScoutStreamShowConnectionsResponse.scout_stream_connections:type_name -> forge.ScoutStreamConnectionInfo
+	1071, // 1096: forge.ScoutStreamDisconnectRequest.machine_id:type_name -> common.MachineId
+	1071, // 1097: forge.ScoutStreamDisconnectResponse.machine_id:type_name -> common.MachineId
+	1071, // 1098: forge.ScoutStreamAdminPingRequest.machine_id:type_name -> common.MachineId
+	917,  // 1099: forge.ScoutStreamAgentPingResponse.error:type_name -> forge.ScoutStreamError
+	1071, // 1100: forge.ScoutStreamConnectionInfo.machine_id:type_name -> common.MachineId
 	78,   // 1101: forge.ScoutStreamError.status:type_name -> forge.ScoutStreamErrorStatus
-	1070, // 1102: forge.RoutingProfile.route_target_imports:type_name -> common.RouteTarget
-	1070, // 1103: forge.RoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
-	917,  // 1104: forge.RoutingProfile.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntry
-	917,  // 1105: forge.RoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
-	1083, // 1106: forge.DomainLegacy.id:type_name -> common.DomainId
-	1067, // 1107: forge.DomainLegacy.created:type_name -> google.protobuf.Timestamp
-	1067, // 1108: forge.DomainLegacy.updated:type_name -> google.protobuf.Timestamp
-	1067, // 1109: forge.DomainLegacy.deleted:type_name -> google.protobuf.Timestamp
-	919,  // 1110: forge.DomainListLegacy.domains:type_name -> forge.DomainLegacy
-	1083, // 1111: forge.DomainDeletionLegacy.id:type_name -> common.DomainId
-	1083, // 1112: forge.DomainSearchQueryLegacy.id:type_name -> common.DomainId
-	1127, // 1113: forge.PxeDomain.new_domain:type_name -> dns.Domain
-	919,  // 1114: forge.PxeDomain.legacy_domain:type_name -> forge.DomainLegacy
-	1066, // 1115: forge.MachinePositionQuery.machine_ids:type_name -> common.MachineId
-	927,  // 1116: forge.MachinePositionInfoList.machine_position_info:type_name -> forge.MachinePositionInfo
-	1066, // 1117: forge.MachinePositionInfo.machine_id:type_name -> common.MachineId
-	1080, // 1118: forge.MachinePositionInfo.switch_id:type_name -> common.SwitchId
-	1077, // 1119: forge.MachinePositionInfo.power_shelf_id:type_name -> common.PowerShelfId
-	1066, // 1120: forge.ModifyDPFStateRequest.machine_id:type_name -> common.MachineId
-	1064, // 1121: forge.DPFStateResponse.dpf_states:type_name -> forge.DPFStateResponse.DPFState
-	1066, // 1122: forge.GetDPFStateRequest.machine_ids:type_name -> common.MachineId
-	1066, // 1123: forge.GetDPFHostSnapshotRequest.host_machine_id:type_name -> common.MachineId
-	934,  // 1124: forge.DPFServiceVersionsResponse.services:type_name -> forge.DPFServiceVersion
-	1128, // 1125: forge.ReleaseDPUServiceSyncHoldRequest.machine_ids:type_name -> common.MachineIdList
-	289,  // 1126: forge.ReleaseDPUServiceSyncHoldRequest.instance_ids:type_name -> forge.InstanceIdList
-	1066, // 1127: forge.DPUServiceSyncReleaseResult.machine_id:type_name -> common.MachineId
+	1075, // 1102: forge.RoutingProfile.route_target_imports:type_name -> common.RouteTarget
+	1075, // 1103: forge.RoutingProfile.route_targets_on_exports:type_name -> common.RouteTarget
+	918,  // 1104: forge.RoutingProfile.accepted_leaks_from_underlay:type_name -> forge.PrefixFilterPolicyEntry
+	918,  // 1105: forge.RoutingProfile.allowed_anycast_prefixes:type_name -> forge.PrefixFilterPolicyEntry
+	1088, // 1106: forge.DomainLegacy.id:type_name -> common.DomainId
+	1072, // 1107: forge.DomainLegacy.created:type_name -> google.protobuf.Timestamp
+	1072, // 1108: forge.DomainLegacy.updated:type_name -> google.protobuf.Timestamp
+	1072, // 1109: forge.DomainLegacy.deleted:type_name -> google.protobuf.Timestamp
+	920,  // 1110: forge.DomainListLegacy.domains:type_name -> forge.DomainLegacy
+	1088, // 1111: forge.DomainDeletionLegacy.id:type_name -> common.DomainId
+	1088, // 1112: forge.DomainSearchQueryLegacy.id:type_name -> common.DomainId
+	1132, // 1113: forge.PxeDomain.new_domain:type_name -> dns.Domain
+	920,  // 1114: forge.PxeDomain.legacy_domain:type_name -> forge.DomainLegacy
+	1071, // 1115: forge.MachinePositionQuery.machine_ids:type_name -> common.MachineId
+	928,  // 1116: forge.MachinePositionInfoList.machine_position_info:type_name -> forge.MachinePositionInfo
+	1071, // 1117: forge.MachinePositionInfo.machine_id:type_name -> common.MachineId
+	1085, // 1118: forge.MachinePositionInfo.switch_id:type_name -> common.SwitchId
+	1082, // 1119: forge.MachinePositionInfo.power_shelf_id:type_name -> common.PowerShelfId
+	1071, // 1120: forge.ModifyDPFStateRequest.machine_id:type_name -> common.MachineId
+	1068, // 1121: forge.DPFStateResponse.dpf_states:type_name -> forge.DPFStateResponse.DPFState
+	1071, // 1122: forge.GetDPFStateRequest.machine_ids:type_name -> common.MachineId
+	1071, // 1123: forge.GetDPFHostSnapshotRequest.host_machine_id:type_name -> common.MachineId
+	935,  // 1124: forge.DPFServiceVersionsResponse.services:type_name -> forge.DPFServiceVersion
+	1133, // 1125: forge.ReleaseDPUServiceSyncHoldRequest.machine_ids:type_name -> common.MachineIdList
+	290,  // 1126: forge.ReleaseDPUServiceSyncHoldRequest.instance_ids:type_name -> forge.InstanceIdList
+	1071, // 1127: forge.DPUServiceSyncReleaseResult.machine_id:type_name -> common.MachineId
 	79,   // 1128: forge.DPUServiceSyncReleaseResult.status:type_name -> forge.DPUServiceSyncReleaseStatus
-	937,  // 1129: forge.ReleaseDPUServiceSyncHoldResponse.results:type_name -> forge.DPUServiceSyncReleaseResult
-	1066, // 1130: forge.FindPendingDPUServiceSyncsByIdsRequest.machine_ids:type_name -> common.MachineId
-	1066, // 1131: forge.ListDPUServiceSyncHistoryRequest.machine_id:type_name -> common.MachineId
-	1066, // 1132: forge.PendingDPUServiceSync.machine_id:type_name -> common.MachineId
-	1067, // 1133: forge.PendingDPUServiceSync.requested_at:type_name -> google.protobuf.Timestamp
-	1086, // 1134: forge.PendingDPUServiceSync.instance_id:type_name -> common.InstanceId
-	1067, // 1135: forge.PendingDPUServiceSync.completed_at:type_name -> google.protobuf.Timestamp
+	938,  // 1129: forge.ReleaseDPUServiceSyncHoldResponse.results:type_name -> forge.DPUServiceSyncReleaseResult
+	1071, // 1130: forge.FindPendingDPUServiceSyncsByIdsRequest.machine_ids:type_name -> common.MachineId
+	1071, // 1131: forge.ListDPUServiceSyncHistoryRequest.machine_id:type_name -> common.MachineId
+	1071, // 1132: forge.PendingDPUServiceSync.machine_id:type_name -> common.MachineId
+	1072, // 1133: forge.PendingDPUServiceSync.requested_at:type_name -> google.protobuf.Timestamp
+	1091, // 1134: forge.PendingDPUServiceSync.instance_id:type_name -> common.InstanceId
+	1072, // 1135: forge.PendingDPUServiceSync.completed_at:type_name -> google.protobuf.Timestamp
 	49,   // 1136: forge.PendingDPUServiceSync.completed_by:type_name -> forge.UpdateInitiator
-	942,  // 1137: forge.ListPendingDPUServiceSyncsResponse.pending:type_name -> forge.PendingDPUServiceSync
+	943,  // 1137: forge.ListPendingDPUServiceSyncsResponse.pending:type_name -> forge.PendingDPUServiceSync
 	80,   // 1138: forge.ComponentResult.status:type_name -> forge.ComponentManagerStatusCode
-	1080, // 1139: forge.SwitchIdList.ids:type_name -> common.SwitchId
-	1077, // 1140: forge.PowerShelfIdList.ids:type_name -> common.PowerShelfId
-	1128, // 1141: forge.GetComponentInventoryRequest.machine_ids:type_name -> common.MachineIdList
-	945,  // 1142: forge.GetComponentInventoryRequest.switch_ids:type_name -> forge.SwitchIdList
-	946,  // 1143: forge.GetComponentInventoryRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	947,  // 1144: forge.GetComponentInventoryRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	947,  // 1145: forge.GetComponentInventoryRequest.switch_bmc_macs:type_name -> forge.MacAddressList
-	944,  // 1146: forge.ComponentInventoryEntry.result:type_name -> forge.ComponentResult
-	1129, // 1147: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
-	949,  // 1148: forge.GetComponentInventoryResponse.entries:type_name -> forge.ComponentInventoryEntry
-	1128, // 1149: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
-	945,  // 1150: forge.ComponentPowerControlRequest.switch_ids:type_name -> forge.SwitchIdList
-	946,  // 1151: forge.ComponentPowerControlRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	947,  // 1152: forge.ComponentPowerControlRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	947,  // 1153: forge.ComponentPowerControlRequest.switch_bmc_macs:type_name -> forge.MacAddressList
-	1130, // 1154: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
-	944,  // 1155: forge.ComponentPowerControlResponse.results:type_name -> forge.ComponentResult
-	945,  // 1156: forge.ComponentConfigureSwitchCertificateRequest.switch_ids:type_name -> forge.SwitchIdList
-	944,  // 1157: forge.ComponentConfigureSwitchCertificateResponse.results:type_name -> forge.ComponentResult
-	944,  // 1158: forge.FirmwareUpdateStatus.result:type_name -> forge.ComponentResult
+	1085, // 1139: forge.SwitchIdList.ids:type_name -> common.SwitchId
+	1082, // 1140: forge.PowerShelfIdList.ids:type_name -> common.PowerShelfId
+	1133, // 1141: forge.GetComponentInventoryRequest.machine_ids:type_name -> common.MachineIdList
+	946,  // 1142: forge.GetComponentInventoryRequest.switch_ids:type_name -> forge.SwitchIdList
+	947,  // 1143: forge.GetComponentInventoryRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	948,  // 1144: forge.GetComponentInventoryRequest.compute_bmc_macs:type_name -> forge.MacAddressList
+	948,  // 1145: forge.GetComponentInventoryRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	945,  // 1146: forge.ComponentInventoryEntry.result:type_name -> forge.ComponentResult
+	1134, // 1147: forge.ComponentInventoryEntry.report:type_name -> site_explorer.EndpointExplorationReport
+	950,  // 1148: forge.GetComponentInventoryResponse.entries:type_name -> forge.ComponentInventoryEntry
+	1133, // 1149: forge.ComponentPowerControlRequest.machine_ids:type_name -> common.MachineIdList
+	946,  // 1150: forge.ComponentPowerControlRequest.switch_ids:type_name -> forge.SwitchIdList
+	947,  // 1151: forge.ComponentPowerControlRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	948,  // 1152: forge.ComponentPowerControlRequest.compute_bmc_macs:type_name -> forge.MacAddressList
+	948,  // 1153: forge.ComponentPowerControlRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	1135, // 1154: forge.ComponentPowerControlRequest.action:type_name -> common.SystemPowerControl
+	945,  // 1155: forge.ComponentPowerControlResponse.results:type_name -> forge.ComponentResult
+	946,  // 1156: forge.ComponentConfigureSwitchCertificateRequest.switch_ids:type_name -> forge.SwitchIdList
+	945,  // 1157: forge.ComponentConfigureSwitchCertificateResponse.results:type_name -> forge.ComponentResult
+	945,  // 1158: forge.FirmwareUpdateStatus.result:type_name -> forge.ComponentResult
 	81,   // 1159: forge.FirmwareUpdateStatus.state:type_name -> forge.FirmwareUpdateState
-	1067, // 1160: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
-	1128, // 1161: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
+	1072, // 1160: forge.FirmwareUpdateStatus.updated_at:type_name -> google.protobuf.Timestamp
+	1133, // 1161: forge.UpdateComputeTrayFirmwareTarget.machine_ids:type_name -> common.MachineIdList
 	84,   // 1162: forge.UpdateComputeTrayFirmwareTarget.components:type_name -> forge.ComputeTrayComponent
-	947,  // 1163: forge.UpdateComputeTrayFirmwareTarget.bmc_macs:type_name -> forge.MacAddressList
-	945,  // 1164: forge.UpdateSwitchFirmwareTarget.switch_ids:type_name -> forge.SwitchIdList
+	948,  // 1163: forge.UpdateComputeTrayFirmwareTarget.bmc_macs:type_name -> forge.MacAddressList
+	946,  // 1164: forge.UpdateSwitchFirmwareTarget.switch_ids:type_name -> forge.SwitchIdList
 	82,   // 1165: forge.UpdateSwitchFirmwareTarget.components:type_name -> forge.NvSwitchComponent
-	947,  // 1166: forge.UpdateSwitchFirmwareTarget.bmc_macs:type_name -> forge.MacAddressList
-	946,  // 1167: forge.UpdatePowerShelfFirmwareTarget.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	948,  // 1166: forge.UpdateSwitchFirmwareTarget.bmc_macs:type_name -> forge.MacAddressList
+	947,  // 1167: forge.UpdatePowerShelfFirmwareTarget.power_shelf_ids:type_name -> forge.PowerShelfIdList
 	83,   // 1168: forge.UpdatePowerShelfFirmwareTarget.components:type_name -> forge.PowerShelfComponent
-	782,  // 1169: forge.UpdateFirmwareObjectTarget.rack_ids:type_name -> forge.RackIdList
-	956,  // 1170: forge.UpdateComponentFirmwareRequest.compute_trays:type_name -> forge.UpdateComputeTrayFirmwareTarget
-	957,  // 1171: forge.UpdateComponentFirmwareRequest.switches:type_name -> forge.UpdateSwitchFirmwareTarget
-	958,  // 1172: forge.UpdateComponentFirmwareRequest.power_shelves:type_name -> forge.UpdatePowerShelfFirmwareTarget
-	959,  // 1173: forge.UpdateComponentFirmwareRequest.racks:type_name -> forge.UpdateFirmwareObjectTarget
-	944,  // 1174: forge.UpdateComponentFirmwareResponse.results:type_name -> forge.ComponentResult
-	1128, // 1175: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
-	945,  // 1176: forge.GetComponentFirmwareStatusRequest.switch_ids:type_name -> forge.SwitchIdList
-	946,  // 1177: forge.GetComponentFirmwareStatusRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	782,  // 1178: forge.GetComponentFirmwareStatusRequest.rack_ids:type_name -> forge.RackIdList
-	947,  // 1179: forge.GetComponentFirmwareStatusRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	947,  // 1180: forge.GetComponentFirmwareStatusRequest.switch_bmc_macs:type_name -> forge.MacAddressList
-	955,  // 1181: forge.GetComponentFirmwareStatusResponse.statuses:type_name -> forge.FirmwareUpdateStatus
-	1128, // 1182: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
-	945,  // 1183: forge.ListComponentFirmwareVersionsRequest.switch_ids:type_name -> forge.SwitchIdList
-	946,  // 1184: forge.ListComponentFirmwareVersionsRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
-	782,  // 1185: forge.ListComponentFirmwareVersionsRequest.rack_ids:type_name -> forge.RackIdList
-	947,  // 1186: forge.ListComponentFirmwareVersionsRequest.compute_bmc_macs:type_name -> forge.MacAddressList
-	947,  // 1187: forge.ListComponentFirmwareVersionsRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	783,  // 1169: forge.UpdateFirmwareObjectTarget.rack_ids:type_name -> forge.RackIdList
+	957,  // 1170: forge.UpdateComponentFirmwareRequest.compute_trays:type_name -> forge.UpdateComputeTrayFirmwareTarget
+	958,  // 1171: forge.UpdateComponentFirmwareRequest.switches:type_name -> forge.UpdateSwitchFirmwareTarget
+	959,  // 1172: forge.UpdateComponentFirmwareRequest.power_shelves:type_name -> forge.UpdatePowerShelfFirmwareTarget
+	960,  // 1173: forge.UpdateComponentFirmwareRequest.racks:type_name -> forge.UpdateFirmwareObjectTarget
+	945,  // 1174: forge.UpdateComponentFirmwareResponse.results:type_name -> forge.ComponentResult
+	1133, // 1175: forge.GetComponentFirmwareStatusRequest.machine_ids:type_name -> common.MachineIdList
+	946,  // 1176: forge.GetComponentFirmwareStatusRequest.switch_ids:type_name -> forge.SwitchIdList
+	947,  // 1177: forge.GetComponentFirmwareStatusRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	783,  // 1178: forge.GetComponentFirmwareStatusRequest.rack_ids:type_name -> forge.RackIdList
+	948,  // 1179: forge.GetComponentFirmwareStatusRequest.compute_bmc_macs:type_name -> forge.MacAddressList
+	948,  // 1180: forge.GetComponentFirmwareStatusRequest.switch_bmc_macs:type_name -> forge.MacAddressList
+	956,  // 1181: forge.GetComponentFirmwareStatusResponse.statuses:type_name -> forge.FirmwareUpdateStatus
+	1133, // 1182: forge.ListComponentFirmwareVersionsRequest.machine_ids:type_name -> common.MachineIdList
+	946,  // 1183: forge.ListComponentFirmwareVersionsRequest.switch_ids:type_name -> forge.SwitchIdList
+	947,  // 1184: forge.ListComponentFirmwareVersionsRequest.power_shelf_ids:type_name -> forge.PowerShelfIdList
+	783,  // 1185: forge.ListComponentFirmwareVersionsRequest.rack_ids:type_name -> forge.RackIdList
+	948,  // 1186: forge.ListComponentFirmwareVersionsRequest.compute_bmc_macs:type_name -> forge.MacAddressList
+	948,  // 1187: forge.ListComponentFirmwareVersionsRequest.switch_bmc_macs:type_name -> forge.MacAddressList
 	84,   // 1188: forge.ComputeTrayFirmwareVersions.component:type_name -> forge.ComputeTrayComponent
-	944,  // 1189: forge.DeviceFirmwareVersions.result:type_name -> forge.ComponentResult
-	965,  // 1190: forge.DeviceFirmwareVersions.compute_fw_versions:type_name -> forge.ComputeTrayFirmwareVersions
-	966,  // 1191: forge.ListComponentFirmwareVersionsResponse.devices:type_name -> forge.DeviceFirmwareVersions
-	287,  // 1192: forge.SpxPartitionCreationRequest.metadata:type_name -> forge.Metadata
-	1089, // 1193: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
-	287,  // 1194: forge.SpxPartition.metadata:type_name -> forge.Metadata
-	1089, // 1195: forge.SpxPartition.id:type_name -> common.SpxPartitionId
-	1089, // 1196: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
-	1089, // 1197: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
-	286,  // 1198: forge.SpxPartitionSearchFilter.label:type_name -> forge.Label
-	969,  // 1199: forge.SpxPartitionList.spx_partitions:type_name -> forge.SpxPartition
-	1089, // 1200: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
-	1080, // 1201: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
-	1077, // 1202: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
-	1088, // 1203: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
+	945,  // 1189: forge.DeviceFirmwareVersions.result:type_name -> forge.ComponentResult
+	966,  // 1190: forge.DeviceFirmwareVersions.compute_fw_versions:type_name -> forge.ComputeTrayFirmwareVersions
+	967,  // 1191: forge.ListComponentFirmwareVersionsResponse.devices:type_name -> forge.DeviceFirmwareVersions
+	288,  // 1192: forge.SpxPartitionCreationRequest.metadata:type_name -> forge.Metadata
+	1094, // 1193: forge.SpxPartitionCreationRequest.id:type_name -> common.SpxPartitionId
+	288,  // 1194: forge.SpxPartition.metadata:type_name -> forge.Metadata
+	1094, // 1195: forge.SpxPartition.id:type_name -> common.SpxPartitionId
+	1094, // 1196: forge.SpxPartitionIdList.spx_partition_ids:type_name -> common.SpxPartitionId
+	1094, // 1197: forge.SpxPartitionDeletionRequest.id:type_name -> common.SpxPartitionId
+	287,  // 1198: forge.SpxPartitionSearchFilter.label:type_name -> forge.Label
+	970,  // 1199: forge.SpxPartitionList.spx_partitions:type_name -> forge.SpxPartition
+	1094, // 1200: forge.SpxPartitionsByIdsRequest.spx_partition_ids:type_name -> common.SpxPartitionId
+	1085, // 1201: forge.AdminForceDeleteSwitchRequest.switch_id:type_name -> common.SwitchId
+	1082, // 1202: forge.AdminForceDeletePowerShelfRequest.power_shelf_id:type_name -> common.PowerShelfId
+	1093, // 1203: forge.OperatingSystem.id:type_name -> common.OperatingSystemId
 	85,   // 1204: forge.OperatingSystem.type:type_name -> forge.OperatingSystemType
 	9,    // 1205: forge.OperatingSystem.status:type_name -> forge.TenantState
-	1087, // 1206: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
-	294,  // 1207: forge.OperatingSystem.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
-	295,  // 1208: forge.OperatingSystem.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
-	1088, // 1209: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1087, // 1210: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
-	294,  // 1211: forge.CreateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
-	295,  // 1212: forge.CreateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
-	294,  // 1213: forge.IpxeTemplateParameters.items:type_name -> forge.IpxeTemplateParameter
-	295,  // 1214: forge.IpxeTemplateArtifacts.items:type_name -> forge.IpxeTemplateArtifact
-	1088, // 1215: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1087, // 1216: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
-	982,  // 1217: forge.UpdateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameters
-	983,  // 1218: forge.UpdateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifacts
-	1088, // 1219: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
-	1088, // 1220: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
-	1088, // 1221: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
-	980,  // 1222: forge.OperatingSystemList.operating_systems:type_name -> forge.OperatingSystem
-	1088, // 1223: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
-	295,  // 1224: forge.IpxeTemplateArtifactList.artifacts:type_name -> forge.IpxeTemplateArtifact
-	1088, // 1225: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
-	993,  // 1226: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.updates:type_name -> forge.IpxeTemplateArtifactUpdateRequest
-	1066, // 1227: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
-	1090, // 1228: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
-	1067, // 1229: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
-	1066, // 1230: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
-	999,  // 1231: forge.GetMachineBootInterfacesResponse.machine_interfaces:type_name -> forge.MachineInterfaceBootInterface
-	1000, // 1232: forge.GetMachineBootInterfacesResponse.predicted_interfaces:type_name -> forge.PredictedBootInterface
-	1001, // 1233: forge.GetMachineBootInterfacesResponse.explored_endpoints:type_name -> forge.ExploredBootInterface
-	1002, // 1234: forge.GetMachineBootInterfacesResponse.retained_interfaces:type_name -> forge.RetainedBootInterface
-	998,  // 1235: forge.GetMachineBootInterfacesResponse.default_boot_interface:type_name -> forge.MachineBootInterface
-	998,  // 1236: forge.GetMachineBootInterfacesResponse.predicted_boot_interface:type_name -> forge.MachineBootInterface
-	1065, // 1237: forge.GetMachineBootInterfacesResponse.reconciliation:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation
-	1073, // 1238: forge.SitePrefix.id:type_name -> common.SitePrefixId
-	1008, // 1239: forge.SitePrefix.config:type_name -> forge.SitePrefixConfig
-	1009, // 1240: forge.SitePrefix.status:type_name -> forge.SitePrefixStatus
-	287,  // 1241: forge.SitePrefix.metadata:type_name -> forge.Metadata
-	1067, // 1242: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
-	1067, // 1243: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
+	1092, // 1206: forge.OperatingSystem.ipxe_template_id:type_name -> common.IpxeTemplateId
+	295,  // 1207: forge.OperatingSystem.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
+	296,  // 1208: forge.OperatingSystem.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
+	1093, // 1209: forge.CreateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1092, // 1210: forge.CreateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	295,  // 1211: forge.CreateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameter
+	296,  // 1212: forge.CreateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifact
+	295,  // 1213: forge.IpxeTemplateParameters.items:type_name -> forge.IpxeTemplateParameter
+	296,  // 1214: forge.IpxeTemplateArtifacts.items:type_name -> forge.IpxeTemplateArtifact
+	1093, // 1215: forge.UpdateOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1092, // 1216: forge.UpdateOperatingSystemRequest.ipxe_template_id:type_name -> common.IpxeTemplateId
+	983,  // 1217: forge.UpdateOperatingSystemRequest.ipxe_template_parameters:type_name -> forge.IpxeTemplateParameters
+	984,  // 1218: forge.UpdateOperatingSystemRequest.ipxe_template_artifacts:type_name -> forge.IpxeTemplateArtifacts
+	1093, // 1219: forge.DeleteOperatingSystemRequest.id:type_name -> common.OperatingSystemId
+	1093, // 1220: forge.OperatingSystemIdList.ids:type_name -> common.OperatingSystemId
+	1093, // 1221: forge.OperatingSystemsByIdsRequest.ids:type_name -> common.OperatingSystemId
+	981,  // 1222: forge.OperatingSystemList.operating_systems:type_name -> forge.OperatingSystem
+	1093, // 1223: forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest.id:type_name -> common.OperatingSystemId
+	296,  // 1224: forge.IpxeTemplateArtifactList.artifacts:type_name -> forge.IpxeTemplateArtifact
+	1093, // 1225: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.id:type_name -> common.OperatingSystemId
+	994,  // 1226: forge.UpdateOperatingSystemIpxeTemplateArtifactRequest.updates:type_name -> forge.IpxeTemplateArtifactUpdateRequest
+	1071, // 1227: forge.GetMachineBootInterfacesRequest.machine_id:type_name -> common.MachineId
+	1095, // 1228: forge.MachineInterfaceBootInterface.interface_id:type_name -> common.MachineInterfaceId
+	1072, // 1229: forge.RetainedBootInterface.recorded_at:type_name -> google.protobuf.Timestamp
+	1071, // 1230: forge.GetMachineBootInterfacesResponse.machine_id:type_name -> common.MachineId
+	1000, // 1231: forge.GetMachineBootInterfacesResponse.machine_interfaces:type_name -> forge.MachineInterfaceBootInterface
+	1001, // 1232: forge.GetMachineBootInterfacesResponse.predicted_interfaces:type_name -> forge.PredictedBootInterface
+	1002, // 1233: forge.GetMachineBootInterfacesResponse.explored_endpoints:type_name -> forge.ExploredBootInterface
+	1003, // 1234: forge.GetMachineBootInterfacesResponse.retained_interfaces:type_name -> forge.RetainedBootInterface
+	999,  // 1235: forge.GetMachineBootInterfacesResponse.default_boot_interface:type_name -> forge.MachineBootInterface
+	999,  // 1236: forge.GetMachineBootInterfacesResponse.predicted_boot_interface:type_name -> forge.MachineBootInterface
+	1069, // 1237: forge.GetMachineBootInterfacesResponse.reconciliation:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation
+	1078, // 1238: forge.SitePrefix.id:type_name -> common.SitePrefixId
+	1009, // 1239: forge.SitePrefix.config:type_name -> forge.SitePrefixConfig
+	1010, // 1240: forge.SitePrefix.status:type_name -> forge.SitePrefixStatus
+	288,  // 1241: forge.SitePrefix.metadata:type_name -> forge.Metadata
+	1072, // 1242: forge.SitePrefix.created_at:type_name -> google.protobuf.Timestamp
+	1072, // 1243: forge.SitePrefix.updated_at:type_name -> google.protobuf.Timestamp
 	90,   // 1244: forge.SitePrefixConfig.routing_scope:type_name -> forge.SitePrefixRoutingScope
 	89,   // 1245: forge.SitePrefixStatus.authority:type_name -> forge.SitePrefixAuthority
 	91,   // 1246: forge.SitePrefixStatus.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
-	1010, // 1247: forge.SitePrefixStatus.quota:type_name -> forge.SitePrefixQuotaUsage
-	1073, // 1248: forge.SitePrefixCreationRequest.id:type_name -> common.SitePrefixId
-	287,  // 1249: forge.SitePrefixCreationRequest.metadata:type_name -> forge.Metadata
-	1073, // 1250: forge.SitePrefixUpdateRequest.id:type_name -> common.SitePrefixId
-	287,  // 1251: forge.SitePrefixUpdateRequest.metadata:type_name -> forge.Metadata
-	1073, // 1252: forge.SitePrefixDeletionRequest.id:type_name -> common.SitePrefixId
-	1007, // 1253: forge.SitePrefixDeletionResult.site_prefix:type_name -> forge.SitePrefix
-	1073, // 1254: forge.SitePrefixStateHistoriesRequest.site_prefix_ids:type_name -> common.SitePrefixId
+	1011, // 1247: forge.SitePrefixStatus.quota:type_name -> forge.SitePrefixQuotaUsage
+	1078, // 1248: forge.SitePrefixCreationRequest.id:type_name -> common.SitePrefixId
+	288,  // 1249: forge.SitePrefixCreationRequest.metadata:type_name -> forge.Metadata
+	1078, // 1250: forge.SitePrefixUpdateRequest.id:type_name -> common.SitePrefixId
+	288,  // 1251: forge.SitePrefixUpdateRequest.metadata:type_name -> forge.Metadata
+	1078, // 1252: forge.SitePrefixDeletionRequest.id:type_name -> common.SitePrefixId
+	1008, // 1253: forge.SitePrefixDeletionResult.site_prefix:type_name -> forge.SitePrefix
+	1078, // 1254: forge.SitePrefixStateHistoriesRequest.site_prefix_ids:type_name -> common.SitePrefixId
 	89,   // 1255: forge.SitePrefixSearchFilter.authority:type_name -> forge.SitePrefixAuthority
 	90,   // 1256: forge.SitePrefixSearchFilter.routing_scope:type_name -> forge.SitePrefixRoutingScope
 	91,   // 1257: forge.SitePrefixSearchFilter.lifecycle_state:type_name -> forge.SitePrefixLifecycleState
 	8,    // 1258: forge.SitePrefixSearchFilter.prefix_match_type:type_name -> forge.PrefixMatchType
-	1073, // 1259: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
-	1073, // 1260: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
-	1007, // 1261: forge.SitePrefixList.site_prefixes:type_name -> forge.SitePrefix
+	1078, // 1259: forge.SitePrefixesByIdsRequest.site_prefix_ids:type_name -> common.SitePrefixId
+	1078, // 1260: forge.SitePrefixIdList.site_prefix_ids:type_name -> common.SitePrefixId
+	1008, // 1261: forge.SitePrefixList.site_prefixes:type_name -> forge.SitePrefix
 	30,   // 1262: forge.InterfaceAddressConfig.address_family:type_name -> forge.AddressFamily
-	1068, // 1263: forge.VpcReleaseInactiveVniRequest.id:type_name -> common.VpcId
-	178,  // 1264: forge.VpcReleaseInactiveVniResult.vpc:type_name -> forge.Vpc
-	1068, // 1265: forge.VpcRoutingStateRequest.id:type_name -> common.VpcId
-	1068, // 1266: forge.VpcRoutingState.id:type_name -> common.VpcId
-	1025, // 1267: forge.VpcRoutingState.retained_allocation:type_name -> forge.VpcRetainedVniAllocation
-	1068, // 1268: forge.VpcChangeRoutingProfileRequest.id:type_name -> common.VpcId
-	1030, // 1269: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
-	251,  // 1270: forge.StateHistories.HistoriesEntry.value:type_name -> forge.StateHistoryRecords
-	346,  // 1271: forge.MachineStateHistories.HistoriesEntry.value:type_name -> forge.MachineStateHistoryRecords
-	349,  // 1272: forge.HealthHistories.HistoriesEntry.value:type_name -> forge.HealthHistoryRecords
-	96,   // 1273: forge.MachineCredentialsUpdateRequest.Credentials.credential_purpose:type_name -> forge.MachineCredentialsUpdateRequest.CredentialPurpose
-	1054, // 1274: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
-	1096, // 1275: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
-	1045, // 1276: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
-	1093, // 1277: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
-	1047, // 1278: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
-	1048, // 1279: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
-	1049, // 1280: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
-	1050, // 1281: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
-	1051, // 1282: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
-	1052, // 1283: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
-	1131, // 1284: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
-	1132, // 1285: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
-	1133, // 1286: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
-	98,   // 1287: forge.MachineCleanupInfo.CleanupStepResult.result:type_name -> forge.MachineCleanupInfo.CleanupResult
-	1066, // 1288: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
-	1067, // 1289: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1067, // 1290: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	1066, // 1291: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
-	1067, // 1292: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
-	1067, // 1293: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
-	660,  // 1294: forge.MachineValidationTestUpdateRequest.Payload.plugin:type_name -> forge.MachineValidationPlugin
-	1066, // 1295: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
-	998,  // 1296: forge.GetMachineBootInterfacesResponse.Reconciliation.desired_boot_interface:type_name -> forge.MachineBootInterface
-	1067, // 1297: forge.GetMachineBootInterfacesResponse.Reconciliation.observed_at:type_name -> google.protobuf.Timestamp
-	108,  // 1298: forge.GetMachineBootInterfacesResponse.Reconciliation.reconciliation_state:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation.State
-	88,   // 1299: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_source:type_name -> forge.BootInterfaceSelectionSource
-	1067, // 1300: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_updated_at:type_name -> google.protobuf.Timestamp
-	157,  // 1301: forge.Forge.Version:input_type -> forge.VersionRequest
-	1134, // 1302: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
-	1135, // 1303: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
-	1136, // 1304: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
-	1137, // 1305: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
-	919,  // 1306: forge.Forge.CreateDomainLegacy:input_type -> forge.DomainLegacy
-	919,  // 1307: forge.Forge.UpdateDomainLegacy:input_type -> forge.DomainLegacy
-	921,  // 1308: forge.Forge.DeleteDomainLegacy:input_type -> forge.DomainDeletionLegacy
-	923,  // 1309: forge.Forge.FindDomainLegacy:input_type -> forge.DomainSearchQueryLegacy
-	179,  // 1310: forge.Forge.CreateVpc:input_type -> forge.VpcCreationRequest
-	180,  // 1311: forge.Forge.UpdateVpc:input_type -> forge.VpcUpdateRequest
-	1026, // 1312: forge.Forge.ChangeVpcRoutingProfile:input_type -> forge.VpcChangeRoutingProfileRequest
-	1021, // 1313: forge.Forge.ReleaseVpcInactiveVni:input_type -> forge.VpcReleaseInactiveVniRequest
-	182,  // 1314: forge.Forge.UpdateVpcVirtualization:input_type -> forge.VpcUpdateVirtualizationRequest
-	184,  // 1315: forge.Forge.DeleteVpc:input_type -> forge.VpcDeletionRequest
-	169,  // 1316: forge.Forge.FindVpcIds:input_type -> forge.VpcSearchFilter
-	171,  // 1317: forge.Forge.FindVpcsByIds:input_type -> forge.VpcsByIdsRequest
-	1023, // 1318: forge.Forge.GetVpcRoutingState:input_type -> forge.VpcRoutingStateRequest
-	968,  // 1319: forge.Forge.CreateSpxPartition:input_type -> forge.SpxPartitionCreationRequest
-	971,  // 1320: forge.Forge.DeleteSpxPartition:input_type -> forge.SpxPartitionDeletionRequest
-	973,  // 1321: forge.Forge.FindSpxPartitionIds:input_type -> forge.SpxPartitionSearchFilter
-	975,  // 1322: forge.Forge.FindSpxPartitionsByIds:input_type -> forge.SpxPartitionsByIdsRequest
-	190,  // 1323: forge.Forge.CreateVpcPrefix:input_type -> forge.VpcPrefixCreationRequest
-	191,  // 1324: forge.Forge.SearchVpcPrefixes:input_type -> forge.VpcPrefixSearchQuery
-	192,  // 1325: forge.Forge.GetVpcPrefixes:input_type -> forge.VpcPrefixGetRequest
-	195,  // 1326: forge.Forge.UpdateVpcPrefix:input_type -> forge.VpcPrefixUpdateRequest
-	196,  // 1327: forge.Forge.DeleteVpcPrefix:input_type -> forge.VpcPrefixDeletionRequest
-	1011, // 1328: forge.Forge.CreateSitePrefix:input_type -> forge.SitePrefixCreationRequest
-	1012, // 1329: forge.Forge.UpdateSitePrefix:input_type -> forge.SitePrefixUpdateRequest
-	1013, // 1330: forge.Forge.DeleteSitePrefix:input_type -> forge.SitePrefixDeletionRequest
-	1016, // 1331: forge.Forge.FindSitePrefixIds:input_type -> forge.SitePrefixSearchFilter
-	1017, // 1332: forge.Forge.FindSitePrefixesByIds:input_type -> forge.SitePrefixesByIdsRequest
-	202,  // 1333: forge.Forge.CreateVpcPeering:input_type -> forge.VpcPeeringCreationRequest
-	203,  // 1334: forge.Forge.FindVpcPeeringIds:input_type -> forge.VpcPeeringSearchFilter
-	204,  // 1335: forge.Forge.FindVpcPeeringsByIds:input_type -> forge.VpcPeeringsByIdsRequest
-	205,  // 1336: forge.Forge.DeleteVpcPeering:input_type -> forge.VpcPeeringDeletionRequest
-	278,  // 1337: forge.Forge.FindNetworkSegmentIds:input_type -> forge.NetworkSegmentSearchFilter
-	280,  // 1338: forge.Forge.FindNetworkSegmentsByIds:input_type -> forge.NetworkSegmentsByIdsRequest
-	272,  // 1339: forge.Forge.CreateNetworkSegment:input_type -> forge.NetworkSegmentCreationRequest
-	274,  // 1340: forge.Forge.AttachNetworkSegmentToVpc:input_type -> forge.AttachNetworkSegmentToVpcRequest
-	273,  // 1341: forge.Forge.DeleteNetworkSegment:input_type -> forge.NetworkSegmentDeletionRequest
-	168,  // 1342: forge.Forge.NetworkSegmentsForVpc:input_type -> forge.VpcSearchQuery
-	215,  // 1343: forge.Forge.FindIBPartitionIds:input_type -> forge.IBPartitionSearchFilter
-	216,  // 1344: forge.Forge.FindIBPartitionsByIds:input_type -> forge.IBPartitionsByIdsRequest
-	211,  // 1345: forge.Forge.CreateIBPartition:input_type -> forge.IBPartitionCreationRequest
-	212,  // 1346: forge.Forge.UpdateIBPartition:input_type -> forge.IBPartitionUpdateRequest
-	213,  // 1347: forge.Forge.DeleteIBPartition:input_type -> forge.IBPartitionDeletionRequest
-	172,  // 1348: forge.Forge.IBPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	230,  // 1349: forge.Forge.FindPowerShelves:input_type -> forge.PowerShelfQuery
-	231,  // 1350: forge.Forge.FindPowerShelfIds:input_type -> forge.PowerShelfSearchFilter
-	232,  // 1351: forge.Forge.FindPowerShelvesByIds:input_type -> forge.PowerShelvesByIdsRequest
-	223,  // 1352: forge.Forge.DecommissionPowerShelf:input_type -> forge.DecommissionPowerShelfRequest
-	225,  // 1353: forge.Forge.DeletePowerShelf:input_type -> forge.PowerShelfDeletionRequest
-	978,  // 1354: forge.Forge.AdminForceDeletePowerShelf:input_type -> forge.AdminForceDeletePowerShelfRequest
-	227,  // 1355: forge.Forge.SetPowerShelfMaintenance:input_type -> forge.PowerShelfMaintenanceRequest
-	255,  // 1356: forge.Forge.FindSwitches:input_type -> forge.SwitchQuery
-	256,  // 1357: forge.Forge.FindSwitchIds:input_type -> forge.SwitchSearchFilter
-	257,  // 1358: forge.Forge.FindSwitchesByIds:input_type -> forge.SwitchesByIdsRequest
-	246,  // 1359: forge.Forge.DeleteSwitch:input_type -> forge.SwitchDeletionRequest
-	248,  // 1360: forge.Forge.DecommissionSwitch:input_type -> forge.DecommissionSwitchRequest
-	976,  // 1361: forge.Forge.AdminForceDeleteSwitch:input_type -> forge.AdminForceDeleteSwitchRequest
-	266,  // 1362: forge.Forge.FindIBFabricIds:input_type -> forge.IBFabricSearchFilter
-	291,  // 1363: forge.Forge.AllocateInstance:input_type -> forge.InstanceAllocationRequest
-	292,  // 1364: forge.Forge.AllocateInstances:input_type -> forge.BatchInstanceAllocationRequest
-	337,  // 1365: forge.Forge.ReleaseInstance:input_type -> forge.InstanceReleaseRequest
-	339,  // 1366: forge.Forge.ReleaseInstances:input_type -> forge.BatchInstanceReleaseRequest
-	309,  // 1367: forge.Forge.UpdateInstanceOperatingSystem:input_type -> forge.InstanceOperatingSystemUpdateRequest
-	310,  // 1368: forge.Forge.UpdateInstanceConfig:input_type -> forge.InstanceConfigUpdateRequest
-	288,  // 1369: forge.Forge.FindInstanceIds:input_type -> forge.InstanceSearchFilter
-	290,  // 1370: forge.Forge.FindInstancesByIds:input_type -> forge.InstancesByIdsRequest
-	1066, // 1371: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
-	413,  // 1372: forge.Forge.GetManagedHostNetworkConfig:input_type -> forge.ManagedHostNetworkConfigRequest
-	478,  // 1373: forge.Forge.RecordDpuNetworkStatus:input_type -> forge.DpuNetworkStatus
-	1066, // 1374: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
-	484,  // 1375: forge.Forge.InsertMachineHealthReport:input_type -> forge.InsertMachineHealthReportRequest
-	495,  // 1376: forge.Forge.RemoveMachineHealthReport:input_type -> forge.RemoveMachineHealthReportRequest
-	487,  // 1377: forge.Forge.ListRackHealthReports:input_type -> forge.ListRackHealthReportsRequest
-	485,  // 1378: forge.Forge.InsertRackHealthReport:input_type -> forge.InsertRackHealthReportRequest
-	486,  // 1379: forge.Forge.RemoveRackHealthReport:input_type -> forge.RemoveRackHealthReportRequest
-	490,  // 1380: forge.Forge.ListSwitchHealthReports:input_type -> forge.ListSwitchHealthReportsRequest
-	488,  // 1381: forge.Forge.InsertSwitchHealthReport:input_type -> forge.InsertSwitchHealthReportRequest
-	489,  // 1382: forge.Forge.RemoveSwitchHealthReport:input_type -> forge.RemoveSwitchHealthReportRequest
-	493,  // 1383: forge.Forge.ListPowerShelfHealthReports:input_type -> forge.ListPowerShelfHealthReportsRequest
-	491,  // 1384: forge.Forge.InsertPowerShelfHealthReport:input_type -> forge.InsertPowerShelfHealthReportRequest
-	492,  // 1385: forge.Forge.RemovePowerShelfHealthReport:input_type -> forge.RemovePowerShelfHealthReportRequest
-	496,  // 1386: forge.Forge.ListNVLinkDomainHealthReports:input_type -> forge.ListNVLinkDomainHealthReportsRequest
-	497,  // 1387: forge.Forge.InsertNVLinkDomainHealthReport:input_type -> forge.InsertNVLinkDomainHealthReportRequest
-	498,  // 1388: forge.Forge.RemoveNVLinkDomainHealthReport:input_type -> forge.RemoveNVLinkDomainHealthReportRequest
-	1066, // 1389: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
-	484,  // 1390: forge.Forge.InsertHealthReportOverride:input_type -> forge.InsertMachineHealthReportRequest
-	495,  // 1391: forge.Forge.RemoveHealthReportOverride:input_type -> forge.RemoveMachineHealthReportRequest
-	430,  // 1392: forge.Forge.DpuAgentUpgradeCheck:input_type -> forge.DpuAgentUpgradeCheckRequest
-	432,  // 1393: forge.Forge.DpuAgentUpgradePolicyAction:input_type -> forge.DpuAgentUpgradePolicyRequest
-	1138, // 1394: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
-	1139, // 1395: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
-	1140, // 1396: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
-	283,  // 1397: forge.Forge.InvokeInstancePower:input_type -> forge.InstancePowerRequest
-	459,  // 1398: forge.Forge.ForgeAgentControl:input_type -> forge.ForgeAgentControlRequest
-	461,  // 1399: forge.Forge.DiscoverMachine:input_type -> forge.MachineDiscoveryInfo
-	465,  // 1400: forge.Forge.RenewMachineCertificate:input_type -> forge.MachineCertificateRenewRequest
-	462,  // 1401: forge.Forge.DiscoveryCompleted:input_type -> forge.MachineDiscoveryCompletedRequest
-	463,  // 1402: forge.Forge.CleanupMachineCompleted:input_type -> forge.MachineCleanupInfo
-	470,  // 1403: forge.Forge.ReportForgeScoutError:input_type -> forge.ForgeScoutErrorReport
-	389,  // 1404: forge.Forge.DiscoverDhcp:input_type -> forge.DhcpDiscovery
-	390,  // 1405: forge.Forge.ExpireDhcpLease:input_type -> forge.ExpireDhcpLeaseRequest
-	359,  // 1406: forge.Forge.AssignStaticAddress:input_type -> forge.AssignStaticAddressRequest
-	361,  // 1407: forge.Forge.RemoveStaticAddress:input_type -> forge.RemoveStaticAddressRequest
-	363,  // 1408: forge.Forge.FindInterfaceAddresses:input_type -> forge.FindInterfaceAddressesRequest
-	358,  // 1409: forge.Forge.FindInterfaces:input_type -> forge.InterfaceSearchQuery
-	357,  // 1410: forge.Forge.DeleteInterface:input_type -> forge.InterfaceDeleteQuery
-	534,  // 1411: forge.Forge.FindIpAddress:input_type -> forge.FindIpAddressRequest
-	343,  // 1412: forge.Forge.FindMachineIds:input_type -> forge.MachineSearchConfig
-	342,  // 1413: forge.Forge.FindMachinesByIds:input_type -> forge.MachinesByIdsRequest
-	344,  // 1414: forge.Forge.FindMachineStateHistories:input_type -> forge.MachineStateHistoriesRequest
-	347,  // 1415: forge.Forge.FindMachineHealthHistories:input_type -> forge.MachineHealthHistoriesRequest
-	228,  // 1416: forge.Forge.FindPowerShelfStateHistories:input_type -> forge.PowerShelfStateHistoriesRequest
-	229,  // 1417: forge.Forge.FindPowerShelfHealthHistories:input_type -> forge.PowerShelfHealthHistoriesRequest
-	787,  // 1418: forge.Forge.FindRackStateHistories:input_type -> forge.RackStateHistoriesRequest
-	788,  // 1419: forge.Forge.FindRackHealthHistories:input_type -> forge.RackHealthHistoriesRequest
-	252,  // 1420: forge.Forge.FindSwitchStateHistories:input_type -> forge.SwitchStateHistoriesRequest
-	253,  // 1421: forge.Forge.FindSwitchHealthHistories:input_type -> forge.SwitchHealthHistoriesRequest
-	276,  // 1422: forge.Forge.FindNetworkSegmentStateHistories:input_type -> forge.NetworkSegmentStateHistoriesRequest
-	198,  // 1423: forge.Forge.FindVpcPrefixStateHistories:input_type -> forge.VpcPrefixStateHistoriesRequest
-	1015, // 1424: forge.Forge.FindSitePrefixStateHistories:input_type -> forge.SitePrefixStateHistoriesRequest
-	352,  // 1425: forge.Forge.FindTenantOrganizationIds:input_type -> forge.TenantSearchFilter
-	351,  // 1426: forge.Forge.FindTenantsByOrganizationIds:input_type -> forge.TenantByOrganizationIdsRequest
-	1128, // 1427: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
-	562,  // 1428: forge.Forge.FindMachineIdsByBmcIps:input_type -> forge.BmcIpList
-	563,  // 1429: forge.Forge.FindMacAddressByBmcIp:input_type -> forge.BmcIp
-	538,  // 1430: forge.Forge.FindBmcIps:input_type -> forge.FindBmcIpsRequest
-	536,  // 1431: forge.Forge.IdentifyUuid:input_type -> forge.IdentifyUuidRequest
-	539,  // 1432: forge.Forge.IdentifyMac:input_type -> forge.IdentifyMacRequest
-	541,  // 1433: forge.Forge.IdentifySerial:input_type -> forge.IdentifySerialRequest
-	455,  // 1434: forge.Forge.GetBMCMetaData:input_type -> forge.BMCMetaDataGetRequest
-	457,  // 1435: forge.Forge.UpdateMachineCredentials:input_type -> forge.MachineCredentialsUpdateRequest
-	472,  // 1436: forge.Forge.GetPxeInstructions:input_type -> forge.PxeInstructionRequest
-	476,  // 1437: forge.Forge.GetCloudInitInstructions:input_type -> forge.CloudInitInstructionsRequest
-	160,  // 1438: forge.Forge.Echo:input_type -> forge.EchoRequest
-	503,  // 1439: forge.Forge.CreateTenant:input_type -> forge.CreateTenantRequest
-	507,  // 1440: forge.Forge.FindTenant:input_type -> forge.FindTenantRequest
-	505,  // 1441: forge.Forge.UpdateTenant:input_type -> forge.UpdateTenantRequest
-	513,  // 1442: forge.Forge.CreateTenantKeyset:input_type -> forge.CreateTenantKeysetRequest
-	520,  // 1443: forge.Forge.FindTenantKeysetIds:input_type -> forge.TenantKeysetSearchFilter
-	522,  // 1444: forge.Forge.FindTenantKeysetsByIds:input_type -> forge.TenantKeysetsByIdsRequest
-	516,  // 1445: forge.Forge.UpdateTenantKeyset:input_type -> forge.UpdateTenantKeysetRequest
-	518,  // 1446: forge.Forge.DeleteTenantKeyset:input_type -> forge.DeleteTenantKeysetRequest
-	523,  // 1447: forge.Forge.ValidateTenantPublicKey:input_type -> forge.ValidateTenantPublicKeyRequest
-	396,  // 1448: forge.Forge.GetBmcCredentials:input_type -> forge.GetBmcCredentialsRequest
-	397,  // 1449: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
-	428,  // 1450: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
-	400,  // 1451: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
-	1141, // 1452: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
-	401,  // 1453: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
-	407,  // 1454: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
-	407,  // 1455: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
-	407,  // 1456: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
-	402,  // 1457: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
-	403,  // 1458: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
-	404,  // 1459: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
-	405,  // 1460: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
-	1142, // 1461: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
-	1143, // 1462: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
-	1144, // 1463: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
-	1145, // 1464: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
-	1146, // 1465: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
-	1147, // 1466: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
-	411,  // 1467: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
-	434,  // 1468: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
-	435,  // 1469: forge.Forge.DecommissionManagedHost:input_type -> forge.DecommissionManagedHostRequest
-	525,  // 1470: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
-	528,  // 1471: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
-	373,  // 1472: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
-	374,  // 1473: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
-	375,  // 1474: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
-	376,  // 1475: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
-	804,  // 1476: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
-	532,  // 1477: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
-	533,  // 1478: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
-	543,  // 1479: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
-	544,  // 1480: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
-	546,  // 1481: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
-	550,  // 1482: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
-	547,  // 1483: forge.Forge.TriggerBmcCredentialRotation:input_type -> forge.BmcCredentialRotationRequest
-	548,  // 1484: forge.Forge.TriggerUefiCredentialRotation:input_type -> forge.UefiCredentialRotationRequest
-	549,  // 1485: forge.Forge.TriggerNicLockdownCredentialRotation:input_type -> forge.NicLockdownCredentialRotationRequest
-	1066, // 1486: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
-	603,  // 1487: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
-	556,  // 1488: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
-	1090, // 1489: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
-	559,  // 1490: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
-	1090, // 1491: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
-	997,  // 1492: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
-	568,  // 1493: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
-	569,  // 1494: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
-	148,  // 1495: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
-	149,  // 1496: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
-	152,  // 1497: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
-	154,  // 1498: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
-	1004, // 1499: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
-	1006, // 1500: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
-	1141, // 1501: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
-	571,  // 1502: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
-	571,  // 1503: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
-	571,  // 1504: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
-	377,  // 1505: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
-	332,  // 1506: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
-	574,  // 1507: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
-	576,  // 1508: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
-	578,  // 1509: forge.Forge.SetDpuUefiPassword:input_type -> forge.SetDpuUefiPasswordRequest
-	591,  // 1510: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
-	592,  // 1511: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	591,  // 1512: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
-	592,  // 1513: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
-	1141, // 1514: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
-	593,  // 1515: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
-	1141, // 1516: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
-	1141, // 1517: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
-	1141, // 1518: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
-	598,  // 1519: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	598,  // 1520: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
-	233,  // 1521: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	234,  // 1522: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	233,  // 1523: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
-	234,  // 1524: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
-	1141, // 1525: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	235,  // 1526: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
-	1141, // 1527: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
-	1141, // 1528: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
-	258,  // 1529: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
-	259,  // 1530: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	258,  // 1531: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
-	259,  // 1532: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
-	1141, // 1533: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
-	260,  // 1534: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
-	1141, // 1535: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
-	1141, // 1536: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
-	263,  // 1537: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
-	264,  // 1538: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
-	263,  // 1539: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
-	264,  // 1540: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
-	1141, // 1541: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
-	265,  // 1542: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
-	1141, // 1543: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
-	146,  // 1544: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
-	680,  // 1545: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
-	682,  // 1546: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
-	684,  // 1547: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
-	689,  // 1548: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
-	686,  // 1549: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
-	690,  // 1550: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
-	692,  // 1551: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
-	1148, // 1552: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
-	1149, // 1553: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
-	1150, // 1554: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
-	1151, // 1555: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
-	1152, // 1556: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
-	1153, // 1557: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
-	1154, // 1558: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
-	1155, // 1559: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
-	1156, // 1560: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
-	1157, // 1561: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
-	1158, // 1562: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
-	1159, // 1563: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
-	1160, // 1564: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
-	1161, // 1565: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
-	1162, // 1566: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
-	1163, // 1567: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
-	1164, // 1568: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
-	1165, // 1569: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
-	1166, // 1570: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
-	1167, // 1571: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
-	1168, // 1572: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
-	1169, // 1573: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
-	1170, // 1574: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
-	1171, // 1575: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
-	1172, // 1576: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
-	1173, // 1577: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
-	1174, // 1578: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
-	1175, // 1579: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
-	1176, // 1580: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
-	1177, // 1581: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
-	1178, // 1582: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
-	1179, // 1583: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
-	1180, // 1584: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
-	1181, // 1585: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
-	1182, // 1586: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
-	1183, // 1587: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
-	1184, // 1588: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
-	1185, // 1589: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
-	1186, // 1590: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
-	1187, // 1591: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
-	1188, // 1592: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
-	1189, // 1593: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
-	1190, // 1594: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
-	711,  // 1595: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
-	713,  // 1596: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
-	715,  // 1597: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
-	718,  // 1598: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
-	719,  // 1599: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
-	725,  // 1600: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
-	728,  // 1601: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
-	580,  // 1602: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
-	584,  // 1603: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
-	582,  // 1604: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
-	1079, // 1605: forge.Forge.GetOsImage:input_type -> common.UUID
-	580,  // 1606: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
-	586,  // 1607: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
-	587,  // 1608: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
-	602,  // 1609: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
-	607,  // 1610: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
-	609,  // 1611: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
-	604,  // 1612: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
-	612,  // 1613: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
-	614,  // 1614: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
-	617,  // 1615: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
-	619,  // 1616: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
-	640,  // 1617: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
-	641,  // 1618: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
-	643,  // 1619: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
-	646,  // 1620: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
-	648,  // 1621: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
-	620,  // 1622: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
-	652,  // 1623: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
-	654,  // 1624: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
-	653,  // 1625: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
-	657,  // 1626: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
-	664,  // 1627: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
-	665,  // 1628: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
-	661,  // 1629: forge.Forge.MachineValidationTestApproveFullHost:input_type -> forge.MachineValidationTestFullHostApprovalRequest
-	667,  // 1630: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
-	449,  // 1631: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
-	633,  // 1632: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
-	635,  // 1633: forge.Forge.AdminGpuReset:input_type -> forge.AdminGpuResetRequest
-	407,  // 1634: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
-	439,  // 1635: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
-	441,  // 1636: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
-	443,  // 1637: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
-	445,  // 1638: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
-	837,  // 1639: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
-	839,  // 1640: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
-	841,  // 1641: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
-	843,  // 1642: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
-	451,  // 1643: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
-	453,  // 1644: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
-	621,  // 1645: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
-	629,  // 1646: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
-	631,  // 1647: forge.Forge.TerminateRackMaintenance:input_type -> forge.RackMaintenanceTerminateRequest
-	142,  // 1648: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
-	1141, // 1649: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
-	1141, // 1650: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
-	139,  // 1651: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
-	694,  // 1652: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
-	696,  // 1653: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
-	701,  // 1654: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
-	703,  // 1655: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
-	703,  // 1656: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
-	703,  // 1657: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
-	707,  // 1658: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
-	731,  // 1659: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
-	847,  // 1660: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
-	848,  // 1661: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
-	747,  // 1662: forge.Forge.CreateSku:input_type -> forge.SkuList
-	1066, // 1663: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
-	1066, // 1664: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
-	745,  // 1665: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
-	746,  // 1666: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
-	748,  // 1667: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
-	1141, // 1668: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
-	750,  // 1669: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
-	760,  // 1670: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
-	744,  // 1671: forge.Forge.ReplaceSku:input_type -> forge.Sku
-	417,  // 1672: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
-	419,  // 1673: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
-	421,  // 1674: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
-	1066, // 1675: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
-	410,  // 1676: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
-	1141, // 1677: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
-	755,  // 1678: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
-	753,  // 1679: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	753,  // 1680: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
-	758,  // 1681: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
-	761,  // 1682: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
-	762,  // 1683: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
-	407,  // 1684: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
-	407,  // 1685: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
-	781,  // 1686: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
-	783,  // 1687: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
-	778,  // 1688: forge.Forge.GetRack:input_type -> forge.GetRackRequest
-	789,  // 1689: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
-	790,  // 1690: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
-	797,  // 1691: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
-	1141, // 1692: forge.Forge.ListRackProfiles:input_type -> google.protobuf.Empty
-	767,  // 1693: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
-	769,  // 1694: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
-	771,  // 1695: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
-	774,  // 1696: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
-	775,  // 1697: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
-	845,  // 1698: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
-	854,  // 1699: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
-	1191, // 1700: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
-	1192, // 1701: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
-	857,  // 1702: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
-	1141, // 1703: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
-	859,  // 1704: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	859,  // 1705: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
-	861,  // 1706: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
-	862,  // 1707: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
-	867,  // 1708: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
-	868,  // 1709: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
-	869,  // 1710: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
-	870,  // 1711: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
-	1141, // 1712: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
-	864,  // 1713: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
-	871,  // 1714: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
-	873,  // 1715: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
-	876,  // 1716: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
-	878,  // 1717: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
-	880,  // 1718: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
-	881,  // 1719: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
-	887,  // 1720: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
-	888,  // 1721: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
-	889,  // 1722: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
-	891,  // 1723: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
-	893,  // 1724: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
-	895,  // 1725: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
-	897,  // 1726: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
-	114,  // 1727: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
-	1066, // 1728: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
-	115,  // 1729: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
-	1066, // 1730: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
-	117,  // 1731: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
-	119,  // 1732: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	122,  // 1733: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
-	119,  // 1734: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
-	127,  // 1735: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	129,  // 1736: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
-	127,  // 1737: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
-	130,  // 1738: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
-	135,  // 1739: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
-	136,  // 1740: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
-	904,  // 1741: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
-	907,  // 1742: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
-	909,  // 1743: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
-	911,  // 1744: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
-	1193, // 1745: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
-	1194, // 1746: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
-	1195, // 1747: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
-	1196, // 1748: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
-	1197, // 1749: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
-	1198, // 1750: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
-	1199, // 1751: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
-	1200, // 1752: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
-	1201, // 1753: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
-	1202, // 1754: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
-	1203, // 1755: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
-	1204, // 1756: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
-	1205, // 1757: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
-	1206, // 1758: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
-	1207, // 1759: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
-	821,  // 1760: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
-	822,  // 1761: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
-	172,  // 1762: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	832,  // 1763: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
-	833,  // 1764: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
-	829,  // 1765: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
-	835,  // 1766: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
-	830,  // 1767: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
-	172,  // 1768: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
-	925,  // 1769: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
-	815,  // 1770: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
-	928,  // 1771: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
-	930,  // 1772: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
-	931,  // 1773: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
-	933,  // 1774: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
-	939,  // 1775: forge.Forge.FindPendingDPUServiceSyncIds:input_type -> forge.FindPendingDPUServiceSyncIdsRequest
-	940,  // 1776: forge.Forge.FindPendingDPUServiceSyncsByIds:input_type -> forge.FindPendingDPUServiceSyncsByIdsRequest
-	941,  // 1777: forge.Forge.ListDPUServiceSyncHistory:input_type -> forge.ListDPUServiceSyncHistoryRequest
-	936,  // 1778: forge.Forge.ReleaseDPUServiceSyncHold:input_type -> forge.ReleaseDPUServiceSyncHoldRequest
-	951,  // 1779: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
-	953,  // 1780: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
-	948,  // 1781: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
-	960,  // 1782: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
-	962,  // 1783: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
-	964,  // 1784: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
-	981,  // 1785: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
-	1088, // 1786: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
-	984,  // 1787: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
-	985,  // 1788: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
-	987,  // 1789: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
-	989,  // 1790: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
-	991,  // 1791: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
-	994,  // 1792: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
-	995,  // 1793: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
-	158,  // 1794: forge.Forge.Version:output_type -> forge.BuildInfo
-	1127, // 1795: forge.Forge.CreateDomain:output_type -> dns.Domain
-	1127, // 1796: forge.Forge.UpdateDomain:output_type -> dns.Domain
-	1208, // 1797: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
-	1209, // 1798: forge.Forge.FindDomain:output_type -> dns.DomainList
-	919,  // 1799: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
-	919,  // 1800: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
-	922,  // 1801: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
-	920,  // 1802: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
-	178,  // 1803: forge.Forge.CreateVpc:output_type -> forge.Vpc
-	181,  // 1804: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
-	1024, // 1805: forge.Forge.ChangeVpcRoutingProfile:output_type -> forge.VpcRoutingState
-	1022, // 1806: forge.Forge.ReleaseVpcInactiveVni:output_type -> forge.VpcReleaseInactiveVniResult
-	183,  // 1807: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
-	185,  // 1808: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
-	170,  // 1809: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
-	186,  // 1810: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
-	1024, // 1811: forge.Forge.GetVpcRoutingState:output_type -> forge.VpcRoutingState
-	969,  // 1812: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
-	972,  // 1813: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
-	970,  // 1814: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
-	974,  // 1815: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
-	187,  // 1816: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
-	193,  // 1817: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
-	194,  // 1818: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
-	187,  // 1819: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
-	197,  // 1820: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
-	1007, // 1821: forge.Forge.CreateSitePrefix:output_type -> forge.SitePrefix
-	1007, // 1822: forge.Forge.UpdateSitePrefix:output_type -> forge.SitePrefix
-	1014, // 1823: forge.Forge.DeleteSitePrefix:output_type -> forge.SitePrefixDeletionResult
-	1018, // 1824: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
-	1019, // 1825: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
-	199,  // 1826: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
-	200,  // 1827: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
-	201,  // 1828: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
-	206,  // 1829: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
-	279,  // 1830: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
-	393,  // 1831: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
-	271,  // 1832: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
-	271,  // 1833: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
-	275,  // 1834: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
-	393,  // 1835: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
-	217,  // 1836: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
-	210,  // 1837: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
-	209,  // 1838: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
-	209,  // 1839: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
-	214,  // 1840: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
-	210,  // 1841: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
-	221,  // 1842: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
-	946,  // 1843: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
-	221,  // 1844: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
-	224,  // 1845: forge.Forge.DecommissionPowerShelf:output_type -> forge.DecommissionPowerShelfResponse
-	226,  // 1846: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
-	979,  // 1847: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
-	1141, // 1848: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
-	244,  // 1849: forge.Forge.FindSwitches:output_type -> forge.SwitchList
-	945,  // 1850: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
-	244,  // 1851: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
-	247,  // 1852: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
-	249,  // 1853: forge.Forge.DecommissionSwitch:output_type -> forge.DecommissionSwitchResponse
-	977,  // 1854: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
-	267,  // 1855: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
-	320,  // 1856: forge.Forge.AllocateInstance:output_type -> forge.Instance
-	293,  // 1857: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
-	338,  // 1858: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
-	341,  // 1859: forge.Forge.ReleaseInstances:output_type -> forge.BatchInstanceReleaseResponse
-	320,  // 1860: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
-	320,  // 1861: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
-	289,  // 1862: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
-	285,  // 1863: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
-	285,  // 1864: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
-	414,  // 1865: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
-	1141, // 1866: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
-	494,  // 1867: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
-	1141, // 1868: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
-	1141, // 1869: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1870: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
-	1141, // 1871: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
-	1141, // 1872: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1873: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
-	1141, // 1874: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
-	1141, // 1875: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1876: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
-	1141, // 1877: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
-	1141, // 1878: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1879: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
-	1141, // 1880: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	1141, // 1881: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
-	494,  // 1882: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
-	1141, // 1883: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
-	1141, // 1884: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
-	431,  // 1885: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
-	433,  // 1886: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
-	1210, // 1887: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
-	1211, // 1888: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
-	1212, // 1889: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
-	284,  // 1890: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
-	460,  // 1891: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
-	467,  // 1892: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
-	466,  // 1893: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
-	468,  // 1894: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
-	469,  // 1895: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
-	471,  // 1896: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
-	392,  // 1897: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
-	391,  // 1898: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
-	360,  // 1899: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
-	362,  // 1900: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
-	365,  // 1901: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
-	355,  // 1902: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
-	1141, // 1903: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
-	535,  // 1904: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
-	1128, // 1905: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
-	356,  // 1906: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
-	345,  // 1907: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
-	348,  // 1908: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1909: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
-	348,  // 1910: forge.Forge.FindPowerShelfHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1911: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
-	348,  // 1912: forge.Forge.FindRackHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1913: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
-	348,  // 1914: forge.Forge.FindSwitchHealthHistories:output_type -> forge.HealthHistories
-	254,  // 1915: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
-	254,  // 1916: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
-	254,  // 1917: forge.Forge.FindSitePrefixStateHistories:output_type -> forge.StateHistories
-	354,  // 1918: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
-	353,  // 1919: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
-	561,  // 1920: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
-	565,  // 1921: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
-	564,  // 1922: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
-	562,  // 1923: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
-	537,  // 1924: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
-	540,  // 1925: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
-	542,  // 1926: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
-	456,  // 1927: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
-	458,  // 1928: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
-	473,  // 1929: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
-	477,  // 1930: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
-	161,  // 1931: forge.Forge.Echo:output_type -> forge.EchoResponse
-	504,  // 1932: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
-	508,  // 1933: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
-	506,  // 1934: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
-	514,  // 1935: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
-	521,  // 1936: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
-	515,  // 1937: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
-	517,  // 1938: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
-	519,  // 1939: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
-	524,  // 1940: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
-	398,  // 1941: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
-	398,  // 1942: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
-	429,  // 1943: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
-	1213, // 1944: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
-	1214, // 1945: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
-	1141, // 1946: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
-	650,  // 1947: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
-	651,  // 1948: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
-	1129, // 1949: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
-	1141, // 1950: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
-	1215, // 1951: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
-	406,  // 1952: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
-	1141, // 1953: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
-	1216, // 1954: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
-	1217, // 1955: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
-	1218, // 1956: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
-	1219, // 1957: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
-	1220, // 1958: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
-	1221, // 1959: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
-	1141, // 1960: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
-	437,  // 1961: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
-	436,  // 1962: forge.Forge.DecommissionManagedHost:output_type -> forge.DecommissionManagedHostResponse
-	526,  // 1963: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
-	529,  // 1964: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
-	1141, // 1965: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
-	1141, // 1966: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
-	1141, // 1967: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
-	1141, // 1968: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
-	1141, // 1969: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
-	1141, // 1970: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
-	1141, // 1971: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
-	1141, // 1972: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
-	545,  // 1973: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
-	1141, // 1974: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
-	551,  // 1975: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
-	1141, // 1976: forge.Forge.TriggerBmcCredentialRotation:output_type -> google.protobuf.Empty
-	1141, // 1977: forge.Forge.TriggerUefiCredentialRotation:output_type -> google.protobuf.Empty
-	1141, // 1978: forge.Forge.TriggerNicLockdownCredentialRotation:output_type -> google.protobuf.Empty
-	1141, // 1979: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
-	1141, // 1980: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
-	557,  // 1981: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
-	559,  // 1982: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
-	1141, // 1983: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
-	1141, // 1984: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
-	1003, // 1985: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
-	570,  // 1986: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
-	570,  // 1987: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
-	150,  // 1988: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
-	151,  // 1989: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
-	153,  // 1990: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
-	156,  // 1991: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
-	1005, // 1992: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
-	1141, // 1993: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
-	572,  // 1994: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
-	1141, // 1995: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
-	1141, // 1996: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
-	1141, // 1997: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
-	1141, // 1998: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
-	333,  // 1999: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
-	575,  // 2000: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
-	577,  // 2001: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
-	579,  // 2002: forge.Forge.SetDpuUefiPassword:output_type -> forge.SetDpuUefiPasswordResponse
-	1141, // 2003: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
-	1141, // 2004: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
-	1141, // 2005: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
-	591,  // 2006: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
-	593,  // 2007: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
-	1141, // 2008: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
-	1141, // 2009: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
-	594,  // 2010: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
-	596,  // 2011: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
-	600,  // 2012: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	600,  // 2013: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
-	1141, // 2014: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1141, // 2015: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
-	1141, // 2016: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
-	233,  // 2017: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
-	235,  // 2018: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
-	1141, // 2019: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	1141, // 2020: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
-	236,  // 2021: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
-	1141, // 2022: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
-	1141, // 2023: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
-	1141, // 2024: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
-	258,  // 2025: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
-	260,  // 2026: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
-	1141, // 2027: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
-	1141, // 2028: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
-	261,  // 2029: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
-	1141, // 2030: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
-	1141, // 2031: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
-	1141, // 2032: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
-	263,  // 2033: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
-	265,  // 2034: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
-	1141, // 2035: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
-	1141, // 2036: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
-	147,  // 2037: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
-	681,  // 2038: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
-	683,  // 2039: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
-	685,  // 2040: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
-	688,  // 2041: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
-	687,  // 2042: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
-	691,  // 2043: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
-	693,  // 2044: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
-	1222, // 2045: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
-	1223, // 2046: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
-	1224, // 2047: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
-	1225, // 2048: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
-	1226, // 2049: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1227, // 2050: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
-	1228, // 2051: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
-	1229, // 2052: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
-	1226, // 2053: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
-	1230, // 2054: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
-	1231, // 2055: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
-	1232, // 2056: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
-	1233, // 2057: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
-	1234, // 2058: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
-	1235, // 2059: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
-	1236, // 2060: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
-	1237, // 2061: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
-	1238, // 2062: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
-	1239, // 2063: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
-	1240, // 2064: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
-	1241, // 2065: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
-	1242, // 2066: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
-	1243, // 2067: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
-	1244, // 2068: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
-	1245, // 2069: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
-	1246, // 2070: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
-	1247, // 2071: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
-	1248, // 2072: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
-	1249, // 2073: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
-	1250, // 2074: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
-	1251, // 2075: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
-	1252, // 2076: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
-	1253, // 2077: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
-	1254, // 2078: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
-	1255, // 2079: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
-	1256, // 2080: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
-	1257, // 2081: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
-	1258, // 2082: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
-	1259, // 2083: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
-	1260, // 2084: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
-	1261, // 2085: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
-	1262, // 2086: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
-	1263, // 2087: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
-	712,  // 2088: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
-	714,  // 2089: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
-	716,  // 2090: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
-	717,  // 2091: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
-	720,  // 2092: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
-	723,  // 2093: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
-	730,  // 2094: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
-	581,  // 2095: forge.Forge.CreateOsImage:output_type -> forge.OsImage
-	585,  // 2096: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
-	583,  // 2097: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
-	581,  // 2098: forge.Forge.GetOsImage:output_type -> forge.OsImage
-	581,  // 2099: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
-	296,  // 2100: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
-	588,  // 2101: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
-	601,  // 2102: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
-	1141, // 2103: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
-	608,  // 2104: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
-	605,  // 2105: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
-	613,  // 2106: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
-	616,  // 2107: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
-	618,  // 2108: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
-	1141, // 2109: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	639,  // 2110: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
-	642,  // 2111: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
-	644,  // 2112: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
-	647,  // 2113: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
-	649,  // 2114: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
-	1141, // 2115: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
-	656,  // 2116: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
-	655,  // 2117: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	655,  // 2118: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
-	658,  // 2119: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
-	663,  // 2120: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
-	666,  // 2121: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
-	662,  // 2122: forge.Forge.MachineValidationTestApproveFullHost:output_type -> forge.MachineValidationTestFullHostApprovalResponse
-	668,  // 2123: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
-	450,  // 2124: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
-	634,  // 2125: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
-	636,  // 2126: forge.Forge.AdminGpuReset:output_type -> forge.AdminGpuResetResponse
-	438,  // 2127: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
-	440,  // 2128: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
-	1264, // 2129: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
-	444,  // 2130: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
-	446,  // 2131: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
-	838,  // 2132: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
-	840,  // 2133: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
-	842,  // 2134: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
-	844,  // 2135: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
-	452,  // 2136: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
-	454,  // 2137: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
-	622,  // 2138: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
-	630,  // 2139: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
-	632,  // 2140: forge.Forge.TerminateRackMaintenance:output_type -> forge.RackMaintenanceTerminateResponse
-	138,  // 2141: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
-	144,  // 2142: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
-	141,  // 2143: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
-	1141, // 2144: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
-	695,  // 2145: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
-	697,  // 2146: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
-	702,  // 2147: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
-	704,  // 2148: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
-	705,  // 2149: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
-	706,  // 2150: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
-	708,  // 2151: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
-	732,  // 2152: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
-	853,  // 2153: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
-	1141, // 2154: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
-	748,  // 2155: forge.Forge.CreateSku:output_type -> forge.SkuIdList
-	744,  // 2156: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
-	1141, // 2157: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
-	1141, // 2158: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
-	1141, // 2159: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
-	1141, // 2160: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
-	748,  // 2161: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
-	747,  // 2162: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
-	1141, // 2163: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
-	744,  // 2164: forge.Forge.ReplaceSku:output_type -> forge.Sku
-	418,  // 2165: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
-	420,  // 2166: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
-	422,  // 2167: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
-	1141, // 2168: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
-	1141, // 2169: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
-	754,  // 2170: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
-	756,  // 2171: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
-	752,  // 2172: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
-	752,  // 2173: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
-	759,  // 2174: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
-	764,  // 2175: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
-	764,  // 2176: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
-	1141, // 2177: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
-	137,  // 2178: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
-	782,  // 2179: forge.Forge.FindRackIds:output_type -> forge.RackIdList
-	780,  // 2180: forge.Forge.FindRacksByIds:output_type -> forge.RackList
-	779,  // 2181: forge.Forge.GetRack:output_type -> forge.GetRackResponse
-	1141, // 2182: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
-	791,  // 2183: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
-	798,  // 2184: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
-	800,  // 2185: forge.Forge.ListRackProfiles:output_type -> forge.ListRackProfilesResponse
-	768,  // 2186: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
-	770,  // 2187: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
-	772,  // 2188: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
-	773,  // 2189: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
-	776,  // 2190: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
-	846,  // 2191: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
-	855,  // 2192: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
-	1265, // 2193: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
-	1266, // 2194: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
-	858,  // 2195: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
-	860,  // 2196: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
-	859,  // 2197: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	859,  // 2198: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
-	1141, // 2199: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
-	863,  // 2200: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
-	1141, // 2201: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
-	1141, // 2202: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
-	1141, // 2203: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
-	1141, // 2204: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
-	864,  // 2205: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
-	865,  // 2206: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
-	872,  // 2207: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
-	875,  // 2208: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
-	877,  // 2209: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
-	1141, // 2210: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
-	1141, // 2211: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
-	1141, // 2212: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
-	886,  // 2213: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
-	886,  // 2214: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
-	890,  // 2215: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
-	892,  // 2216: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
-	894,  // 2217: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
-	896,  // 2218: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
-	898,  // 2219: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
-	111,  // 2220: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
-	1141, // 2221: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
-	116,  // 2222: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
-	113,  // 2223: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
-	118,  // 2224: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
-	123,  // 2225: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	123,  // 2226: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
-	1141, // 2227: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
-	126,  // 2228: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	126,  // 2229: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
-	1141, // 2230: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
-	132,  // 2231: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
-	133,  // 2232: forge.Forge.GetJWKS:output_type -> forge.Jwks
-	134,  // 2233: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
-	905,  // 2234: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
-	908,  // 2235: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
-	910,  // 2236: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
-	912,  // 2237: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
-	1267, // 2238: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
-	1268, // 2239: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
-	1269, // 2240: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
-	1270, // 2241: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
-	1271, // 2242: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
-	1272, // 2243: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
-	1273, // 2244: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
-	1274, // 2245: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
-	1275, // 2246: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
-	1276, // 2247: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
-	1277, // 2248: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
-	1278, // 2249: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
-	1279, // 2250: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
-	1280, // 2251: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
-	1281, // 2252: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
-	823,  // 2253: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
-	818,  // 2254: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
-	818,  // 2255: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
-	834,  // 2256: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
-	828,  // 2257: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
-	827,  // 2258: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
-	836,  // 2259: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
-	831,  // 2260: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
-	828,  // 2261: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
-	926,  // 2262: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
-	816,  // 2263: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
-	1141, // 2264: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
-	929,  // 2265: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
-	932,  // 2266: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
-	935,  // 2267: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
-	1128, // 2268: forge.Forge.FindPendingDPUServiceSyncIds:output_type -> common.MachineIdList
-	943,  // 2269: forge.Forge.FindPendingDPUServiceSyncsByIds:output_type -> forge.ListPendingDPUServiceSyncsResponse
-	943,  // 2270: forge.Forge.ListDPUServiceSyncHistory:output_type -> forge.ListPendingDPUServiceSyncsResponse
-	938,  // 2271: forge.Forge.ReleaseDPUServiceSyncHold:output_type -> forge.ReleaseDPUServiceSyncHoldResponse
-	952,  // 2272: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
-	954,  // 2273: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
-	950,  // 2274: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
-	961,  // 2275: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
-	963,  // 2276: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
-	967,  // 2277: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
-	980,  // 2278: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
-	980,  // 2279: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
-	980,  // 2280: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
-	986,  // 2281: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
-	988,  // 2282: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
-	990,  // 2283: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
-	992,  // 2284: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	992,  // 2285: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
-	996,  // 2286: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
-	1794, // [1794:2287] is the sub-list for method output_type
-	1301, // [1301:1794] is the sub-list for method input_type
-	1301, // [1301:1301] is the sub-list for extension type_name
-	1301, // [1301:1301] is the sub-list for extension extendee
-	0,    // [0:1301] is the sub-list for field type_name
+	1071, // 1263: forge.ManagedHostResetRequest.machine_id:type_name -> common.MachineId
+	109,  // 1264: forge.ManagedHostResetRequest.mode:type_name -> forge.ManagedHostResetRequest.Mode
+	49,   // 1265: forge.ManagedHostResetRequest.initiator:type_name -> forge.UpdateInitiator
+	1070, // 1266: forge.ManagedHostResetListResponse.hosts:type_name -> forge.ManagedHostResetListResponse.ManagedHostResetListItem
+	1073, // 1267: forge.VpcReleaseInactiveVniRequest.id:type_name -> common.VpcId
+	179,  // 1268: forge.VpcReleaseInactiveVniResult.vpc:type_name -> forge.Vpc
+	1073, // 1269: forge.VpcRoutingStateRequest.id:type_name -> common.VpcId
+	1073, // 1270: forge.VpcRoutingState.id:type_name -> common.VpcId
+	1029, // 1271: forge.VpcRoutingState.retained_allocation:type_name -> forge.VpcRetainedVniAllocation
+	1073, // 1272: forge.VpcChangeRoutingProfileRequest.id:type_name -> common.VpcId
+	1034, // 1273: forge.DNSMessage.DNSResponse.rrs:type_name -> forge.DNSMessage.DNSResponse.DNSRR
+	252,  // 1274: forge.StateHistories.HistoriesEntry.value:type_name -> forge.StateHistoryRecords
+	347,  // 1275: forge.MachineStateHistories.HistoriesEntry.value:type_name -> forge.MachineStateHistoryRecords
+	350,  // 1276: forge.HealthHistories.HistoriesEntry.value:type_name -> forge.HealthHistoryRecords
+	96,   // 1277: forge.MachineCredentialsUpdateRequest.Credentials.credential_purpose:type_name -> forge.MachineCredentialsUpdateRequest.CredentialPurpose
+	1058, // 1278: forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.pair:type_name -> forge.ForgeAgentControlResponse.ForgeAgentControlExtraInfo.KeyValuePair
+	1101, // 1279: forge.ForgeAgentControlResponse.MachineValidation.validation_id:type_name -> common.MachineValidationId
+	1049, // 1280: forge.ForgeAgentControlResponse.MachineValidation.filter:type_name -> forge.ForgeAgentControlResponse.MachineValidationFilter
+	1098, // 1281: forge.ForgeAgentControlResponse.MachineValidationFilter.contexts:type_name -> common.StringList
+	1051, // 1282: forge.ForgeAgentControlResponse.MlxAction.device_actions:type_name -> forge.ForgeAgentControlResponse.MlxDeviceAction
+	1052, // 1283: forge.ForgeAgentControlResponse.MlxDeviceAction.noop:type_name -> forge.ForgeAgentControlResponse.MlxDeviceNoop
+	1053, // 1284: forge.ForgeAgentControlResponse.MlxDeviceAction.lock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceLock
+	1054, // 1285: forge.ForgeAgentControlResponse.MlxDeviceAction.unlock:type_name -> forge.ForgeAgentControlResponse.MlxDeviceUnlock
+	1055, // 1286: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_profile:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyProfile
+	1056, // 1287: forge.ForgeAgentControlResponse.MlxDeviceAction.apply_firmware:type_name -> forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware
+	1136, // 1288: forge.ForgeAgentControlResponse.MlxDeviceApplyProfile.serialized_profile:type_name -> mlx_device.SerializableMlxConfigProfile
+	1137, // 1289: forge.ForgeAgentControlResponse.MlxDeviceApplyFirmware.profile:type_name -> mlx_device.FirmwareFlasherProfile
+	1138, // 1290: forge.ForgeAgentControlResponse.FirmwareUpgrade.task:type_name -> scout_firmware_upgrade.ScoutFirmwareUpgradeTask
+	98,   // 1291: forge.MachineCleanupInfo.CleanupStepResult.result:type_name -> forge.MachineCleanupInfo.CleanupResult
+	1071, // 1292: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.id:type_name -> common.MachineId
+	1072, // 1293: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1072, // 1294: forge.DpuReprovisioningListResponse.DpuReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	1071, // 1295: forge.HostReprovisioningListResponse.HostReprovisioningListItem.id:type_name -> common.MachineId
+	1072, // 1296: forge.HostReprovisioningListResponse.HostReprovisioningListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1072, // 1297: forge.HostReprovisioningListResponse.HostReprovisioningListItem.initiated_at:type_name -> google.protobuf.Timestamp
+	661,  // 1298: forge.MachineValidationTestUpdateRequest.Payload.plugin:type_name -> forge.MachineValidationPlugin
+	1071, // 1299: forge.DPFStateResponse.DPFState.machine_id:type_name -> common.MachineId
+	999,  // 1300: forge.GetMachineBootInterfacesResponse.Reconciliation.desired_boot_interface:type_name -> forge.MachineBootInterface
+	1072, // 1301: forge.GetMachineBootInterfacesResponse.Reconciliation.observed_at:type_name -> google.protobuf.Timestamp
+	108,  // 1302: forge.GetMachineBootInterfacesResponse.Reconciliation.reconciliation_state:type_name -> forge.GetMachineBootInterfacesResponse.Reconciliation.State
+	88,   // 1303: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_source:type_name -> forge.BootInterfaceSelectionSource
+	1072, // 1304: forge.GetMachineBootInterfacesResponse.Reconciliation.selection_updated_at:type_name -> google.protobuf.Timestamp
+	1071, // 1305: forge.ManagedHostResetListResponse.ManagedHostResetListItem.id:type_name -> common.MachineId
+	1072, // 1306: forge.ManagedHostResetListResponse.ManagedHostResetListItem.requested_at:type_name -> google.protobuf.Timestamp
+	1072, // 1307: forge.ManagedHostResetListResponse.ManagedHostResetListItem.started_at:type_name -> google.protobuf.Timestamp
+	158,  // 1308: forge.Forge.Version:input_type -> forge.VersionRequest
+	1139, // 1309: forge.Forge.CreateDomain:input_type -> dns.CreateDomainRequest
+	1140, // 1310: forge.Forge.UpdateDomain:input_type -> dns.UpdateDomainRequest
+	1141, // 1311: forge.Forge.DeleteDomain:input_type -> dns.DomainDeletionRequest
+	1142, // 1312: forge.Forge.FindDomain:input_type -> dns.DomainSearchQuery
+	920,  // 1313: forge.Forge.CreateDomainLegacy:input_type -> forge.DomainLegacy
+	920,  // 1314: forge.Forge.UpdateDomainLegacy:input_type -> forge.DomainLegacy
+	922,  // 1315: forge.Forge.DeleteDomainLegacy:input_type -> forge.DomainDeletionLegacy
+	924,  // 1316: forge.Forge.FindDomainLegacy:input_type -> forge.DomainSearchQueryLegacy
+	180,  // 1317: forge.Forge.CreateVpc:input_type -> forge.VpcCreationRequest
+	181,  // 1318: forge.Forge.UpdateVpc:input_type -> forge.VpcUpdateRequest
+	1030, // 1319: forge.Forge.ChangeVpcRoutingProfile:input_type -> forge.VpcChangeRoutingProfileRequest
+	1025, // 1320: forge.Forge.ReleaseVpcInactiveVni:input_type -> forge.VpcReleaseInactiveVniRequest
+	183,  // 1321: forge.Forge.UpdateVpcVirtualization:input_type -> forge.VpcUpdateVirtualizationRequest
+	185,  // 1322: forge.Forge.DeleteVpc:input_type -> forge.VpcDeletionRequest
+	170,  // 1323: forge.Forge.FindVpcIds:input_type -> forge.VpcSearchFilter
+	172,  // 1324: forge.Forge.FindVpcsByIds:input_type -> forge.VpcsByIdsRequest
+	1027, // 1325: forge.Forge.GetVpcRoutingState:input_type -> forge.VpcRoutingStateRequest
+	969,  // 1326: forge.Forge.CreateSpxPartition:input_type -> forge.SpxPartitionCreationRequest
+	972,  // 1327: forge.Forge.DeleteSpxPartition:input_type -> forge.SpxPartitionDeletionRequest
+	974,  // 1328: forge.Forge.FindSpxPartitionIds:input_type -> forge.SpxPartitionSearchFilter
+	976,  // 1329: forge.Forge.FindSpxPartitionsByIds:input_type -> forge.SpxPartitionsByIdsRequest
+	191,  // 1330: forge.Forge.CreateVpcPrefix:input_type -> forge.VpcPrefixCreationRequest
+	192,  // 1331: forge.Forge.SearchVpcPrefixes:input_type -> forge.VpcPrefixSearchQuery
+	193,  // 1332: forge.Forge.GetVpcPrefixes:input_type -> forge.VpcPrefixGetRequest
+	196,  // 1333: forge.Forge.UpdateVpcPrefix:input_type -> forge.VpcPrefixUpdateRequest
+	197,  // 1334: forge.Forge.DeleteVpcPrefix:input_type -> forge.VpcPrefixDeletionRequest
+	1012, // 1335: forge.Forge.CreateSitePrefix:input_type -> forge.SitePrefixCreationRequest
+	1013, // 1336: forge.Forge.UpdateSitePrefix:input_type -> forge.SitePrefixUpdateRequest
+	1014, // 1337: forge.Forge.DeleteSitePrefix:input_type -> forge.SitePrefixDeletionRequest
+	1017, // 1338: forge.Forge.FindSitePrefixIds:input_type -> forge.SitePrefixSearchFilter
+	1018, // 1339: forge.Forge.FindSitePrefixesByIds:input_type -> forge.SitePrefixesByIdsRequest
+	203,  // 1340: forge.Forge.CreateVpcPeering:input_type -> forge.VpcPeeringCreationRequest
+	204,  // 1341: forge.Forge.FindVpcPeeringIds:input_type -> forge.VpcPeeringSearchFilter
+	205,  // 1342: forge.Forge.FindVpcPeeringsByIds:input_type -> forge.VpcPeeringsByIdsRequest
+	206,  // 1343: forge.Forge.DeleteVpcPeering:input_type -> forge.VpcPeeringDeletionRequest
+	279,  // 1344: forge.Forge.FindNetworkSegmentIds:input_type -> forge.NetworkSegmentSearchFilter
+	281,  // 1345: forge.Forge.FindNetworkSegmentsByIds:input_type -> forge.NetworkSegmentsByIdsRequest
+	273,  // 1346: forge.Forge.CreateNetworkSegment:input_type -> forge.NetworkSegmentCreationRequest
+	275,  // 1347: forge.Forge.AttachNetworkSegmentToVpc:input_type -> forge.AttachNetworkSegmentToVpcRequest
+	274,  // 1348: forge.Forge.DeleteNetworkSegment:input_type -> forge.NetworkSegmentDeletionRequest
+	169,  // 1349: forge.Forge.NetworkSegmentsForVpc:input_type -> forge.VpcSearchQuery
+	216,  // 1350: forge.Forge.FindIBPartitionIds:input_type -> forge.IBPartitionSearchFilter
+	217,  // 1351: forge.Forge.FindIBPartitionsByIds:input_type -> forge.IBPartitionsByIdsRequest
+	212,  // 1352: forge.Forge.CreateIBPartition:input_type -> forge.IBPartitionCreationRequest
+	213,  // 1353: forge.Forge.UpdateIBPartition:input_type -> forge.IBPartitionUpdateRequest
+	214,  // 1354: forge.Forge.DeleteIBPartition:input_type -> forge.IBPartitionDeletionRequest
+	173,  // 1355: forge.Forge.IBPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	231,  // 1356: forge.Forge.FindPowerShelves:input_type -> forge.PowerShelfQuery
+	232,  // 1357: forge.Forge.FindPowerShelfIds:input_type -> forge.PowerShelfSearchFilter
+	233,  // 1358: forge.Forge.FindPowerShelvesByIds:input_type -> forge.PowerShelvesByIdsRequest
+	224,  // 1359: forge.Forge.DecommissionPowerShelf:input_type -> forge.DecommissionPowerShelfRequest
+	226,  // 1360: forge.Forge.DeletePowerShelf:input_type -> forge.PowerShelfDeletionRequest
+	979,  // 1361: forge.Forge.AdminForceDeletePowerShelf:input_type -> forge.AdminForceDeletePowerShelfRequest
+	228,  // 1362: forge.Forge.SetPowerShelfMaintenance:input_type -> forge.PowerShelfMaintenanceRequest
+	256,  // 1363: forge.Forge.FindSwitches:input_type -> forge.SwitchQuery
+	257,  // 1364: forge.Forge.FindSwitchIds:input_type -> forge.SwitchSearchFilter
+	258,  // 1365: forge.Forge.FindSwitchesByIds:input_type -> forge.SwitchesByIdsRequest
+	247,  // 1366: forge.Forge.DeleteSwitch:input_type -> forge.SwitchDeletionRequest
+	249,  // 1367: forge.Forge.DecommissionSwitch:input_type -> forge.DecommissionSwitchRequest
+	977,  // 1368: forge.Forge.AdminForceDeleteSwitch:input_type -> forge.AdminForceDeleteSwitchRequest
+	267,  // 1369: forge.Forge.FindIBFabricIds:input_type -> forge.IBFabricSearchFilter
+	292,  // 1370: forge.Forge.AllocateInstance:input_type -> forge.InstanceAllocationRequest
+	293,  // 1371: forge.Forge.AllocateInstances:input_type -> forge.BatchInstanceAllocationRequest
+	338,  // 1372: forge.Forge.ReleaseInstance:input_type -> forge.InstanceReleaseRequest
+	340,  // 1373: forge.Forge.ReleaseInstances:input_type -> forge.BatchInstanceReleaseRequest
+	310,  // 1374: forge.Forge.UpdateInstanceOperatingSystem:input_type -> forge.InstanceOperatingSystemUpdateRequest
+	311,  // 1375: forge.Forge.UpdateInstanceConfig:input_type -> forge.InstanceConfigUpdateRequest
+	289,  // 1376: forge.Forge.FindInstanceIds:input_type -> forge.InstanceSearchFilter
+	291,  // 1377: forge.Forge.FindInstancesByIds:input_type -> forge.InstancesByIdsRequest
+	1071, // 1378: forge.Forge.FindInstanceByMachineID:input_type -> common.MachineId
+	414,  // 1379: forge.Forge.GetManagedHostNetworkConfig:input_type -> forge.ManagedHostNetworkConfigRequest
+	479,  // 1380: forge.Forge.RecordDpuNetworkStatus:input_type -> forge.DpuNetworkStatus
+	1071, // 1381: forge.Forge.ListMachineHealthReports:input_type -> common.MachineId
+	485,  // 1382: forge.Forge.InsertMachineHealthReport:input_type -> forge.InsertMachineHealthReportRequest
+	496,  // 1383: forge.Forge.RemoveMachineHealthReport:input_type -> forge.RemoveMachineHealthReportRequest
+	488,  // 1384: forge.Forge.ListRackHealthReports:input_type -> forge.ListRackHealthReportsRequest
+	486,  // 1385: forge.Forge.InsertRackHealthReport:input_type -> forge.InsertRackHealthReportRequest
+	487,  // 1386: forge.Forge.RemoveRackHealthReport:input_type -> forge.RemoveRackHealthReportRequest
+	491,  // 1387: forge.Forge.ListSwitchHealthReports:input_type -> forge.ListSwitchHealthReportsRequest
+	489,  // 1388: forge.Forge.InsertSwitchHealthReport:input_type -> forge.InsertSwitchHealthReportRequest
+	490,  // 1389: forge.Forge.RemoveSwitchHealthReport:input_type -> forge.RemoveSwitchHealthReportRequest
+	494,  // 1390: forge.Forge.ListPowerShelfHealthReports:input_type -> forge.ListPowerShelfHealthReportsRequest
+	492,  // 1391: forge.Forge.InsertPowerShelfHealthReport:input_type -> forge.InsertPowerShelfHealthReportRequest
+	493,  // 1392: forge.Forge.RemovePowerShelfHealthReport:input_type -> forge.RemovePowerShelfHealthReportRequest
+	497,  // 1393: forge.Forge.ListNVLinkDomainHealthReports:input_type -> forge.ListNVLinkDomainHealthReportsRequest
+	498,  // 1394: forge.Forge.InsertNVLinkDomainHealthReport:input_type -> forge.InsertNVLinkDomainHealthReportRequest
+	499,  // 1395: forge.Forge.RemoveNVLinkDomainHealthReport:input_type -> forge.RemoveNVLinkDomainHealthReportRequest
+	1071, // 1396: forge.Forge.ListHealthReportOverrides:input_type -> common.MachineId
+	485,  // 1397: forge.Forge.InsertHealthReportOverride:input_type -> forge.InsertMachineHealthReportRequest
+	496,  // 1398: forge.Forge.RemoveHealthReportOverride:input_type -> forge.RemoveMachineHealthReportRequest
+	431,  // 1399: forge.Forge.DpuAgentUpgradeCheck:input_type -> forge.DpuAgentUpgradeCheckRequest
+	433,  // 1400: forge.Forge.DpuAgentUpgradePolicyAction:input_type -> forge.DpuAgentUpgradePolicyRequest
+	1143, // 1401: forge.Forge.LookupRecord:input_type -> dns.DnsResourceRecordLookupRequest
+	1144, // 1402: forge.Forge.GetAllDomains:input_type -> dns.GetAllDomainsRequest
+	1145, // 1403: forge.Forge.GetAllDomainMetadata:input_type -> dns.DomainMetadataRequest
+	284,  // 1404: forge.Forge.InvokeInstancePower:input_type -> forge.InstancePowerRequest
+	460,  // 1405: forge.Forge.ForgeAgentControl:input_type -> forge.ForgeAgentControlRequest
+	462,  // 1406: forge.Forge.DiscoverMachine:input_type -> forge.MachineDiscoveryInfo
+	466,  // 1407: forge.Forge.RenewMachineCertificate:input_type -> forge.MachineCertificateRenewRequest
+	463,  // 1408: forge.Forge.DiscoveryCompleted:input_type -> forge.MachineDiscoveryCompletedRequest
+	464,  // 1409: forge.Forge.CleanupMachineCompleted:input_type -> forge.MachineCleanupInfo
+	471,  // 1410: forge.Forge.ReportForgeScoutError:input_type -> forge.ForgeScoutErrorReport
+	390,  // 1411: forge.Forge.DiscoverDhcp:input_type -> forge.DhcpDiscovery
+	391,  // 1412: forge.Forge.ExpireDhcpLease:input_type -> forge.ExpireDhcpLeaseRequest
+	360,  // 1413: forge.Forge.AssignStaticAddress:input_type -> forge.AssignStaticAddressRequest
+	362,  // 1414: forge.Forge.RemoveStaticAddress:input_type -> forge.RemoveStaticAddressRequest
+	364,  // 1415: forge.Forge.FindInterfaceAddresses:input_type -> forge.FindInterfaceAddressesRequest
+	359,  // 1416: forge.Forge.FindInterfaces:input_type -> forge.InterfaceSearchQuery
+	358,  // 1417: forge.Forge.DeleteInterface:input_type -> forge.InterfaceDeleteQuery
+	535,  // 1418: forge.Forge.FindIpAddress:input_type -> forge.FindIpAddressRequest
+	344,  // 1419: forge.Forge.FindMachineIds:input_type -> forge.MachineSearchConfig
+	343,  // 1420: forge.Forge.FindMachinesByIds:input_type -> forge.MachinesByIdsRequest
+	345,  // 1421: forge.Forge.FindMachineStateHistories:input_type -> forge.MachineStateHistoriesRequest
+	348,  // 1422: forge.Forge.FindMachineHealthHistories:input_type -> forge.MachineHealthHistoriesRequest
+	229,  // 1423: forge.Forge.FindPowerShelfStateHistories:input_type -> forge.PowerShelfStateHistoriesRequest
+	230,  // 1424: forge.Forge.FindPowerShelfHealthHistories:input_type -> forge.PowerShelfHealthHistoriesRequest
+	788,  // 1425: forge.Forge.FindRackStateHistories:input_type -> forge.RackStateHistoriesRequest
+	789,  // 1426: forge.Forge.FindRackHealthHistories:input_type -> forge.RackHealthHistoriesRequest
+	253,  // 1427: forge.Forge.FindSwitchStateHistories:input_type -> forge.SwitchStateHistoriesRequest
+	254,  // 1428: forge.Forge.FindSwitchHealthHistories:input_type -> forge.SwitchHealthHistoriesRequest
+	277,  // 1429: forge.Forge.FindNetworkSegmentStateHistories:input_type -> forge.NetworkSegmentStateHistoriesRequest
+	199,  // 1430: forge.Forge.FindVpcPrefixStateHistories:input_type -> forge.VpcPrefixStateHistoriesRequest
+	1016, // 1431: forge.Forge.FindSitePrefixStateHistories:input_type -> forge.SitePrefixStateHistoriesRequest
+	353,  // 1432: forge.Forge.FindTenantOrganizationIds:input_type -> forge.TenantSearchFilter
+	352,  // 1433: forge.Forge.FindTenantsByOrganizationIds:input_type -> forge.TenantByOrganizationIdsRequest
+	1133, // 1434: forge.Forge.FindConnectedDevicesByDpuMachineIds:input_type -> common.MachineIdList
+	563,  // 1435: forge.Forge.FindMachineIdsByBmcIps:input_type -> forge.BmcIpList
+	564,  // 1436: forge.Forge.FindMacAddressByBmcIp:input_type -> forge.BmcIp
+	539,  // 1437: forge.Forge.FindBmcIps:input_type -> forge.FindBmcIpsRequest
+	537,  // 1438: forge.Forge.IdentifyUuid:input_type -> forge.IdentifyUuidRequest
+	540,  // 1439: forge.Forge.IdentifyMac:input_type -> forge.IdentifyMacRequest
+	542,  // 1440: forge.Forge.IdentifySerial:input_type -> forge.IdentifySerialRequest
+	456,  // 1441: forge.Forge.GetBMCMetaData:input_type -> forge.BMCMetaDataGetRequest
+	458,  // 1442: forge.Forge.UpdateMachineCredentials:input_type -> forge.MachineCredentialsUpdateRequest
+	473,  // 1443: forge.Forge.GetPxeInstructions:input_type -> forge.PxeInstructionRequest
+	477,  // 1444: forge.Forge.GetCloudInitInstructions:input_type -> forge.CloudInitInstructionsRequest
+	161,  // 1445: forge.Forge.Echo:input_type -> forge.EchoRequest
+	504,  // 1446: forge.Forge.CreateTenant:input_type -> forge.CreateTenantRequest
+	508,  // 1447: forge.Forge.FindTenant:input_type -> forge.FindTenantRequest
+	506,  // 1448: forge.Forge.UpdateTenant:input_type -> forge.UpdateTenantRequest
+	514,  // 1449: forge.Forge.CreateTenantKeyset:input_type -> forge.CreateTenantKeysetRequest
+	521,  // 1450: forge.Forge.FindTenantKeysetIds:input_type -> forge.TenantKeysetSearchFilter
+	523,  // 1451: forge.Forge.FindTenantKeysetsByIds:input_type -> forge.TenantKeysetsByIdsRequest
+	517,  // 1452: forge.Forge.UpdateTenantKeyset:input_type -> forge.UpdateTenantKeysetRequest
+	519,  // 1453: forge.Forge.DeleteTenantKeyset:input_type -> forge.DeleteTenantKeysetRequest
+	524,  // 1454: forge.Forge.ValidateTenantPublicKey:input_type -> forge.ValidateTenantPublicKeyRequest
+	397,  // 1455: forge.Forge.GetBmcCredentials:input_type -> forge.GetBmcCredentialsRequest
+	398,  // 1456: forge.Forge.GetSwitchNvosCredentials:input_type -> forge.GetSwitchNvosCredentialsRequest
+	429,  // 1457: forge.Forge.GetAllManagedHostNetworkStatus:input_type -> forge.ManagedHostNetworkStatusRequest
+	401,  // 1458: forge.Forge.GetSiteExplorationReport:input_type -> forge.GetSiteExplorationRequest
+	1146, // 1459: forge.Forge.GetSiteExplorerLastRun:input_type -> google.protobuf.Empty
+	402,  // 1460: forge.Forge.ClearSiteExplorationError:input_type -> forge.ClearSiteExplorationErrorRequest
+	408,  // 1461: forge.Forge.IsBmcInManagedHost:input_type -> forge.BmcEndpointRequest
+	408,  // 1462: forge.Forge.BmcCredentialStatus:input_type -> forge.BmcEndpointRequest
+	408,  // 1463: forge.Forge.Explore:input_type -> forge.BmcEndpointRequest
+	403,  // 1464: forge.Forge.ReExploreEndpoint:input_type -> forge.ReExploreEndpointRequest
+	404,  // 1465: forge.Forge.RefreshEndpointReport:input_type -> forge.RefreshEndpointReportRequest
+	405,  // 1466: forge.Forge.DeleteExploredEndpoint:input_type -> forge.DeleteExploredEndpointRequest
+	406,  // 1467: forge.Forge.PauseExploredEndpointRemediation:input_type -> forge.PauseExploredEndpointRemediationRequest
+	1147, // 1468: forge.Forge.FindExploredEndpointIds:input_type -> site_explorer.ExploredEndpointSearchFilter
+	1148, // 1469: forge.Forge.FindExploredEndpointsByIds:input_type -> site_explorer.ExploredEndpointsByIdsRequest
+	1149, // 1470: forge.Forge.FindExploredManagedHostIds:input_type -> site_explorer.ExploredManagedHostSearchFilter
+	1150, // 1471: forge.Forge.FindExploredManagedHostsByIds:input_type -> site_explorer.ExploredManagedHostsByIdsRequest
+	1151, // 1472: forge.Forge.FindExploredMlxDeviceHostIds:input_type -> site_explorer.ExploredMlxDeviceHostSearchFilter
+	1152, // 1473: forge.Forge.FindExploredMlxDevicesByIds:input_type -> site_explorer.ExploredMlxDevicesByIdsRequest
+	412,  // 1474: forge.Forge.UpdateMachineHardwareInfo:input_type -> forge.UpdateMachineHardwareInfoRequest
+	435,  // 1475: forge.Forge.AdminForceDeleteMachine:input_type -> forge.AdminForceDeleteMachineRequest
+	436,  // 1476: forge.Forge.DecommissionManagedHost:input_type -> forge.DecommissionManagedHostRequest
+	526,  // 1477: forge.Forge.AdminListResourcePools:input_type -> forge.ListResourcePoolsRequest
+	529,  // 1478: forge.Forge.AdminGrowResourcePool:input_type -> forge.GrowResourcePoolRequest
+	374,  // 1479: forge.Forge.UpdateMachineMetadata:input_type -> forge.MachineMetadataUpdateRequest
+	375,  // 1480: forge.Forge.UpdateRackMetadata:input_type -> forge.RackMetadataUpdateRequest
+	376,  // 1481: forge.Forge.UpdateSwitchMetadata:input_type -> forge.SwitchMetadataUpdateRequest
+	377,  // 1482: forge.Forge.UpdatePowerShelfMetadata:input_type -> forge.PowerShelfMetadataUpdateRequest
+	805,  // 1483: forge.Forge.UpdateMachineNvLinkInfo:input_type -> forge.UpdateMachineNvLinkInfoRequest
+	533,  // 1484: forge.Forge.SetMaintenance:input_type -> forge.MaintenanceRequest
+	534,  // 1485: forge.Forge.SetDynamicConfig:input_type -> forge.SetDynamicConfigRequest
+	544,  // 1486: forge.Forge.TriggerDpuReprovisioning:input_type -> forge.DpuReprovisioningRequest
+	545,  // 1487: forge.Forge.ListDpuWaitingForReprovisioning:input_type -> forge.DpuReprovisioningListRequest
+	547,  // 1488: forge.Forge.TriggerHostReprovisioning:input_type -> forge.HostReprovisioningRequest
+	551,  // 1489: forge.Forge.ListHostsWaitingForReprovisioning:input_type -> forge.HostReprovisioningListRequest
+	1022, // 1490: forge.Forge.TriggerManagedHostReset:input_type -> forge.ManagedHostResetRequest
+	1023, // 1491: forge.Forge.ListManagedHostsWaitingForReset:input_type -> forge.ManagedHostResetListRequest
+	548,  // 1492: forge.Forge.TriggerBmcCredentialRotation:input_type -> forge.BmcCredentialRotationRequest
+	549,  // 1493: forge.Forge.TriggerUefiCredentialRotation:input_type -> forge.UefiCredentialRotationRequest
+	550,  // 1494: forge.Forge.TriggerNicLockdownCredentialRotation:input_type -> forge.NicLockdownCredentialRotationRequest
+	1071, // 1495: forge.Forge.MarkManualFirmwareUpgradeComplete:input_type -> common.MachineId
+	604,  // 1496: forge.Forge.ReportScoutFirmwareUpgradeStatus:input_type -> forge.ScoutFirmwareUpgradeStatusRequest
+	557,  // 1497: forge.Forge.GetDpuInfoList:input_type -> forge.GetDpuInfoListRequest
+	1095, // 1498: forge.Forge.GetMachineBootOverride:input_type -> common.MachineInterfaceId
+	560,  // 1499: forge.Forge.SetMachineBootOverride:input_type -> forge.MachineBootOverride
+	1095, // 1500: forge.Forge.ClearMachineBootOverride:input_type -> common.MachineInterfaceId
+	998,  // 1501: forge.Forge.GetMachineBootInterfaces:input_type -> forge.GetMachineBootInterfacesRequest
+	569,  // 1502: forge.Forge.GetNetworkTopology:input_type -> forge.NetworkTopologyRequest
+	570,  // 1503: forge.Forge.FindNetworkDevicesByDeviceIds:input_type -> forge.NetworkDeviceIdList
+	149,  // 1504: forge.Forge.CreateCredential:input_type -> forge.CredentialCreationRequest
+	150,  // 1505: forge.Forge.DeleteCredential:input_type -> forge.CredentialDeletionRequest
+	153,  // 1506: forge.Forge.RotateCredential:input_type -> forge.RotateCredentialRequest
+	155,  // 1507: forge.Forge.GetCredentialRotationStatus:input_type -> forge.CredentialRotationStatusRequest
+	1005, // 1508: forge.Forge.GetContainerRegistryCredential:input_type -> forge.GetContainerRegistryCredentialRequest
+	1007, // 1509: forge.Forge.SetContainerRegistryCredential:input_type -> forge.SetContainerRegistryCredentialRequest
+	1146, // 1510: forge.Forge.GetRouteServers:input_type -> google.protobuf.Empty
+	572,  // 1511: forge.Forge.AddRouteServers:input_type -> forge.RouteServers
+	572,  // 1512: forge.Forge.RemoveRouteServers:input_type -> forge.RouteServers
+	572,  // 1513: forge.Forge.ReplaceRouteServers:input_type -> forge.RouteServers
+	378,  // 1514: forge.Forge.UpdateAgentReportedInventory:input_type -> forge.DpuAgentInventoryReport
+	333,  // 1515: forge.Forge.UpdateInstancePhoneHomeLastContact:input_type -> forge.InstancePhoneHomeLastContactRequest
+	575,  // 1516: forge.Forge.SetHostUefiPassword:input_type -> forge.SetHostUefiPasswordRequest
+	577,  // 1517: forge.Forge.ClearHostUefiPassword:input_type -> forge.ClearHostUefiPasswordRequest
+	579,  // 1518: forge.Forge.SetDpuUefiPassword:input_type -> forge.SetDpuUefiPasswordRequest
+	592,  // 1519: forge.Forge.AddExpectedMachine:input_type -> forge.ExpectedMachine
+	593,  // 1520: forge.Forge.DeleteExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	592,  // 1521: forge.Forge.UpdateExpectedMachine:input_type -> forge.ExpectedMachine
+	593,  // 1522: forge.Forge.GetExpectedMachine:input_type -> forge.ExpectedMachineRequest
+	1146, // 1523: forge.Forge.GetAllExpectedMachines:input_type -> google.protobuf.Empty
+	594,  // 1524: forge.Forge.ReplaceAllExpectedMachines:input_type -> forge.ExpectedMachineList
+	1146, // 1525: forge.Forge.DeleteAllExpectedMachines:input_type -> google.protobuf.Empty
+	1146, // 1526: forge.Forge.GetAllExpectedMachinesLinked:input_type -> google.protobuf.Empty
+	1146, // 1527: forge.Forge.GetAllUnexpectedMachines:input_type -> google.protobuf.Empty
+	599,  // 1528: forge.Forge.CreateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	599,  // 1529: forge.Forge.UpdateExpectedMachines:input_type -> forge.BatchExpectedMachineOperationRequest
+	234,  // 1530: forge.Forge.AddExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	235,  // 1531: forge.Forge.DeleteExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	234,  // 1532: forge.Forge.UpdateExpectedPowerShelf:input_type -> forge.ExpectedPowerShelf
+	235,  // 1533: forge.Forge.GetExpectedPowerShelf:input_type -> forge.ExpectedPowerShelfRequest
+	1146, // 1534: forge.Forge.GetAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	236,  // 1535: forge.Forge.ReplaceAllExpectedPowerShelves:input_type -> forge.ExpectedPowerShelfList
+	1146, // 1536: forge.Forge.DeleteAllExpectedPowerShelves:input_type -> google.protobuf.Empty
+	1146, // 1537: forge.Forge.GetAllExpectedPowerShelvesLinked:input_type -> google.protobuf.Empty
+	259,  // 1538: forge.Forge.AddExpectedSwitch:input_type -> forge.ExpectedSwitch
+	260,  // 1539: forge.Forge.DeleteExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	259,  // 1540: forge.Forge.UpdateExpectedSwitch:input_type -> forge.ExpectedSwitch
+	260,  // 1541: forge.Forge.GetExpectedSwitch:input_type -> forge.ExpectedSwitchRequest
+	1146, // 1542: forge.Forge.GetAllExpectedSwitches:input_type -> google.protobuf.Empty
+	261,  // 1543: forge.Forge.ReplaceAllExpectedSwitches:input_type -> forge.ExpectedSwitchList
+	1146, // 1544: forge.Forge.DeleteAllExpectedSwitches:input_type -> google.protobuf.Empty
+	1146, // 1545: forge.Forge.GetAllExpectedSwitchesLinked:input_type -> google.protobuf.Empty
+	264,  // 1546: forge.Forge.AddExpectedRack:input_type -> forge.ExpectedRack
+	265,  // 1547: forge.Forge.DeleteExpectedRack:input_type -> forge.ExpectedRackRequest
+	264,  // 1548: forge.Forge.UpdateExpectedRack:input_type -> forge.ExpectedRack
+	265,  // 1549: forge.Forge.GetExpectedRack:input_type -> forge.ExpectedRackRequest
+	1146, // 1550: forge.Forge.GetAllExpectedRacks:input_type -> google.protobuf.Empty
+	266,  // 1551: forge.Forge.ReplaceAllExpectedRacks:input_type -> forge.ExpectedRackList
+	1146, // 1552: forge.Forge.DeleteAllExpectedRacks:input_type -> google.protobuf.Empty
+	147,  // 1553: forge.Forge.AttestQuote:input_type -> forge.AttestQuoteRequest
+	681,  // 1554: forge.Forge.CreateInstanceType:input_type -> forge.CreateInstanceTypeRequest
+	683,  // 1555: forge.Forge.FindInstanceTypeIds:input_type -> forge.FindInstanceTypeIdsRequest
+	685,  // 1556: forge.Forge.FindInstanceTypesByIds:input_type -> forge.FindInstanceTypesByIdsRequest
+	690,  // 1557: forge.Forge.UpdateInstanceType:input_type -> forge.UpdateInstanceTypeRequest
+	687,  // 1558: forge.Forge.DeleteInstanceType:input_type -> forge.DeleteInstanceTypeRequest
+	691,  // 1559: forge.Forge.AssociateMachinesWithInstanceType:input_type -> forge.AssociateMachinesWithInstanceTypeRequest
+	693,  // 1560: forge.Forge.RemoveMachineInstanceTypeAssociation:input_type -> forge.RemoveMachineInstanceTypeAssociationRequest
+	1153, // 1561: forge.Forge.CreateMeasurementBundle:input_type -> measured_boot.CreateMeasurementBundleRequest
+	1154, // 1562: forge.Forge.DeleteMeasurementBundle:input_type -> measured_boot.DeleteMeasurementBundleRequest
+	1155, // 1563: forge.Forge.RenameMeasurementBundle:input_type -> measured_boot.RenameMeasurementBundleRequest
+	1156, // 1564: forge.Forge.UpdateMeasurementBundle:input_type -> measured_boot.UpdateMeasurementBundleRequest
+	1157, // 1565: forge.Forge.ShowMeasurementBundle:input_type -> measured_boot.ShowMeasurementBundleRequest
+	1158, // 1566: forge.Forge.ShowMeasurementBundles:input_type -> measured_boot.ShowMeasurementBundlesRequest
+	1159, // 1567: forge.Forge.ListMeasurementBundles:input_type -> measured_boot.ListMeasurementBundlesRequest
+	1160, // 1568: forge.Forge.ListMeasurementBundleMachines:input_type -> measured_boot.ListMeasurementBundleMachinesRequest
+	1161, // 1569: forge.Forge.FindClosestBundleMatch:input_type -> measured_boot.FindClosestBundleMatchRequest
+	1162, // 1570: forge.Forge.DeleteMeasurementJournal:input_type -> measured_boot.DeleteMeasurementJournalRequest
+	1163, // 1571: forge.Forge.ShowMeasurementJournal:input_type -> measured_boot.ShowMeasurementJournalRequest
+	1164, // 1572: forge.Forge.ShowMeasurementJournals:input_type -> measured_boot.ShowMeasurementJournalsRequest
+	1165, // 1573: forge.Forge.ListMeasurementJournal:input_type -> measured_boot.ListMeasurementJournalRequest
+	1166, // 1574: forge.Forge.AttestCandidateMachine:input_type -> measured_boot.AttestCandidateMachineRequest
+	1167, // 1575: forge.Forge.ShowCandidateMachine:input_type -> measured_boot.ShowCandidateMachineRequest
+	1168, // 1576: forge.Forge.ShowCandidateMachines:input_type -> measured_boot.ShowCandidateMachinesRequest
+	1169, // 1577: forge.Forge.ListCandidateMachines:input_type -> measured_boot.ListCandidateMachinesRequest
+	1170, // 1578: forge.Forge.CreateMeasurementSystemProfile:input_type -> measured_boot.CreateMeasurementSystemProfileRequest
+	1171, // 1579: forge.Forge.DeleteMeasurementSystemProfile:input_type -> measured_boot.DeleteMeasurementSystemProfileRequest
+	1172, // 1580: forge.Forge.RenameMeasurementSystemProfile:input_type -> measured_boot.RenameMeasurementSystemProfileRequest
+	1173, // 1581: forge.Forge.ShowMeasurementSystemProfile:input_type -> measured_boot.ShowMeasurementSystemProfileRequest
+	1174, // 1582: forge.Forge.ShowMeasurementSystemProfiles:input_type -> measured_boot.ShowMeasurementSystemProfilesRequest
+	1175, // 1583: forge.Forge.ListMeasurementSystemProfiles:input_type -> measured_boot.ListMeasurementSystemProfilesRequest
+	1176, // 1584: forge.Forge.ListMeasurementSystemProfileBundles:input_type -> measured_boot.ListMeasurementSystemProfileBundlesRequest
+	1177, // 1585: forge.Forge.ListMeasurementSystemProfileMachines:input_type -> measured_boot.ListMeasurementSystemProfileMachinesRequest
+	1178, // 1586: forge.Forge.CreateMeasurementReport:input_type -> measured_boot.CreateMeasurementReportRequest
+	1179, // 1587: forge.Forge.DeleteMeasurementReport:input_type -> measured_boot.DeleteMeasurementReportRequest
+	1180, // 1588: forge.Forge.PromoteMeasurementReport:input_type -> measured_boot.PromoteMeasurementReportRequest
+	1181, // 1589: forge.Forge.RevokeMeasurementReport:input_type -> measured_boot.RevokeMeasurementReportRequest
+	1182, // 1590: forge.Forge.ShowMeasurementReportForId:input_type -> measured_boot.ShowMeasurementReportForIdRequest
+	1183, // 1591: forge.Forge.ShowMeasurementReportsForMachine:input_type -> measured_boot.ShowMeasurementReportsForMachineRequest
+	1184, // 1592: forge.Forge.ShowMeasurementReports:input_type -> measured_boot.ShowMeasurementReportsRequest
+	1185, // 1593: forge.Forge.ListMeasurementReport:input_type -> measured_boot.ListMeasurementReportRequest
+	1186, // 1594: forge.Forge.MatchMeasurementReport:input_type -> measured_boot.MatchMeasurementReportRequest
+	1187, // 1595: forge.Forge.ImportSiteMeasurements:input_type -> measured_boot.ImportSiteMeasurementsRequest
+	1188, // 1596: forge.Forge.ExportSiteMeasurements:input_type -> measured_boot.ExportSiteMeasurementsRequest
+	1189, // 1597: forge.Forge.AddMeasurementTrustedMachine:input_type -> measured_boot.AddMeasurementTrustedMachineRequest
+	1190, // 1598: forge.Forge.RemoveMeasurementTrustedMachine:input_type -> measured_boot.RemoveMeasurementTrustedMachineRequest
+	1191, // 1599: forge.Forge.AddMeasurementTrustedProfile:input_type -> measured_boot.AddMeasurementTrustedProfileRequest
+	1192, // 1600: forge.Forge.RemoveMeasurementTrustedProfile:input_type -> measured_boot.RemoveMeasurementTrustedProfileRequest
+	1193, // 1601: forge.Forge.ListMeasurementTrustedMachines:input_type -> measured_boot.ListMeasurementTrustedMachinesRequest
+	1194, // 1602: forge.Forge.ListMeasurementTrustedProfiles:input_type -> measured_boot.ListMeasurementTrustedProfilesRequest
+	1195, // 1603: forge.Forge.ListAttestationSummary:input_type -> measured_boot.ListAttestationSummaryRequest
+	712,  // 1604: forge.Forge.CreateNetworkSecurityGroup:input_type -> forge.CreateNetworkSecurityGroupRequest
+	714,  // 1605: forge.Forge.FindNetworkSecurityGroupIds:input_type -> forge.FindNetworkSecurityGroupIdsRequest
+	716,  // 1606: forge.Forge.FindNetworkSecurityGroupsByIds:input_type -> forge.FindNetworkSecurityGroupsByIdsRequest
+	719,  // 1607: forge.Forge.UpdateNetworkSecurityGroup:input_type -> forge.UpdateNetworkSecurityGroupRequest
+	720,  // 1608: forge.Forge.DeleteNetworkSecurityGroup:input_type -> forge.DeleteNetworkSecurityGroupRequest
+	726,  // 1609: forge.Forge.GetNetworkSecurityGroupPropagationStatus:input_type -> forge.GetNetworkSecurityGroupPropagationStatusRequest
+	729,  // 1610: forge.Forge.GetNetworkSecurityGroupAttachments:input_type -> forge.GetNetworkSecurityGroupAttachmentsRequest
+	581,  // 1611: forge.Forge.CreateOsImage:input_type -> forge.OsImageAttributes
+	585,  // 1612: forge.Forge.DeleteOsImage:input_type -> forge.DeleteOsImageRequest
+	583,  // 1613: forge.Forge.ListOsImage:input_type -> forge.ListOsImageRequest
+	1084, // 1614: forge.Forge.GetOsImage:input_type -> common.UUID
+	581,  // 1615: forge.Forge.UpdateOsImage:input_type -> forge.OsImageAttributes
+	587,  // 1616: forge.Forge.GetIpxeTemplate:input_type -> forge.GetIpxeTemplateRequest
+	588,  // 1617: forge.Forge.ListIpxeTemplates:input_type -> forge.ListIpxeTemplatesRequest
+	603,  // 1618: forge.Forge.RebootCompleted:input_type -> forge.MachineRebootCompletedRequest
+	608,  // 1619: forge.Forge.PersistValidationResult:input_type -> forge.MachineValidationResultPostRequest
+	610,  // 1620: forge.Forge.GetMachineValidationResults:input_type -> forge.MachineValidationGetRequest
+	605,  // 1621: forge.Forge.MachineValidationCompleted:input_type -> forge.MachineValidationCompletedRequest
+	613,  // 1622: forge.Forge.MachineSetAutoUpdate:input_type -> forge.MachineSetAutoUpdateRequest
+	615,  // 1623: forge.Forge.GetMachineValidationExternalConfig:input_type -> forge.GetMachineValidationExternalConfigRequest
+	618,  // 1624: forge.Forge.GetMachineValidationExternalConfigs:input_type -> forge.GetMachineValidationExternalConfigsRequest
+	620,  // 1625: forge.Forge.AddUpdateMachineValidationExternalConfig:input_type -> forge.AddUpdateMachineValidationExternalConfigRequest
+	641,  // 1626: forge.Forge.GetMachineValidationRuns:input_type -> forge.MachineValidationRunListGetRequest
+	642,  // 1627: forge.Forge.FindMachineValidationRunItemIds:input_type -> forge.MachineValidationRunItemSearchFilter
+	644,  // 1628: forge.Forge.FindMachineValidationRunItemsByIds:input_type -> forge.MachineValidationRunItemsByIdsRequest
+	647,  // 1629: forge.Forge.GetMachineValidationAttempt:input_type -> forge.MachineValidationAttemptGetRequest
+	649,  // 1630: forge.Forge.HeartbeatMachineValidationRun:input_type -> forge.MachineValidationHeartbeatRequest
+	621,  // 1631: forge.Forge.RemoveMachineValidationExternalConfig:input_type -> forge.RemoveMachineValidationExternalConfigRequest
+	653,  // 1632: forge.Forge.GetMachineValidationTests:input_type -> forge.MachineValidationTestsGetRequest
+	655,  // 1633: forge.Forge.AddMachineValidationTest:input_type -> forge.MachineValidationTestAddRequest
+	654,  // 1634: forge.Forge.UpdateMachineValidationTest:input_type -> forge.MachineValidationTestUpdateRequest
+	658,  // 1635: forge.Forge.MachineValidationTestVerfied:input_type -> forge.MachineValidationTestVerfiedRequest
+	665,  // 1636: forge.Forge.MachineValidationTestNextVersion:input_type -> forge.MachineValidationTestNextVersionRequest
+	666,  // 1637: forge.Forge.MachineValidationTestEnableDisableTest:input_type -> forge.MachineValidationTestEnableDisableTestRequest
+	662,  // 1638: forge.Forge.MachineValidationTestApproveFullHost:input_type -> forge.MachineValidationTestFullHostApprovalRequest
+	668,  // 1639: forge.Forge.UpdateMachineValidationRun:input_type -> forge.MachineValidationRunRequest
+	450,  // 1640: forge.Forge.AdminBmcReset:input_type -> forge.AdminBmcResetRequest
+	634,  // 1641: forge.Forge.AdminPowerControl:input_type -> forge.AdminPowerControlRequest
+	636,  // 1642: forge.Forge.AdminGpuReset:input_type -> forge.AdminGpuResetRequest
+	408,  // 1643: forge.Forge.DisableSecureBoot:input_type -> forge.BmcEndpointRequest
+	440,  // 1644: forge.Forge.Lockdown:input_type -> forge.LockdownRequest
+	442,  // 1645: forge.Forge.LockdownStatus:input_type -> forge.LockdownStatusRequest
+	444,  // 1646: forge.Forge.MachineSetup:input_type -> forge.MachineSetupRequest
+	446,  // 1647: forge.Forge.SetDpuFirstBootOrder:input_type -> forge.SetDpuFirstBootOrderRequest
+	838,  // 1648: forge.Forge.CreateBmcUser:input_type -> forge.CreateBmcUserRequest
+	840,  // 1649: forge.Forge.DeleteBmcUser:input_type -> forge.DeleteBmcUserRequest
+	842,  // 1650: forge.Forge.SetBmcRootPassword:input_type -> forge.SetBmcRootPasswordRequest
+	844,  // 1651: forge.Forge.ProbeBmcVendor:input_type -> forge.ProbeBmcVendorRequest
+	452,  // 1652: forge.Forge.EnableInfiniteBoot:input_type -> forge.EnableInfiniteBootRequest
+	454,  // 1653: forge.Forge.IsInfiniteBootEnabled:input_type -> forge.IsInfiniteBootEnabledRequest
+	622,  // 1654: forge.Forge.OnDemandMachineValidation:input_type -> forge.MachineValidationOnDemandRequest
+	630,  // 1655: forge.Forge.OnDemandRackMaintenance:input_type -> forge.RackMaintenanceOnDemandRequest
+	632,  // 1656: forge.Forge.TerminateRackMaintenance:input_type -> forge.RackMaintenanceTerminateRequest
+	143,  // 1657: forge.Forge.TpmAddCaCert:input_type -> forge.TpmCaCert
+	1146, // 1658: forge.Forge.TpmShowCaCerts:input_type -> google.protobuf.Empty
+	1146, // 1659: forge.Forge.TpmShowUnmatchedEkCerts:input_type -> google.protobuf.Empty
+	140,  // 1660: forge.Forge.TpmDeleteCaCert:input_type -> forge.TpmCaCertId
+	695,  // 1661: forge.Forge.RedfishBrowse:input_type -> forge.RedfishBrowseRequest
+	697,  // 1662: forge.Forge.RedfishListActions:input_type -> forge.RedfishListActionsRequest
+	702,  // 1663: forge.Forge.RedfishCreateAction:input_type -> forge.RedfishCreateActionRequest
+	704,  // 1664: forge.Forge.RedfishApproveAction:input_type -> forge.RedfishActionID
+	704,  // 1665: forge.Forge.RedfishApplyAction:input_type -> forge.RedfishActionID
+	704,  // 1666: forge.Forge.RedfishCancelAction:input_type -> forge.RedfishActionID
+	708,  // 1667: forge.Forge.UfmBrowse:input_type -> forge.UfmBrowseRequest
+	732,  // 1668: forge.Forge.GetDesiredFirmwareVersions:input_type -> forge.GetDesiredFirmwareVersionsRequest
+	848,  // 1669: forge.Forge.UpsertHostFirmwareConfig:input_type -> forge.UpsertHostFirmwareConfigRequest
+	849,  // 1670: forge.Forge.DeleteHostFirmwareConfig:input_type -> forge.DeleteHostFirmwareConfigRequest
+	748,  // 1671: forge.Forge.CreateSku:input_type -> forge.SkuList
+	1071, // 1672: forge.Forge.GenerateSkuFromMachine:input_type -> common.MachineId
+	1071, // 1673: forge.Forge.VerifySkuForMachine:input_type -> common.MachineId
+	746,  // 1674: forge.Forge.AssignSkuToMachine:input_type -> forge.SkuMachinePair
+	747,  // 1675: forge.Forge.RemoveSkuAssociation:input_type -> forge.RemoveSkuRequest
+	749,  // 1676: forge.Forge.DeleteSku:input_type -> forge.SkuIdList
+	1146, // 1677: forge.Forge.GetAllSkuIds:input_type -> google.protobuf.Empty
+	751,  // 1678: forge.Forge.FindSkusByIds:input_type -> forge.SkusByIdsRequest
+	761,  // 1679: forge.Forge.UpdateSkuMetadata:input_type -> forge.SkuUpdateMetadataRequest
+	745,  // 1680: forge.Forge.ReplaceSku:input_type -> forge.Sku
+	418,  // 1681: forge.Forge.GetManagedHostQuarantineState:input_type -> forge.GetManagedHostQuarantineStateRequest
+	420,  // 1682: forge.Forge.SetManagedHostQuarantineState:input_type -> forge.SetManagedHostQuarantineStateRequest
+	422,  // 1683: forge.Forge.ClearManagedHostQuarantineState:input_type -> forge.ClearManagedHostQuarantineStateRequest
+	1071, // 1684: forge.Forge.ResetHostReprovisioning:input_type -> common.MachineId
+	411,  // 1685: forge.Forge.CopyBfbToDpuRshim:input_type -> forge.CopyBfbToDpuRshimRequest
+	1146, // 1686: forge.Forge.GetAllDpaInterfaceIds:input_type -> google.protobuf.Empty
+	756,  // 1687: forge.Forge.FindDpaInterfacesByIds:input_type -> forge.DpaInterfacesByIdsRequest
+	754,  // 1688: forge.Forge.CreateDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	754,  // 1689: forge.Forge.EnsureDpaInterface:input_type -> forge.DpaInterfaceCreationRequest
+	759,  // 1690: forge.Forge.DeleteDpaInterface:input_type -> forge.DpaInterfaceDeletionRequest
+	762,  // 1691: forge.Forge.GetPowerOptions:input_type -> forge.PowerOptionRequest
+	763,  // 1692: forge.Forge.UpdatePowerOption:input_type -> forge.PowerOptionUpdateRequest
+	408,  // 1693: forge.Forge.AllowIngestionAndPowerOn:input_type -> forge.BmcEndpointRequest
+	408,  // 1694: forge.Forge.DetermineMachineIngestionState:input_type -> forge.BmcEndpointRequest
+	782,  // 1695: forge.Forge.FindRackIds:input_type -> forge.RackSearchFilter
+	784,  // 1696: forge.Forge.FindRacksByIds:input_type -> forge.RacksByIdsRequest
+	779,  // 1697: forge.Forge.GetRack:input_type -> forge.GetRackRequest
+	790,  // 1698: forge.Forge.DeleteRack:input_type -> forge.DeleteRackRequest
+	791,  // 1699: forge.Forge.AdminForceDeleteRack:input_type -> forge.AdminForceDeleteRackRequest
+	798,  // 1700: forge.Forge.GetRackProfile:input_type -> forge.GetRackProfileRequest
+	1146, // 1701: forge.Forge.ListRackProfiles:input_type -> google.protobuf.Empty
+	768,  // 1702: forge.Forge.CreateComputeAllocation:input_type -> forge.CreateComputeAllocationRequest
+	770,  // 1703: forge.Forge.FindComputeAllocationIds:input_type -> forge.FindComputeAllocationIdsRequest
+	772,  // 1704: forge.Forge.FindComputeAllocationsByIds:input_type -> forge.FindComputeAllocationsByIdsRequest
+	775,  // 1705: forge.Forge.UpdateComputeAllocation:input_type -> forge.UpdateComputeAllocationRequest
+	776,  // 1706: forge.Forge.DeleteComputeAllocation:input_type -> forge.DeleteComputeAllocationRequest
+	846,  // 1707: forge.Forge.SetFirmwareUpdateTimeWindow:input_type -> forge.SetFirmwareUpdateTimeWindowRequest
+	855,  // 1708: forge.Forge.ListHostFirmware:input_type -> forge.ListHostFirmwareRequest
+	1196, // 1709: forge.Forge.PublishMlxDeviceReport:input_type -> mlx_device.PublishMlxDeviceReportRequest
+	1197, // 1710: forge.Forge.PublishMlxObservationReport:input_type -> mlx_device.PublishMlxObservationReportRequest
+	858,  // 1711: forge.Forge.TrimTable:input_type -> forge.TrimTableRequest
+	1146, // 1712: forge.Forge.ListNvlinkNmxcEndpoints:input_type -> google.protobuf.Empty
+	860,  // 1713: forge.Forge.CreateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	860,  // 1714: forge.Forge.UpdateNvlinkNmxcEndpoint:input_type -> forge.NvlinkNmxcEndpoint
+	862,  // 1715: forge.Forge.DeleteNvlinkNmxcEndpoint:input_type -> forge.DeleteNvlinkNmxcEndpointRequest
+	863,  // 1716: forge.Forge.CreateRemediation:input_type -> forge.CreateRemediationRequest
+	868,  // 1717: forge.Forge.ApproveRemediation:input_type -> forge.ApproveRemediationRequest
+	869,  // 1718: forge.Forge.RevokeRemediation:input_type -> forge.RevokeRemediationRequest
+	870,  // 1719: forge.Forge.EnableRemediation:input_type -> forge.EnableRemediationRequest
+	871,  // 1720: forge.Forge.DisableRemediation:input_type -> forge.DisableRemediationRequest
+	1146, // 1721: forge.Forge.FindRemediationIds:input_type -> google.protobuf.Empty
+	865,  // 1722: forge.Forge.FindRemediationsByIds:input_type -> forge.RemediationIdList
+	872,  // 1723: forge.Forge.FindAppliedRemediationIds:input_type -> forge.FindAppliedRemediationIdsRequest
+	874,  // 1724: forge.Forge.FindAppliedRemediations:input_type -> forge.FindAppliedRemediationsRequest
+	877,  // 1725: forge.Forge.GetNextRemediationForMachine:input_type -> forge.GetNextRemediationForMachineRequest
+	879,  // 1726: forge.Forge.RemediationApplied:input_type -> forge.RemediationAppliedRequest
+	881,  // 1727: forge.Forge.SetPrimaryDpu:input_type -> forge.SetPrimaryDpuRequest
+	882,  // 1728: forge.Forge.SetPrimaryInterface:input_type -> forge.SetPrimaryInterfaceRequest
+	888,  // 1729: forge.Forge.CreateDpuExtensionService:input_type -> forge.CreateDpuExtensionServiceRequest
+	889,  // 1730: forge.Forge.UpdateDpuExtensionService:input_type -> forge.UpdateDpuExtensionServiceRequest
+	890,  // 1731: forge.Forge.DeleteDpuExtensionService:input_type -> forge.DeleteDpuExtensionServiceRequest
+	892,  // 1732: forge.Forge.FindDpuExtensionServiceIds:input_type -> forge.DpuExtensionServiceSearchFilter
+	894,  // 1733: forge.Forge.FindDpuExtensionServicesByIds:input_type -> forge.DpuExtensionServicesByIdsRequest
+	896,  // 1734: forge.Forge.GetDpuExtensionServiceVersionsInfo:input_type -> forge.GetDpuExtensionServiceVersionsInfoRequest
+	898,  // 1735: forge.Forge.FindInstancesByDpuExtensionService:input_type -> forge.FindInstancesByDpuExtensionServiceRequest
+	115,  // 1736: forge.Forge.TriggerMachineAttestation:input_type -> forge.SpdmMachineAttestationTriggerRequest
+	1071, // 1737: forge.Forge.CancelMachineAttestation:input_type -> common.MachineId
+	116,  // 1738: forge.Forge.ListAttestationMachines:input_type -> forge.SpdmListAttestationMachinesRequest
+	1071, // 1739: forge.Forge.GetAttestationMachine:input_type -> common.MachineId
+	118,  // 1740: forge.Forge.SignMachineIdentity:input_type -> forge.MachineIdentityRequest
+	120,  // 1741: forge.Forge.GetTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	123,  // 1742: forge.Forge.SetTenantIdentityConfiguration:input_type -> forge.SetTenantIdentityConfigRequest
+	120,  // 1743: forge.Forge.DeleteTenantIdentityConfiguration:input_type -> forge.GetTenantIdentityConfigRequest
+	128,  // 1744: forge.Forge.GetTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	130,  // 1745: forge.Forge.SetTokenDelegation:input_type -> forge.TokenDelegationRequest
+	128,  // 1746: forge.Forge.DeleteTokenDelegation:input_type -> forge.GetTokenDelegationRequest
+	131,  // 1747: forge.Forge.ReencryptTenantIdentitySecrets:input_type -> forge.ReencryptTenantIdentitySecretsRequest
+	136,  // 1748: forge.Forge.GetJWKS:input_type -> forge.JwksRequest
+	137,  // 1749: forge.Forge.GetOpenIDConfiguration:input_type -> forge.OpenIdConfigRequest
+	905,  // 1750: forge.Forge.ScoutStream:input_type -> forge.ScoutStreamApiBoundMessage
+	908,  // 1751: forge.Forge.ScoutStreamShowConnections:input_type -> forge.ScoutStreamShowConnectionsRequest
+	910,  // 1752: forge.Forge.ScoutStreamDisconnect:input_type -> forge.ScoutStreamDisconnectRequest
+	912,  // 1753: forge.Forge.ScoutStreamPing:input_type -> forge.ScoutStreamAdminPingRequest
+	1198, // 1754: forge.Forge.MlxAdminProfileSync:input_type -> mlx_device.MlxAdminProfileSyncRequest
+	1199, // 1755: forge.Forge.MlxAdminProfileShow:input_type -> mlx_device.MlxAdminProfileShowRequest
+	1200, // 1756: forge.Forge.MlxAdminProfileCompare:input_type -> mlx_device.MlxAdminProfileCompareRequest
+	1201, // 1757: forge.Forge.MlxAdminProfileList:input_type -> mlx_device.MlxAdminProfileListRequest
+	1202, // 1758: forge.Forge.MlxAdminLockdownLock:input_type -> mlx_device.MlxAdminLockdownLockRequest
+	1203, // 1759: forge.Forge.MlxAdminLockdownUnlock:input_type -> mlx_device.MlxAdminLockdownUnlockRequest
+	1204, // 1760: forge.Forge.MlxAdminLockdownStatus:input_type -> mlx_device.MlxAdminLockdownStatusRequest
+	1205, // 1761: forge.Forge.MlxAdminShowDevice:input_type -> mlx_device.MlxAdminDeviceInfoRequest
+	1206, // 1762: forge.Forge.MlxAdminShowMachine:input_type -> mlx_device.MlxAdminDeviceReportRequest
+	1207, // 1763: forge.Forge.MlxAdminRegistryList:input_type -> mlx_device.MlxAdminRegistryListRequest
+	1208, // 1764: forge.Forge.MlxAdminRegistryShow:input_type -> mlx_device.MlxAdminRegistryShowRequest
+	1209, // 1765: forge.Forge.MlxAdminConfigQuery:input_type -> mlx_device.MlxAdminConfigQueryRequest
+	1210, // 1766: forge.Forge.MlxAdminConfigSet:input_type -> mlx_device.MlxAdminConfigSetRequest
+	1211, // 1767: forge.Forge.MlxAdminConfigSync:input_type -> mlx_device.MlxAdminConfigSyncRequest
+	1212, // 1768: forge.Forge.MlxAdminConfigCompare:input_type -> mlx_device.MlxAdminConfigCompareRequest
+	822,  // 1769: forge.Forge.FindNVLinkPartitionIds:input_type -> forge.NVLinkPartitionSearchFilter
+	823,  // 1770: forge.Forge.FindNVLinkPartitionsByIds:input_type -> forge.NVLinkPartitionsByIdsRequest
+	173,  // 1771: forge.Forge.NVLinkPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	833,  // 1772: forge.Forge.FindNVLinkLogicalPartitionIds:input_type -> forge.NVLinkLogicalPartitionSearchFilter
+	834,  // 1773: forge.Forge.FindNVLinkLogicalPartitionsByIds:input_type -> forge.NVLinkLogicalPartitionsByIdsRequest
+	830,  // 1774: forge.Forge.CreateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionCreationRequest
+	836,  // 1775: forge.Forge.UpdateNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionUpdateRequest
+	831,  // 1776: forge.Forge.DeleteNVLinkLogicalPartition:input_type -> forge.NVLinkLogicalPartitionDeletionRequest
+	173,  // 1777: forge.Forge.NVLinkLogicalPartitionsForTenant:input_type -> forge.TenantSearchQuery
+	926,  // 1778: forge.Forge.GetMachinePositionInfo:input_type -> forge.MachinePositionQuery
+	816,  // 1779: forge.Forge.NmxcBrowse:input_type -> forge.NmxcBrowseRequest
+	929,  // 1780: forge.Forge.ModifyDPFState:input_type -> forge.ModifyDPFStateRequest
+	931,  // 1781: forge.Forge.GetDPFState:input_type -> forge.GetDPFStateRequest
+	932,  // 1782: forge.Forge.GetDPFHostSnapshot:input_type -> forge.GetDPFHostSnapshotRequest
+	934,  // 1783: forge.Forge.GetDPFServiceVersions:input_type -> forge.GetDPFServiceVersionsRequest
+	940,  // 1784: forge.Forge.FindPendingDPUServiceSyncIds:input_type -> forge.FindPendingDPUServiceSyncIdsRequest
+	941,  // 1785: forge.Forge.FindPendingDPUServiceSyncsByIds:input_type -> forge.FindPendingDPUServiceSyncsByIdsRequest
+	942,  // 1786: forge.Forge.ListDPUServiceSyncHistory:input_type -> forge.ListDPUServiceSyncHistoryRequest
+	937,  // 1787: forge.Forge.ReleaseDPUServiceSyncHold:input_type -> forge.ReleaseDPUServiceSyncHoldRequest
+	952,  // 1788: forge.Forge.ComponentPowerControl:input_type -> forge.ComponentPowerControlRequest
+	954,  // 1789: forge.Forge.ComponentConfigureSwitchCertificate:input_type -> forge.ComponentConfigureSwitchCertificateRequest
+	949,  // 1790: forge.Forge.GetComponentInventory:input_type -> forge.GetComponentInventoryRequest
+	961,  // 1791: forge.Forge.UpdateComponentFirmware:input_type -> forge.UpdateComponentFirmwareRequest
+	963,  // 1792: forge.Forge.GetComponentFirmwareStatus:input_type -> forge.GetComponentFirmwareStatusRequest
+	965,  // 1793: forge.Forge.ListComponentFirmwareVersions:input_type -> forge.ListComponentFirmwareVersionsRequest
+	982,  // 1794: forge.Forge.CreateOperatingSystem:input_type -> forge.CreateOperatingSystemRequest
+	1093, // 1795: forge.Forge.GetOperatingSystem:input_type -> common.OperatingSystemId
+	985,  // 1796: forge.Forge.UpdateOperatingSystem:input_type -> forge.UpdateOperatingSystemRequest
+	986,  // 1797: forge.Forge.DeleteOperatingSystem:input_type -> forge.DeleteOperatingSystemRequest
+	988,  // 1798: forge.Forge.FindOperatingSystemIds:input_type -> forge.OperatingSystemSearchFilter
+	990,  // 1799: forge.Forge.FindOperatingSystemsByIds:input_type -> forge.OperatingSystemsByIdsRequest
+	992,  // 1800: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.GetOperatingSystemCachableIpxeTemplateArtifactsRequest
+	995,  // 1801: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:input_type -> forge.UpdateOperatingSystemIpxeTemplateArtifactRequest
+	996,  // 1802: forge.Forge.ReWrapSecrets:input_type -> forge.ReWrapSecretsRequest
+	159,  // 1803: forge.Forge.Version:output_type -> forge.BuildInfo
+	1132, // 1804: forge.Forge.CreateDomain:output_type -> dns.Domain
+	1132, // 1805: forge.Forge.UpdateDomain:output_type -> dns.Domain
+	1213, // 1806: forge.Forge.DeleteDomain:output_type -> dns.DomainDeletionResult
+	1214, // 1807: forge.Forge.FindDomain:output_type -> dns.DomainList
+	920,  // 1808: forge.Forge.CreateDomainLegacy:output_type -> forge.DomainLegacy
+	920,  // 1809: forge.Forge.UpdateDomainLegacy:output_type -> forge.DomainLegacy
+	923,  // 1810: forge.Forge.DeleteDomainLegacy:output_type -> forge.DomainDeletionResultLegacy
+	921,  // 1811: forge.Forge.FindDomainLegacy:output_type -> forge.DomainListLegacy
+	179,  // 1812: forge.Forge.CreateVpc:output_type -> forge.Vpc
+	182,  // 1813: forge.Forge.UpdateVpc:output_type -> forge.VpcUpdateResult
+	1028, // 1814: forge.Forge.ChangeVpcRoutingProfile:output_type -> forge.VpcRoutingState
+	1026, // 1815: forge.Forge.ReleaseVpcInactiveVni:output_type -> forge.VpcReleaseInactiveVniResult
+	184,  // 1816: forge.Forge.UpdateVpcVirtualization:output_type -> forge.VpcUpdateVirtualizationResult
+	186,  // 1817: forge.Forge.DeleteVpc:output_type -> forge.VpcDeletionResult
+	171,  // 1818: forge.Forge.FindVpcIds:output_type -> forge.VpcIdList
+	187,  // 1819: forge.Forge.FindVpcsByIds:output_type -> forge.VpcList
+	1028, // 1820: forge.Forge.GetVpcRoutingState:output_type -> forge.VpcRoutingState
+	970,  // 1821: forge.Forge.CreateSpxPartition:output_type -> forge.SpxPartition
+	973,  // 1822: forge.Forge.DeleteSpxPartition:output_type -> forge.SpxPartitionDeletionResult
+	971,  // 1823: forge.Forge.FindSpxPartitionIds:output_type -> forge.SpxPartitionIdList
+	975,  // 1824: forge.Forge.FindSpxPartitionsByIds:output_type -> forge.SpxPartitionList
+	188,  // 1825: forge.Forge.CreateVpcPrefix:output_type -> forge.VpcPrefix
+	194,  // 1826: forge.Forge.SearchVpcPrefixes:output_type -> forge.VpcPrefixIdList
+	195,  // 1827: forge.Forge.GetVpcPrefixes:output_type -> forge.VpcPrefixList
+	188,  // 1828: forge.Forge.UpdateVpcPrefix:output_type -> forge.VpcPrefix
+	198,  // 1829: forge.Forge.DeleteVpcPrefix:output_type -> forge.VpcPrefixDeletionResult
+	1008, // 1830: forge.Forge.CreateSitePrefix:output_type -> forge.SitePrefix
+	1008, // 1831: forge.Forge.UpdateSitePrefix:output_type -> forge.SitePrefix
+	1015, // 1832: forge.Forge.DeleteSitePrefix:output_type -> forge.SitePrefixDeletionResult
+	1019, // 1833: forge.Forge.FindSitePrefixIds:output_type -> forge.SitePrefixIdList
+	1020, // 1834: forge.Forge.FindSitePrefixesByIds:output_type -> forge.SitePrefixList
+	200,  // 1835: forge.Forge.CreateVpcPeering:output_type -> forge.VpcPeering
+	201,  // 1836: forge.Forge.FindVpcPeeringIds:output_type -> forge.VpcPeeringIdList
+	202,  // 1837: forge.Forge.FindVpcPeeringsByIds:output_type -> forge.VpcPeeringList
+	207,  // 1838: forge.Forge.DeleteVpcPeering:output_type -> forge.VpcPeeringDeletionResult
+	280,  // 1839: forge.Forge.FindNetworkSegmentIds:output_type -> forge.NetworkSegmentIdList
+	394,  // 1840: forge.Forge.FindNetworkSegmentsByIds:output_type -> forge.NetworkSegmentList
+	272,  // 1841: forge.Forge.CreateNetworkSegment:output_type -> forge.NetworkSegment
+	272,  // 1842: forge.Forge.AttachNetworkSegmentToVpc:output_type -> forge.NetworkSegment
+	276,  // 1843: forge.Forge.DeleteNetworkSegment:output_type -> forge.NetworkSegmentDeletionResult
+	394,  // 1844: forge.Forge.NetworkSegmentsForVpc:output_type -> forge.NetworkSegmentList
+	218,  // 1845: forge.Forge.FindIBPartitionIds:output_type -> forge.IBPartitionIdList
+	211,  // 1846: forge.Forge.FindIBPartitionsByIds:output_type -> forge.IBPartitionList
+	210,  // 1847: forge.Forge.CreateIBPartition:output_type -> forge.IBPartition
+	210,  // 1848: forge.Forge.UpdateIBPartition:output_type -> forge.IBPartition
+	215,  // 1849: forge.Forge.DeleteIBPartition:output_type -> forge.IBPartitionDeletionResult
+	211,  // 1850: forge.Forge.IBPartitionsForTenant:output_type -> forge.IBPartitionList
+	222,  // 1851: forge.Forge.FindPowerShelves:output_type -> forge.PowerShelfList
+	947,  // 1852: forge.Forge.FindPowerShelfIds:output_type -> forge.PowerShelfIdList
+	222,  // 1853: forge.Forge.FindPowerShelvesByIds:output_type -> forge.PowerShelfList
+	225,  // 1854: forge.Forge.DecommissionPowerShelf:output_type -> forge.DecommissionPowerShelfResponse
+	227,  // 1855: forge.Forge.DeletePowerShelf:output_type -> forge.PowerShelfDeletionResult
+	980,  // 1856: forge.Forge.AdminForceDeletePowerShelf:output_type -> forge.AdminForceDeletePowerShelfResponse
+	1146, // 1857: forge.Forge.SetPowerShelfMaintenance:output_type -> google.protobuf.Empty
+	245,  // 1858: forge.Forge.FindSwitches:output_type -> forge.SwitchList
+	946,  // 1859: forge.Forge.FindSwitchIds:output_type -> forge.SwitchIdList
+	245,  // 1860: forge.Forge.FindSwitchesByIds:output_type -> forge.SwitchList
+	248,  // 1861: forge.Forge.DeleteSwitch:output_type -> forge.SwitchDeletionResult
+	250,  // 1862: forge.Forge.DecommissionSwitch:output_type -> forge.DecommissionSwitchResponse
+	978,  // 1863: forge.Forge.AdminForceDeleteSwitch:output_type -> forge.AdminForceDeleteSwitchResponse
+	268,  // 1864: forge.Forge.FindIBFabricIds:output_type -> forge.IBFabricIdList
+	321,  // 1865: forge.Forge.AllocateInstance:output_type -> forge.Instance
+	294,  // 1866: forge.Forge.AllocateInstances:output_type -> forge.BatchInstanceAllocationResponse
+	339,  // 1867: forge.Forge.ReleaseInstance:output_type -> forge.InstanceReleaseResult
+	342,  // 1868: forge.Forge.ReleaseInstances:output_type -> forge.BatchInstanceReleaseResponse
+	321,  // 1869: forge.Forge.UpdateInstanceOperatingSystem:output_type -> forge.Instance
+	321,  // 1870: forge.Forge.UpdateInstanceConfig:output_type -> forge.Instance
+	290,  // 1871: forge.Forge.FindInstanceIds:output_type -> forge.InstanceIdList
+	286,  // 1872: forge.Forge.FindInstancesByIds:output_type -> forge.InstanceList
+	286,  // 1873: forge.Forge.FindInstanceByMachineID:output_type -> forge.InstanceList
+	415,  // 1874: forge.Forge.GetManagedHostNetworkConfig:output_type -> forge.ManagedHostNetworkConfigResponse
+	1146, // 1875: forge.Forge.RecordDpuNetworkStatus:output_type -> google.protobuf.Empty
+	495,  // 1876: forge.Forge.ListMachineHealthReports:output_type -> forge.ListHealthReportResponse
+	1146, // 1877: forge.Forge.InsertMachineHealthReport:output_type -> google.protobuf.Empty
+	1146, // 1878: forge.Forge.RemoveMachineHealthReport:output_type -> google.protobuf.Empty
+	495,  // 1879: forge.Forge.ListRackHealthReports:output_type -> forge.ListHealthReportResponse
+	1146, // 1880: forge.Forge.InsertRackHealthReport:output_type -> google.protobuf.Empty
+	1146, // 1881: forge.Forge.RemoveRackHealthReport:output_type -> google.protobuf.Empty
+	495,  // 1882: forge.Forge.ListSwitchHealthReports:output_type -> forge.ListHealthReportResponse
+	1146, // 1883: forge.Forge.InsertSwitchHealthReport:output_type -> google.protobuf.Empty
+	1146, // 1884: forge.Forge.RemoveSwitchHealthReport:output_type -> google.protobuf.Empty
+	495,  // 1885: forge.Forge.ListPowerShelfHealthReports:output_type -> forge.ListHealthReportResponse
+	1146, // 1886: forge.Forge.InsertPowerShelfHealthReport:output_type -> google.protobuf.Empty
+	1146, // 1887: forge.Forge.RemovePowerShelfHealthReport:output_type -> google.protobuf.Empty
+	495,  // 1888: forge.Forge.ListNVLinkDomainHealthReports:output_type -> forge.ListHealthReportResponse
+	1146, // 1889: forge.Forge.InsertNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	1146, // 1890: forge.Forge.RemoveNVLinkDomainHealthReport:output_type -> google.protobuf.Empty
+	495,  // 1891: forge.Forge.ListHealthReportOverrides:output_type -> forge.ListHealthReportResponse
+	1146, // 1892: forge.Forge.InsertHealthReportOverride:output_type -> google.protobuf.Empty
+	1146, // 1893: forge.Forge.RemoveHealthReportOverride:output_type -> google.protobuf.Empty
+	432,  // 1894: forge.Forge.DpuAgentUpgradeCheck:output_type -> forge.DpuAgentUpgradeCheckResponse
+	434,  // 1895: forge.Forge.DpuAgentUpgradePolicyAction:output_type -> forge.DpuAgentUpgradePolicyResponse
+	1215, // 1896: forge.Forge.LookupRecord:output_type -> dns.DnsResourceRecordLookupResponse
+	1216, // 1897: forge.Forge.GetAllDomains:output_type -> dns.GetAllDomainsResponse
+	1217, // 1898: forge.Forge.GetAllDomainMetadata:output_type -> dns.DomainMetadataResponse
+	285,  // 1899: forge.Forge.InvokeInstancePower:output_type -> forge.InstancePowerResult
+	461,  // 1900: forge.Forge.ForgeAgentControl:output_type -> forge.ForgeAgentControlResponse
+	468,  // 1901: forge.Forge.DiscoverMachine:output_type -> forge.MachineDiscoveryResult
+	467,  // 1902: forge.Forge.RenewMachineCertificate:output_type -> forge.MachineCertificateResult
+	469,  // 1903: forge.Forge.DiscoveryCompleted:output_type -> forge.MachineDiscoveryCompletedResponse
+	470,  // 1904: forge.Forge.CleanupMachineCompleted:output_type -> forge.MachineCleanupResult
+	472,  // 1905: forge.Forge.ReportForgeScoutError:output_type -> forge.ForgeScoutErrorReportResult
+	393,  // 1906: forge.Forge.DiscoverDhcp:output_type -> forge.DhcpRecord
+	392,  // 1907: forge.Forge.ExpireDhcpLease:output_type -> forge.ExpireDhcpLeaseResponse
+	361,  // 1908: forge.Forge.AssignStaticAddress:output_type -> forge.AssignStaticAddressResponse
+	363,  // 1909: forge.Forge.RemoveStaticAddress:output_type -> forge.RemoveStaticAddressResponse
+	366,  // 1910: forge.Forge.FindInterfaceAddresses:output_type -> forge.FindInterfaceAddressesResponse
+	356,  // 1911: forge.Forge.FindInterfaces:output_type -> forge.InterfaceList
+	1146, // 1912: forge.Forge.DeleteInterface:output_type -> google.protobuf.Empty
+	536,  // 1913: forge.Forge.FindIpAddress:output_type -> forge.FindIpAddressResponse
+	1133, // 1914: forge.Forge.FindMachineIds:output_type -> common.MachineIdList
+	357,  // 1915: forge.Forge.FindMachinesByIds:output_type -> forge.MachineList
+	346,  // 1916: forge.Forge.FindMachineStateHistories:output_type -> forge.MachineStateHistories
+	349,  // 1917: forge.Forge.FindMachineHealthHistories:output_type -> forge.HealthHistories
+	255,  // 1918: forge.Forge.FindPowerShelfStateHistories:output_type -> forge.StateHistories
+	349,  // 1919: forge.Forge.FindPowerShelfHealthHistories:output_type -> forge.HealthHistories
+	255,  // 1920: forge.Forge.FindRackStateHistories:output_type -> forge.StateHistories
+	349,  // 1921: forge.Forge.FindRackHealthHistories:output_type -> forge.HealthHistories
+	255,  // 1922: forge.Forge.FindSwitchStateHistories:output_type -> forge.StateHistories
+	349,  // 1923: forge.Forge.FindSwitchHealthHistories:output_type -> forge.HealthHistories
+	255,  // 1924: forge.Forge.FindNetworkSegmentStateHistories:output_type -> forge.StateHistories
+	255,  // 1925: forge.Forge.FindVpcPrefixStateHistories:output_type -> forge.StateHistories
+	255,  // 1926: forge.Forge.FindSitePrefixStateHistories:output_type -> forge.StateHistories
+	355,  // 1927: forge.Forge.FindTenantOrganizationIds:output_type -> forge.TenantOrganizationIdList
+	354,  // 1928: forge.Forge.FindTenantsByOrganizationIds:output_type -> forge.TenantList
+	562,  // 1929: forge.Forge.FindConnectedDevicesByDpuMachineIds:output_type -> forge.ConnectedDeviceList
+	566,  // 1930: forge.Forge.FindMachineIdsByBmcIps:output_type -> forge.MachineIdBmcIpPairs
+	565,  // 1931: forge.Forge.FindMacAddressByBmcIp:output_type -> forge.MacAddressBmcIp
+	563,  // 1932: forge.Forge.FindBmcIps:output_type -> forge.BmcIpList
+	538,  // 1933: forge.Forge.IdentifyUuid:output_type -> forge.IdentifyUuidResponse
+	541,  // 1934: forge.Forge.IdentifyMac:output_type -> forge.IdentifyMacResponse
+	543,  // 1935: forge.Forge.IdentifySerial:output_type -> forge.IdentifySerialResponse
+	457,  // 1936: forge.Forge.GetBMCMetaData:output_type -> forge.BMCMetaDataGetResponse
+	459,  // 1937: forge.Forge.UpdateMachineCredentials:output_type -> forge.MachineCredentialsUpdateResponse
+	474,  // 1938: forge.Forge.GetPxeInstructions:output_type -> forge.PxeInstructions
+	478,  // 1939: forge.Forge.GetCloudInitInstructions:output_type -> forge.CloudInitInstructions
+	162,  // 1940: forge.Forge.Echo:output_type -> forge.EchoResponse
+	505,  // 1941: forge.Forge.CreateTenant:output_type -> forge.CreateTenantResponse
+	509,  // 1942: forge.Forge.FindTenant:output_type -> forge.FindTenantResponse
+	507,  // 1943: forge.Forge.UpdateTenant:output_type -> forge.UpdateTenantResponse
+	515,  // 1944: forge.Forge.CreateTenantKeyset:output_type -> forge.CreateTenantKeysetResponse
+	522,  // 1945: forge.Forge.FindTenantKeysetIds:output_type -> forge.TenantKeysetIdList
+	516,  // 1946: forge.Forge.FindTenantKeysetsByIds:output_type -> forge.TenantKeySetList
+	518,  // 1947: forge.Forge.UpdateTenantKeyset:output_type -> forge.UpdateTenantKeysetResponse
+	520,  // 1948: forge.Forge.DeleteTenantKeyset:output_type -> forge.DeleteTenantKeysetResponse
+	525,  // 1949: forge.Forge.ValidateTenantPublicKey:output_type -> forge.ValidateTenantPublicKeyResponse
+	399,  // 1950: forge.Forge.GetBmcCredentials:output_type -> forge.GetBmcCredentialsResponse
+	399,  // 1951: forge.Forge.GetSwitchNvosCredentials:output_type -> forge.GetBmcCredentialsResponse
+	430,  // 1952: forge.Forge.GetAllManagedHostNetworkStatus:output_type -> forge.ManagedHostNetworkStatusResponse
+	1218, // 1953: forge.Forge.GetSiteExplorationReport:output_type -> site_explorer.SiteExplorationReport
+	1219, // 1954: forge.Forge.GetSiteExplorerLastRun:output_type -> site_explorer.SiteExplorerLastRunResponse
+	1146, // 1955: forge.Forge.ClearSiteExplorationError:output_type -> google.protobuf.Empty
+	651,  // 1956: forge.Forge.IsBmcInManagedHost:output_type -> forge.IsBmcInManagedHostResponse
+	652,  // 1957: forge.Forge.BmcCredentialStatus:output_type -> forge.BmcCredentialStatusResponse
+	1134, // 1958: forge.Forge.Explore:output_type -> site_explorer.EndpointExplorationReport
+	1146, // 1959: forge.Forge.ReExploreEndpoint:output_type -> google.protobuf.Empty
+	1220, // 1960: forge.Forge.RefreshEndpointReport:output_type -> site_explorer.ExploredEndpoint
+	407,  // 1961: forge.Forge.DeleteExploredEndpoint:output_type -> forge.DeleteExploredEndpointResponse
+	1146, // 1962: forge.Forge.PauseExploredEndpointRemediation:output_type -> google.protobuf.Empty
+	1221, // 1963: forge.Forge.FindExploredEndpointIds:output_type -> site_explorer.ExploredEndpointIdList
+	1222, // 1964: forge.Forge.FindExploredEndpointsByIds:output_type -> site_explorer.ExploredEndpointList
+	1223, // 1965: forge.Forge.FindExploredManagedHostIds:output_type -> site_explorer.ExploredManagedHostIdList
+	1224, // 1966: forge.Forge.FindExploredManagedHostsByIds:output_type -> site_explorer.ExploredManagedHostList
+	1225, // 1967: forge.Forge.FindExploredMlxDeviceHostIds:output_type -> site_explorer.ExploredMlxDeviceHostIdList
+	1226, // 1968: forge.Forge.FindExploredMlxDevicesByIds:output_type -> site_explorer.ExploredMlxDeviceList
+	1146, // 1969: forge.Forge.UpdateMachineHardwareInfo:output_type -> google.protobuf.Empty
+	438,  // 1970: forge.Forge.AdminForceDeleteMachine:output_type -> forge.AdminForceDeleteMachineResponse
+	437,  // 1971: forge.Forge.DecommissionManagedHost:output_type -> forge.DecommissionManagedHostResponse
+	527,  // 1972: forge.Forge.AdminListResourcePools:output_type -> forge.ResourcePools
+	530,  // 1973: forge.Forge.AdminGrowResourcePool:output_type -> forge.GrowResourcePoolResponse
+	1146, // 1974: forge.Forge.UpdateMachineMetadata:output_type -> google.protobuf.Empty
+	1146, // 1975: forge.Forge.UpdateRackMetadata:output_type -> google.protobuf.Empty
+	1146, // 1976: forge.Forge.UpdateSwitchMetadata:output_type -> google.protobuf.Empty
+	1146, // 1977: forge.Forge.UpdatePowerShelfMetadata:output_type -> google.protobuf.Empty
+	1146, // 1978: forge.Forge.UpdateMachineNvLinkInfo:output_type -> google.protobuf.Empty
+	1146, // 1979: forge.Forge.SetMaintenance:output_type -> google.protobuf.Empty
+	1146, // 1980: forge.Forge.SetDynamicConfig:output_type -> google.protobuf.Empty
+	1146, // 1981: forge.Forge.TriggerDpuReprovisioning:output_type -> google.protobuf.Empty
+	546,  // 1982: forge.Forge.ListDpuWaitingForReprovisioning:output_type -> forge.DpuReprovisioningListResponse
+	1146, // 1983: forge.Forge.TriggerHostReprovisioning:output_type -> google.protobuf.Empty
+	552,  // 1984: forge.Forge.ListHostsWaitingForReprovisioning:output_type -> forge.HostReprovisioningListResponse
+	1146, // 1985: forge.Forge.TriggerManagedHostReset:output_type -> google.protobuf.Empty
+	1024, // 1986: forge.Forge.ListManagedHostsWaitingForReset:output_type -> forge.ManagedHostResetListResponse
+	1146, // 1987: forge.Forge.TriggerBmcCredentialRotation:output_type -> google.protobuf.Empty
+	1146, // 1988: forge.Forge.TriggerUefiCredentialRotation:output_type -> google.protobuf.Empty
+	1146, // 1989: forge.Forge.TriggerNicLockdownCredentialRotation:output_type -> google.protobuf.Empty
+	1146, // 1990: forge.Forge.MarkManualFirmwareUpgradeComplete:output_type -> google.protobuf.Empty
+	1146, // 1991: forge.Forge.ReportScoutFirmwareUpgradeStatus:output_type -> google.protobuf.Empty
+	558,  // 1992: forge.Forge.GetDpuInfoList:output_type -> forge.GetDpuInfoListResponse
+	560,  // 1993: forge.Forge.GetMachineBootOverride:output_type -> forge.MachineBootOverride
+	1146, // 1994: forge.Forge.SetMachineBootOverride:output_type -> google.protobuf.Empty
+	1146, // 1995: forge.Forge.ClearMachineBootOverride:output_type -> google.protobuf.Empty
+	1004, // 1996: forge.Forge.GetMachineBootInterfaces:output_type -> forge.GetMachineBootInterfacesResponse
+	571,  // 1997: forge.Forge.GetNetworkTopology:output_type -> forge.NetworkTopologyData
+	571,  // 1998: forge.Forge.FindNetworkDevicesByDeviceIds:output_type -> forge.NetworkTopologyData
+	151,  // 1999: forge.Forge.CreateCredential:output_type -> forge.CredentialCreationResult
+	152,  // 2000: forge.Forge.DeleteCredential:output_type -> forge.CredentialDeletionResult
+	154,  // 2001: forge.Forge.RotateCredential:output_type -> forge.RotateCredentialResult
+	157,  // 2002: forge.Forge.GetCredentialRotationStatus:output_type -> forge.CredentialRotationStatusResult
+	1006, // 2003: forge.Forge.GetContainerRegistryCredential:output_type -> forge.GetContainerRegistryCredentialResponse
+	1146, // 2004: forge.Forge.SetContainerRegistryCredential:output_type -> google.protobuf.Empty
+	573,  // 2005: forge.Forge.GetRouteServers:output_type -> forge.RouteServerEntries
+	1146, // 2006: forge.Forge.AddRouteServers:output_type -> google.protobuf.Empty
+	1146, // 2007: forge.Forge.RemoveRouteServers:output_type -> google.protobuf.Empty
+	1146, // 2008: forge.Forge.ReplaceRouteServers:output_type -> google.protobuf.Empty
+	1146, // 2009: forge.Forge.UpdateAgentReportedInventory:output_type -> google.protobuf.Empty
+	334,  // 2010: forge.Forge.UpdateInstancePhoneHomeLastContact:output_type -> forge.InstancePhoneHomeLastContactResponse
+	576,  // 2011: forge.Forge.SetHostUefiPassword:output_type -> forge.SetHostUefiPasswordResponse
+	578,  // 2012: forge.Forge.ClearHostUefiPassword:output_type -> forge.ClearHostUefiPasswordResponse
+	580,  // 2013: forge.Forge.SetDpuUefiPassword:output_type -> forge.SetDpuUefiPasswordResponse
+	1146, // 2014: forge.Forge.AddExpectedMachine:output_type -> google.protobuf.Empty
+	1146, // 2015: forge.Forge.DeleteExpectedMachine:output_type -> google.protobuf.Empty
+	1146, // 2016: forge.Forge.UpdateExpectedMachine:output_type -> google.protobuf.Empty
+	592,  // 2017: forge.Forge.GetExpectedMachine:output_type -> forge.ExpectedMachine
+	594,  // 2018: forge.Forge.GetAllExpectedMachines:output_type -> forge.ExpectedMachineList
+	1146, // 2019: forge.Forge.ReplaceAllExpectedMachines:output_type -> google.protobuf.Empty
+	1146, // 2020: forge.Forge.DeleteAllExpectedMachines:output_type -> google.protobuf.Empty
+	595,  // 2021: forge.Forge.GetAllExpectedMachinesLinked:output_type -> forge.LinkedExpectedMachineList
+	597,  // 2022: forge.Forge.GetAllUnexpectedMachines:output_type -> forge.UnexpectedMachineList
+	601,  // 2023: forge.Forge.CreateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	601,  // 2024: forge.Forge.UpdateExpectedMachines:output_type -> forge.BatchExpectedMachineOperationResponse
+	1146, // 2025: forge.Forge.AddExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1146, // 2026: forge.Forge.DeleteExpectedPowerShelf:output_type -> google.protobuf.Empty
+	1146, // 2027: forge.Forge.UpdateExpectedPowerShelf:output_type -> google.protobuf.Empty
+	234,  // 2028: forge.Forge.GetExpectedPowerShelf:output_type -> forge.ExpectedPowerShelf
+	236,  // 2029: forge.Forge.GetAllExpectedPowerShelves:output_type -> forge.ExpectedPowerShelfList
+	1146, // 2030: forge.Forge.ReplaceAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	1146, // 2031: forge.Forge.DeleteAllExpectedPowerShelves:output_type -> google.protobuf.Empty
+	237,  // 2032: forge.Forge.GetAllExpectedPowerShelvesLinked:output_type -> forge.LinkedExpectedPowerShelfList
+	1146, // 2033: forge.Forge.AddExpectedSwitch:output_type -> google.protobuf.Empty
+	1146, // 2034: forge.Forge.DeleteExpectedSwitch:output_type -> google.protobuf.Empty
+	1146, // 2035: forge.Forge.UpdateExpectedSwitch:output_type -> google.protobuf.Empty
+	259,  // 2036: forge.Forge.GetExpectedSwitch:output_type -> forge.ExpectedSwitch
+	261,  // 2037: forge.Forge.GetAllExpectedSwitches:output_type -> forge.ExpectedSwitchList
+	1146, // 2038: forge.Forge.ReplaceAllExpectedSwitches:output_type -> google.protobuf.Empty
+	1146, // 2039: forge.Forge.DeleteAllExpectedSwitches:output_type -> google.protobuf.Empty
+	262,  // 2040: forge.Forge.GetAllExpectedSwitchesLinked:output_type -> forge.LinkedExpectedSwitchList
+	1146, // 2041: forge.Forge.AddExpectedRack:output_type -> google.protobuf.Empty
+	1146, // 2042: forge.Forge.DeleteExpectedRack:output_type -> google.protobuf.Empty
+	1146, // 2043: forge.Forge.UpdateExpectedRack:output_type -> google.protobuf.Empty
+	264,  // 2044: forge.Forge.GetExpectedRack:output_type -> forge.ExpectedRack
+	266,  // 2045: forge.Forge.GetAllExpectedRacks:output_type -> forge.ExpectedRackList
+	1146, // 2046: forge.Forge.ReplaceAllExpectedRacks:output_type -> google.protobuf.Empty
+	1146, // 2047: forge.Forge.DeleteAllExpectedRacks:output_type -> google.protobuf.Empty
+	148,  // 2048: forge.Forge.AttestQuote:output_type -> forge.AttestQuoteResponse
+	682,  // 2049: forge.Forge.CreateInstanceType:output_type -> forge.CreateInstanceTypeResponse
+	684,  // 2050: forge.Forge.FindInstanceTypeIds:output_type -> forge.FindInstanceTypeIdsResponse
+	686,  // 2051: forge.Forge.FindInstanceTypesByIds:output_type -> forge.FindInstanceTypesByIdsResponse
+	689,  // 2052: forge.Forge.UpdateInstanceType:output_type -> forge.UpdateInstanceTypeResponse
+	688,  // 2053: forge.Forge.DeleteInstanceType:output_type -> forge.DeleteInstanceTypeResponse
+	692,  // 2054: forge.Forge.AssociateMachinesWithInstanceType:output_type -> forge.AssociateMachinesWithInstanceTypeResponse
+	694,  // 2055: forge.Forge.RemoveMachineInstanceTypeAssociation:output_type -> forge.RemoveMachineInstanceTypeAssociationResponse
+	1227, // 2056: forge.Forge.CreateMeasurementBundle:output_type -> measured_boot.CreateMeasurementBundleResponse
+	1228, // 2057: forge.Forge.DeleteMeasurementBundle:output_type -> measured_boot.DeleteMeasurementBundleResponse
+	1229, // 2058: forge.Forge.RenameMeasurementBundle:output_type -> measured_boot.RenameMeasurementBundleResponse
+	1230, // 2059: forge.Forge.UpdateMeasurementBundle:output_type -> measured_boot.UpdateMeasurementBundleResponse
+	1231, // 2060: forge.Forge.ShowMeasurementBundle:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1232, // 2061: forge.Forge.ShowMeasurementBundles:output_type -> measured_boot.ShowMeasurementBundlesResponse
+	1233, // 2062: forge.Forge.ListMeasurementBundles:output_type -> measured_boot.ListMeasurementBundlesResponse
+	1234, // 2063: forge.Forge.ListMeasurementBundleMachines:output_type -> measured_boot.ListMeasurementBundleMachinesResponse
+	1231, // 2064: forge.Forge.FindClosestBundleMatch:output_type -> measured_boot.ShowMeasurementBundleResponse
+	1235, // 2065: forge.Forge.DeleteMeasurementJournal:output_type -> measured_boot.DeleteMeasurementJournalResponse
+	1236, // 2066: forge.Forge.ShowMeasurementJournal:output_type -> measured_boot.ShowMeasurementJournalResponse
+	1237, // 2067: forge.Forge.ShowMeasurementJournals:output_type -> measured_boot.ShowMeasurementJournalsResponse
+	1238, // 2068: forge.Forge.ListMeasurementJournal:output_type -> measured_boot.ListMeasurementJournalResponse
+	1239, // 2069: forge.Forge.AttestCandidateMachine:output_type -> measured_boot.AttestCandidateMachineResponse
+	1240, // 2070: forge.Forge.ShowCandidateMachine:output_type -> measured_boot.ShowCandidateMachineResponse
+	1241, // 2071: forge.Forge.ShowCandidateMachines:output_type -> measured_boot.ShowCandidateMachinesResponse
+	1242, // 2072: forge.Forge.ListCandidateMachines:output_type -> measured_boot.ListCandidateMachinesResponse
+	1243, // 2073: forge.Forge.CreateMeasurementSystemProfile:output_type -> measured_boot.CreateMeasurementSystemProfileResponse
+	1244, // 2074: forge.Forge.DeleteMeasurementSystemProfile:output_type -> measured_boot.DeleteMeasurementSystemProfileResponse
+	1245, // 2075: forge.Forge.RenameMeasurementSystemProfile:output_type -> measured_boot.RenameMeasurementSystemProfileResponse
+	1246, // 2076: forge.Forge.ShowMeasurementSystemProfile:output_type -> measured_boot.ShowMeasurementSystemProfileResponse
+	1247, // 2077: forge.Forge.ShowMeasurementSystemProfiles:output_type -> measured_boot.ShowMeasurementSystemProfilesResponse
+	1248, // 2078: forge.Forge.ListMeasurementSystemProfiles:output_type -> measured_boot.ListMeasurementSystemProfilesResponse
+	1249, // 2079: forge.Forge.ListMeasurementSystemProfileBundles:output_type -> measured_boot.ListMeasurementSystemProfileBundlesResponse
+	1250, // 2080: forge.Forge.ListMeasurementSystemProfileMachines:output_type -> measured_boot.ListMeasurementSystemProfileMachinesResponse
+	1251, // 2081: forge.Forge.CreateMeasurementReport:output_type -> measured_boot.CreateMeasurementReportResponse
+	1252, // 2082: forge.Forge.DeleteMeasurementReport:output_type -> measured_boot.DeleteMeasurementReportResponse
+	1253, // 2083: forge.Forge.PromoteMeasurementReport:output_type -> measured_boot.PromoteMeasurementReportResponse
+	1254, // 2084: forge.Forge.RevokeMeasurementReport:output_type -> measured_boot.RevokeMeasurementReportResponse
+	1255, // 2085: forge.Forge.ShowMeasurementReportForId:output_type -> measured_boot.ShowMeasurementReportForIdResponse
+	1256, // 2086: forge.Forge.ShowMeasurementReportsForMachine:output_type -> measured_boot.ShowMeasurementReportsForMachineResponse
+	1257, // 2087: forge.Forge.ShowMeasurementReports:output_type -> measured_boot.ShowMeasurementReportsResponse
+	1258, // 2088: forge.Forge.ListMeasurementReport:output_type -> measured_boot.ListMeasurementReportResponse
+	1259, // 2089: forge.Forge.MatchMeasurementReport:output_type -> measured_boot.MatchMeasurementReportResponse
+	1260, // 2090: forge.Forge.ImportSiteMeasurements:output_type -> measured_boot.ImportSiteMeasurementsResponse
+	1261, // 2091: forge.Forge.ExportSiteMeasurements:output_type -> measured_boot.ExportSiteMeasurementsResponse
+	1262, // 2092: forge.Forge.AddMeasurementTrustedMachine:output_type -> measured_boot.AddMeasurementTrustedMachineResponse
+	1263, // 2093: forge.Forge.RemoveMeasurementTrustedMachine:output_type -> measured_boot.RemoveMeasurementTrustedMachineResponse
+	1264, // 2094: forge.Forge.AddMeasurementTrustedProfile:output_type -> measured_boot.AddMeasurementTrustedProfileResponse
+	1265, // 2095: forge.Forge.RemoveMeasurementTrustedProfile:output_type -> measured_boot.RemoveMeasurementTrustedProfileResponse
+	1266, // 2096: forge.Forge.ListMeasurementTrustedMachines:output_type -> measured_boot.ListMeasurementTrustedMachinesResponse
+	1267, // 2097: forge.Forge.ListMeasurementTrustedProfiles:output_type -> measured_boot.ListMeasurementTrustedProfilesResponse
+	1268, // 2098: forge.Forge.ListAttestationSummary:output_type -> measured_boot.ListAttestationSummaryResponse
+	713,  // 2099: forge.Forge.CreateNetworkSecurityGroup:output_type -> forge.CreateNetworkSecurityGroupResponse
+	715,  // 2100: forge.Forge.FindNetworkSecurityGroupIds:output_type -> forge.FindNetworkSecurityGroupIdsResponse
+	717,  // 2101: forge.Forge.FindNetworkSecurityGroupsByIds:output_type -> forge.FindNetworkSecurityGroupsByIdsResponse
+	718,  // 2102: forge.Forge.UpdateNetworkSecurityGroup:output_type -> forge.UpdateNetworkSecurityGroupResponse
+	721,  // 2103: forge.Forge.DeleteNetworkSecurityGroup:output_type -> forge.DeleteNetworkSecurityGroupResponse
+	724,  // 2104: forge.Forge.GetNetworkSecurityGroupPropagationStatus:output_type -> forge.GetNetworkSecurityGroupPropagationStatusResponse
+	731,  // 2105: forge.Forge.GetNetworkSecurityGroupAttachments:output_type -> forge.GetNetworkSecurityGroupAttachmentsResponse
+	582,  // 2106: forge.Forge.CreateOsImage:output_type -> forge.OsImage
+	586,  // 2107: forge.Forge.DeleteOsImage:output_type -> forge.DeleteOsImageResponse
+	584,  // 2108: forge.Forge.ListOsImage:output_type -> forge.ListOsImageResponse
+	582,  // 2109: forge.Forge.GetOsImage:output_type -> forge.OsImage
+	582,  // 2110: forge.Forge.UpdateOsImage:output_type -> forge.OsImage
+	297,  // 2111: forge.Forge.GetIpxeTemplate:output_type -> forge.IpxeTemplate
+	589,  // 2112: forge.Forge.ListIpxeTemplates:output_type -> forge.IpxeTemplateList
+	602,  // 2113: forge.Forge.RebootCompleted:output_type -> forge.MachineRebootCompletedResponse
+	1146, // 2114: forge.Forge.PersistValidationResult:output_type -> google.protobuf.Empty
+	609,  // 2115: forge.Forge.GetMachineValidationResults:output_type -> forge.MachineValidationResultList
+	606,  // 2116: forge.Forge.MachineValidationCompleted:output_type -> forge.MachineValidationCompletedResponse
+	614,  // 2117: forge.Forge.MachineSetAutoUpdate:output_type -> forge.MachineSetAutoUpdateResponse
+	617,  // 2118: forge.Forge.GetMachineValidationExternalConfig:output_type -> forge.GetMachineValidationExternalConfigResponse
+	619,  // 2119: forge.Forge.GetMachineValidationExternalConfigs:output_type -> forge.GetMachineValidationExternalConfigsResponse
+	1146, // 2120: forge.Forge.AddUpdateMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	640,  // 2121: forge.Forge.GetMachineValidationRuns:output_type -> forge.MachineValidationRunList
+	643,  // 2122: forge.Forge.FindMachineValidationRunItemIds:output_type -> forge.MachineValidationRunItemIdList
+	645,  // 2123: forge.Forge.FindMachineValidationRunItemsByIds:output_type -> forge.MachineValidationRunItemList
+	648,  // 2124: forge.Forge.GetMachineValidationAttempt:output_type -> forge.MachineValidationAttempt
+	650,  // 2125: forge.Forge.HeartbeatMachineValidationRun:output_type -> forge.MachineValidationHeartbeatResponse
+	1146, // 2126: forge.Forge.RemoveMachineValidationExternalConfig:output_type -> google.protobuf.Empty
+	657,  // 2127: forge.Forge.GetMachineValidationTests:output_type -> forge.MachineValidationTestsGetResponse
+	656,  // 2128: forge.Forge.AddMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	656,  // 2129: forge.Forge.UpdateMachineValidationTest:output_type -> forge.MachineValidationTestAddUpdateResponse
+	659,  // 2130: forge.Forge.MachineValidationTestVerfied:output_type -> forge.MachineValidationTestVerfiedResponse
+	664,  // 2131: forge.Forge.MachineValidationTestNextVersion:output_type -> forge.MachineValidationTestNextVersionResponse
+	667,  // 2132: forge.Forge.MachineValidationTestEnableDisableTest:output_type -> forge.MachineValidationTestEnableDisableTestResponse
+	663,  // 2133: forge.Forge.MachineValidationTestApproveFullHost:output_type -> forge.MachineValidationTestFullHostApprovalResponse
+	669,  // 2134: forge.Forge.UpdateMachineValidationRun:output_type -> forge.MachineValidationRunResponse
+	451,  // 2135: forge.Forge.AdminBmcReset:output_type -> forge.AdminBmcResetResponse
+	635,  // 2136: forge.Forge.AdminPowerControl:output_type -> forge.AdminPowerControlResponse
+	637,  // 2137: forge.Forge.AdminGpuReset:output_type -> forge.AdminGpuResetResponse
+	439,  // 2138: forge.Forge.DisableSecureBoot:output_type -> forge.DisableSecureBootResponse
+	441,  // 2139: forge.Forge.Lockdown:output_type -> forge.LockdownResponse
+	1269, // 2140: forge.Forge.LockdownStatus:output_type -> site_explorer.LockdownStatus
+	445,  // 2141: forge.Forge.MachineSetup:output_type -> forge.MachineSetupResponse
+	447,  // 2142: forge.Forge.SetDpuFirstBootOrder:output_type -> forge.SetDpuFirstBootOrderResponse
+	839,  // 2143: forge.Forge.CreateBmcUser:output_type -> forge.CreateBmcUserResponse
+	841,  // 2144: forge.Forge.DeleteBmcUser:output_type -> forge.DeleteBmcUserResponse
+	843,  // 2145: forge.Forge.SetBmcRootPassword:output_type -> forge.SetBmcRootPasswordResponse
+	845,  // 2146: forge.Forge.ProbeBmcVendor:output_type -> forge.ProbeBmcVendorResponse
+	453,  // 2147: forge.Forge.EnableInfiniteBoot:output_type -> forge.EnableInfiniteBootResponse
+	455,  // 2148: forge.Forge.IsInfiniteBootEnabled:output_type -> forge.IsInfiniteBootEnabledResponse
+	623,  // 2149: forge.Forge.OnDemandMachineValidation:output_type -> forge.MachineValidationOnDemandResponse
+	631,  // 2150: forge.Forge.OnDemandRackMaintenance:output_type -> forge.RackMaintenanceOnDemandResponse
+	633,  // 2151: forge.Forge.TerminateRackMaintenance:output_type -> forge.RackMaintenanceTerminateResponse
+	139,  // 2152: forge.Forge.TpmAddCaCert:output_type -> forge.TpmCaAddedCaStatus
+	145,  // 2153: forge.Forge.TpmShowCaCerts:output_type -> forge.TpmCaCertDetailCollection
+	142,  // 2154: forge.Forge.TpmShowUnmatchedEkCerts:output_type -> forge.TpmEkCertStatusCollection
+	1146, // 2155: forge.Forge.TpmDeleteCaCert:output_type -> google.protobuf.Empty
+	696,  // 2156: forge.Forge.RedfishBrowse:output_type -> forge.RedfishBrowseResponse
+	698,  // 2157: forge.Forge.RedfishListActions:output_type -> forge.RedfishListActionsResponse
+	703,  // 2158: forge.Forge.RedfishCreateAction:output_type -> forge.RedfishCreateActionResponse
+	705,  // 2159: forge.Forge.RedfishApproveAction:output_type -> forge.RedfishApproveActionResponse
+	706,  // 2160: forge.Forge.RedfishApplyAction:output_type -> forge.RedfishApplyActionResponse
+	707,  // 2161: forge.Forge.RedfishCancelAction:output_type -> forge.RedfishCancelActionResponse
+	709,  // 2162: forge.Forge.UfmBrowse:output_type -> forge.UfmBrowseResponse
+	733,  // 2163: forge.Forge.GetDesiredFirmwareVersions:output_type -> forge.GetDesiredFirmwareVersionsResponse
+	854,  // 2164: forge.Forge.UpsertHostFirmwareConfig:output_type -> forge.HostFirmwareConfigResponse
+	1146, // 2165: forge.Forge.DeleteHostFirmwareConfig:output_type -> google.protobuf.Empty
+	749,  // 2166: forge.Forge.CreateSku:output_type -> forge.SkuIdList
+	745,  // 2167: forge.Forge.GenerateSkuFromMachine:output_type -> forge.Sku
+	1146, // 2168: forge.Forge.VerifySkuForMachine:output_type -> google.protobuf.Empty
+	1146, // 2169: forge.Forge.AssignSkuToMachine:output_type -> google.protobuf.Empty
+	1146, // 2170: forge.Forge.RemoveSkuAssociation:output_type -> google.protobuf.Empty
+	1146, // 2171: forge.Forge.DeleteSku:output_type -> google.protobuf.Empty
+	749,  // 2172: forge.Forge.GetAllSkuIds:output_type -> forge.SkuIdList
+	748,  // 2173: forge.Forge.FindSkusByIds:output_type -> forge.SkuList
+	1146, // 2174: forge.Forge.UpdateSkuMetadata:output_type -> google.protobuf.Empty
+	745,  // 2175: forge.Forge.ReplaceSku:output_type -> forge.Sku
+	419,  // 2176: forge.Forge.GetManagedHostQuarantineState:output_type -> forge.GetManagedHostQuarantineStateResponse
+	421,  // 2177: forge.Forge.SetManagedHostQuarantineState:output_type -> forge.SetManagedHostQuarantineStateResponse
+	423,  // 2178: forge.Forge.ClearManagedHostQuarantineState:output_type -> forge.ClearManagedHostQuarantineStateResponse
+	1146, // 2179: forge.Forge.ResetHostReprovisioning:output_type -> google.protobuf.Empty
+	1146, // 2180: forge.Forge.CopyBfbToDpuRshim:output_type -> google.protobuf.Empty
+	755,  // 2181: forge.Forge.GetAllDpaInterfaceIds:output_type -> forge.DpaInterfaceIdList
+	757,  // 2182: forge.Forge.FindDpaInterfacesByIds:output_type -> forge.DpaInterfaceList
+	753,  // 2183: forge.Forge.CreateDpaInterface:output_type -> forge.DpaInterface
+	753,  // 2184: forge.Forge.EnsureDpaInterface:output_type -> forge.DpaInterface
+	760,  // 2185: forge.Forge.DeleteDpaInterface:output_type -> forge.DpaInterfaceDeletionResult
+	765,  // 2186: forge.Forge.GetPowerOptions:output_type -> forge.PowerOptionResponse
+	765,  // 2187: forge.Forge.UpdatePowerOption:output_type -> forge.PowerOptionResponse
+	1146, // 2188: forge.Forge.AllowIngestionAndPowerOn:output_type -> google.protobuf.Empty
+	138,  // 2189: forge.Forge.DetermineMachineIngestionState:output_type -> forge.MachineIngestionStateResponse
+	783,  // 2190: forge.Forge.FindRackIds:output_type -> forge.RackIdList
+	781,  // 2191: forge.Forge.FindRacksByIds:output_type -> forge.RackList
+	780,  // 2192: forge.Forge.GetRack:output_type -> forge.GetRackResponse
+	1146, // 2193: forge.Forge.DeleteRack:output_type -> google.protobuf.Empty
+	792,  // 2194: forge.Forge.AdminForceDeleteRack:output_type -> forge.AdminForceDeleteRackResponse
+	799,  // 2195: forge.Forge.GetRackProfile:output_type -> forge.GetRackProfileResponse
+	801,  // 2196: forge.Forge.ListRackProfiles:output_type -> forge.ListRackProfilesResponse
+	769,  // 2197: forge.Forge.CreateComputeAllocation:output_type -> forge.CreateComputeAllocationResponse
+	771,  // 2198: forge.Forge.FindComputeAllocationIds:output_type -> forge.FindComputeAllocationIdsResponse
+	773,  // 2199: forge.Forge.FindComputeAllocationsByIds:output_type -> forge.FindComputeAllocationsByIdsResponse
+	774,  // 2200: forge.Forge.UpdateComputeAllocation:output_type -> forge.UpdateComputeAllocationResponse
+	777,  // 2201: forge.Forge.DeleteComputeAllocation:output_type -> forge.DeleteComputeAllocationResponse
+	847,  // 2202: forge.Forge.SetFirmwareUpdateTimeWindow:output_type -> forge.SetFirmwareUpdateTimeWindowResponse
+	856,  // 2203: forge.Forge.ListHostFirmware:output_type -> forge.ListHostFirmwareResponse
+	1270, // 2204: forge.Forge.PublishMlxDeviceReport:output_type -> mlx_device.PublishMlxDeviceReportResponse
+	1271, // 2205: forge.Forge.PublishMlxObservationReport:output_type -> mlx_device.PublishMlxObservationReportResponse
+	859,  // 2206: forge.Forge.TrimTable:output_type -> forge.TrimTableResponse
+	861,  // 2207: forge.Forge.ListNvlinkNmxcEndpoints:output_type -> forge.NvlinkNmxcEndpointList
+	860,  // 2208: forge.Forge.CreateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	860,  // 2209: forge.Forge.UpdateNvlinkNmxcEndpoint:output_type -> forge.NvlinkNmxcEndpoint
+	1146, // 2210: forge.Forge.DeleteNvlinkNmxcEndpoint:output_type -> google.protobuf.Empty
+	864,  // 2211: forge.Forge.CreateRemediation:output_type -> forge.CreateRemediationResponse
+	1146, // 2212: forge.Forge.ApproveRemediation:output_type -> google.protobuf.Empty
+	1146, // 2213: forge.Forge.RevokeRemediation:output_type -> google.protobuf.Empty
+	1146, // 2214: forge.Forge.EnableRemediation:output_type -> google.protobuf.Empty
+	1146, // 2215: forge.Forge.DisableRemediation:output_type -> google.protobuf.Empty
+	865,  // 2216: forge.Forge.FindRemediationIds:output_type -> forge.RemediationIdList
+	866,  // 2217: forge.Forge.FindRemediationsByIds:output_type -> forge.RemediationList
+	873,  // 2218: forge.Forge.FindAppliedRemediationIds:output_type -> forge.AppliedRemediationIdList
+	876,  // 2219: forge.Forge.FindAppliedRemediations:output_type -> forge.AppliedRemediationList
+	878,  // 2220: forge.Forge.GetNextRemediationForMachine:output_type -> forge.GetNextRemediationForMachineResponse
+	1146, // 2221: forge.Forge.RemediationApplied:output_type -> google.protobuf.Empty
+	1146, // 2222: forge.Forge.SetPrimaryDpu:output_type -> google.protobuf.Empty
+	1146, // 2223: forge.Forge.SetPrimaryInterface:output_type -> google.protobuf.Empty
+	887,  // 2224: forge.Forge.CreateDpuExtensionService:output_type -> forge.DpuExtensionService
+	887,  // 2225: forge.Forge.UpdateDpuExtensionService:output_type -> forge.DpuExtensionService
+	891,  // 2226: forge.Forge.DeleteDpuExtensionService:output_type -> forge.DeleteDpuExtensionServiceResponse
+	893,  // 2227: forge.Forge.FindDpuExtensionServiceIds:output_type -> forge.DpuExtensionServiceIdList
+	895,  // 2228: forge.Forge.FindDpuExtensionServicesByIds:output_type -> forge.DpuExtensionServiceList
+	897,  // 2229: forge.Forge.GetDpuExtensionServiceVersionsInfo:output_type -> forge.DpuExtensionServiceVersionInfoList
+	899,  // 2230: forge.Forge.FindInstancesByDpuExtensionService:output_type -> forge.FindInstancesByDpuExtensionServiceResponse
+	112,  // 2231: forge.Forge.TriggerMachineAttestation:output_type -> forge.SpdmMachineAttestationTriggerResponse
+	1146, // 2232: forge.Forge.CancelMachineAttestation:output_type -> google.protobuf.Empty
+	117,  // 2233: forge.Forge.ListAttestationMachines:output_type -> forge.SpdmListAttestationMachinesResponse
+	114,  // 2234: forge.Forge.GetAttestationMachine:output_type -> forge.SpdmGetAttestationMachineResponse
+	119,  // 2235: forge.Forge.SignMachineIdentity:output_type -> forge.MachineIdentityResponse
+	124,  // 2236: forge.Forge.GetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	124,  // 2237: forge.Forge.SetTenantIdentityConfiguration:output_type -> forge.TenantIdentityConfigResponse
+	1146, // 2238: forge.Forge.DeleteTenantIdentityConfiguration:output_type -> google.protobuf.Empty
+	127,  // 2239: forge.Forge.GetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	127,  // 2240: forge.Forge.SetTokenDelegation:output_type -> forge.TokenDelegationResponse
+	1146, // 2241: forge.Forge.DeleteTokenDelegation:output_type -> google.protobuf.Empty
+	133,  // 2242: forge.Forge.ReencryptTenantIdentitySecrets:output_type -> forge.ReencryptTenantIdentitySecretsResponse
+	134,  // 2243: forge.Forge.GetJWKS:output_type -> forge.Jwks
+	135,  // 2244: forge.Forge.GetOpenIDConfiguration:output_type -> forge.OpenIdConfiguration
+	906,  // 2245: forge.Forge.ScoutStream:output_type -> forge.ScoutStreamScoutBoundMessage
+	909,  // 2246: forge.Forge.ScoutStreamShowConnections:output_type -> forge.ScoutStreamShowConnectionsResponse
+	911,  // 2247: forge.Forge.ScoutStreamDisconnect:output_type -> forge.ScoutStreamDisconnectResponse
+	913,  // 2248: forge.Forge.ScoutStreamPing:output_type -> forge.ScoutStreamAdminPingResponse
+	1272, // 2249: forge.Forge.MlxAdminProfileSync:output_type -> mlx_device.MlxAdminProfileSyncResponse
+	1273, // 2250: forge.Forge.MlxAdminProfileShow:output_type -> mlx_device.MlxAdminProfileShowResponse
+	1274, // 2251: forge.Forge.MlxAdminProfileCompare:output_type -> mlx_device.MlxAdminProfileCompareResponse
+	1275, // 2252: forge.Forge.MlxAdminProfileList:output_type -> mlx_device.MlxAdminProfileListResponse
+	1276, // 2253: forge.Forge.MlxAdminLockdownLock:output_type -> mlx_device.MlxAdminLockdownLockResponse
+	1277, // 2254: forge.Forge.MlxAdminLockdownUnlock:output_type -> mlx_device.MlxAdminLockdownUnlockResponse
+	1278, // 2255: forge.Forge.MlxAdminLockdownStatus:output_type -> mlx_device.MlxAdminLockdownStatusResponse
+	1279, // 2256: forge.Forge.MlxAdminShowDevice:output_type -> mlx_device.MlxAdminDeviceInfoResponse
+	1280, // 2257: forge.Forge.MlxAdminShowMachine:output_type -> mlx_device.MlxAdminDeviceReportResponse
+	1281, // 2258: forge.Forge.MlxAdminRegistryList:output_type -> mlx_device.MlxAdminRegistryListResponse
+	1282, // 2259: forge.Forge.MlxAdminRegistryShow:output_type -> mlx_device.MlxAdminRegistryShowResponse
+	1283, // 2260: forge.Forge.MlxAdminConfigQuery:output_type -> mlx_device.MlxAdminConfigQueryResponse
+	1284, // 2261: forge.Forge.MlxAdminConfigSet:output_type -> mlx_device.MlxAdminConfigSetResponse
+	1285, // 2262: forge.Forge.MlxAdminConfigSync:output_type -> mlx_device.MlxAdminConfigSyncResponse
+	1286, // 2263: forge.Forge.MlxAdminConfigCompare:output_type -> mlx_device.MlxAdminConfigCompareResponse
+	824,  // 2264: forge.Forge.FindNVLinkPartitionIds:output_type -> forge.NVLinkPartitionIdList
+	819,  // 2265: forge.Forge.FindNVLinkPartitionsByIds:output_type -> forge.NVLinkPartitionList
+	819,  // 2266: forge.Forge.NVLinkPartitionsForTenant:output_type -> forge.NVLinkPartitionList
+	835,  // 2267: forge.Forge.FindNVLinkLogicalPartitionIds:output_type -> forge.NVLinkLogicalPartitionIdList
+	829,  // 2268: forge.Forge.FindNVLinkLogicalPartitionsByIds:output_type -> forge.NVLinkLogicalPartitionList
+	828,  // 2269: forge.Forge.CreateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartition
+	837,  // 2270: forge.Forge.UpdateNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionUpdateResult
+	832,  // 2271: forge.Forge.DeleteNVLinkLogicalPartition:output_type -> forge.NVLinkLogicalPartitionDeletionResult
+	829,  // 2272: forge.Forge.NVLinkLogicalPartitionsForTenant:output_type -> forge.NVLinkLogicalPartitionList
+	927,  // 2273: forge.Forge.GetMachinePositionInfo:output_type -> forge.MachinePositionInfoList
+	817,  // 2274: forge.Forge.NmxcBrowse:output_type -> forge.NmxcBrowseResponse
+	1146, // 2275: forge.Forge.ModifyDPFState:output_type -> google.protobuf.Empty
+	930,  // 2276: forge.Forge.GetDPFState:output_type -> forge.DPFStateResponse
+	933,  // 2277: forge.Forge.GetDPFHostSnapshot:output_type -> forge.DPFHostSnapshotResponse
+	936,  // 2278: forge.Forge.GetDPFServiceVersions:output_type -> forge.DPFServiceVersionsResponse
+	1133, // 2279: forge.Forge.FindPendingDPUServiceSyncIds:output_type -> common.MachineIdList
+	944,  // 2280: forge.Forge.FindPendingDPUServiceSyncsByIds:output_type -> forge.ListPendingDPUServiceSyncsResponse
+	944,  // 2281: forge.Forge.ListDPUServiceSyncHistory:output_type -> forge.ListPendingDPUServiceSyncsResponse
+	939,  // 2282: forge.Forge.ReleaseDPUServiceSyncHold:output_type -> forge.ReleaseDPUServiceSyncHoldResponse
+	953,  // 2283: forge.Forge.ComponentPowerControl:output_type -> forge.ComponentPowerControlResponse
+	955,  // 2284: forge.Forge.ComponentConfigureSwitchCertificate:output_type -> forge.ComponentConfigureSwitchCertificateResponse
+	951,  // 2285: forge.Forge.GetComponentInventory:output_type -> forge.GetComponentInventoryResponse
+	962,  // 2286: forge.Forge.UpdateComponentFirmware:output_type -> forge.UpdateComponentFirmwareResponse
+	964,  // 2287: forge.Forge.GetComponentFirmwareStatus:output_type -> forge.GetComponentFirmwareStatusResponse
+	968,  // 2288: forge.Forge.ListComponentFirmwareVersions:output_type -> forge.ListComponentFirmwareVersionsResponse
+	981,  // 2289: forge.Forge.CreateOperatingSystem:output_type -> forge.OperatingSystem
+	981,  // 2290: forge.Forge.GetOperatingSystem:output_type -> forge.OperatingSystem
+	981,  // 2291: forge.Forge.UpdateOperatingSystem:output_type -> forge.OperatingSystem
+	987,  // 2292: forge.Forge.DeleteOperatingSystem:output_type -> forge.DeleteOperatingSystemResponse
+	989,  // 2293: forge.Forge.FindOperatingSystemIds:output_type -> forge.OperatingSystemIdList
+	991,  // 2294: forge.Forge.FindOperatingSystemsByIds:output_type -> forge.OperatingSystemList
+	993,  // 2295: forge.Forge.GetOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	993,  // 2296: forge.Forge.UpdateOperatingSystemCachableIpxeTemplateArtifacts:output_type -> forge.IpxeTemplateArtifactList
+	997,  // 2297: forge.Forge.ReWrapSecrets:output_type -> forge.ReWrapSecretsResponse
+	1803, // [1803:2298] is the sub-list for method output_type
+	1308, // [1308:1803] is the sub-list for method input_type
+	1308, // [1308:1308] is the sub-list for extension type_name
+	1308, // [1308:1308] is the sub-list for extension extendee
+	0,    // [0:1308] is the sub-list for field type_name
 }
 
 func init() { file_nico_nico_proto_init() }
@@ -76801,32 +77119,33 @@ func file_nico_nico_proto_init() {
 	file_nico_nico_proto_msgTypes[903].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[907].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[911].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[912].OneofWrappers = []any{}
 	file_nico_nico_proto_msgTypes[915].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[917].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[919].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[921].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[936].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[938].OneofWrappers = []any{
+	file_nico_nico_proto_msgTypes[918].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[920].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[922].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[924].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[939].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[941].OneofWrappers = []any{
 		(*ForgeAgentControlResponse_MlxDeviceAction_Noop)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_Lock)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_Unlock)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_ApplyProfile)(nil),
 		(*ForgeAgentControlResponse_MlxDeviceAction_ApplyFirmware)(nil),
 	}
-	file_nico_nico_proto_msgTypes[942].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[943].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[947].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[948].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[949].OneofWrappers = []any{}
-	file_nico_nico_proto_msgTypes[956].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[945].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[946].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[950].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[951].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[952].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[959].OneofWrappers = []any{}
+	file_nico_nico_proto_msgTypes[960].OneofWrappers = []any{}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
 		File: protoimpl.DescBuilder{
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_nico_nico_proto_rawDesc), len(file_nico_nico_proto_rawDesc)),
-			NumEnums:      109,
-			NumMessages:   957,
+			NumEnums:      110,
+			NumMessages:   961,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
+++ b/rest-api/proto/core/gen/v1/nico_nico_grpc.pb.go
@@ -205,6 +205,8 @@ const (
 	Forge_ListDpuWaitingForReprovisioning_FullMethodName                    = "/forge.Forge/ListDpuWaitingForReprovisioning"
 	Forge_TriggerHostReprovisioning_FullMethodName                          = "/forge.Forge/TriggerHostReprovisioning"
 	Forge_ListHostsWaitingForReprovisioning_FullMethodName                  = "/forge.Forge/ListHostsWaitingForReprovisioning"
+	Forge_TriggerManagedHostReset_FullMethodName                            = "/forge.Forge/TriggerManagedHostReset"
+	Forge_ListManagedHostsWaitingForReset_FullMethodName                    = "/forge.Forge/ListManagedHostsWaitingForReset"
 	Forge_TriggerBmcCredentialRotation_FullMethodName                       = "/forge.Forge/TriggerBmcCredentialRotation"
 	Forge_TriggerUefiCredentialRotation_FullMethodName                      = "/forge.Forge/TriggerUefiCredentialRotation"
 	Forge_TriggerNicLockdownCredentialRotation_FullMethodName               = "/forge.Forge/TriggerNicLockdownCredentialRotation"
@@ -849,6 +851,11 @@ type ForgeClient interface {
 	TriggerHostReprovisioning(ctx context.Context, in *HostReprovisioningRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
 	// List hosts waiting for reprovisioning
 	ListHostsWaitingForReprovisioning(ctx context.Context, in *HostReprovisioningListRequest, opts ...grpc.CallOption) (*HostReprovisioningListResponse, error)
+	// Trigger a reset of a managed host: tear down its instance and DPF
+	// resources, then re-ingest it from DPU discovery.
+	TriggerManagedHostReset(ctx context.Context, in *ManagedHostResetRequest, opts ...grpc.CallOption) (*emptypb.Empty, error)
+	// List managed hosts waiting for reset
+	ListManagedHostsWaitingForReset(ctx context.Context, in *ManagedHostResetListRequest, opts ...grpc.CallOption) (*ManagedHostResetListResponse, error)
 	// Operator "force-converge this BMC now" escape hatch for a single host/DPU
 	// BMC. This is asynchronous: the handler only persists (Set) or removes
 	// (Clear) the machine's `bmc_credential_rotation_requested` flag and returns;
@@ -3256,6 +3263,26 @@ func (c *forgeClient) ListHostsWaitingForReprovisioning(ctx context.Context, in 
 	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
 	out := new(HostReprovisioningListResponse)
 	err := c.cc.Invoke(ctx, Forge_ListHostsWaitingForReprovisioning_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *forgeClient) TriggerManagedHostReset(ctx context.Context, in *ManagedHostResetRequest, opts ...grpc.CallOption) (*emptypb.Empty, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(emptypb.Empty)
+	err := c.cc.Invoke(ctx, Forge_TriggerManagedHostReset_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *forgeClient) ListManagedHostsWaitingForReset(ctx context.Context, in *ManagedHostResetListRequest, opts ...grpc.CallOption) (*ManagedHostResetListResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(ManagedHostResetListResponse)
+	err := c.cc.Invoke(ctx, Forge_ListManagedHostsWaitingForReset_FullMethodName, in, out, cOpts...)
 	if err != nil {
 		return nil, err
 	}
@@ -6706,6 +6733,11 @@ type ForgeServer interface {
 	TriggerHostReprovisioning(context.Context, *HostReprovisioningRequest) (*emptypb.Empty, error)
 	// List hosts waiting for reprovisioning
 	ListHostsWaitingForReprovisioning(context.Context, *HostReprovisioningListRequest) (*HostReprovisioningListResponse, error)
+	// Trigger a reset of a managed host: tear down its instance and DPF
+	// resources, then re-ingest it from DPU discovery.
+	TriggerManagedHostReset(context.Context, *ManagedHostResetRequest) (*emptypb.Empty, error)
+	// List managed hosts waiting for reset
+	ListManagedHostsWaitingForReset(context.Context, *ManagedHostResetListRequest) (*ManagedHostResetListResponse, error)
 	// Operator "force-converge this BMC now" escape hatch for a single host/DPU
 	// BMC. This is asynchronous: the handler only persists (Set) or removes
 	// (Clear) the machine's `bmc_credential_rotation_requested` flag and returns;
@@ -7836,6 +7868,12 @@ func (UnimplementedForgeServer) TriggerHostReprovisioning(context.Context, *Host
 }
 func (UnimplementedForgeServer) ListHostsWaitingForReprovisioning(context.Context, *HostReprovisioningListRequest) (*HostReprovisioningListResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method ListHostsWaitingForReprovisioning not implemented")
+}
+func (UnimplementedForgeServer) TriggerManagedHostReset(context.Context, *ManagedHostResetRequest) (*emptypb.Empty, error) {
+	return nil, status.Error(codes.Unimplemented, "method TriggerManagedHostReset not implemented")
+}
+func (UnimplementedForgeServer) ListManagedHostsWaitingForReset(context.Context, *ManagedHostResetListRequest) (*ManagedHostResetListResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method ListManagedHostsWaitingForReset not implemented")
 }
 func (UnimplementedForgeServer) TriggerBmcCredentialRotation(context.Context, *BmcCredentialRotationRequest) (*emptypb.Empty, error) {
 	return nil, status.Error(codes.Unimplemented, "method TriggerBmcCredentialRotation not implemented")
@@ -12062,6 +12100,42 @@ func _Forge_ListHostsWaitingForReprovisioning_Handler(srv interface{}, ctx conte
 	}
 	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
 		return srv.(ForgeServer).ListHostsWaitingForReprovisioning(ctx, req.(*HostReprovisioningListRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Forge_TriggerManagedHostReset_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ManagedHostResetRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ForgeServer).TriggerManagedHostReset(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Forge_TriggerManagedHostReset_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ForgeServer).TriggerManagedHostReset(ctx, req.(*ManagedHostResetRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _Forge_ListManagedHostsWaitingForReset_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(ManagedHostResetListRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(ForgeServer).ListManagedHostsWaitingForReset(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: Forge_ListManagedHostsWaitingForReset_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(ForgeServer).ListManagedHostsWaitingForReset(ctx, req.(*ManagedHostResetListRequest))
 	}
 	return interceptor(ctx, in, info, handler)
 }
@@ -18387,6 +18461,14 @@ var Forge_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "ListHostsWaitingForReprovisioning",
 			Handler:    _Forge_ListHostsWaitingForReprovisioning_Handler,
+		},
+		{
+			MethodName: "TriggerManagedHostReset",
+			Handler:    _Forge_TriggerManagedHostReset_Handler,
+		},
+		{
+			MethodName: "ListManagedHostsWaitingForReset",
+			Handler:    _Forge_ListManagedHostsWaitingForReset_Handler,
 		},
 		{
 			MethodName: "TriggerBmcCredentialRotation",

--- a/rest-api/proto/core/src/v1/nico_nico.proto
+++ b/rest-api/proto/core/src/v1/nico_nico.proto
@@ -407,6 +407,13 @@ service Forge {
   rpc TriggerHostReprovisioning(HostReprovisioningRequest) returns (google.protobuf.Empty);
   // List hosts waiting for reprovisioning
   rpc ListHostsWaitingForReprovisioning(HostReprovisioningListRequest) returns (HostReprovisioningListResponse);
+
+  // Trigger a reset of a managed host: tear down its instance and DPF
+  // resources, then re-ingest it from DPU discovery.
+  rpc TriggerManagedHostReset(ManagedHostResetRequest) returns (google.protobuf.Empty);
+  // List managed hosts waiting for reset
+  rpc ListManagedHostsWaitingForReset(ManagedHostResetListRequest) returns (ManagedHostResetListResponse);
+
   // Operator "force-converge this BMC now" escape hatch for a single host/DPU
   // BMC. This is asynchronous: the handler only persists (Set) or removes
   // (Clear) the machine's `bmc_credential_rotation_requested` flag and returns;
@@ -10382,6 +10389,39 @@ message InterfaceAddressConfig {
   // and debugging; the tenant is not expected to access this address. Writers
   // must set this value on at most one family entry.
   optional string tenant_vrf_loopback_ip = 7;
+}
+
+message ManagedHostResetRequest {
+  enum Mode {
+    // Zero value so an omitted mode is rejected, not defaulted to an action.
+    Unspecified = 0;
+    Set = 1;
+    Clear = 2;
+  }
+  // Host to reset. Not a DPU: a reset tears down every DPU attached to the
+  // host, so it is only expressible against the host.
+  common.MachineId machine_id = 1;
+  Mode mode = 2;
+  UpdateInitiator initiator = 3;
+
+  // Operator acknowledgment that resetting an assigned host destroys the live
+  // tenant instance and its data. The server rejects a Set on an assigned host
+  // unless this is set.
+  bool allow_reset_with_instance = 4;
+}
+
+message ManagedHostResetListRequest {
+}
+
+message ManagedHostResetListResponse {
+  message ManagedHostResetListItem {
+    common.MachineId id = 1; // Host machine ID
+    string state = 2; // ManagedHost state
+    string initiator = 3; // Who requested this reset.
+    google.protobuf.Timestamp requested_at = 4; // When the reset was requested.
+    optional google.protobuf.Timestamp started_at = 5; // When the reset started.
+  }
+  repeated ManagedHostResetListItem hosts = 1;
 }
 
 // Selects a fixed, versioned mlxconfig profile for DPU provisioning.


### PR DESCRIPTION
## Description

DPU reprovisioning is only acted on when a host is in `Ready` or
`Assigned { Ready }`. When a DPU becomes corrupted — a missing OS, missing
files — the host is usually parked in a non-ready state such as `Failed` or
`HostInit`, where the reprovision hinge never fires. The only recovery today is
force-deleting the machine, which removes it entirely and requires re-adding and
re-ingesting it from scratch.

This PR adds the managed host reset mechanism, so a DPF-ingested host can be
recovered from any state except `ForceDeletion` without deleting it. The request
is recorded in a new nullable `reset_requested` column, and the state controller
then moves the host into a new `Reset` state that deletes the tenant instance
and the host's DPF CRs, waits for them to drain, and re-enters DPU discovery,
which recreates the CRs and re-ingests the host.

Two new RPCs, `TriggerManagedHostReset` and `ListManagedHostsWaitingForReset`,
are restricted to `ForgeAdminCLI`.

Guards on `mode = Set`:

- The host must be DPF-ingested (`dpf.used_for_ingestion == true`), since
  re-ingestion re-registers DPF CRs.
- The host must not be in `ForceDeletion`, where the controller no longer
  manages it and the reset would never run.
- A live instance requires `allow_reset_with_instance`, because the reset
  destroys that instance and its data.
- The host must already carry a `HostUpdateInProgress` alert classified
  `PreventAllocations`, applied with
  `machine health-report add --template host-update <id>`.
- The target must be the host, not an individual DPU.

`mode = Clear` withdraws a request that has not started yet; once teardown
begins it is refused. Re-running `Set` on a host that is already resetting is
allowed and restarts the teardown.

The `nico-admin-cli managed-host reset` surface follows in a separate PR, since
it only compiles once this proto has landed.

## Related issues

Closes #3148

## Type of Change

- [x] **Add** - New feature or capability

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated

API-contract tests cover a `Set` persisting and appearing in the pending list,
rejection of a DPU target and of a host with no acknowledging alert, rejection
of a host not ingested through DPF, rejection of a force-deleting host, the
live-instance rule in both directions, and `Clear` being refused once
`started_at` is stamped.

Controller tests drive the state machine against a DPF mock: the host holds in
`DeletingCrs` while the CRs still exist, and re-enters `DpuDiscoveringState`
once they are gone.

## Additional Notes

- The `HostUpdateInProgress` alert is a precondition, not something the reset
  applies. Without it the request is refused rather than falling back to a
  default message.
- Resetting a host with a live instance destroys that instance and its data. The
  caller acknowledges this by setting `allow_reset_with_instance`.
[Managed Host Reset — Design.pdf](https://github.com/user-attachments/files/32095762/Managed.Host.Reset.Design.pdf)
