### PR TITLE
fix(rest-api): bracket IPv6 hosts in database URLs

### DIFF
--- a/rest-api/db/pkg/db/config.go
+++ b/rest-api/db/pkg/db/config.go
@@ -6,9 +6,11 @@ package db
 import (
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"os"
 	"strconv"
+	"strings"
 
 	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/credential"
 )
@@ -67,17 +69,23 @@ func ConfigFromEnv() (Config, error) {
 }
 
 // BuildDSN builds the Data Source Name (DSN) string for connecting to
-// the database.
+// the database. IPv6 hosts may be supplied with or without brackets.
 func (c *Config) BuildDSN() string {
+	host := c.Host
+	if strings.HasPrefix(host, "[") && strings.HasSuffix(host, "]") {
+		host = host[1 : len(host)-1]
+	}
+
 	dsn := fmt.Sprintf(
-		"postgres://%v:%v@%v:%v/%v?sslmode=",
+		"postgres://%v:%v@%v/%v?sslmode=",
 		url.PathEscape(c.Credential.User),
 		url.PathEscape(c.Credential.Password.Value),
-		c.Host,
-		c.Port,
+		net.JoinHostPort(host, strconv.Itoa(c.Port)),
 		c.DBName,
 	)
 
+	// `sslmode=disable` broke hostssl-only servers in v1.3.1. Keep `prefer`
+	// explicit so a missing CA path still allows TLS negotiation.
 	if len(c.CACertificatePath) > 0 {
 		dsn += fmt.Sprintf("prefer&sslrootcert=%v", c.CACertificatePath)
 	} else {

--- a/rest-api/db/pkg/db/config_test.go
+++ b/rest-api/db/pkg/db/config_test.go
@@ -4,53 +4,72 @@
 package db
 
 import (
+	"net/url"
+	"os"
+	"strings"
 	"testing"
 
 	"github.com/NVIDIA/infra-controller/rest-api/common/pkg/credential"
+	"github.com/jackc/pgx/v5"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
-func validConfig() Config {
-	return Config{
-		Host:       "db.example.internal",
-		Port:       5432,
-		DBName:     "forge",
-		Credential: credential.New("forge", "s3cr3t"),
+func TestConfig_BuildDSN(t *testing.T) {
+	// Keep local PostgreSQL environment settings out of the parser checks.
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(name, "PG") {
+			t.Setenv(name, "")
+		}
 	}
-}
 
-// TestBuildDSN_NoCACert_UsesSSlModePrefer is a regression test for the bug
-// introduced in v1.3.1 (PR #193) where BuildDSN started appending
-// sslmode=disable when no CA certificate path is configured.
-//
-// In v1.0.4, NewSession built the DSN with no sslmode parameter at all, so
-// pgx defaulted to "prefer" (try TLS, fall back to plaintext). This allowed
-// connections to PostgreSQL clusters whose pg_hba.conf only contains hostssl
-// rules (e.g. CloudNativePG defaults). The explicit sslmode=disable introduced
-// by the refactor causes pg_hba.conf to reject those connections with:
-//
-//	FATAL: pg_hba.conf rejects connection for host "...", no encryption (SQLSTATE 28000)
-func TestBuildDSN_NoCACert_UsesSSlModePrefer(t *testing.T) {
-	cfg := validConfig()
-	// No CACertificatePath set — mirrors the production API deployment, which
-	// mounts no DB CA cert and therefore leaves CACertificatePath empty.
+	tests := []struct {
+		name              string
+		host              string
+		wantHost          string
+		caCertificatePath string
+	}{
+		{name: "hostname", host: "db.example.internal", wantHost: "db.example.internal"},
+		{name: "IPv4", host: "192.0.2.1", wantHost: "192.0.2.1"},
+		{name: "IPv6", host: "2001:db8::1", wantHost: "2001:db8::1"},
+		{name: "bracketed IPv6", host: "[2001:db8::1]", wantHost: "2001:db8::1"},
+		{name: "CA certificate", host: "db.example.internal", caCertificatePath: "/var/secrets/db/ca.crt"},
+	}
 
-	dsn := cfg.BuildDSN()
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := Config{
+				Host:              tt.host,
+				Port:              6432,
+				DBName:            "forge",
+				Credential:        credential.New("forge+%/?", "s3cr3t:@+%/?"),
+				CACertificatePath: tt.caCertificatePath,
+			}
 
-	assert.Contains(t, dsn, "sslmode=prefer",
-		"DSN must use sslmode=prefer when no CA cert is configured so that "+
-			"TLS negotiation succeeds against servers with hostssl pg_hba rules")
-	assert.NotContains(t, dsn, "sslmode=disable",
-		"sslmode=disable breaks connections to CloudNativePG clusters whose "+
-			"pg_hba.conf requires encrypted connections (regression since v1.3.1)")
-}
+			dsn := cfg.BuildDSN()
+			parsedURL, err := url.Parse(dsn)
+			require.NoError(t, err)
 
-func TestBuildDSN_WithCACert_UsesSSlModePreferAndRootCert(t *testing.T) {
-	cfg := validConfig()
-	cfg.CACertificatePath = "/var/secrets/db/ca.crt"
+			wantQuery := url.Values{"sslmode": {"prefer"}}
+			if tt.caCertificatePath != "" {
+				wantQuery.Set("sslrootcert", tt.caCertificatePath)
+			}
+			assert.Equal(t, wantQuery, parsedURL.Query())
 
-	dsn := cfg.BuildDSN()
+			if tt.caCertificatePath != "" {
+				// pgx opens the CA file while parsing; this row only checks
+				// that the configured path is included in the URL.
+				return
+			}
 
-	assert.Contains(t, dsn, "sslmode=prefer")
-	assert.Contains(t, dsn, "sslrootcert=/var/secrets/db/ca.crt")
+			parsed, err := pgx.ParseConfig(dsn)
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantHost, parsed.Host)
+			assert.EqualValues(t, cfg.Port, parsed.Port)
+			assert.Equal(t, cfg.Credential.User, parsed.User)
+			assert.Equal(t, cfg.Credential.Password.Value, parsed.Password)
+			assert.Equal(t, cfg.DBName, parsed.Database)
+		})
+	}
 }


