### PR TITLE
feat(simple-sdk): support instance IP address filters

### DIFF
--- a/rest-api/sdk/simple/instance.go
+++ b/rest-api/sdk/simple/instance.go
@@ -49,9 +49,10 @@ type DpuExtensionServiceDeploymentRequest struct {
 
 // InstanceFilter encapsulates instance list filter parameters
 type InstanceFilter struct {
-	Name  *string
-	Query *string
-	VpcID *string
+	Name      *string
+	Query     *string
+	VpcID     *string
+	IPAddress *string
 }
 
 // InstanceUpdateRequest represents a simplified request to update an Instance
@@ -253,6 +254,9 @@ func (im InstanceManager) GetInstances(ctx context.Context, instanceFilter *Inst
 		}
 		if instanceFilter.VpcID != nil {
 			gir = gir.VpcId(*instanceFilter.VpcID)
+		}
+		if instanceFilter.IPAddress != nil {
+			gir = gir.IpAddress(*instanceFilter.IPAddress)
 		}
 	}
 	// If no explicit VPC filter was provided, fall back to the client's default VPC (if set).

--- a/rest-api/sdk/simple/instance_test.go
+++ b/rest-api/sdk/simple/instance_test.go
@@ -188,6 +188,7 @@ func TestFilterOutIDs(t *testing.T) {
 
 func TestInstanceManager_GetInstances(t *testing.T) {
 	instanceName := "host-1"
+	ipAddress := "10.0.0.5"
 	query := "02c241b7-d2e3-4bf5-8384-07137f4f3410"
 	explicitVpcID := "vpc-2"
 	pageNumber := 2
@@ -216,9 +217,10 @@ func TestInstanceManager_GetInstances(t *testing.T) {
 			name:         "query composes with filters and pagination",
 			defaultVpcID: "vpc-1",
 			filter: &InstanceFilter{
-				Name:  &instanceName,
-				Query: &query,
-				VpcID: &explicitVpcID,
+				Name:      &instanceName,
+				Query:     &query,
+				VpcID:     &explicitVpcID,
+				IPAddress: &ipAddress,
 			},
 			pagination: &PaginationFilter{
 				PageNumber: &pageNumber,
@@ -226,6 +228,7 @@ func TestInstanceManager_GetInstances(t *testing.T) {
 				OrderBy:    &orderBy,
 			},
 			wantQuery: url.Values{
+				"ipAddress":  {ipAddress},
 				"name":       {instanceName},
 				"orderBy":    {orderBy},
 				"pageNumber": {"2"},


### PR DESCRIPTION
This PR adds support for IP address filter to simple SDK GetInstances method.

Same as in https://github.com/dsx-ai-factory/infra-controller/pull/5982 this change can break consumers that pass unkeyed literals for filter struct. They will have to update code to pass additional unkeyed literal, or - better - switch to keyed form.

## Related issues
None.

## Type of Change
- [x] **Add** - New feature or capability

## Breaking Changes
- [x] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

## Additional Notes
None