### PR TITLE
chore(dpf): sync CRDs with latest nightly

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -948,7 +948,7 @@ events, so consumers handle them identically.
 | Field | Type | Default | Description |
 | ------- | ------ | --------- | ------------- |
 | `bfb_url` | `Option<String>` | BF3 bf-bundle URL | BlueField firmware bundle used for BF3 provisioning. Mutually exclusive with `bluefield_software`; BF4 requires `bluefield_software` instead. |
-| `bluefield_software` | `Option<BlueFieldSoftwareConfig>` | — | BF4 OS ISO and PSID-to-PLDM firmware source. BF4 requires this field with exactly one `pldm_fw_bundle` entry. |
+| `bluefield_software` | `Option<BlueFieldSoftwareConfig>` | — | BF4 OS ISO and PSID-to-PLDM firmware source. BF4 requires this field with at least one `pldm_fw_bundle` entry. |
 | `flavor_name` | `String` | `carbide-dpu-flavor` | Base name for the generated BF3/generic-BF4 `DPUFlavor` or Astra `DPUFlavorTemplate`. |
 | `deployment_name` | `String` | `nico-deployment-v2` | Name of the generated `DPUDeployment`. |
 | `node_label_key` | `String` | `carbide.nvidia.com/controlled.node.v2` | Label key used to select DPU nodes for this deployment. |

--- a/crates/api-core/src/cfg/file.rs
+++ b/crates/api-core/src/cfg/file.rs
@@ -2374,18 +2374,15 @@ fn append_gb200_label_suffix(label_key: &str) -> String {
 /// the `provisioning.dpu.nvidia.com/v1alpha1` `BlueFieldSoftware` CR.
 ///
 /// The PLDM firmware bundle is PSID-specific, so `pldm_fw_bundle` maps each PSID
-/// to its bundle URL. One `BlueFieldSoftware` CR and one DPUDeployment are
-/// created per PSID (see
-/// [`DpfDeploymentConfig::per_psid_deployment_name`] and
-/// [`DpfDeploymentConfig::per_psid_node_label_key`]).
+/// to its bundle URL. A single `BlueFieldSoftware` CR carries the complete map
+/// so DPF can select the matching bundle for each DPU model.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct DpfBlueFieldSoftwareConfig {
     /// OS ISO URL used by the DPU OS installation flow (`spec.osIso`). Shared
     /// across all PSIDs.
     pub os_iso: String,
-    /// Map of PSID → PLDM firmware bundle URL (`spec.pldmFwBundle`). Each entry
-    /// fans out to its own `BlueFieldSoftware` CR and DPUDeployment.
+    /// Map of PSID → PLDM firmware bundle URL (`spec.pldmFwBundle`).
     #[serde(default)]
     pub pldm_fw_bundle: BTreeMap<String, String>,
 }