### PR DESCRIPTION
The shared REST database URL builder joins the host and port without adding IPv6 brackets. With host `2001:db8::1` and port `6432`, `pgx` reads `2001:db8::1:6432` as the host and falls back to port `5432`.

Use Go's `net.JoinHostPort` so that configuration produces `[2001:db8::1]:6432`. Hostnames, IPv4, already-bracketed IPv6, and the existing credential and TLS settings stay unchanged. This fixes the shared REST builder; the `nico-api` deployment templates and separate switch-manager builder are outside this PR.

## Related issues

This supports https://github.com/NVIDIA/infra-controller/issues/6005

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same unchanged diff. The coordinator reviewed the complete final diff after adopting the fixes.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 8 | 2 | 6 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **8** | **2** | **6** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Declined** -- Credential escaping is unchanged. Repairing the existing handling of colons in usernames is separate from IPv6 host formatting.
2. **Declined** -- Database-name escaping is an existing, separate concern.
3. **Declined** -- CA-path query escaping is an existing, separate concern.
4. **Adopted** -- Retain the explanation for `sslmode=prefer` beside the production branch; the earlier `disable` setting broke servers requiring TLS.
5. **Declined** -- The separate switch-manager database builder needs its own IPv6 change.
6. **Declined** -- The switch-manager TLS policy is unchanged and outside this fix.
7. **Declined** -- Operator documentation belongs in a separate docs PR. The method comment states the accepted host forms.
8. **Adopted** -- Remove the CA row's unused expected host; that row checks the URL query without opening a certificate file.

### common-nits-reviewer

No findings.

</details>

Closes #6005
