### PR TITLE
docs: add SRE troubleshooting playbooks

### DIFF
--- a/docs/index.yml
+++ b/docs/index.yml
@@ -274,32 +274,44 @@ navigation:
               contents:
                 - page: Overview and General Troubleshooting
                   path: playbooks/stuck_objects/stuck_objects.md
-                - page: Common Mitigations
-                  path: playbooks/stuck_objects/common_mitigations.md
-                - page: Stuck in WaitingForNetworkConfig and DPU Health
-                  path: playbooks/stuck_objects/waiting_for_network_config.md
-                - page: Adding New Machines to an Existing Site
-                  path: playbooks/stuck_objects/adding_new_machines.md
-                - page: State Machine Debugging
-                  path: playbooks/stuck_objects/state_machine_debugging.md
                 - page: Diagnostic Tools
                   path: playbooks/stuck_objects/diagnostic_tools.md
+                - page: State Machine Debugging
+                  path: playbooks/stuck_objects/state_machine_debugging.md
+                - page: Common Mitigations
+                  path: playbooks/stuck_objects/common_mitigations.md
+                - page: Adding New Machines to an Existing Site
+                  path: playbooks/stuck_objects/adding_new_machines.md
+                - page: Dell PowerEdge Missing DPU Boot Device
+                  path: playbooks/stuck_objects/dell_poweredge_boot_issues.md
                 - page: DPU Provisioning Failures
                   path: playbooks/stuck_objects/dpu_provisioning_failures.md
-                - page: Host Ingestion Failures
-                  path: playbooks/stuck_objects/host_ingestion_failures.md
                 - page: Health Alerts and Overrides
                   path: playbooks/stuck_objects/health_alerts.md
-                - page: Network Connectivity Issues
-                  path: playbooks/stuck_objects/network_connectivity.md
+                - page: Host Ingestion Failures
+                  path: playbooks/stuck_objects/host_ingestion_failures.md
+                - page: Instance Boot Connection Timeout
+                  path: playbooks/stuck_objects/instance_boot_connection_timeout.md
                 - page: Instance and Fabric Issues
                   path: playbooks/stuck_objects/instance_and_fabric_issues.md
+                - page: Lenovo SR675 V3 Stuck Polling BIOS Setup
+                  path: playbooks/stuck_objects/lenovo_sr675_v3_polling_bios_setup.md
+                - page: Managed Host Stuck in UEFI Setup
+                  path: playbooks/stuck_objects/host_initializing_uefi_setup.md
+                - page: Network Connectivity Issues
+                  path: playbooks/stuck_objects/network_connectivity.md
                 - page: Site Controller Health
                   path: playbooks/stuck_objects/site_controller_health.md
+                - page: Stuck in WaitingForNetworkConfig and DPU Health
+                  path: playbooks/stuck_objects/waiting_for_network_config.md
+                - page: Troubleshooting BgpPeeringTor Alerts
+                  path: playbooks/stuck_objects/bgp_peering_tor_alert.md
                 - page: Troubleshooting noDpuLogsWarning Alerts
                   path: playbooks/troubleshooting_noDpuLogsWarning_alerts.md
             - section: Debugging Machine
               contents:
+                - page: Booting into Linux Scout
+                  path: playbooks/debugging_machine/force_linux_scout_boot.md
                 - page: Collecting Debug Bundles
                   path: playbooks/debugging_machine/debug_bundle.md
         - page: NVLink Domain Health Reports

--- a/docs/index.yml
+++ b/docs/index.yml
@@ -296,6 +296,8 @@ navigation:
                   path: playbooks/stuck_objects/instance_and_fabric_issues.md
                 - page: Lenovo SR675 V3 Stuck Polling BIOS Setup
                   path: playbooks/stuck_objects/lenovo_sr675_v3_polling_bios_setup.md
+                - page: Machine Stuck in DPUInitializing/Init During Ingestion
+                  path: playbooks/stuck_objects/dpu_initializing_init.md
                 - page: Managed Host Stuck in UEFI Setup
                   path: playbooks/stuck_objects/host_initializing_uefi_setup.md
                 - page: Network Connectivity Issues

