### PR TITLE
fix(rest-api): redact password and nvOsPassword in audit request bodies

### DIFF
--- a/rest-api/api/pkg/middleware/audit.go
+++ b/rest-api/api/pkg/middleware/audit.go
@@ -71,6 +71,8 @@ var obfuscateFields = []string{
 	"defaultBmcUsername",
 	"defaultBmcPassword",
 	"authenticationData",
+	"password",
+	"nvOsPassword",
 }
 
 const auditObfuscatedValue = "*******************"

--- a/rest-api/api/pkg/middleware/audit_test.go
+++ b/rest-api/api/pkg/middleware/audit_test.go
@@ -10,15 +10,61 @@ import (
 )
 
 func TestObfuscateRequestBody(t *testing.T) {
-	body := map[string]interface{}{
-		"siteId": "site-1",
-		"authenticationData": map[string]interface{}{
-			"shared": "download-token",
+	tests := []struct {
+		name string
+		body map[string]interface{}
+		want map[string]interface{}
+	}{
+		{
+			name: "obfuscates authenticationData and preserves non-secret fields",
+			body: map[string]interface{}{
+				"siteId": "site-1",
+				"authenticationData": map[string]interface{}{
+					"shared": "download-token",
+				},
+			},
+			want: map[string]interface{}{
+				"siteId":             "site-1",
+				"authenticationData": auditObfuscatedValue,
+			},
+		},
+		{
+			// Regression: the BMC credential password field must never be
+			// persisted in plaintext in the audit body. It is not redacted by
+			// the handler's Temporal-payload redaction, which is a separate path.
+			name: "obfuscates BMC credential password",
+			body: map[string]interface{}{
+				"siteId":             "site-1",
+				"kind":               "SiteWideRoot",
+				"password":           "synthetic-secret",
+				"defaultBmcPassword": "synthetic-default",
+			},
+			want: map[string]interface{}{
+				"siteId":             "site-1",
+				"kind":               "SiteWideRoot",
+				"password":           auditObfuscatedValue,
+				"defaultBmcPassword": auditObfuscatedValue,
+			},
+		},
+		{
+			// Regression: the expected-switch NVOS password field must never be
+			// persisted in plaintext in the audit body.
+			name: "obfuscates expected switch nvOsPassword",
+			body: map[string]interface{}{
+				"nvOsUsername": "admin",
+				"nvOsPassword": "synthetic-secret",
+			},
+			want: map[string]interface{}{
+				"nvOsUsername": "admin",
+				"nvOsPassword": auditObfuscatedValue,
+			},
 		},
 	}
 
-	obfuscateRequestBody(body)
-
-	assert.Equal(t, "site-1", body["siteId"])
-	assert.Equal(t, auditObfuscatedValue, body["authenticationData"])
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			obfuscateRequestBody(tt.body)
+			assert.Equal(t, tt.want, tt.body)
+		})
+	}
 }


### PR DESCRIPTION
## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