@@ -2550,14 +2547,9 @@ impl DpfDeploymentsConfig {
                 (None, None) => errors.push(format!(
                     "deployment {name:?} sets neither bfb_url nor bluefield_software; set exactly one"
                 )),
-                // Exactly one PSID entry is allowed for now. Multi-PSID support
-                // is pending a DPF change that lets one `BlueFieldSoftware` CR
-                // carry a PSID→PLDM map; until then a single BF4 deployment uses
-                // the one entry's PLDM bundle.
-                (None, Some(bfs)) if bfs.pldm_fw_bundle.len() != 1 => errors.push(format!(
-                    "deployment {name:?} bluefield_software.pldm_fw_bundle must have exactly one \
-                     PSID → PLDM bundle URL entry (found {}).",
-                    bfs.pldm_fw_bundle.len()
+                (None, Some(bfs)) if bfs.pldm_fw_bundle.is_empty() => errors.push(format!(
+                    "deployment {name:?} bluefield_software.pldm_fw_bundle must have at least one \
+                     PSID → PLDM bundle URL entry.",
                 )),
                 _ => {}
             }
@@ -8114,16 +8106,7 @@ helm_repo_url = "oci://registry.example.test/doca"
     }
 
     #[test]
-    fn validate_provisioning_sources_requires_exactly_one_psid() {
-        // Exactly one PSID entry is accepted.
-        let one = DpfDeploymentsConfig {
-            bf3: DpfDeploymentConfig::default(),
-            bf4_generic: Some(bf4_config(None, Some(bf4_with_psids(&["MT_0000000884"])))),
-            bf4_astra: None,
-        };
-        assert!(one.validate_provisioning_sources().is_ok());
-
-        // More than one PSID is rejected (multi-PSID support is pending a DPF change).
+    fn validate_provisioning_sources_accepts_multiple_psids() {
         let many = DpfDeploymentsConfig {
             bf3: DpfDeploymentConfig::default(),
             bf4_generic: Some(bf4_config(
@@ -8132,6 +8115,6 @@ helm_repo_url = "oci://registry.example.test/doca"
             )),
             bf4_astra: None,
         };
-        assert!(many.validate_provisioning_sources().is_err());
+        assert!(many.validate_provisioning_sources().is_ok());
     }
 }

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -928,13 +928,9 @@ async fn initialize_dpf_sdk(
         let bfs = bf4.bluefield_software.as_ref().ok_or_else(|| {
             eyre::eyre!("bf4_generic DPF deployment is missing bluefield_software")
         })?;
-        let pldm_url =
-            bfs.pldm_fw_bundle.values().next().ok_or_else(|| {
-                eyre::eyre!("bf4_generic DPF deployment has an empty pldm_fw_bundle")
-            })?;
         let params = carbide_dpf::BlueFieldSoftwareParams {
             os_iso: bfs.os_iso.clone(),
-            pldm_fw_bundle: Some(pldm_url.clone()),
+            pldm_fw_bundle: Some(bfs.pldm_fw_bundle.clone()),
         };
         init_configs.push((
             "bf4_generic",
@@ -947,13 +943,9 @@ async fn initialize_dpf_sdk(
             .bluefield_software
             .as_ref()
             .ok_or_else(|| eyre::eyre!("bf4_astra DPF deployment is missing bluefield_software"))?;
-        let pldm_url =
-            bfs.pldm_fw_bundle.values().next().ok_or_else(|| {
-                eyre::eyre!("bf4_astra DPF deployment has an empty pldm_fw_bundle")
-            })?;
         let params = carbide_dpf::BlueFieldSoftwareParams {
             os_iso: bfs.os_iso.clone(),
-            pldm_fw_bundle: Some(pldm_url.clone()),
+            pldm_fw_bundle: Some(bfs.pldm_fw_bundle.clone()),
         };
         init_configs.push((
             "bf4_astra",

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -846,8 +846,7 @@ async fn initialize_dpf_sdk(
     let deployment_type_labels = build_deployment_type_labels(carbide_config);
 
     // Builds the SDK init config for one DPUDeployment. BF4 uses a single
-    // `BlueFieldSoftware` source (the CR itself carries the PSID→PLDM mapping);
-    // config validation guarantees exactly one PSID entry.
+    // `BlueFieldSoftware` source whose CR carries the complete PSID→PLDM mapping.
     let make_init_config =
         |deployment: &crate::cfg::file::DpfDeploymentConfig,
          deployment_type: DpuDeploymentType,
@@ -923,8 +922,7 @@ async fn initialize_dpf_sdk(
     ];
 
     if let Some(bf4) = &carbide_config.dpf.deployments.bf4_generic {
-        // Validation guarantees `bluefield_software` is set with exactly one PSID
-        // entry for a BF4 deployment.
+        // Validation guarantees `bluefield_software` has at least one PSID entry.
         let bfs = bf4.bluefield_software.as_ref().ok_or_else(|| {
             eyre::eyre!("bf4_generic DPF deployment is missing bluefield_software")
         })?;

--- a/crates/dpf/Makefile.toml
+++ b/crates/dpf/Makefile.toml
@@ -8,7 +8,7 @@ default_to_workspace = false
 DOCA_REPO_URL = "https://github.com/NVIDIA/doca-platform.git"
 DOCA_BRANCH = "v0.1.0-carbide-47c105e2-nightly"
 # Comment out DOCA_COMMIT when a tag/branch exists.
-DOCA_COMMIT = "8cb2a6378cfc8165afac270541b376105d26019c"
+DOCA_COMMIT = "53fec54d1036248e5278f6b7ada00cff45c82c6f"
 DOCA_CLONE_DIR = "${CARGO_MAKE_WORKING_DIRECTORY}/doca-platform"
 CRD_SOURCE_PATH = "${DOCA_CLONE_DIR}/deploy/charts/dpf-operator/templates/crds"
 CRD_DEST_PATH = "${CARGO_MAKE_WORKING_DIRECTORY}/crds"

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_bluefieldsoftwares.provisioning.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_bluefieldsoftwares.provisioning.dpu.nvidia.com.yaml
@@ -50,14 +50,11 @@ spec:
           spec:
             description: BlueFieldSpec defines the desired state of BlueFieldSoftware.
             properties:
-              forceFwUpdate:
-                default: false
-                description: ForceFwUpdate points to the force firmware update flag.
-                type: boolean
               nicFw:
                 description: |-
                   NicFw points to the NIC firmware binary used for E/W NIC firmware updates.
-                  Use this when a specific NIC firmware binary is required and is not included in the platform PLDM firmware bundle.
+                  Use this when a specific NIC firmware binary is required and is not included in the
+                  platform PLDM firmware bundle.
                   In production, prefer using PlatformPldmFwBundle.
                 minLength: 1
                 type: string
@@ -67,15 +64,24 @@ spec:
                 minLength: 1
                 type: string
               platformPldmFwBundle:
-                description: PlatformPldmFwBundle points to the Vera Rubin PLDM firmware
-                  bundle used for NIC firmware updates.
+                description: |-
+                  PlatformPldmFwBundle points to the platform PLDM firmware bundle used for E/W NIC
+                  firmware updates.
                 minLength: 1
                 type: string
               pldmFwBundle:
-                description: PldmFwBundle points to the BluefieldPLDM firmware bundle
-                  for baseline firmware updates.
-                minLength: 1
-                type: string
+                additionalProperties:
+                  type: string
+                description: |-
+                  PldmFwBundle maps each PSID to the PLDM firmware bundle URL used for that DPU model's
+                  baseline firmware updates. Each PSID's bundle is a complete PLDM package for that device.
+                  Keys are matched case-insensitively against the BMC-reported DPUDevice status PSID.
+                minProperties: 1
+                type: object
+                x-kubernetes-validations:
+                - message: pldmFwBundle entries must have non-empty PSID keys and
+                    non-empty bundle URLs
+                  rule: self.all(k, size(k) > 0 && size(self[k]) > 0)
             required:
             - osIso
             type: object
@@ -153,13 +159,24 @@ spec:
                   successfully downloaded
                 properties:
                   nicFw:
+                    description: |-
+                      NicFw is the local path of the E/W NIC firmware binary, either downloaded from
+                      spec.nicFw or unpacked from the platform PLDM firmware bundle.
                     type: string
                   osIso:
+                    description: OsIso is the local path of the downloaded OS ISO.
                     type: string
                   platformPldmFwBundle:
+                    description: PlatformPldmFwBundle is the local path of the downloaded
+                      platform PLDM firmware bundle.
                     type: string
                   pldmFwBundle:
-                    type: string
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      PldmFwBundle maps each PSID to the local path of its downloaded PLDM firmware bundle.
+                      Keys are matched case-insensitively against the BMC-reported DPUDevice PSID.
+                    type: object
                 type: object
               observedGeneration:
                 description: ObservedGeneration records the Generation observed on
@@ -180,25 +197,48 @@ spec:
               versions:
                 description: Versions tracks the versions of the components
                 properties:
-                  bfNicFwVersion:
-                    type: string
-                  bmcErotVersion:
-                    type: string
-                  bmcVersion:
-                    type: string
+                  bluefieldSoftwareVersions:
+                    additionalProperties:
+                      description: BluefieldDeviceVersions holds firmware versions
+                        extracted from a single PSID's PLDM bundle.
+                      properties:
+                        bfNicFwVersion:
+                          description: BFNicFwVersion is the BlueField NIC firmware
+                            version shipped in the bundle.
+                          minLength: 1
+                          type: string
+                        bmcErotVersion:
+                          description: BMCErotVersion is the BMC ERoT (External Root
+                            of Trust) firmware version shipped in the bundle.
+                          minLength: 1
+                          type: string
+                        bmcVersion:
+                          description: BMCVersion is the DPU BMC firmware version
+                            shipped in the bundle.
+                          minLength: 1
+                          type: string
+                        sbiosVersion:
+                          description: SBIOSVersion is the DPU SBIOS firmware version
+                            shipped in the bundle.
+                          minLength: 1
+                          type: string
+                      type: object
+                    description: |-
+                      BluefieldSoftwareVersions maps each PSID to the firmware versions from that device's
+                      PLDM bundle. Keys are matched case-insensitively against the BMC-reported DPUDevice PSID.
+                    type: object
                   doca:
                     description: DOCA is the formatted, user-facing DOCA version derived
                       from the OS ISO.
                     type: string
                   ewNicFwVersion:
-                    type: string
-                  fwBundleVersion:
+                    description: |-
+                      EWNicFwVersion is the E/W NIC firmware version taken from the platform PLDM bundle.
+                      It is not keyed by PSID because a BlueFieldSoftware carries a single platform bundle.
                     type: string
                   osISOVersion:
                     description: OSISOVersion is the raw DOCA version for the OS ISO,
                       taken from the ISO filename
-                    type: string
-                  sbiosVersion:
                     type: string
                 type: object
             required:

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpfoperatorconfigs.operator.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpfoperatorconfigs.operator.dpu.nvidia.com.yaml
@@ -125,6 +125,86 @@ spec:
                         type: object
                     type: object
                 type: object
+              coreDNS:
+                description: CoreDNS is the configuration for CoreDNS serving Kamaji
+                  DPU clusters with a Keepalived endpoint.
+                properties:
+                  deployment:
+                    description: |-
+                      Deployment contains the configuration for the CoreDNS deployment.
+                      It contains the image for the CoreDNS container and its resource requirements.
+                    properties:
+                      image:
+                        description: Image is a reference to a container image.
+                        pattern: ^((?:(?:(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9])(?:\.(?:[a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9-]*[a-zA-Z0-9]))*|\[(?:[a-fA-F0-9:]+)\])(?::[0-9]+)?/)?[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*(?:/[a-z0-9]+(?:(?:[._]|__|[-]+)[a-z0-9]+)*)*)(?::([\w][\w.-]{0,127}))?(?:@([A-Za-z][A-Za-z0-9]*(?:[-_+.][A-Za-z][A-Za-z0-9]*)*[:][[:xdigit:]]{32,}))?$
+                        type: string
+                      resources:
+                        description: |-
+                          Resources defines the memory and CPU resource requests and limits for the component.
+                          This field is optional, and if not set, the component will use the default resource.
+                        properties:
+                          limits:
+                            description: Limits defines the resource limits for the
+                              component.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU is the amount of CPU requested by
+                                  the component.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory is the amount of Memory requested
+                                  by the component.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                          requests:
+                            description: Requests defines the resource requests for
+                              the component.
+                            properties:
+                              cpu:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: CPU is the amount of CPU requested by
+                                  the component.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                              memory:
+                                anyOf:
+                                - type: integer
+                                - type: string
+                                description: Memory is the amount of Memory requested
+                                  by the component.
+                                pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                                x-kubernetes-int-or-string: true
+                            type: object
+                        type: object
+                    type: object
+                  disable:
+                    description: Disable ensures the component is not deployed when
+                      set to true.
+                    type: boolean
+                  helmChart:
+                    description: |-
+                      HelmChart overrides the helm chart used by the ServiceSet controller.
+                      The URL must begin with either 'oci://' or 'https://', ensuring it points to a valid
+                      OCI registry or a web-based repository.
+                    pattern: ^(oci://|https://).+$
+                    type: string
+                  upstreamNameservers:
+                    description: |-
+                      UpstreamNameservers is passed to the CoreDNS forward plugin for names outside the cluster domain.
+                      It accepts the same space-separated nameserver or resolv.conf path syntax as the CoreDNS chart.
+                    minLength: 1
+                    type: string
+                type: object
               deploymentMode:
                 description: |-
                   DeploymentMode selects zero-trust vs host-trusted deployment alignment.
@@ -278,9 +358,16 @@ spec:
                     type: boolean
                   disableDPUReadyTaints:
                     description: |-
-                      DisableDPUReadyTaints disables the DPU ready taints feature in the DPU Service Controller.
-                      This feature adds taints to the worker nodes when the DPU is not ready.
-                      This is useful when the DPU is used for networking and the node should not be scheduled until the DPU is ready.
+                      DisableDPUReadyTaints is a full taint kill-switch for the DPUReady controller.
+                      When set to true, no taint managed by this controller (NoSchedule for critical
+                      DPUServices, or NoExecute for HostNetworkReady) is added, removed, or otherwise
+                      touched on host worker nodes.
+                    type: boolean
+                  disableHostNetworkReadyNoExecuteTaints:
+                    description: |-
+                      DisableHostNetworkReadyNoExecuteTaints disables NoExecute taints on host worker nodes
+                      based on HostNetworkReady. When unset or true, the feature is disabled (safe default).
+                      Set to false to enable NoExecute tainting when HostNetworkReady != True.
                     type: boolean
                   image:
                     description: |-
@@ -1553,6 +1640,16 @@ spec:
                               Deprecated: Use RegistryConfiguration instead.
                             minLength: 1
                             type: string
+                          discoveredDPUDeviceBMCFactoryResetPolicy:
+                            description: |-
+                              DiscoveredDPUDeviceBMCFactoryResetPolicy is the BMC factory reset policy DPUDiscovery
+                              sets on the DPUDevices it creates. It is applied at creation time only: changing it
+                              does not affect DPUDevices that already exist, and it is not consulted when a
+                              DPUDevice is reconciled. When unset, the discovery controller uses OnInitialization.
+                            enum:
+                            - OnInitialization
+                            - Never
+                            type: string
                           skipDPUNodeDiscovery:
                             default: true
                             description: SkipDPUNodeDiscovery is a flag to skip the
@@ -1598,6 +1695,14 @@ spec:
                     format: duration
                     pattern: ^([0-9]+(h|m|s|ms|us|µs|ns))+$
                     type: string
+                  osInstallRetries:
+                    description: |-
+                      OSInstallRetries is the maximum number of retryable OS installation attempts in zero-trust mode
+                      before the DPU transitions to Error. Attempts are counted in-process and reset on controller restart.
+                      When unset, the provisioning controller defaults to 2.
+                    format: int32
+                    minimum: 1
+                    type: integer
                   osInstallTimeout:
                     description: |-
                       OSInstallTimeout is the maximum time allowed for OS installation in zero-trust mode.
@@ -1620,19 +1725,19 @@ spec:
                     properties:
                       address:
                         description: |-
-                          Address is the address used to access the BFB Registry. The address must start with "http://".
+                          Address is the address used to access the BFB Registry. The address must start with "http://" or "https://".
                           By default, the BFB Registry can be accessed via its Service.
                           For non-kubernetes environments, this must be set due to the lack of kubelet on worker nodes.
                           For zero-trust environments, this must be set so that the BFB Registry can be accessed from DPU BMC.
                           Deprecated: Address is deprecated and will be removed in a future release.
-                        pattern: ^http://
+                        pattern: ^https?://
                         type: string
                       loadBalancerAddress:
                         description: |-
                           LoadBalancerAddress is the address of the load balancer for the BFB Registry which the hostagent/redfish use to fetch the BFB and generated bf.cfg.
                           To enable the load balancer, you need to deploy your own load balancer controller and configure the LoadBalancerAddress field.
                           Then check the bfb-registry nodeport service and make your load balancer controller to distribute the requests to the bfb-registry nodeport.
-                        pattern: ^http://
+                        pattern: ^https?://
                         type: string
                       port:
                         description: |-
@@ -1745,6 +1850,49 @@ spec:
                       spiffe configures the SPIFFE-based DPU Agent identity flow. Edits are accepted post-bootstrap
                       but do NOT retro-apply to already-provisioned DPUs.
                     properties:
+                      dpuAgentExchangedSPIFFEIDTemplate:
+                        description: |-
+                          DPUAgentExchangedSPIFFEIDTemplate renders the post-exchange SPIFFE ID subject. It receives
+                          the same Go template data as DPUAgentSPIFFEIDTemplate.
+                          The rendered identity may use a different trust domain and must depend on the DPU serial.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      dpuAgentSPIFFEIDTemplate:
+                        description: |-
+                          DPUAgentSPIFFEIDTemplate renders the local SPIFFE workload identity registered with SPIRE.
+                          It uses Go text/template syntax and receives TrustDomain, normalized SerialNumber, DPUMeta,
+                          DPUSpec, DPUDeviceMeta, and DPUDeviceSpec. Metadata labels and annotations can be accessed
+                          with the built-in index function.
+                          The rendered identity must use SPIRETrustDomain and depend on the DPU serial.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      dpuServiceExchangedSPIFFEIDTemplate:
+                        description: |-
+                          DPUServiceExchangedSPIFFEIDTemplate renders the post-exchange DPUService subject. It
+                          receives the same template data as DPUServiceSPIFFEIDTemplate and may use a different trust
+                          domain.
+                          DPF renders and validates it so the identity layout is declared in one place, but does not
+                          consume it: unlike the DPU Agent, a DPUService identity is never presented back to DPF.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
+                      dpuServiceSPIFFEIDTemplate:
+                        description: |-
+                          DPUServiceSPIFFEIDTemplate renders the identity registered with SPIRE for a DPUService that
+                          opts in through its own spec.security.spiffe. It receives TrustDomain, normalized
+                          SerialNumber, Namespace and ServiceID, plus DPUMeta, DPUSpec, DPUServiceMeta and
+                          DPUServiceSpec.
+                          The rendered identity must use SPIRETrustDomain and depend on the namespace, the service ID
+                          and the DPU serial, which together identify one DPUService workload. Dropping any of them
+                          hands a single SVID to distinct workloads, and nothing detects that later: SPIRE keys
+                          entries on the identity, the parent and the selectors, so two DPUServices differing only in
+                          namespace produce two entries carrying the same identity. A label cannot stand in for the
+                          namespace, since nothing ties one to the other.
+                        maxLength: 2048
+                        minLength: 1
+                        type: string
                       kubeAPIAudience:
                         description: |-
                           KubeAPIAudience is the audience claim the DPU Agent's JWT-SVID must carry; it must match an
@@ -1780,6 +1928,15 @@ spec:
                         maxLength: 253
                         minLength: 1
                         pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                        type: string
+                      tokenExchangeEndpoint:
+                        description: |-
+                          tokenExchangeEndpoint exchanges the SPIRE JWT-SVID before the DSX SPIFFE Helper writes it.
+                          When omitted, the DSX SPIFFE Helper writes the SPIRE JWT-SVID directly.
+                          The returned token's audience must match kubeAPIAudience, or the kube-apiserver rejects the
+                          DPU Agent. Only https: the JWT-SVID is sent here as a bearer credential.
+                        maxLength: 2048
+                        pattern: ^https://[^[:space:]"\\]+$
                         type: string
                       trustBundle:
                         description: trustBundle references a ConfigMap holding the
@@ -2544,6 +2701,13 @@ spec:
               rule: '!has(self.deploymentMode) || self.deploymentMode != ''zero-trust''
                 || !has(self.networking) || !has(self.networking.controlPlaneMTU)
                 || self.networking.controlPlaneMTU <= 1500'
+            - message: 'deploymentMode is immutable after creation: it cannot be changed
+                once set, because already provisioned DPUs keep the trust boundary
+                they were provisioned under. Switch the cluster to another deploymentMode
+                by deleting and recreating DPFOperatorConfig (DR escape hatch); existing
+                DPUs require re-provisioning.'
+              rule: '!has(oldSelf.deploymentMode) || (has(self.deploymentMode) &&
+                self.deploymentMode == oldSelf.deploymentMode)'
             - message: spiffe configuration requires deploymentMode=zero-trust
               rule: '!has(self.security) || !has(self.security.spiffe) || self.deploymentMode
                 == ''zero-trust'''
@@ -2624,6 +2788,11 @@ spec:
                   the object the last time it was patched.
                 format: int64
                 type: integer
+              targetVersion:
+                description: |-
+                  TargetVersion is the version of the DPF Operator that is being deployed. It differs from
+                  Version while an upgrade is in progress.
+                type: string
               version:
                 description: Version is the version of the DPF Operator that is currently
                   deployed.

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpudevices.provisioning.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpudevices.provisioning.dpu.nvidia.com.yaml
@@ -52,6 +52,20 @@ spec:
                   per-device BMC credentials. The secret must contain a "password" key with the BMC credential value.
                   If specified, this password takes precedence over the shared bmc-shared-password secret.
                 type: string
+              bmcFactoryResetPolicy:
+                default: OnInitialization
+                description: |-
+                  BMCFactoryResetPolicy controls whether DPF resets this DPU BMC to factory defaults
+                  while initializing the DPUDevice. The reset clears all BMC configuration, including
+                  network settings, so the BMC must obtain its address via DHCP.
+                  - OnInitialization (default): reset the BMC once, while the DPUDevice is initialized.
+                  - Never: never reset.
+                  The value is honored only until the factory reset step finishes; changing it
+                  after BMCFactoryResetReady is True has no effect.
+                enum:
+                - OnInitialization
+                - Never
+                type: string
               bmcIp:
                 description: |-
                   BMCIP is the IP address of the BMC (Base Management Controller) on the device.
@@ -169,6 +183,13 @@ spec:
               bmcCredentialSecretName:
                 description: BMCCredentialSecretName is the name of the Secret last
                   used successfully for BMC authentication.
+                type: string
+              bmcFactoryResetRequestTime:
+                description: |-
+                  BMCFactoryResetRequestTime is when DPF submitted ResetToDefaults to the BMC.
+                  It is nil until the request has been accepted, and once set it is never cleared:
+                  it is what keeps the BMC from being reset again for this DPUDevice.
+                format: date-time
                 type: string
               bmcIp:
                 description: |-

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuflavors.provisioning.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuflavors.provisioning.dpu.nvidia.com.yaml
@@ -138,6 +138,21 @@ spec:
                       registry.
                     type: string
                 type: object
+              dma:
+                description: |-
+                  DMA configures the DMA SF that e.g. SNAP DOCA service uses to DMA host
+                  memory over the second Grace PCI link on BlueField-4 socket-direct
+                  systems.
+                properties:
+                  enabled:
+                    description: |-
+                      Enabled controls whether the dpu-agent creates the DMA SF. Defaults to
+                      false when unset, so the presence of the dma struct alone does not enable
+                      creation. Only takes effect on BlueField-4 socket-direct systems. The
+                      created Scalable Function always uses sfnum 8000, the SNAP discovery ABI
+                      value.
+                    type: boolean
+                type: object
               dpuMode:
                 description: |-
                   DpuMode is deprecated and no longer used by provisioning workflows.
@@ -193,9 +208,9 @@ spec:
                       properties:
                         conf:
                           description: |-
-                            Conf is the <conf_name> argument passed to `mlxconfig set_system_conf`.
-                            The per-ASIC index is appended automatically by the daemon based on the
-                            device's detected Network Bay ASIC index, e.g. set_system_conf <conf>[0].
+                            Conf is the mlxconfig system configuration profile name. The daemon resolves
+                            the profile parameters for the device's detected Network Bay ASIC and manages
+                            them through the regular mlxconfig validation and apply flow.
                           type: string
                       required:
                       - conf
@@ -340,6 +355,15 @@ spec:
                           - P0
                           - P1
                           type: string
+                        force:
+                          description: |-
+                            force applies the parameters with `mlxconfig --force` and skips the `mlxconfig q` filter,
+                            so parameters firmware does not yet expose are applied now instead of deferred to a later
+                            reboot. Required when a parameter is gated behind another parameter in the same batch.
+                            Requires DOCA 3.5.0 or later; on an older DOCA version the operation fails.
+                            `--force` skips validation for the whole batch, so an invalid value is applied silently.
+                            Ignored under `spec.hostNetworkInterfaceConfigs[].nvconfig`.
+                          type: boolean
                         parameters:
                           description: |-
                             Parameters are the parameters to be set for the device.
@@ -349,7 +373,7 @@ spec:
                             maxLength: 200
                             pattern: ^[^=\s]+=[^\s]*$
                             type: string
-                          maxItems: 32
+                          maxItems: 64
                           minItems: 1
                           type: array
                           x-kubernetes-list-type: atomic
@@ -365,32 +389,6 @@ spec:
                   - portNumber
                   type: object
                 type: array
-              hostOSInit:
-                description: |-
-                  hostOSInit configures when the DPU agent releases host OS init after DELAY_HOST_OS_INIT=0x3
-                  (ENABLE_USER) is set in nvconfig. Omitted releaseAfter defaults to dpuServiceCriticalPodsReady
-                  at agent runtime. Has no effect unless nvconfig requests that hold.
-                properties:
-                  releaseAfter:
-                    description: |-
-                      releaseAfter selects which operational readiness gate must be True before the agent
-                      calls mlxreg to release the host. When omitted, dpuServiceCriticalPodsReady is used.
-                    properties:
-                      dpuServiceCriticalPodsReady:
-                        description: dpuServiceCriticalPodsReady waits for DPU.status.operationalConditions[DPUServiceCriticalPodsReady]
-                          == True.
-                        type: object
-                      operationalReady:
-                        description: operationalReady waits for DPU.status.operationalConditions[OperationalReady]
-                          == True.
-                        type: object
-                    type: object
-                    x-kubernetes-validations:
-                    - message: exactly one of operationalReady or dpuServiceCriticalPodsReady
-                        must be set
-                      rule: '(has(self.operationalReady) ? 1 : 0) + (has(self.dpuServiceCriticalPodsReady)
-                        ? 1 : 0) == 1'
-                type: object
               nvconfig:
                 description: |-
                   NVConfig contains the device-specific configuration (firmware settings, device parameters).
@@ -411,6 +409,15 @@ spec:
                       - P0
                       - P1
                       type: string
+                    force:
+                      description: |-
+                        force applies the parameters with `mlxconfig --force` and skips the `mlxconfig q` filter,
+                        so parameters firmware does not yet expose are applied now instead of deferred to a later
+                        reboot. Required when a parameter is gated behind another parameter in the same batch.
+                        Requires DOCA 3.5.0 or later; on an older DOCA version the operation fails.
+                        `--force` skips validation for the whole batch, so an invalid value is applied silently.
+                        Ignored under `spec.hostNetworkInterfaceConfigs[].nvconfig`.
+                      type: boolean
                     parameters:
                       description: |-
                         Parameters are the parameters to be set for the device.
@@ -420,7 +427,7 @@ spec:
                         maxLength: 200
                         pattern: ^[^=\s]+=[^\s]*$
                         type: string
-                      maxItems: 32
+                      maxItems: 64
                       minItems: 1
                       type: array
                       x-kubernetes-list-type: atomic
@@ -444,8 +451,10 @@ spec:
                 description: OVS contains the OVS configuration for the DPUFlavor.
                 properties:
                   rawConfigScript:
-                    description: RawConfigScript is the raw configuration script for
-                      OVS.
+                    description: |-
+                      RawConfigScript is the raw configuration script for OVS.
+                      The DPU agent runs this script once per boot. A restart of the agent in the
+                      same boot does not re-run it; a reboot or power cycle does.
                     type: string
                 type: object
               packages:
@@ -494,39 +503,18 @@ spec:
                 x-kubernetes-validations:
                 - message: package names must be unique
                   rule: self.all(x, self.exists_one(y, x.name == y.name))
-              scalableFunctions:
-                description: ScalableFunctions configures Scalable Functions (SFs)
-                  created on the DPU.
+              serviceReadiness:
+                description: serviceReadiness configures the Service Readiness phase.
                 properties:
-                  dma:
+                  gate:
                     description: |-
-                      DMA configures the DMA SF that e.g. SNAP DOCA service uses to DMA host
-                      memory over the second Grace PCI link on BlueField-4 socket-direct
-                      systems.
-                    properties:
-                      enabled:
-                        description: |-
-                          Enabled controls whether the dpu-agent creates the DMA SF. The presence of
-                          the dma struct alone does not enable creation; enabled must be set
-                          explicitly. Only takes effect on BlueField-4 socket-direct systems.
-                        type: boolean
-                      macAddress:
-                        description: |-
-                          MACAddress pins the DMA SF's MAC address (canonical colon-separated
-                          48-bit form, e.g. "02:40:51:7c:e3:0f"). Defaults to a deterministic,
-                          vendor-compatible derivation when unset.
-                        pattern: ^([0-9A-Fa-f]{2}:){5}[0-9A-Fa-f]{2}$
-                        type: string
-                      sfNum:
-                        description: |-
-                          SFNum is the number of the DMA Scalable Function. Defaults to 8000 when
-                          unset. Only takes effect on BlueField-4 socket-direct systems.
-                        format: int32
-                        minimum: 1
-                        type: integer
-                    required:
-                    - enabled
-                    type: object
+                      gate is the DPU.status.operationalConditions entry that must be True before the DPU leaves
+                      the Service Readiness phase. When unset the phase does not wait, and a host hold requested
+                      via DELAY_HOST_OS_INIT is released on DPUServiceCriticalPodsReady.
+                    enum:
+                    - DPUServiceCriticalPodsReady
+                    - OperationalReady
+                    type: string
                 type: object
               sysctl:
                 description: Sysctl contains the sysctl configuration for the DPUFlavor.

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpunodes.provisioning.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpunodes.provisioning.dpu.nvidia.com.yaml
@@ -210,14 +210,8 @@ spec:
                 type: boolean
               rebootMethod:
                 description: |-
-                  RebootMethod is the host-level reboot method recommended by child DPUs in
-                  DPURebooting phase, aggregated by priority (most disruptive wins, ties broken
-                  by ascending DPU name):
-                  PowerCycle > SystemLevelReset > SystemReboot > HostlessDPUReboot > FirmwareReset > DPUWarmReboot > NoAction > Unknown.
-
-                  Stamped once at least one DPU reports a method, preserved across the
-                  rebooting -> idle transition, and cleared with DPUNodeRebootInProgress
-                  when the DPUNode loses all its DPUs.
+                  RebootMethod is the host operation required by the child DPUs in
+                  DPURebooting phase: PowerCycle or SystemLevelReset.
                 enum:
                 - Unknown
                 - NoAction
@@ -226,7 +220,6 @@ spec:
                 - SystemLevelReset
                 - FirmwareReset
                 - DPUWarmReboot
-                - HostlessDPUReboot
                 type: string
             type: object
         type: object

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpus.provisioning.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpus.provisioning.dpu.nvidia.com.yaml
@@ -324,6 +324,28 @@ spec:
                 description: AgentStatus contains the information reported from inside
                   the DPU
                 properties:
+                  clock:
+                    description: |-
+                      Clock is the DPU clock compared against the host clock, recorded while the DPU agent was
+                      acquiring its identity. A DPU whose clock is skewed cannot verify the API server certificate,
+                      so it never obtains the identity it would need to report this itself. Set by the host agent,
+                      in trusted-host mode only.
+                    properties:
+                      dpuTime:
+                        description: dpuTime is the DPU clock as reported by the DPU
+                          agent.
+                        format: date-time
+                        type: string
+                      hostTime:
+                        description: |-
+                          hostTime is the host clock when that report arrived. The host is the trusted side of the
+                          comparison, so a difference is attributed to the DPU.
+                        format: date-time
+                        type: string
+                    required:
+                    - dpuTime
+                    - hostTime
+                    type: object
                   conditions:
                     description: Conditions contains the conditions reported from
                       inside the DPU
@@ -404,25 +426,12 @@ spec:
                         description: succeeded indicates host OS init was released
                           or was already cleared.
                         properties:
-                          releaseAfter:
-                            description: releaseAfter echoes the effective gate used
-                              for release.
-                            properties:
-                              dpuServiceCriticalPodsReady:
-                                description: dpuServiceCriticalPodsReady waits for
-                                  DPU.status.operationalConditions[DPUServiceCriticalPodsReady]
-                                  == True.
-                                type: object
-                              operationalReady:
-                                description: operationalReady waits for DPU.status.operationalConditions[OperationalReady]
-                                  == True.
-                                type: object
-                            type: object
-                            x-kubernetes-validations:
-                            - message: exactly one of operationalReady or dpuServiceCriticalPodsReady
-                                must be set
-                              rule: '(has(self.operationalReady) ? 1 : 0) + (has(self.dpuServiceCriticalPodsReady)
-                                ? 1 : 0) == 1'
+                          gate:
+                            description: gate echoes the effective gate used for release.
+                            enum:
+                            - DPUServiceCriticalPodsReady
+                            - OperationalReady
+                            type: string
                         type: object
                     type: object
                     x-kubernetes-validations:
@@ -563,7 +572,6 @@ spec:
                     - SystemLevelReset
                     - FirmwareReset
                     - DPUWarmReboot
-                    - HostlessDPUReboot
                     type: string
                   rebootSequenceCount:
                     description: |-
@@ -857,7 +865,7 @@ spec:
                 - DPU Config
                 - DPU Cluster Config
                 - Host Network Configuration
-                - Host OS Init Release
+                - Service Readiness
                 - Ready
                 - Error
                 - Deleting
@@ -887,7 +895,7 @@ spec:
                 - DPU Config
                 - DPU Cluster Config
                 - Host Network Configuration
-                - Host OS Init Release
+                - Service Readiness
                 - Ready
                 - Error
                 - Deleting
@@ -921,7 +929,6 @@ spec:
                     - SystemLevelReset
                     - FirmwareReset
                     - DPUWarmReboot
-                    - HostlessDPUReboot
                     type: string
                   phase:
                     description: Phase is the current host reboot progress.
@@ -955,8 +962,8 @@ spec:
             - phase
             type: object
             x-kubernetes-validations:
-            - message: 'identityMode is stamp-once: can only transition from unset
-                to a value'
+            - message: 'identityMode is immutable once set: can only transition from
+                unset to a value'
               rule: '!has(oldSelf.identityMode) || (has(self.identityMode) && self.identityMode
                 == oldSelf.identityMode)'
         type: object

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuservices.svc.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuservices.svc.dpu.nvidia.com.yaml
@@ -267,6 +267,26 @@ spec:
                           resource will be admitted but the child Pods will be denied at
                           Pod admission time.
                     type: boolean
+                  spiffe:
+                    description: |-
+                      SPIFFE opts this DPUService into SPIFFE workload identity. When set, one SPIRE
+                      ClusterStaticEntry is registered per targeted DPU, parented to that DPU's SPIRE
+                      agent, so the service's pods can obtain an SVID. The identity defaults to
+                      `spiffe://<trustDomain>/dpu/<serial>/service/<namespace>/<serviceID>` and is
+                      configurable through `DPFOperatorConfig.spec.security.spiffe`.
+                      The namespace qualifies the service ID, which is only unique within one.
+
+                      Presence-gated: `spiffe: {}` enables it. It has no sub-fields yet.
+
+                      Requires `DPFOperatorConfig.spec.security.spiffe`, and only covers DPUs in SPIFFE
+                      identity mode (`DPU.status.identityMode: Spiffe`); bootstrap-token DPUs are skipped.
+                      Both are reported on the SPIFFEEntriesReady condition rather than rejected at
+                      admission. Must not be set when deployInCluster is true, since in-cluster
+                      DPUServices run on the host and have no per-DPU SPIRE agent to parent to.
+
+                      When set on a DPUServiceTemplate, the DPUDeployment controller propagates it to
+                      generated DPUServices that target DPUClusters.
+                    type: object
                 type: object
               serviceDaemonSet:
                 description: ServiceDaemonSet specifies the configuration for the
@@ -460,6 +480,9 @@ spec:
                 true
               rule: '!(has(self.deployInCluster) && self.deployInCluster && has(self.security)
                 && has(self.security.privileged))'
+            - message: security.spiffe must not be set when deployInCluster is true
+              rule: '!(has(self.deployInCluster) && self.deployInCluster && has(self.security)
+                && has(self.security.spiffe))'
             - message: security.privileged must be set when deployInCluster is false
               optionalOldSelf: true
               rule: (has(self.deployInCluster) && self.deployInCluster) || (has(self.security)

--- a/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuservicetemplates.svc.dpu.nvidia.com.yaml
+++ b/crates/dpf/crds/apiextensions.k8s.io_v1_customresourcedefinition_dpuservicetemplates.svc.dpu.nvidia.com.yaml
@@ -139,6 +139,26 @@ spec:
                           resource will be admitted but the child Pods will be denied at
                           Pod admission time.
                     type: boolean
+                  spiffe:
+                    description: |-
+                      SPIFFE opts this DPUService into SPIFFE workload identity. When set, one SPIRE
+                      ClusterStaticEntry is registered per targeted DPU, parented to that DPU's SPIRE
+                      agent, so the service's pods can obtain an SVID. The identity defaults to
+                      `spiffe://<trustDomain>/dpu/<serial>/service/<namespace>/<serviceID>` and is
+                      configurable through `DPFOperatorConfig.spec.security.spiffe`.
+                      The namespace qualifies the service ID, which is only unique within one.
+
+                      Presence-gated: `spiffe: {}` enables it. It has no sub-fields yet.
+
+                      Requires `DPFOperatorConfig.spec.security.spiffe`, and only covers DPUs in SPIFFE
+                      identity mode (`DPU.status.identityMode: Spiffe`); bootstrap-token DPUs are skipped.
+                      Both are reported on the SPIFFEEntriesReady condition rather than rejected at
+                      admission. Must not be set when deployInCluster is true, since in-cluster
+                      DPUServices run on the host and have no per-DPU SPIRE agent to parent to.
+
+                      When set on a DPUServiceTemplate, the DPUDeployment controller propagates it to
+                      generated DPUServices that target DPUClusters.
+                    type: object
                 type: object
             required:
             - deploymentServiceName

--- a/crates/dpf/src/crds/mod.rs
+++ b/crates/dpf/src/crds/mod.rs
@@ -19,5 +19,9 @@
     unreachable_pub,
     reason = "kopium emits public re-exports inside private generated prelude modules"
 )]
+#![allow(
+    clippy::enum_variant_names,
+    reason = "kopium-generated CRD enums preserve upstream variant names"
+)]
 
 include!(concat!(env!("OUT_DIR"), "/crds/mod.rs"));

--- a/crates/dpf/src/flavor.rs
+++ b/crates/dpf/src/flavor.rs
@@ -608,8 +608,8 @@ fn flavor_bf4_with_topology(
             // rawConfigScript sets the value during provisioning. Retain this ordered oneshot so
             // DPF versions with systemdServices support also enforce it after network readiness.
             systemd_services: Some(vec![ovn_encap_systemd_service()]),
-            host_os_init: None,
-            scalable_functions: None,
+            dma: None,
+            service_readiness: None,
         },
     })
 }
@@ -650,8 +650,8 @@ pub fn flavor_bf4_astra(
         }),
         system_reserved_resources: None,
         systemd_services: Some(vec![]),
-        host_os_init: None,
-        scalable_functions: None,
+        dma: None,
+        service_readiness: None,
     };
 
     let flavor = DPUFlavor {
@@ -880,8 +880,8 @@ fn default_flavor_with_topology(
             // rawConfigScript sets the value during provisioning. Retain this ordered oneshot so
             // DPF versions with systemdServices support also enforce it after network readiness.
             systemd_services: Some(vec![ovn_encap_systemd_service()]),
-            host_os_init: None,
-            scalable_functions: None,
+            dma: None,
+            service_readiness: None,
         },
     })
 }
@@ -1195,6 +1195,7 @@ fn get_bf4_nvconfig(num_of_vfs: u32, pf_total_sf: u32) -> DpuFlavorNvconfig {
         // DPF does not allow anyother wild card. It takes only '*'
         device: Some(DpuFlavorNvconfigDevice::KopiumVariant0), //"*"
         parameters: Some(parameters),
+        force: None,
     }
 }
 
@@ -1627,6 +1628,7 @@ fn get_nvconfig(
         // DPF does not allow anyother wild card. It takes only '*'
         device: Some(DpuFlavorNvconfigDevice::KopiumVariant0), //"*"
         parameters: Some(parameters),
+        force: None,
     }
 }
 
@@ -1658,6 +1660,7 @@ fn get_bf4_astra_nvconfig(pf_total_sf: u32) -> DpuFlavorNvconfig {
         // DPF does not allow anyother wild card. It takes only '*'
         device: Some(DpuFlavorNvconfigDevice::KopiumVariant0), //"*"
         parameters: Some(parameters),
+        force: None,
     }
 }
 

--- a/crates/dpf/src/sdk.rs
+++ b/crates/dpf/src/sdk.rs
@@ -646,9 +646,13 @@ async fn create_bluefield_software<R: BlueFieldSoftwareRepository>(
 ) -> Result<String, DpfError> {
     let mut hasher = Sha256::new();
     hasher.update(params.os_iso.as_bytes());
-    if let Some(pldm) = params.pldm_fw_bundle.as_deref() {
-        hasher.update(b"\0");
-        hasher.update(pldm.as_bytes());
+    if let Some(pldm_fw_bundle) = params.pldm_fw_bundle.as_ref() {
+        for (key, pldm) in pldm_fw_bundle.iter() {
+            hasher.update(b"\0");
+            hasher.update(key.as_bytes());
+            hasher.update(b"\0");
+            hasher.update(pldm.as_bytes());
+        }
     }
     let name = format!(
         "{}-{}",
@@ -667,7 +671,6 @@ async fn create_bluefield_software<R: BlueFieldSoftwareRepository>(
             pldm_fw_bundle: params.pldm_fw_bundle.clone(),
             nic_fw: None,
             platform_pldm_fw_bundle: None,
-            force_fw_update: None,
         },
         status: None,
     };
@@ -2323,6 +2326,7 @@ fn dpu_service_to_resource(service: &DetachedDpuServiceDefinition) -> DPUService
             paused: None,
             security: Some(DpuServiceSecurity {
                 privileged: Some(service.security_privileged),
+                spiffe: None,
             }),
             service_daemon_set: Some(DpuServiceServiceDaemonSet {
                 annotations: None,
@@ -2509,6 +2513,7 @@ impl<R: DpuDeviceRepository, L: ResourceLabeler> DpfSdk<R, L> {
                 cluster: None,
                 nic_device_count: None,
                 values,
+                bmc_factory_reset_policy: None,
             },
             status: None,
         };
@@ -6037,6 +6042,7 @@ mod tests {
                 }),
                 nic_device_count: None,
                 values: None,
+                bmc_factory_reset_policy: None,
             },
             status: None,
         };
@@ -6447,6 +6453,7 @@ mod tests {
                 cluster: None,
                 nic_device_count: None,
                 values: None,
+                bmc_factory_reset_policy: None,
             },
             status: None,
         };
@@ -6496,6 +6503,7 @@ mod tests {
                 cluster: None,
                 nic_device_count: None,
                 values: Some(BTreeMap::new()),
+                bmc_factory_reset_policy: None,
             },
             status: None,
         };

--- a/crates/dpf/src/test/sdk_initialization.rs
+++ b/crates/dpf/src/test/sdk_initialization.rs
@@ -143,7 +143,10 @@ fn unscoped_astra_config() -> InitDpfResourcesConfig {
     InitDpfResourcesConfig {
         bluefield_software: Some(BlueFieldSoftwareParams {
             os_iso: "http://example.com/astra.iso".to_string(),
-            pldm_fw_bundle: Some("http://example.com/astra.pldm".to_string()),
+            pldm_fw_bundle: Some(BTreeMap::from([(
+                "pldmid001".to_string(),
+                "http://example.com/astra.pldm".to_string(),
+            )])),
         }),
         deployment_name: "astra-deployment".to_string(),
         deployment_type: DpuDeploymentType::Bf4Astra,
@@ -774,7 +777,10 @@ fn config_rejects_unscoped_astra() {
     let result = InitDpfResourcesConfigBuilder::default()
         .bluefield_software(BlueFieldSoftwareParams {
             os_iso: "http://example.com/astra.iso".to_string(),
-            pldm_fw_bundle: Some("http://example.com/astra.pldm".to_string()),
+            pldm_fw_bundle: Some(BTreeMap::from([(
+                "pldmid001".to_string(),
+                "http://example.com/astra.pldm".to_string(),
+            )])),
         })
         .deployment_name("astra-deployment")
         .deployment_type(DpuDeploymentType::Bf4Astra)
@@ -798,7 +804,10 @@ async fn test_create_initialization_objects_bluefield_software() {
     let config = InitDpfResourcesConfigBuilder::default()
         .bluefield_software(BlueFieldSoftwareParams {
             os_iso: "http://example.com/os.iso".to_string(),
-            pldm_fw_bundle: Some("http://example.com/fw.pldm".to_string()),
+            pldm_fw_bundle: Some(BTreeMap::from([(
+                "pldmid001".to_string(),
+                "http://example.com/astra.pldm".to_string(),
+            )])),
         })
         .deployment_name("bf4-dep")
         .deployment_type(DpuDeploymentType::Bf4Generic)
@@ -822,8 +831,8 @@ async fn test_create_initialization_objects_bluefield_software() {
     assert_eq!(bfsw.len(), 1);
     assert_eq!(bfsw[0].spec.os_iso, "http://example.com/os.iso");
     assert_eq!(
-        bfsw[0].spec.pldm_fw_bundle.as_deref(),
-        Some("http://example.com/fw.pldm")
+        bfsw[0].spec.pldm_fw_bundle.clone().unwrap().values().last(),
+        Some(&"http://example.com/astra.pldm".to_string())
     );
 
     // The DPUDeployment references the BlueFieldSoftware CR, not a BFB.
@@ -892,7 +901,10 @@ async fn scoped_bf3_gb200_bf4_and_astra_initialization_coexists() {
         InitDpfResourcesConfigBuilder::default()
             .bluefield_software(BlueFieldSoftwareParams {
                 os_iso: "http://example.com/bf4.iso".to_string(),
-                pldm_fw_bundle: Some("http://example.com/bf4.pldm".to_string()),
+                pldm_fw_bundle: Some(BTreeMap::from([(
+                    "pldmid001".to_string(),
+                    "http://example.com/bf4.pldm".to_string(),
+                )])),
             })
             .deployment_name("bf4-deployment")
             .flavor_name("bf4-flavor")
@@ -906,7 +918,10 @@ async fn scoped_bf3_gb200_bf4_and_astra_initialization_coexists() {
         InitDpfResourcesConfigBuilder::default()
             .bluefield_software(BlueFieldSoftwareParams {
                 os_iso: "http://example.com/astra.iso".to_string(),
-                pldm_fw_bundle: Some("http://example.com/astra.pldm".to_string()),
+                pldm_fw_bundle: Some(BTreeMap::from([(
+                    "pldmid001".to_string(),
+                    "http://example.com/astra.pldm".to_string(),
+                )])),
             })
             .deployment_name("astra-deployment")
             .flavor_name("astra-flavor")
@@ -1572,7 +1587,10 @@ async fn reinitialization_preserves_operator_extra_scripts() {
     let config = InitDpfResourcesConfigBuilder::default()
         .bluefield_software(BlueFieldSoftwareParams {
             os_iso: "http://example.com/bf4.iso".to_string(),
-            pldm_fw_bundle: Some("http://example.com/bf4.pldm".to_string()),
+            pldm_fw_bundle: Some(BTreeMap::from([(
+                "pldmid001".to_string(),
+                "http://example.com/bf4.pldm".to_string(),
+            )])),
         })
         .deployment_name("bf4-deployment")
         .flavor_name("bf4-flavor")

--- a/crates/dpf/src/types.rs
+++ b/crates/dpf/src/types.rs
@@ -160,9 +160,9 @@ pub struct InitDpfResourcesConfig {
 pub struct BlueFieldSoftwareParams {
     /// OS ISO URL used by the DPU OS installation flow (`spec.osIso`).
     pub os_iso: String,
-    /// Optional PLDM firmware bundle URL for baseline firmware updates
+    /// Optional PLDM firmware bundle URLs for baseline firmware updates
     /// (`spec.pldmFwBundle`).
-    pub pldm_fw_bundle: Option<String>,
+    pub pldm_fw_bundle: Option<BTreeMap<String, String>>,
 }
 
 impl Default for InitDpfResourcesConfig {
@@ -845,7 +845,7 @@ impl From<DpuStatusPhase> for DpuPhase {
                 Self::Provisioning("PerformArmForceRestart".into())
             }
             DpuStatusPhase::UpdateFirmware => Self::Provisioning("UpdateFirmware".into()),
-            DpuStatusPhase::HostOsInitRelease => Self::Provisioning("HostOsInitRelease".into()),
+            DpuStatusPhase::ServiceReadiness => Self::Provisioning("ServiceReadiness".into()),
         }
     }
 }

--- a/docs/manuals/dpf.md
+++ b/docs/manuals/dpf.md
@@ -817,8 +817,7 @@ node_label_key  = "carbide.nvidia.com/controlled.node.bf4"
 # Shared across all PSIDs
 os_iso = "https://artifacts.example.com/bfb.3.3.x.iso"
  
-# PSID -> PLDM firmware bundle URL.
-# Currently exactly one PSID entry is supported.
+# PSID -> PLDM firmware bundle URLs. Include one entry for each DPU model.
 [dpf.deployments.bf4_generic.bluefield_software.pldm_fw_bundle]
 "MT_000000xxxx" = "https://artifacts.example.com/bf4/mt_000000xxxx.pldm"
 ```
@@ -829,7 +828,7 @@ Per-deployment field reference:
 | --- | :---: | --- | --- |
 | `bfb_url` | no | BF3 bf-bundle URL | BlueField firmware bundle (BFB) used to provision the DPU. Mutually exclusive with `bluefield_software`. |
 | `bluefield_software.os_iso` | BF4 only | — | OS ISO URL used by BF4 deployments in place of a BFB. Required when `bluefield_software` is set. |
-| `bluefield_software.pldm_fw_bundle` | BF4 only | — | Map of PSID → PLDM firmware bundle URL. Currently exactly one entry is supported. |
+| `bluefield_software.pldm_fw_bundle` | BF4 only | — | Non-empty map of PSID → PLDM firmware bundle URL. Include one entry for each DPU model served by the deployment. |
 | `flavor_name` | yes | `carbide-dpu-flavor` | Base name for the generated `DPUFlavor` (BF3/generic BF4) or `DPUFlavorTemplate` (Astra) CR. |
 | `deployment_name` | yes | `nico-deployment-v2` | `DPUDeployment` CR name. |
 | `node_label_key` | yes | `carbide.nvidia.com/controlled.node.v2` | Node-selector label key applied to this deployment's DPUNodes. |


### PR DESCRIPTION
Sync the pinned DPF nightly CRDs and adapt NICo to the generated schema changes, including PSID-keyed PLDM firmware bundles.

## Related issues

None.

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

None.