--- a/docs/playbooks/debugging_machine/force_linux_scout_boot.md
+++ b/docs/playbooks/debugging_machine/force_linux_scout_boot.md
@@ -1,0 +1,68 @@
+# Force a Managed Host to Boot into Linux Scout
+
+Use this playbook when you need the Linux Scout environment for managed-host
+diagnostics and the normal NICo boot workflow does not select it.
+
+## Prerequisites
+
+- Access to the managed host's serial or remote console.
+- The static PXE URL that the managed host can reach.
+- The managed host CPU architecture: x86-64 or Arm.
+
+## Open the iPXE Debug Shell
+
+1. Boot the managed host from its BlueField DPU network interface.
+1. When NICo briefly displays `Press p key to override boot procedure`, press
+   <kbd>p</kbd> several times.
+1. Select **iPXE Debug Shell** from the menu:
+
+   ```text
+                                   NICo
+
+   Boot according to NICo workflow
+   Print information about this machine
+   Boot to local drive
+   Retry boot
+   iPXE Debug Shell
+   Reboot System
+   ```
+
+## Configure the Network
+
+At the `nico>` prompt, request an address through DHCP:
+
+```text
+nico> dhcp
+```
+
+A successful request configures the DPU network interface and returns to the
+prompt:
+
+```text
+Type "exit" to return to menu
+nico> dhcp
+Configuring (net0 xx:xx:xx:xx:xx:xx)....... ok
+nico>
+```
+
+## Boot Linux Scout
+
+Replace `<static-pxe-url>` with the static PXE endpoint that is reachable from
+the managed host. The standard site-local endpoint is described in
+[IP and Network Configuration](../../provisioning/ip-and-network-configuration.md).
+
+For an x86-64 managed host, run:
+
+```text
+nico> chain <static-pxe-url>/public/blobs/internal/x86_64/scout.efi console=tty0 console=ttyS1,115200 pci=realloc=off iommu=off cli_cmd=auto-detect
+```
+
+For an Arm managed host, including an NVIDIA GB200 or GB300 system, run:
+
+```text
+nico> chain <static-pxe-url>/public/blobs/internal/aarch64/scout.efi console=tty0 console=ttyAMA0,115200 pci=realloc=off iommu=off cli_cmd=auto-detect
+```
+
+The managed host boots into Linux Scout. If it does not, verify that DHCP
+completed, the static PXE endpoint is reachable, and the selected artifact
+matches the CPU architecture.

