### PR TITLE
docs: explain ExpectedMachine allocation for each address family

### DIFF
--- a/docs/provisioning/expected-machine-interfaces.md
+++ b/docs/provisioning/expected-machine-interfaces.md
@@ -49,13 +49,18 @@ For host boot selection and DPU management policy, see
 
 ## IP Allocation Policies
 
+NICo uses the current Expected Machine configuration for each family's first
+successful DHCP or Static allocation. IPv4 and IPv6 initialize independently.
+The allocation behavior below requires the
+[ExpectedMachine allocation implementation](https://github.com/dsx-ai-factory/infra-controller/pull/6012).
+
 Choose one policy for each declared interface:
 
 | Policy | Behavior |
 |---|---|
 | `dynamic` | NICo allocates an address from the segment selected by the DHCP relay or DHCPv6 link address. |
-| `fixed` | NICo reserves `fixed_ip` before it processes DHCP for the interface. An explicit Fixed policy requires the address to belong to a configured managed prefix. |
-| `retained` | NICo allocates an address through DHCP, then keeps that address static for the lifetime of the machine-interface record. |
+| `fixed` | NICo reserves `fixed_ip` as Static before serving DHCP for that address family. An explicit Fixed policy requires the address to belong to a configured managed prefix. |
+| `retained` | NICo selects an address through DHCP and immediately stores it as Static. It remains reserved until explicit removal or deletion of the machine-interface record. |
 
 `dynamic` and `retained` entries cannot include `fixed_ip`. A `fixed` entry
 must include it.
@@ -71,19 +76,50 @@ NICo uses these defaults when `ip_allocation` is omitted:
 The `fixed_ip` inference preserves manifests created before explicit allocation
 policies were available.
 
-### Retained Address Lifetime
+For repeated MAC entries, DHCP prefers a Fixed declaration for the requested
+family, then an addressless Dynamic or Retained declaration. Equally applicable
+declarations keep their list order. A Fixed declaration for only the other
+family supplies interface metadata, but the requested family uses ordinary
+DHCP; it does not inherit a Fixed reservation or retention.
 
-A retained address remains static only while its machine-interface record
-exists. Deleting the interface record removes the retained address. A later
-ingestion can receive a different address.
+### Address Allocation Lifetime
 
-Expected Machine configuration is an ingestion baseline. NICo can replace an
-existing DHCP or SLAAC address with a Fixed reservation, and it can retain an
-existing DHCP address. It does not automatically reverse an existing Static
-address to Dynamic or replace one Fixed Static address with another.
+After a family has a DHCP or Static allocation, Expected Machine edits leave
+its address and allocation type unchanged, even before machine association.
+The first allocation of the other family still uses the current configuration.
 
-For a policy change that NICo cannot reconcile automatically, update the
-Expected Machine configuration first, then use the targeted interface command:
+Creating or associating an interface without allocating an address does not
+select its allocation policy. A failed allocation also leaves the family free
+to use corrected configuration on its next attempt.
+
+An inferred SLAAC address does not prevent a first DHCP or Static allocation,
+which can replace it. DHCPv6 `INFO_REQUEST` observation alone does not select
+an allocation policy. However, NICo can create a Fixed reservation during that
+request. The reservation counts as the family's first Static allocation even
+though the response contains no address.
+
+After lease expiry or explicit Static-address removal, NICo uses ordinary
+DHCP for subsequent pool allocation while the machine-interface record remains.
+It does not reapply Fixed or Retained configuration. Reserved segments still
+reject clients without reservations.
+
+A retained address is not written back to the Expected Machine configuration.
+Deleting the interface record removes its addresses and per-family allocation
+history. A recreated interface uses the current configuration, so later
+ingestion can select a different Retained address.
+
+Existing DHCP allocations keep their stored type during upgrade, including
+allocations awaiting conversion to Static under the earlier Retained behavior.
+Removal history begins when the updated address-removal code runs. NICo cannot
+reconstruct earlier removals. If older code removed a family's allocation,
+NICo can treat its next allocation as the first and apply the current
+Expected Machine configuration.
+
+To change an existing allocation, update the Expected Machine configuration
+first, then explicitly assign or remove the address. The `assign-address`
+command can replace a DHCP, SLAAC, or Static address. The `remove-address`
+command removes a Static address; it does not cause NICo to reapply the
+Expected Machine allocation policy:
 
 ```bash
 # Find the interface ID and its current addresses.

--- a/docs/provisioning/ip-and-network-configuration.md
+++ b/docs/provisioning/ip-and-network-configuration.md
@@ -90,17 +90,21 @@ BMC, and host BMC interfaces. Every role supports three allocation policies:
 | Policy | Behavior |
 |---|---|
 | **Dynamic** | At DHCP discovery, NICo allocates an address from the segment selected by the DHCP relay or DHCPv6 link address. |
-| **Fixed** | NICo reserves the configured `fixed_ip` before DHCP. The address normally selects the managed segment whose prefix contains it; [legacy inferred reservations](expected-machine-interfaces.md#network-segment-selection) can fall back to `static-assignments`. |
-| **Retained** | NICo allocates an address through DHCP, then keeps it static for the lifetime of the machine-interface record. |
+| **Fixed** | NICo reserves the configured `fixed_ip` as Static for its address family before serving DHCP. The address normally selects the managed segment whose prefix contains it; [legacy inferred reservations](expected-machine-interfaces.md#network-segment-selection) can fall back to `static-assignments`. |
+| **Retained** | NICo selects an address through DHCP and immediately stores it as Static. It remains reserved until explicit removal or deletion of the machine-interface record. |
 
 All four interface roles (`host`, `dpu_os`, `dpu_bmc`, and `host_bmc`) support
 all three policies. The default is Dynamic for every role except `host_bmc`,
 which defaults to Retained. A declaration with `fixed_ip` and no explicit
 policy remains Fixed for backward compatibility.
 
-Mixing policies within the same site and Expected Machine is supported.
-See [Configure Expected Machine Interfaces](expected-machine-interfaces.md)
-for the complete field reference and examples.
+NICo applies the current configuration separately to each family's first
+successful DHCP or Static allocation. Mixing policies within the same site
+and Expected Machine is supported.
+Refer to [Configure Expected Machine Interfaces](expected-machine-interfaces.md)
+for the complete field reference and examples, and
+[Address Allocation Lifetime](expected-machine-interfaces.md#address-allocation-lifetime)
+for per-family allocation, recovery, and rollout limits.
 
 #### Physical Management Networks
 
@@ -133,7 +137,7 @@ Explicit `unspecified`/`Unspecified` resets the policy to Auto.
 
 | Expected Machine configuration | Effective policy | Behavior |
 |---|---|---|
-| Omit both fields, or select Auto without an address | **Retained** (default) | DHCP selects an address; Site Explorer makes it static for that machine-interface row's lifetime. |
+| Omit both fields, or select Auto without an address | **Retained** (default) | DHCP selects the family's first address and immediately stores it as Static. |
 | Set `bmc_ip_address`; omit `bmc_ip_allocation` or select Auto | **Fixed** | NICo reserves and serves the configured address. |
 | Select Dynamic without an address | **Dynamic** | DHCP allocates a normal lease that can expire and change. |
 | Select Retained without an address | **Retained** | Same retained behavior as the default. |
@@ -195,11 +199,12 @@ enum number `2` for the Underlay segment type:
 
 For this fixed declaration:
 
-- NICo records the fixed intent with the Expected Machine. The API update path
-  and Site Explorer reconciliation materialize the machine-interface
-  reservation; the DHCP path also restores it if the interface was deleted.
-- The first DHCP DISCOVER from that BMC's MAC is answered with the reserved
-  address; `nico-dhcp` does not draw another address for that host.
+- NICo records the fixed intent with the Expected Machine. The reservation
+  applies only before that family's first DHCP or Static allocation. Updating the
+  template does not guarantee immediate allocation of a missing family.
+- After NICo creates the reservation, DHCP DISCOVER from that BMC's MAC is
+  answered with the reserved address; `nico-dhcp` does not draw another address
+  for that host.
 - For a BMC on a managed segment, the address must fall within that segment's
   prefix. It can be inside the segment's otherwise-dynamic pool: once the
   reservation exists, NICo's address-uniqueness constraint prevents the
@@ -207,11 +212,10 @@ For this fixed declaration:
 - The optional `underlay` segment guard rejects the configuration if the
   containing segment has another type.
 
-Reconciliation can replace an existing DHCP or SLAAC address with the Fixed
-reservation. It does not automatically replace one Fixed Static address with
-another or return a Static address to Dynamic allocation. For those changes,
-follow the targeted procedure in
-[Retained Address Lifetime](expected-machine-interfaces.md#retained-address-lifetime).
+Expected Machine edits do not replace an existing DHCP or Static allocation.
+For the SLAAC exception, allocation lifetime, and targeted address changes,
+refer to
+[Address Allocation Lifetime](expected-machine-interfaces.md#address-allocation-lifetime).
 
 The legacy top-level `bmc_ip_address` and `bmc_ip_allocation` fields remain
 supported. They act as explicit overrides when a matching `host_bmc` entry is
@@ -289,14 +293,18 @@ an explicit site security decision.
 
 `nico-dhcp` is **not** a standalone DHCP daemon. It is a [Kea DHCP](https://www.isc.org/kea/) hooks library (`cdylib`) loaded into the upstream Kea v4 server inside the `nico-dhcp` container. Every DHCPDISCOVER/REQUEST is intercepted by the hooks library and forwarded to `nico-api` over mTLS gRPC (the `discover_dhcp` RPC). `nico-api` decides what address to lease based on:
 
-- Whether the source MAC matches a Fixed Expected Machine interface
-  reservation, including one declared through the compatible top-level
-  `bmc_ip_address` field.
-- Otherwise, whether the source MAC has a Dynamic or Retained Expected Machine
-  policy or is a known host, host BMC, DPU BMC, or DPU OS interface.
-  `nico-api` uses relay metadata to select the applicable network segment.
-  Dynamic interfaces receive the next free address. Retained interfaces reuse
-  their existing static address, or receive a new address when none exists.
+- Whether the interface already has a DHCP or Static address for the requested
+  family. NICo reuses it without applying later Expected Machine edits.
+- For a family's first DHCP or Static allocation, the source MAC's current Expected
+  Machine policy. Fixed uses a matching-family configured address; Dynamic and
+  Retained use the segment selected by relay metadata. Retained stores the
+  address directly as Static. Without an applicable declaration, NICo uses
+  ordinary DHCP.
+- After a DHCP or Static address is removed while its interface record remains,
+  ordinary DHCP allocation rules apply instead of Fixed or Retained intent.
+  Refer to
+  [Address Allocation Lifetime](expected-machine-interfaces.md#address-allocation-lifetime)
+  for the removal-history support boundary.
 - Vendor class (option 60) determines whether the client is a PXE/iPXE/BlueField boot client, which influences the boot options returned.
 
 The hook callouts (`lease4_select` and `lease4_renew`) overwrite the lease that Kea would have selected — `yiaddr`, valid lifetime, and DHCP options are replaced with the values `nico-api` produced, and the hook can return `SKIP` to cancel Kea's own lease assignment and database write. The result is written to Kea's memfile (`kea-leases4.csv`), but the authoritative record lives in `nico-api`. From an operator perspective this means:
@@ -353,11 +361,10 @@ To configure these flows:
    it serves. In the shared HostInband topology, both the host BMC and host OS
    paths must produce relay metadata for that HostInband prefix.
 3. **For Fixed policies**, upload `expected_machines.json` with the applicable
-   interface reservations before the device first powers on. NICo can replace
-   an existing DHCP or SLAAC address with a Fixed reservation. If the interface
-   already has a Static address that blocks the change, follow the targeted
-   address update procedure in
-   [Retained Address Lifetime](expected-machine-interfaces.md#retained-address-lifetime).
+   interface reservations before the device first powers on. If the family
+   already has a DHCP or Static allocation, changing the template does not
+   replace it. Follow the targeted address update procedure in
+   [Address Allocation Lifetime](expected-machine-interfaces.md#address-allocation-lifetime).
 4. **For reservation-only segments**, set
    `allocation_strategy = "reserved"` and configure every Fixed reservation
    before DHCP. Dynamic and Retained declarations cannot acquire their first


### PR DESCRIPTION
The Expected Machine guides describe converting existing DHCP addresses to `Static` and replacing them after template edits. This documentation companion to [#6012](https://github.com/dsx-ai-factory/infra-controller/pull/6012) updates both guides to explain how IPv4 and IPv6 each use the current configuration for their first DHCP or `Static` allocation. The documented behavior depends on that implementation.

The guides now describe immediate `Static` storage for new `Retained` allocations, preservation of existing allocations after template edits, and ordinary DHCP after expiry or address removal. They also explain explicit address changes, interface recreation, and upgrade limitations. The general lifetime section has a clearer heading and updated links.

## Related issues

This supports https://github.com/dsx-ai-factory/infra-controller/issues/6011

Parent implementation: https://github.com/dsx-ai-factory/infra-controller/issues/4188

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered both documentation pages. Findings about allocation behavior were checked against the companion implementation, not the docs branch's older code.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 1 | 1 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 14 | 6 | 8 |
| common-nits-reviewer | 0 | 0 | 0 |
| **Total** | **15** | **7** | **8** |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

1. **Adopted** -- Clarified that existing DHCP allocations retain their stored type during upgrade, including pending `Retained` conversions.

### Claude CLI

1. **Declined** -- The companion implementation preserves existing DHCP and `Static` allocations after template edits.
2. **Declined** -- It inserts new `Retained` allocations as `Static` immediately; Site Explorer no longer converts them later.
3. **Declined** -- Recorded removals prevent recovery from reapplying edited `Fixed` or `Retained` configuration.
4. **Declined** -- `Retained` allocation now applies to the requested family; the old bulk conversion was removed.
5. **Declined** -- Declaration selection explicitly prefers `Fixed` for the requested family.
6. **Declined** -- Implementation PR links are permitted and already used in these docs.
7. **Declined** -- The migration that records allocation removals exists in the companion implementation.
8. **Adopted** -- Moved the implementation prerequisite above all allocation rules.
9. **Adopted** -- Replaced ambiguous stateful allocation terminology with DHCP or `Static` allocation.
10. **Adopted** -- Renamed the general lifetime section and updated its links.
11. **Adopted** -- Explained the allocation rule before its exceptions.
12. **Adopted** -- Kept the policy table's introduction together.
13. **Adopted** -- Included SLAAC among addresses `assign-address` can replace.
14. **Declined** -- `Static` removal preserving allocation history is verified by the companion implementation.

CodeRabbit CLI and `common-nits-reviewer` returned no findings.

</details>