--- a/docs/playbooks/stuck_objects/bgp_peering_tor_alert.md
+++ b/docs/playbooks/stuck_objects/bgp_peering_tor_alert.md
@@ -1,0 +1,96 @@
+# Troubleshoot a BgpPeeringTor Health Alert
+
+Use this playbook when a managed host or DPU reports `BgpPeeringTor` and the
+alert identifies the `p0` or `p1` top-of-rack (ToR) uplink.
+
+## Symptoms and Impact
+
+- HBN reports `p0_if` or `p1_if` as `Idle` or `Active` instead of established.
+- `ethtool` reports that the affected link is not detected.
+- `ip link` reports `NO-CARRIER` and `state DOWN`.
+- Optical diagnostics report no transmit or receive power.
+
+The DPU cannot peer with the ToR switch over the affected link. A primary `p0`
+failure can block normal PXE provisioning even when `p1` remains established.
+For the health-policy behavior, refer to
+[Waiting for Network Configuration and DPU Health](waiting_for_network_config.md#bgppeeringtor).
+
+Access the DPU OS directly or through its BMC serial console. Most diagnostic
+commands require root privileges.
+
+## Check BGP State
+
+Run `show bgp summary` in the `doca-hbn` container:
+
+```bash
+crictl exec "$(crictl ps | awk '/hbn/ {print $1; exit}')" \
+  vtysh -c 'show bgp summary'
+```
+
+An affected interface remains in `Idle` or `Active`, often with `never` in the
+`Up/Down` column:
+
+```text
+Neighbor        V  AS  MsgRcvd  MsgSent  Up/Down  State/PfxRcd
+p0_if           4   0        0        0  never    Idle
+p1_if           4   0        0        0  never    Idle
+```
+
+A healthy interface has nonzero message counters and uptime. Depending on the
+FRR output format, an established session displays a received-prefix count in
+`State/PfxRcd` rather than the word `Established`.
+
+## Check the Physical Links
+
+1. Check link detection:
+
+   ```bash
+   ethtool p0 | grep -i 'link detected'
+   ethtool p1 | grep -i 'link detected'
+   ```
+
+1. Check carrier state:
+
+   ```bash
+   ip link show p0
+   ip link show p1
+   ```
+
+   `NO-CARRIER` and `state DOWN` indicate a physical-link failure.
+
+1. Inspect optical power and module temperature on each affected interface:
+
+   ```bash
+   ethtool -m p0 | grep -E 'optical power|temperature'
+   ethtool -m p1 | grep -E 'optical power|temperature'
+   ```
+
+   Near-zero transmit and receive power with a normal module temperature points
+   to an unplugged, loose, or failed active optical cable.
+
+## Restore the Link
+
+1. Ask the data center operator to reseat the affected cable.
+1. Replace the cable if reseating it does not restore carrier.
+1. Identify both the logical interface and physical port in the request. DPU
+   physical ports 1 and 2 correspond to `p0` and `p1`, respectively.
+1. If the DPU reports carrier but BGP remains down, have the networking team
+   verify that the corresponding ToR port is enabled and correctly configured.
+1. Consider DPU replacement only after the cable and ToR port have been ruled
+   out.
+
+## Verify Recovery
+
+1. Confirm that `ethtool` reports `Link detected: yes` and `ip link` reports
+   `state UP` without `NO-CARRIER`.
+1. Run the HBN BGP summary again. Confirm that `p0_if` and `p1_if` have nonzero
+   uptime and increasing message counters.
+1. Confirm that the `BgpPeeringTor` alert clears from the NICo health report:
+
+   ```bash
+   nico-admin-cli dpu health-report show <dpu-machine-id>
+   nico-admin-cli machine health-report show <host-machine-id>
+   ```
+
+For additional probe variants and configuration checks, refer to
+[DPU ToR Uplink Health](../../dpu-management/dpu_configuration.md#dpu-tor-uplink-health).

--- a/docs/playbooks/stuck_objects/dell_poweredge_boot_issues.md
+++ b/docs/playbooks/stuck_objects/dell_poweredge_boot_issues.md
@@ -1,0 +1,164 @@
+# Restore a Missing DPU Boot Device on Dell PowerEdge
+
+Use this playbook when a Dell PowerEdge server with a DPU no longer lists its
+UEFI HTTP device. This issue has been observed on PowerEdge R750, R760, and
+XE9680 systems.
+
+## Symptoms and Impact
+
+- The server repeatedly selects boot devices other than the DPU.
+- A terminating instance boots the tenant operating system from local storage
+  instead of booting through the DPU.
+- Re-ingestion remains in `HostInitializing/SetBootOrder`.
+- Redfish does not return an `HTTP Device` boot option for the DPU.
+
+Without the DPU boot option, NICo cannot restore the expected boot order.
+Provisioning, termination, wiping, and re-ingestion can remain blocked.
+
+## Confirm That the Boot Device Is Missing
+
+1. Set the BMC connection variables. Obtain credentials from your approved
+   credential store.
+
+   ```bash
+   export BMC_IP=<bmc-ip-address>
+   export BMC_USER=<bmc-username>
+   export BMC_PASS=<bmc-password>
+   ```
+
+1. List the boot options:
+
+   ```bash
+   for device in $(curl --silent --insecure \
+     --user "${BMC_USER}:${BMC_PASS}" \
+     "https://${BMC_IP}/redfish/v1/Systems/System.Embedded.1" \
+     | jq -r '.Boot.BootOrder[]'); do
+     curl --silent --insecure \
+       --user "${BMC_USER}:${BMC_PASS}" \
+       "https://${BMC_IP}/redfish/v1/Systems/System.Embedded.1/BootOptions/${device}" \
+       | jq -r '"\(.DisplayName)\t\(.BootOptionEnabled)"'
+   done
+   ```
+
+1. Check for an enabled `HTTP Device` entry. A healthy system includes output
+   similar to:
+
+   ```text
+   BOSS in SL 16: ubuntu                               false
+   HTTP Device 1: NIC in Slot 40 Port 1 Partition 1   true
+   ```
+
+If no HTTP device appears, continue with this procedure.
+
+## Cause
+
+A PCIe training failure can prevent UEFI from detecting the DPU during boot.
+UEFI then removes the corresponding device from `BootOptions`. iDRAC System
+Lockdown prevents NICo from restoring the boot configuration until lockdown is
+disabled and the server is rebooted.
+
+## Disable System Lockdown
+
+1. Check the current state:
+
+   ```bash
+   nico-admin-cli bmc-machine lockdown-status --machine <machine-id>
+   ```
+
+1. Disable lockdown and reboot the host so the change takes effect:
+
+   ```bash
+   nico-admin-cli bmc-machine lockdown \
+     --machine <machine-id> --disable --reboot
+   ```
+
+You can also disable lockdown from the iDRAC dashboard by selecting
+**More Actions > Turn off the System Lockdown Mode**, then power cycling the
+host.
+
+## Restore the DPU Boot Device
+
+Try NICo machine setup first:
+
+1. Get the primary DPU interface MAC address:
+
+   ```bash
+   MAC_ADDRESS=$(nico-admin-cli -f json machine show <machine-id> \
+     | jq -r '.interfaces[] | select(.primary_interface == true) | .mac_address')
+   ```
+
+1. Run machine setup against the BMC:
+
+   ```bash
+   nico-admin-cli redfish \
+     --address "${BMC_IP}" \
+     --username "${BMC_USER}" \
+     --password "${BMC_PASS}" \
+     machine-setup --boot-interface-mac "${MAC_ADDRESS}"
+   ```
+
+1. Force-restart the host to apply pending UEFI changes:
+
+   ```bash
+   nico-admin-cli redfish \
+     --address "${BMC_IP}" \
+     --username "${BMC_USER}" \
+     --password "${BMC_PASS}" \
+     force-restart
+   ```
+
+If machine setup cannot restore the device, configure it from the UEFI UI:
+
+1. Open the iDRAC remote console and set the next boot device to **BIOS Setup**.
+1. Cold power cycle the system.
+1. At the UEFI password prompt, paste the password using the console's virtual
+   clipboard.
+1. Go to **System BIOS > Network Settings**, disable the PXE devices, and enable
+   **HTTP Device1** under UEFI.
+1. In **HTTP Device1 Settings**, select the DPU interface. Confirm the slot
+   against the server inventory and cabling. Common mappings are:
+
+   | Model | DPU Interface Example |
+   |---|---|
+   | PowerEdge R760 | NIC PCI Slot 2 |
+   | PowerEdge R750 | NIC in Slot 5 Port 1 |
+   | PowerEdge XE9680 | NIC in Slot 40 Port 1 Partition 1 |
+
+1. Save the settings and exit.
+1. If the host still selects local storage first, return to
+   **System BIOS > Boot Settings > UEFI Boot Settings** and move
+   **HTTP Device 1** to the first position.
+
+## Re-enable System Lockdown
+
+<Warning>
+
+Re-enable lockdown after restoring the boot configuration. Leaving lockdown
+disabled weakens the intended BMC security posture.
+
+</Warning>
+
+```bash
+nico-admin-cli bmc-machine lockdown \
+  --machine <machine-id> --enable
+```
+
+If the BMC requires a reboot to apply the change, add `--reboot`. From the
+iDRAC UI, select **More Actions > Turn on the System Lockdown Mode**.
+
+## Verify Recovery
+
+1. List the Redfish boot options again and confirm that an enabled
+   `HTTP Device` entry is present.
+1. Confirm that the host boots through the DPU rather than from the tenant OS
+   on local storage.
+1. If the host was stuck in `HostInitializing/SetBootOrder`, confirm that it
+   advances to the next state.
+1. Confirm that System Lockdown is enabled:
+
+   ```bash
+   nico-admin-cli bmc-machine lockdown-status --machine <machine-id>
+   ```
+
+For vendor background, refer to the
+[Dell iDRAC System Lockdown overview](https://www.dell.com/support/kbdoc/en-uk/000135182/idrac9-how-to-enable-and-disable-lockdown-mode).

--- a/docs/playbooks/stuck_objects/dpu_initializing_init.md
+++ b/docs/playbooks/stuck_objects/dpu_initializing_init.md
@@ -1,0 +1,116 @@
+# Machine Stuck in DPUInitializing/Init During Ingestion
+
+Use this playbook when a predicted host remains in `DPUInitializing/Init`
+during ingestion and its NVIDIA BlueField-2 DPU exposes InfiniBand interfaces
+instead of the Ethernet interfaces that NICo expects.
+
+## Symptoms
+
+Inspect the machine event history:
+
+```bash
+nico-admin-cli -f json machine show <host-machine-id> \
+  | jq -r '.events[] | "\(.time) \(.event)"' \
+  | tail -20
+```
+
+The most recent event remains similar to this output:
+
+```json
+{
+  "state": "dpuinit",
+  "dpu_states": {
+    "states": {
+      "<dpu-machine-id>": {
+        "dpustate": "init"
+      }
+    }
+  }
+}
+```
+
+Set `BMC_IP` to the DPU BMC address and set `BMC_USER` and `BMC_PASS` to
+credentials for that BMC. Query its Redfish network-port collection:
+
+```bash
+curl --silent --show-error --insecure \
+  --user "${BMC_USER}:${BMC_PASS}" \
+  --header "Content-Type: application/json" \
+  "https://${BMC_IP}/redfish/v1/Chassis/Card1/NetworkAdapters/NvidiaNetworkAdapter/Ports" \
+  | jq -r '.Members[] | .["@odata.id"]'
+```
+
+On an affected DPU, the member paths end in `ib0` and `ib1` instead of `eth0`
+and `eth1`.
+
+Log in to the DPU Arm OS and inspect its interfaces:
+
+```bash
+ip -brief link show
+sudo mst status -v
+```
+
+The affected configuration has these characteristics:
+
+- `ib0` and `ib1` exist instead of `p0` and `p1`.
+- `mst status -v` reports `net-ib0` and `net-ib1`.
+- The UEFI configuration reports the following values:
+
+  ```text
+  Device Name          Mellanox Network Adapter
+  Chip Type            BlueField-2
+  Network Link Type    <InfiniBand>
+  ```
+
+## Root Cause
+
+Both DPU network ports are configured with the InfiniBand link type. NICo
+expects these ports to use Ethernet and cannot advance DPU initialization while
+they expose InfiniBand interfaces.
+
+## Change the Network Link Type
+
+<Warning>
+A full host power cycle is disruptive. Confirm that the host has no assigned
+tenant workload before continuing.
+</Warning>
+
+1. Open the DPU console through its BMC.
+1. Reboot the DPU Arm OS and press Esc twice while the firmware starts to
+   enter UEFI setup.
+1. Enter the UEFI password when prompted.
+1. Go to **Device Manager > Network Device List**.
+1. Select the first network device by its **MAC address**, open
+   **Mellanox Network Adapter**, and set **Network Link Type** to **Ethernet**.
+   Press Esc and save the change.
+1. Repeat the previous step for the second network device.
+1. Exit UEFI setup. Use the BMC to power off the host, wait 30 seconds, and
+   power it on.
+
+<Note>
+A reset does not replace the final power cycle. After changing the link type,
+the network devices can disappear from UEFI setup until the host completes a
+full power cycle.
+</Note>
+
+## Verify Recovery
+
+1. Wait for the DPU to finish booting.
+1. Repeat the Redfish query. Confirm that the member paths end in `eth0` and
+   `eth1`, not `ib0` and `ib1`.
+1. Run `ip -brief link show` and `sudo mst status -v` on the DPU. Confirm that
+   `p0` and `p1` are present and that `net-ib0` and `net-ib1` are absent.
+1. Inspect the machine event history again:
+
+   ```bash
+   nico-admin-cli -f json machine show <host-machine-id> \
+     | jq -r '.events[] | "\(.time) \(.event)"'
+   ```
+
+   Confirm that the DPU advances beyond `DPUInitializing/Init`.
+
+## Related Playbooks
+
+- [DPU Provisioning Failures](dpu_provisioning_failures.md)
+- [Host Ingestion Failures](host_ingestion_failures.md)
+- [Network Connectivity Issues](network_connectivity.md)

--- a/docs/playbooks/stuck_objects/dpu_provisioning_failures.md
+++ b/docs/playbooks/stuck_objects/dpu_provisioning_failures.md
@@ -54,6 +54,10 @@ Check:
 - DPF operator status.
 - `nico-dpu-agent` startup logs once the OS boots.
 
+If an NVIDIA BlueField-2 DPU remains in `DPUInitializing/Init` and exposes
+`ib0` and `ib1` instead of Ethernet interfaces, use
+[Machine Stuck in DPUInitializing/Init During Ingestion](dpu_initializing_init.md).
+
 ### `WaitingForNetworkConfig`
 
 The parent state determines what this repeated substate name means:

--- a/docs/playbooks/stuck_objects/host_initializing_uefi_setup.md
+++ b/docs/playbooks/stuck_objects/host_initializing_uefi_setup.md
@@ -1,0 +1,89 @@
+# Managed Host Stuck in UEFI Setup
+
+Use this playbook when a managed host remains at
+`HostInitializing/UefiSetup/SetUefiPassword` and the controller reports a
+Redfish `Bios.ChangePassword` failure.
+
+## Symptoms
+
+- Machine history reaches `setuefipassword` and does not advance.
+- NICo logs report HTTP 400 from `Bios.ChangePassword`.
+- The BMC reports that `OldPassword` is absent or has an unsupported format.
+
+Inspect the recent state history:
+
+```bash
+nico-admin-cli -f json machine show <machine-id> \
+  | jq -r '.events[] | "\(.time) \(.event)"' \
+  | tail -10
+```
+
+## Cause
+
+The password known to NICo does not match the UEFI password on the BMC. This
+can happen after force-deletion when NICo cannot resolve the required
+credential or cannot reach the BMC during its best-effort UEFI cleanup. On
+re-ingestion, the BMC rejects the password-change request and host
+initialization cannot continue.
+
+NICo force-deletion attempts to clear a recorded host UEFI password before
+removing the machine. It logs a warning and continues when that cleanup cannot
+complete. The `--delete-bmc-credentials` option removes saved BMC login
+credentials; it does not request UEFI-password cleanup.
+
+## Clear the Recorded UEFI Password
+
+Request UEFI-password clearing for the affected host:
+
+```bash
+nico-admin-cli host clear-uefi-password --query <machine-id>
+```
+
+The command also accepts a host MAC address. NICo must have a recorded UEFI
+password and enough BMC information to select the current credential. If NICo
+reports that no password is recorded, do not repeatedly run the command; use
+the BMC procedure below to reconcile the device state.
+
+## Reconcile the BMC Directly
+
+When NICo cannot clear the password from its recorded state, use the Redfish
+command with the password configured on the BMC. Obtain BMC
+and UEFI credentials from your approved credential store.
+
+```bash
+nico-admin-cli redfish \
+  --address <bmc-ip-address> \
+  --username <bmc-username> \
+  --password <bmc-password> \
+  change-uefi-password \
+  --current-password <current-uefi-password> \
+  --new-password ''
+```
+
+After the BMC accepts the clear operation, allow the NICo state controller to
+retry `SetUefiPassword` and apply the configured site credential.
+
+<Warning>
+
+Do not force-delete the machine again as the first remediation. Preserve its
+state and logs until you have confirmed why UEFI cleanup or credential
+selection failed.
+
+</Warning>
+
+## Verify Recovery
+
+1. Confirm that state history advances past `setuefipassword`:
+
+   ```bash
+   nico-admin-cli -f json machine show <machine-id> \
+     | jq -r '.events[] | "\(.time) \(.event)"' \
+     | tail -10
+   ```
+
+1. Confirm that the host leaves `HostInitializing/UefiSetup`.
+1. Confirm that NICo logs no longer report a `Bios.ChangePassword` failure for
+   the host.
+
+For force-deletion behavior and its cleanup options, refer to
+[Force Deleting and Rebuilding Hosts](../force_delete.md).

--- a/docs/playbooks/stuck_objects/instance_boot_connection_timeout.md
+++ b/docs/playbooks/stuck_objects/instance_boot_connection_timeout.md
@@ -1,0 +1,81 @@
+# Troubleshoot an Instance Boot Connection Timeout
+
+Use this playbook when an assigned machine times out while downloading a tenant
+operating-system image from a PXE or HTTP server hosted on another instance.
+
+## Symptoms and Data to Collect
+
+The console shows an iPXE timeout similar to:
+
+```text
+http://192.0.2.20:8080/boot/tenant-os... Connection timed out
+(https://ipxe.org/4c0a6092)
+```
+
+Collect the following before changing the network configuration:
+
+- The failing tenant instance ID.
+- The complete URL from the console, including IP address and port.
+- The tenant instance VPC ID.
+- The PXE server instance ID and VPC ID.
+
+If the instances use different VPCs without peering, the boot path is
+unreachable. If they use the same VPC or peered VPCs, investigate routing and
+tenant-defined security controls.
+
+## Identify Both VPCs
+
+1. Show the failing instance and record its `VPC ID`:
+
+   ```bash
+   nico-admin-cli instance show <tenant-instance-id>
+   ```
+
+1. Find the instance that owns the IP address in the timed-out URL:
+
+   ```bash
+   nico-admin-cli instance show | grep -F '<pxe-server-ip>'
+   ```
+
+1. Show that instance and record its `VPC ID`:
+
+   ```bash
+   nico-admin-cli instance show <pxe-server-instance-id>
+   ```
+
+## Check VPC Peering
+
+If the VPC IDs differ, list the peerings for each VPC:
+
+```bash
+nico-admin-cli vpc-peering show --vpc-id <tenant-vpc-id>
+nico-admin-cli vpc-peering show --vpc-id <pxe-server-vpc-id>
+```
+
+- If no peering connects the two VPCs, place both instances in one VPC or
+  configure peering. Refer to
+  [VPC Peering](../../manuals/vpc/vpc_peering_management.md).
+- If the VPCs are already peered, or the instances use the same VPC, continue
+  with path and policy checks.
+
+## Check the Network Path
+
+1. From an instance in the tenant VPC, test the PXE server IP and port.
+1. Verify routes in both directions between the tenant and PXE server
+   interfaces.
+1. Check network security groups and host firewalls for the protocol and port
+   in the failed URL. Refer to
+   [Network Security Groups](../../manuals/networking/network_security_groups.md).
+1. Verify that the HTTP service is listening on the PXE server and bound to the
+   expected address.
+
+## Verify Recovery
+
+1. Confirm that the two instances are in the same VPC or connected by an active
+   VPC peering.
+1. Retry the instance boot.
+1. Confirm that the console downloads the boot image without an iPXE timeout
+   and that the managed host boots the tenant operating system.
+
+The [iPXE error reference](https://ipxe.org/4c0a6092) describes the timeout
+status reported by the boot client.

--- a/docs/playbooks/stuck_objects/lenovo_sr675_v3_polling_bios_setup.md
+++ b/docs/playbooks/stuck_objects/lenovo_sr675_v3_polling_bios_setup.md
@@ -1,0 +1,143 @@
+# Lenovo SR675 V3 Stuck Polling BIOS Setup
+
+Use this playbook when a Lenovo ThinkSystem SR675 V3 OVX remains in
+`Assigned/HostPlatformConfiguration/PollingBiosSetup` and an instance cannot
+finish termination.
+
+## Symptoms
+
+- An instance remains in `Terminating`.
+- Managed-host history advances through `ConfigureBios`, then stops at
+  `PollingBiosSetup`.
+- Manual BIOS changes fail or appear to succeed without changing the effective
+  configuration.
+
+Inspect the affected instance and host:
+
+```bash
+nico-admin-cli instance show
+nico-admin-cli -f json machine show <machine-id> \
+  | jq -r '.events[] | "\(.time) \(.event)"' \
+  | tail -10
+```
+
+## Cause
+
+NICo is waiting for the BMC to apply the requested BIOS settings and boot
+order. On an affected server, the BMC can silently retain inconsistent UEFI
+state, so NICo never observes the desired settings.
+
+Clearing CMOS resets that UEFI state. Running machine setup afterward reapplies
+the settings and boot interface that NICo requires.
+
+<Warning>
+
+Clearing CMOS resets firmware configuration. Record any site-specific BIOS
+settings and confirm the maintenance window before continuing.
+
+</Warning>
+
+## Clear CMOS
+
+1. Set the BMC connection variables. Obtain credentials from your approved
+   credential store.
+
+   ```bash
+   export BMC_IP=<bmc-ip-address>
+   export BMC_USER=<bmc-username>
+   export BMC_PASS=<bmc-password>
+   ```
+
+1. Force the server off:
+
+   ```bash
+   curl --fail --silent --show-error --insecure \
+     --user "${BMC_USER}:${BMC_PASS}" \
+     --header 'Content-Type: application/json' \
+     --data '{"ResetType":"ForceOff"}' \
+     --request POST \
+     "https://${BMC_IP}/redfish/v1/Systems/1/Actions/ComputerSystem.Reset"
+   ```
+
+1. Confirm that the server is off:
+
+   ```bash
+   curl --fail --silent --show-error --insecure \
+     --user "${BMC_USER}:${BMC_PASS}" \
+     "https://${BMC_IP}/redfish/v1/Systems/1" \
+     | jq -r '.PowerState'
+   ```
+
+   Continue only when the command returns `Off`.
+
+1. Invoke the Lenovo CMOS-clear action. Replace `<uefi-password>` with the
+   existing UEFI administrator password:
+
+   ```bash
+   curl --fail --silent --show-error --insecure \
+     --user "${BMC_USER}:${BMC_PASS}" \
+     --header 'Content-Type: application/json' \
+     --data '{"UefiAdminPassword":"<uefi-password>"}' \
+     --request POST \
+     "https://${BMC_IP}/redfish/v1/Systems/1/Actions/Oem/LenovoComputerSystem.RemoteClearCMOS"
+   ```
+
+1. Power the server on:
+
+   ```bash
+   curl --fail --silent --show-error --insecure \
+     --user "${BMC_USER}:${BMC_PASS}" \
+     --header 'Content-Type: application/json' \
+     --data '{"ResetType":"On"}' \
+     --request POST \
+     "https://${BMC_IP}/redfish/v1/Systems/1/Actions/ComputerSystem.Reset"
+   ```
+
+## Reapply Machine Setup
+
+1. Get the primary boot-interface MAC address:
+
+   ```bash
+   MAC_ADDRESS=$(nico-admin-cli -f json machine show <machine-id> \
+     | jq -r '.interfaces[] | select(.primary_interface == true) | .mac_address')
+   ```
+
+1. Run machine setup after the server begins booting:
+
+   ```bash
+   nico-admin-cli redfish \
+     --address "${BMC_IP}" \
+     --username "${BMC_USER}" \
+     --password "${BMC_PASS}" \
+     machine-setup --boot-interface-mac "${MAC_ADDRESS}"
+   ```
+
+1. Check which setup operations remain:
+
+   ```bash
+   nico-admin-cli redfish \
+     --address "${BMC_IP}" \
+     --username "${BMC_USER}" \
+     --password "${BMC_PASS}" \
+     machine-setup-status --boot-interface-mac "${MAC_ADDRESS}"
+   ```
+
+   If machine setup ran too early in the boot process, wait for the BMC to
+   become ready and rerun it.
+
+## Verify Recovery
+
+1. Confirm that machine history advances past `PollingBiosSetup`:
+
+   ```bash
+   nico-admin-cli -f json machine show <machine-id> \
+     | jq -r '.events[] | "\(.time) \(.event)"' \
+     | tail -10
+   ```
+
+1. Confirm that the host leaves
+   `Assigned/HostPlatformConfiguration/PollingBiosSetup`.
+1. Confirm that the instance completes termination.
+
+For general state inspection, refer to
+[State Machine Debugging](state_machine_debugging.md).

--- a/docs/playbooks/stuck_objects/network_connectivity.md
+++ b/docs/playbooks/stuck_objects/network_connectivity.md
@@ -114,6 +114,10 @@ kubectl -n <nico-namespace> logs deploy/nico-pxe --tail=500 | grep <mac-or-ip>
 
 If there are no PXE or HTTP requests, inspect the serial console and boot order.
 If requests exist but the host does not advance, inspect scout or DPU agent logs.
+For a tenant OS image download that times out across VPCs, use
+[Troubleshoot an Instance Boot Connection Timeout](instance_boot_connection_timeout.md).
+To enter Scout outside the normal boot workflow, use
+[Force a Managed Host to Boot into Linux Scout](../debugging_machine/force_linux_scout_boot.md).
 
 ## DPU Agent Cannot Reach `nico-api`
 

--- a/docs/playbooks/stuck_objects/waiting_for_network_config.md
+++ b/docs/playbooks/stuck_objects/waiting_for_network_config.md
@@ -120,6 +120,8 @@ sudo crictl exec -ti <doca-hbn-container-id> vtysh -c 'show bgp summary'
 
 Restore the p0 session before retrying normal PXE provisioning. Setting the
 minimum healthy link count to `1` does not remove the p0 dependency.
+For cable, optical-power, carrier, and ToR-port diagnostics, use
+[Troubleshoot a `BgpPeeringTor` Health Alert](bgp_peering_tor_alert.md).
 
 ### `BgpPeeringRouteServer` and `BgpStats`
 


### PR DESCRIPTION
Converts externally shareable SRE runbooks into Fern playbooks so operators can
troubleshoot common machine, DPU, network, and firmware failures from the public
documentation. Adds seven playbooks, links related existing guidance, and
reorganizes the Playbooks navigation for faster discovery.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

Validated with:

- `rumdl check --config docs/.rumdl.toml`
- `fern docs md check`
- `fern check`
- `git diff --check`

The source pages were reviewed against the DORI documentation style guide
before conversion.
