### PR TITLE
perf(machine-a-tron): bound resident memory with jemalloc and one BMC mock per device

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2464,6 +2464,7 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 2.0.18",
+ "tikv-jemallocator",
  "tokio",
  "tokio-util",
  "toml 1.1.2+spec-1.1.0",
@@ -11204,6 +11205,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.1+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd8aa5b2ab86a2cefa406d889139c162cbb230092f7d1d7cbc1716405d852a3b"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0359b4327f954e0567e69fb191cf1436617748813819c94b8cd4a431422d053a"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/crates/axum-utils/src/authority_router.rs
+++ b/crates/axum-utils/src/authority_router.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::sync::Arc;
 
@@ -34,18 +35,34 @@ use crate::router::call_router_with_new_request;
 /// The lookup order is the `host` parameter of `Forwarded`, the `Host`
 /// header, the URI authority, and finally the router stored under an empty
 /// string.
-pub fn authority_router(routers: Arc<RwLock<HashMap<String, Router>>>) -> Router {
+///
+/// Map values only have to borrow as the router to dispatch to, so callers
+/// can keep bookkeeping about each entry next to its router.
+pub fn authority_router<R>(routers: Arc<RwLock<HashMap<String, R>>>) -> Router
+where
+    R: Borrow<Router> + Send + Sync + 'static,
+{
     Router::new()
-        .route("/{*all}", any(process))
+        .route("/{*all}", any(process::<R>))
         .with_state(AuthorityRouter { routers })
 }
 
-#[derive(Clone)]
-struct AuthorityRouter {
-    routers: Arc<RwLock<HashMap<String, Router>>>,
+struct AuthorityRouter<R> {
+    routers: Arc<RwLock<HashMap<String, R>>>,
 }
 
-async fn process(State(state): State<AuthorityRouter>, request: Request<Body>) -> Response {
+impl<R> Clone for AuthorityRouter<R> {
+    fn clone(&self) -> Self {
+        Self {
+            routers: self.routers.clone(),
+        }
+    }
+}
+
+async fn process<R>(State(state): State<AuthorityRouter<R>>, request: Request<Body>) -> Response
+where
+    R: Borrow<Router> + Send + Sync + 'static,
+{
     let forwarded_host = forwarded_host(&request);
     let host = request
         .headers()
@@ -96,18 +113,26 @@ fn forwarded_host<B>(request: &Request<B>) -> Option<String> {
         })
 }
 
-async fn find_router(
-    routers: &Arc<RwLock<HashMap<String, Router>>>,
+async fn find_router<R>(
+    routers: &RwLock<HashMap<String, R>>,
     forwarded_host: Option<&str>,
     host: Option<&str>,
     authority: Option<&str>,
-) -> Option<Router> {
+) -> Option<Router>
+where
+    R: Borrow<Router>,
+{
     let routers = routers.read().await;
+    let lookup = |key: &str| {
+        routers
+            .get(key)
+            .map(|entry| Borrow::<Router>::borrow(entry).clone())
+    };
     forwarded_host
-        .and_then(|forwarded_host| routers.get(forwarded_host).cloned())
-        .or_else(|| host.and_then(|host| routers.get(host).cloned()))
-        .or_else(|| authority.and_then(|authority| routers.get(authority).cloned()))
-        .or_else(|| routers.get("").cloned())
+        .and_then(lookup)
+        .or_else(|| host.and_then(lookup))
+        .or_else(|| authority.and_then(lookup))
+        .or_else(|| lookup(""))
 }
 
 fn no_router_response(

--- a/crates/bmc-mock/src/combined_server.rs
+++ b/crates/bmc-mock/src/combined_server.rs
@@ -15,6 +15,7 @@
  * limitations under the License.
  */
 
+use std::borrow::Borrow;
 use std::collections::HashMap;
 use std::net::{SocketAddr, TcpListener};
 use std::sync::Arc;
@@ -71,12 +72,18 @@ impl Drop for CombinedServer {
 }
 
 impl CombinedServer {
-    pub fn run(
+    /// Serves every router in `routers_by_ip_address`, dispatching by request authority. Map
+    /// values only have to borrow as a [`Router`], so callers can store bookkeeping beside each
+    /// router.
+    pub fn run<R>(
         name: &str,
-        routers_by_ip_address: Arc<RwLock<HashMap<String, Router>>>,
+        routers_by_ip_address: Arc<RwLock<HashMap<String, R>>>,
         listener_or_address: Option<ListenerOrAddress>,
         server_config: rustls::ServerConfig,
-    ) -> Self {
+    ) -> Self
+    where
+        R: Borrow<Router> + Send + Sync + 'static,
+    {
         Self::run_router(
             name,
             combined_router(routers_by_ip_address),

--- a/crates/machine-a-tron/Cargo.toml
+++ b/crates/machine-a-tron/Cargo.toml
@@ -64,6 +64,7 @@ tempfile = { workspace = true }
 duration-str = { workspace = true }
 rand = { workspace = true }
 russh = { workspace = true }
+tikv-jemallocator = { workspace = true }
 
 # [local-dependencies]
 carbide-api-model = { path = "../api-model" }

--- a/crates/machine-a-tron/Dockerfile
+++ b/crates/machine-a-tron/Dockerfile
@@ -38,6 +38,7 @@ ENV CI_COMMIT_SHORT_SHA=${CI_COMMIT_SHORT_SHA}
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
+    make \
     pkg-config \
     protobuf-compiler \
     libprotobuf-dev \

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -14,7 +14,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+use std::borrow::Borrow;
 use std::collections::HashMap;
+use std::net::Ipv4Addr;
 use std::sync::Arc;
 
 use axum::Router;
@@ -24,16 +26,41 @@ use bmc_mock::{BmcState, Callbacks, CombinedServer, HardwareType, HostnameQueryi
 use tokio::sync::RwLock;
 use uuid::Uuid;
 
-use crate::config::MachineATronContext;
+use crate::config::MachineATronConfig;
 use crate::machine_state_machine::MachineStateError;
 use crate::mock_ssh_server;
 use crate::mock_ssh_server::{MockSshServerHandle, PromptBehavior};
 
-/// BmcMockWrapper launches a single instance of bmc-mock, configured to mock a single BMC for
+/// Console simulators machine-a-tron starts next to a device's Redfish mock.
+#[derive(Clone, Copy, Debug, Default)]
+pub(super) struct ConsoleSimulators {
+    /// Serve the BMC's SSH serial console from an in-process mock SSH server.
+    pub(super) ssh_server: bool,
+    /// Serve IPMI from an external `ipmi_sim` process.
+    pub(super) ipmi: bool,
+}
+
+impl From<&MachineATronConfig> for ConsoleSimulators {
+    fn from(config: &MachineATronConfig) -> Self {
+        Self {
+            ssh_server: config.mock_bmc_ssh_server,
+            ipmi: config.enable_ipmi_simulation,
+        }
+    }
+}
+
+/// BmcMockWrapper holds a single instance of bmc-mock, configured to mock a single BMC for
 /// either a DPU or a Host. It will rewrite certain responses to customize them for the machines
 /// machine-a-tron is mocking.
+///
+/// Each device builds one wrapper and keeps it for the life of the process. `SetupBmc` runs once
+/// per device, after the BMC obtains its DHCP lease at startup, and is retried only when a console
+/// simulator fails to start; the retry re-publishes this wrapper instead of building a new one.
+/// Host power cycles never reach `SetupBmc`, so the BMC's Redfish model, accounts (including
+/// passwords rotated by the control plane) and sessions carry across them. That state lives only
+/// in memory: a process restart returns every BMC to its factory credentials.
 pub(super) struct BmcMockWrapper {
-    app_context: Arc<MachineATronContext>,
+    consoles: ConsoleSimulators,
     bmc_mock_router: Router,
     bmc_mock_state: BmcState,
     hostname: Arc<dyn HostnameQuerying>,
@@ -41,12 +68,16 @@ pub(super) struct BmcMockWrapper {
     requires_ssh_console: bool,
     stable_id: String,
     ssh_prompt_behavior: PromptBehavior,
+    /// Tags this wrapper's registry entries so it never removes another BMC's router.
+    registration: Uuid,
+    /// Registry key (the BMC's DHCP address) this router is currently published under.
+    registered_authority: Option<String>,
 }
 
 impl BmcMockWrapper {
     pub(super) fn new(
         machine_info: &MachineInfo,
-        app_context: Arc<MachineATronContext>,
+        consoles: ConsoleSimulators,
         callbacks: Arc<dyn Callbacks>,
         hostname: Arc<dyn HostnameQuerying>,
         host_id: Uuid,
@@ -78,7 +109,7 @@ impl BmcMockWrapper {
         };
 
         BmcMockWrapper {
-            app_context,
+            consoles,
             bmc_mock_router,
             bmc_mock_state,
             hostname,
@@ -86,13 +117,43 @@ impl BmcMockWrapper {
             requires_ssh_console,
             stable_id: host_id.to_string(),
             ssh_prompt_behavior,
+            registration: Uuid::new_v4(),
+            registered_authority: None,
         }
+    }
+
+    /// Publishes this BMC's router in the shared registry under `ip_address`.
+    ///
+    /// Registering again under the same address replaces the entry, so a retried `SetupBmc`
+    /// keeps the registry at one entry per BMC. If the address differs from the previous
+    /// registration, the previous key is removed only while it still holds this wrapper's
+    /// router: DHCP may have handed that address to another BMC in the meantime, and that BMC's
+    /// registration is left alone.
+    pub(super) async fn register(&mut self, registry: &BmcMockRegistry, ip_address: Ipv4Addr) {
+        let authority = ip_address.to_string();
+        let mut registry = registry.write().await;
+        if let Some(previous) = self.registered_authority.take()
+            && previous != authority
+            && registry
+                .get(&previous)
+                .is_some_and(|entry| entry.owner == self.registration)
+        {
+            registry.remove(&previous);
+        }
+        registry.insert(
+            authority.clone(),
+            RegisteredBmc {
+                owner: self.registration,
+                router: self.bmc_mock_router.clone(),
+            },
+        );
+        self.registered_authority = Some(authority);
     }
 
     /// Starts per-machine console simulators when Redfish is served by a combined BMC mock.
     /// Returns `None` when no simulator is enabled for the hardware profile.
     pub(super) async fn start(&self) -> Result<Option<BmcMockWrapperHandle>, MachineStateError> {
-        let ssh_handle = if self.app_context.app_config.mock_bmc_ssh_server
+        let ssh_handle = if self.consoles.ssh_server
             && (self.requires_ssh_console || self.bmc_mock_state.has_enabled_ssh_serial_console())
         {
             Some(
@@ -139,16 +200,12 @@ impl BmcMockWrapper {
         .map_err(MachineStateError::IpmiSim)
     }
 
-    pub(super) fn router(&self) -> &Router {
-        &self.bmc_mock_router
-    }
-
     pub(super) fn state(&self) -> &BmcState {
         &self.bmc_mock_state
     }
 
     fn need_ipmi_sim(&self) -> bool {
-        self.app_context.app_config.enable_ipmi_simulation && self.needs_ipmi_console
+        self.consoles.ipmi && self.needs_ipmi_console
     }
 }
 
@@ -170,6 +227,214 @@ impl BmcMockWrapperHandle {
     }
 }
 
-/// BmcMockRegistry is shared state that MachineATron's mock hosts can use to register their BMC
-/// mock routers, so that a single shared instance of BMC mock can delegate to them.
-pub type BmcMockRegistry = Arc<RwLock<HashMap<String, Router>>>;
+/// A BMC mock router published in the [`BmcMockRegistry`], tagged with the wrapper that owns it
+/// so a wrapper moving to a new address can tell whether its old key still holds its own router.
+pub struct RegisteredBmc {
+    owner: Uuid,
+    router: Router,
+}
+
+impl Borrow<Router> for RegisteredBmc {
+    fn borrow(&self) -> &Router {
+        &self.router
+    }
+}
+
+/// BmcMockRegistry is shared state that MachineATron's mock hosts use to publish their BMC mock
+/// routers, keyed by the BMC's DHCP address, so that a single shared listener can delegate to them.
+pub type BmcMockRegistry = Arc<RwLock<HashMap<String, RegisteredBmc>>>;
+
+#[cfg(test)]
+mod tests {
+    use std::borrow::Cow;
+
+    use axum::body::Body;
+    use axum::http::{Method, Request, StatusCode, header};
+    use base64::Engine;
+    use base64::prelude::BASE64_STANDARD;
+    use bmc_mock::mac_address_pool::PoolConfig as MacAddressPoolConfig;
+    use bmc_mock::{
+        DUMMY_FACTORY_PASSWORD, DUMMY_FACTORY_USERNAME, HostMachineInfo, MockPowerState,
+        SetSystemPowerError, SystemPowerControl,
+    };
+    use mac_address::MacAddress;
+    use tower::ServiceExt;
+
+    use super::*;
+
+    #[derive(Debug)]
+    struct PoweredOn;
+
+    impl Callbacks for PoweredOn {
+        fn get_power_state(&self) -> MockPowerState {
+            MockPowerState::On
+        }
+
+        fn send_power_command(
+            &self,
+            _reset_type: SystemPowerControl,
+        ) -> Result<(), SetSystemPowerError> {
+            Ok(())
+        }
+
+        fn state_refresh_indication(&self) {}
+    }
+
+    #[derive(Debug)]
+    struct Localhost;
+
+    impl HostnameQuerying for Localhost {
+        fn get_hostname(&'_ self) -> Cow<'_, str> {
+            Cow::Borrowed("localhost")
+        }
+    }
+
+    fn dell_host_bmc() -> BmcMockWrapper {
+        let mac = MacAddress::new([2, 0, 0, 0, 0, 3]);
+        let machine_info = MachineInfo::Host(HostMachineInfo {
+            hw_type: HardwareType::DellPowerEdgeR750,
+            rack_placement: None,
+            bmc_mac_address: mac,
+            serial: "test-host".to_string(),
+            dpus: Vec::new(),
+            non_dpu_mac_address: None,
+            nvos_mac_addresses: Vec::new(),
+            switch_serial_number: None,
+            hw_mac_addr_pool: MacAddressPoolConfig::new(mac, 24).unwrap(),
+            delta_psu_power: None,
+            initial_host_firmware: None,
+            desired_host_firmware: None,
+        });
+        BmcMockWrapper::new(
+            &machine_info,
+            ConsoleSimulators::default(),
+            Arc::new(PoweredOn),
+            Arc::new(Localhost),
+            Uuid::new_v4(),
+            Arc::new(InjectionStore::new()),
+            None,
+        )
+    }
+
+    async fn registered_router(registry: &BmcMockRegistry, authority: &str) -> Router {
+        registry
+            .read()
+            .await
+            .get(authority)
+            .map(|entry| entry.router.clone())
+            .expect("BMC is registered")
+    }
+
+    fn basic_auth(password: &str) -> String {
+        format!(
+            "Basic {}",
+            BASE64_STANDARD.encode(format!("{DUMMY_FACTORY_USERNAME}:{password}"))
+        )
+    }
+
+    async fn get_systems(router: Router, password: &str) -> StatusCode {
+        router
+            .oneshot(
+                Request::builder()
+                    .uri("/redfish/v1/Systems")
+                    .header(header::AUTHORIZATION, basic_auth(password))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+            .status()
+    }
+
+    #[tokio::test]
+    async fn reregistering_under_the_same_address_keeps_one_entry() {
+        let registry = BmcMockRegistry::default();
+        let mut bmc = dell_host_bmc();
+        let ip_address = Ipv4Addr::new(10, 0, 0, 5);
+
+        bmc.register(&registry, ip_address).await;
+        bmc.register(&registry, ip_address).await;
+
+        let registry = registry.read().await;
+        assert_eq!(registry.keys().collect::<Vec<_>>(), ["10.0.0.5"]);
+        assert_eq!(registry["10.0.0.5"].owner, bmc.registration);
+    }
+
+    #[tokio::test]
+    async fn reregistering_publishes_the_same_bmc_state() {
+        // `SetupBmc` is retried when a console simulator fails to start. The retry publishes the
+        // wrapper the actor already holds rather than a new one, so account changes made through
+        // the registered router in the meantime stay in force.
+        let registry = BmcMockRegistry::default();
+        let mut bmc = dell_host_bmc();
+        let ip_address = Ipv4Addr::new(10, 0, 0, 5);
+        bmc.register(&registry, ip_address).await;
+
+        // The factory password only unlocks the account service, like a BMC that requires a
+        // password change before serving anything else.
+        let router = registered_router(&registry, "10.0.0.5").await;
+        assert_eq!(
+            get_systems(router.clone(), DUMMY_FACTORY_PASSWORD).await,
+            StatusCode::FORBIDDEN
+        );
+        let response = router
+            .oneshot(
+                Request::builder()
+                    .method(Method::PATCH)
+                    .uri(format!(
+                        "/redfish/v1/AccountService/Accounts/{DUMMY_FACTORY_USERNAME}"
+                    ))
+                    .header(header::AUTHORIZATION, basic_auth(DUMMY_FACTORY_PASSWORD))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(r#"{"Password":"rotated"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        bmc.register(&registry, ip_address).await;
+        assert!(bmc.start().await.unwrap().is_none());
+
+        let router = registered_router(&registry, "10.0.0.5").await;
+        assert_eq!(get_systems(router.clone(), "rotated").await, StatusCode::OK);
+        assert_eq!(
+            get_systems(router, DUMMY_FACTORY_PASSWORD).await,
+            StatusCode::UNAUTHORIZED
+        );
+    }
+
+    #[tokio::test]
+    async fn new_address_moves_the_registration() {
+        let registry = BmcMockRegistry::default();
+        let mut bmc = dell_host_bmc();
+
+        bmc.register(&registry, Ipv4Addr::new(10, 0, 0, 5)).await;
+        bmc.register(&registry, Ipv4Addr::new(10, 0, 0, 9)).await;
+
+        let registry = registry.read().await;
+        assert_eq!(registry.keys().collect::<Vec<_>>(), ["10.0.0.9"]);
+        assert_eq!(registry["10.0.0.9"].owner, bmc.registration);
+    }
+
+    #[tokio::test]
+    async fn new_address_leaves_another_bmc_under_the_old_address_alone() {
+        let registry = BmcMockRegistry::default();
+        let mut first = dell_host_bmc();
+        let mut second = dell_host_bmc();
+        let old_address = Ipv4Addr::new(10, 0, 0, 5);
+
+        first.register(&registry, old_address).await;
+        // DHCP hands the first BMC's old address to the second BMC before the first BMC
+        // registers under its new one.
+        second.register(&registry, old_address).await;
+        first.register(&registry, Ipv4Addr::new(10, 0, 0, 9)).await;
+
+        let registry = registry.read().await;
+        let mut keys = registry.keys().collect::<Vec<_>>();
+        keys.sort();
+        assert_eq!(keys, ["10.0.0.5", "10.0.0.9"]);
+        assert_eq!(registry["10.0.0.5"].owner, second.registration);
+        assert_eq!(registry["10.0.0.9"].owner, first.registration);
+    }
+}

--- a/crates/machine-a-tron/src/bmc_mock_wrapper.rs
+++ b/crates/machine-a-tron/src/bmc_mock_wrapper.rs
@@ -128,7 +128,8 @@ impl BmcMockWrapper {
     /// keeps the registry at one entry per BMC. If the address differs from the previous
     /// registration, the previous key is removed only while it still holds this wrapper's
     /// router: DHCP may have handed that address to another BMC in the meantime, and that BMC's
-    /// registration is left alone.
+    /// registration is left alone. Replacing an entry that belongs to another BMC is logged,
+    /// since it means two BMCs claim one DHCP address.
     pub(super) async fn register(&mut self, registry: &BmcMockRegistry, ip_address: Ipv4Addr) {
         let authority = ip_address.to_string();
         let mut registry = registry.write().await;
@@ -139,6 +140,16 @@ impl BmcMockWrapper {
                 .is_some_and(|entry| entry.owner == self.registration)
         {
             registry.remove(&previous);
+        }
+        if let Some(replaced) = registry.get(&authority)
+            && replaced.owner != self.registration
+        {
+            tracing::warn!(
+                authority = %authority,
+                replaced_owner = %replaced.owner,
+                owner = %self.registration,
+                "BMC registration replaced another BMC's router under the same address; two BMCs claim one DHCP address",
+            );
         }
         registry.insert(
             authority.clone(),
@@ -415,6 +426,23 @@ mod tests {
         let registry = registry.read().await;
         assert_eq!(registry.keys().collect::<Vec<_>>(), ["10.0.0.9"]);
         assert_eq!(registry["10.0.0.9"].owner, bmc.registration);
+    }
+
+    #[tokio::test]
+    async fn another_bmc_under_the_same_address_replaces_the_entry() {
+        // The registry cannot tell which of two BMCs claiming one DHCP address is right, so the
+        // latest registration wins and the replacement is logged.
+        let registry = BmcMockRegistry::default();
+        let mut first = dell_host_bmc();
+        let mut second = dell_host_bmc();
+        let address = Ipv4Addr::new(10, 0, 0, 5);
+
+        first.register(&registry, address).await;
+        second.register(&registry, address).await;
+
+        let registry = registry.read().await;
+        assert_eq!(registry.keys().collect::<Vec<_>>(), ["10.0.0.5"]);
+        assert_eq!(registry["10.0.0.5"].owner, second.registration);
     }
 
     #[tokio::test]

--- a/crates/machine-a-tron/src/lib.rs
+++ b/crates/machine-a-tron/src/lib.rs
@@ -45,7 +45,7 @@ mod switch_simulator;
 
 use std::time::{Duration, Instant};
 
-pub use bmc_mock_wrapper::BmcMockRegistry;
+pub use bmc_mock_wrapper::{BmcMockRegistry, RegisteredBmc};
 pub use config::{
     DhcpType, LenovoGb300RackConfig, LogFormat, MachineATronArgs, MachineATronConfig,
     MachineATronContext, MachineConfig, PersistedDevice, PersistedDpuMachine, RackConfig,

--- a/crates/machine-a-tron/src/machine_state_machine.rs
+++ b/crates/machine-a-tron/src/machine_state_machine.rs
@@ -36,7 +36,7 @@ use tokio::time::Instant;
 use uuid::Uuid;
 
 use crate::api_client::{ClientApiError, DpuNetworkStatusArgs, MockDiscoveryData};
-use crate::bmc_mock_wrapper::{BmcMockWrapper, BmcMockWrapperHandle};
+use crate::bmc_mock_wrapper::{BmcMockWrapper, BmcMockWrapperHandle, ConsoleSimulators};
 use crate::config::{MachineATronContext, MachineConfig};
 use crate::dhcp_wrapper::{
     DhcpRelayError, DhcpRelayResult, DhcpRequestInfo, DhcpRequester, DhcpResponseInfo,
@@ -120,6 +120,11 @@ pub(super) struct MachineStateMachine {
     pub(super) installed_os: OsImage,
 
     fsm: MachineFsm,
+    /// Built on the first `SetupBmc` and kept for the life of the process. `SetupBmc` runs once
+    /// per machine, after the BMC's DHCP lease is obtained; a retry after a failed start
+    /// re-publishes this wrapper under that lease instead of building a new one. It is never
+    /// unregistered: the BMC stays reachable while the host is off.
+    bmc_mock_wrapper: Option<BmcMockWrapper>,
     bmc_mock: Option<Arc<BmcMockWrapperHandle>>,
     bmc_state: Option<BmcState>,
     bmc_injection: Arc<InjectionStore>,
@@ -342,6 +347,7 @@ impl MachineStateMachine {
         MachineStateMachine {
             fsm,
             actions: actions.into_iter().collect(),
+            bmc_mock_wrapper: None,
             bmc_mock: None,
             bmc_state: None,
             bmc_injection: Arc::new(InjectionStore::new()),
@@ -390,6 +396,7 @@ impl MachineStateMachine {
             fsm,
             actions: actions.into_iter().collect(),
             bmc_dhcp_info: None,
+            bmc_mock_wrapper: None,
             bmc_mock: None,
             bmc_state: None,
             bmc_injection: Arc::new(InjectionStore::new()),
@@ -671,12 +678,13 @@ impl MachineStateMachine {
     }
 
     async fn setup_bmc(
-        &self,
+        &mut self,
     ) -> Result<(Option<Arc<BmcMockWrapperHandle>>, BmcState), MachineStateError> {
         let Some(dhcp_info) = &self.bmc_dhcp_info else {
             return Err(MachineStateError::NoBmcDhcpInfo);
         };
-        self.run_bmc_mock(dhcp_info.ip_address).await
+        let ip_address = dhcp_info.ip_address;
+        self.run_bmc_mock(ip_address).await
     }
 
     async fn bmc_dhcp_discovery(&self) -> DhcpRelayResult<DhcpResponseInfo> {
@@ -1229,13 +1237,13 @@ impl MachineStateMachine {
         MaybeOsImage(self.fsm.booted_os())
     }
 
-    async fn run_bmc_mock(
-        &self,
-        ip_address: Ipv4Addr,
-    ) -> Result<(Option<Arc<BmcMockWrapperHandle>>, BmcState), MachineStateError> {
+    /// Builds this machine's BMC mock. Called once per machine: `SetupBmc` runs once and its
+    /// retry path reuses the wrapper, so accounts, sessions and applied firmware persist in
+    /// memory until the process exits.
+    fn build_bmc_mock(&self) -> BmcMockWrapper {
         let bmc_mock = BmcMockWrapper::new(
             &self.machine_info,
-            self.app_context.clone(),
+            ConsoleSimulators::from(&self.app_context.app_config),
             Arc::new(LiveStateCallbacks::new(
                 self.live_state.clone(),
                 self.bmc_command_channel.clone(),
@@ -1257,15 +1265,24 @@ impl MachineStateMachine {
                 .account_service_state
                 .change_factory_default_password(pw);
         }
+        bmc_mock
+    }
 
-        let maybe_bmc_mock_handle = {
-            self.app_context
-                .bmc_registry
-                .write()
-                .await
-                .insert(ip_address.to_string(), bmc_mock.router().clone());
-            bmc_mock.start().await?.map(Arc::new)
+    async fn run_bmc_mock(
+        &mut self,
+        ip_address: Ipv4Addr,
+    ) -> Result<(Option<Arc<BmcMockWrapperHandle>>, BmcState), MachineStateError> {
+        let bmc_mock = match &mut self.bmc_mock_wrapper {
+            Some(bmc_mock) => bmc_mock,
+            None => {
+                let bmc_mock = self.build_bmc_mock();
+                self.bmc_mock_wrapper.insert(bmc_mock)
+            }
         };
+        bmc_mock
+            .register(&self.app_context.bmc_registry, ip_address)
+            .await;
+        let maybe_bmc_mock_handle = bmc_mock.start().await?.map(Arc::new);
         if let Some(ssh_host_key) = maybe_bmc_mock_handle
             .as_ref()
             .and_then(|handle| handle.ssh_handle.as_ref())

--- a/crates/machine-a-tron/src/main.rs
+++ b/crates/machine-a-tron/src/main.rs
@@ -49,6 +49,14 @@ use tokio::sync::mpsc;
 use crate::logging::init_logging;
 use crate::ufm_mock::HostedUfmMock;
 
+// Simulated fleets allocate and free short-lived Redfish state from many worker threads. With
+// glibc malloc that memory stayed in per-thread arenas and resident size ratcheted up to the pod
+// limit under sustained Redfish load; jemalloc's decay-based purging returns freed pages to the
+// OS and kept resident size bounded under the same load. Purging is triggered by allocation
+// activity rather than by background threads, so an idle process is slower to shrink.
+#[global_allocator]
+static GLOBAL: tikv_jemallocator::Jemalloc = tikv_jemallocator::Jemalloc;
+
 #[tokio::main(flavor = "multi_thread", worker_threads = 32)]
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = MachineATronArgs::parse();

--- a/crates/machine-a-tron/src/power_shelf_simulator.rs
+++ b/crates/machine-a-tron/src/power_shelf_simulator.rs
@@ -31,7 +31,7 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::actor::{Actor, ActorCallbacks, ActorMailbox, ActorResult, AlarmId};
-use crate::bmc_mock_wrapper::{BmcMockWrapper, BmcMockWrapperHandle};
+use crate::bmc_mock_wrapper::{BmcMockWrapper, BmcMockWrapperHandle, ConsoleSimulators};
 use crate::config::{self, MachineATronContext, MachineConfig, PersistedDevice};
 use crate::dhcp_wrapper::{DhcpRequestInfo, DhcpRequester, DhcpResponseInfo, vendor_class};
 use crate::machine_state_machine::{MachineStateError, OsImage};
@@ -109,6 +109,9 @@ pub(crate) struct PowerShelfActor {
     config: Arc<MachineConfig>,
     live_state: Arc<RwLock<PowerShelfLiveState>>,
     bmc_injection: Arc<InjectionStore>,
+    /// Built on the first `SetupBmc` attempt and re-published, not rebuilt, if that action is
+    /// retried after a failed start.
+    bmc_mock_wrapper: Option<BmcMockWrapper>,
     _bmc_mock: Option<Arc<BmcMockWrapperHandle>>,
     bmc_dhcp_info: Option<DhcpResponseInfo>,
     fsm: PowerShelfFsm,
@@ -138,6 +141,7 @@ impl PowerShelfActor {
             config,
             live_state: Arc::new(RwLock::new(PowerShelfLiveState::new(&fsm))),
             bmc_injection: Arc::new(InjectionStore::new()),
+            bmc_mock_wrapper: None,
             _bmc_mock: None,
             bmc_dhcp_info: None,
             fsm,
@@ -178,6 +182,7 @@ impl PowerShelfActor {
             config,
             live_state: Arc::new(RwLock::new(PowerShelfLiveState::new(&fsm))),
             bmc_injection: Arc::new(InjectionStore::new()),
+            bmc_mock_wrapper: None,
             _bmc_mock: None,
             bmc_dhcp_info: None,
             fsm,
@@ -336,18 +341,11 @@ impl PowerShelfActor {
             .await
     }
 
-    async fn setup_bmc(
-        &mut self,
-        mailbox: &ActorMailbox<PowerShelfMessage>,
-    ) -> Result<(), MachineStateError> {
-        let dhcp_info = self
-            .bmc_dhcp_info
-            .as_ref()
-            .ok_or(MachineStateError::NoBmcDhcpInfo)?;
+    fn build_bmc_mock(&self, mailbox: &ActorMailbox<PowerShelfMessage>) -> BmcMockWrapper {
         let machine_info = MachineInfo::Host(self.host_info.clone());
         let bmc_mock = BmcMockWrapper::new(
             &machine_info,
-            self.app_context.clone(),
+            ConsoleSimulators::from(&self.app_context.app_config),
             Arc::new(PowerShelfCallbacks {
                 state: self.live_state.clone(),
                 mailbox: mailbox.clone(),
@@ -366,15 +364,29 @@ impl PowerShelfActor {
                 .account_service_state
                 .change_factory_default_password(password);
         }
+        bmc_mock
+    }
 
-        let bmc_handle = {
-            self.app_context
-                .bmc_registry
-                .write()
-                .await
-                .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
-            bmc_mock.start().await?.map(Arc::new)
+    async fn setup_bmc(
+        &mut self,
+        mailbox: &ActorMailbox<PowerShelfMessage>,
+    ) -> Result<(), MachineStateError> {
+        let ip_address = self
+            .bmc_dhcp_info
+            .as_ref()
+            .ok_or(MachineStateError::NoBmcDhcpInfo)?
+            .ip_address;
+        let bmc_mock = match &mut self.bmc_mock_wrapper {
+            Some(bmc_mock) => bmc_mock,
+            None => {
+                let bmc_mock = self.build_bmc_mock(mailbox);
+                self.bmc_mock_wrapper.insert(bmc_mock)
+            }
         };
+        bmc_mock
+            .register(&self.app_context.bmc_registry, ip_address)
+            .await;
+        let bmc_handle = bmc_mock.start().await?.map(Arc::new);
 
         if let Some(ssh_host_key) = bmc_handle
             .as_ref()
@@ -386,7 +398,7 @@ impl PowerShelfActor {
 
         {
             let mut state = self.live_state.write().unwrap();
-            state.bmc_ip = Some(dhcp_info.ip_address);
+            state.bmc_ip = Some(ip_address);
             state.ipmi_port = bmc_handle.as_ref().and_then(|handle| handle.ipmi_port());
             state.ssh_endpoint_port = bmc_handle
                 .as_ref()

--- a/crates/machine-a-tron/src/switch_simulator.rs
+++ b/crates/machine-a-tron/src/switch_simulator.rs
@@ -30,7 +30,7 @@ use tokio::task::JoinHandle;
 use uuid::Uuid;
 
 use crate::actor::{Actor, ActorCallbacks, ActorMailbox, ActorResult, AlarmId};
-use crate::bmc_mock_wrapper::{BmcMockWrapper, BmcMockWrapperHandle};
+use crate::bmc_mock_wrapper::{BmcMockWrapper, BmcMockWrapperHandle, ConsoleSimulators};
 use crate::config::{self, MachineATronContext, MachineConfig, PersistedDevice};
 use crate::dhcp_wrapper::{DhcpRequestInfo, DhcpRequester, DhcpResponseInfo, vendor_class};
 use crate::machine_state_machine::{MachineStateError, OsImage};
@@ -114,6 +114,9 @@ pub(crate) struct SwitchActor {
     config: Arc<MachineConfig>,
     live_state: Arc<RwLock<SwitchLiveState>>,
     bmc_injection: Arc<InjectionStore>,
+    /// Built on the first `SetupBmc` attempt and re-published, not rebuilt, if that action is
+    /// retried after a failed start.
+    bmc_mock_wrapper: Option<BmcMockWrapper>,
     _bmc_mock: Option<Arc<BmcMockWrapperHandle>>,
     bmc_dhcp_info: Option<DhcpResponseInfo>,
     fsm: SwitchFsm,
@@ -144,6 +147,7 @@ impl SwitchActor {
             config,
             live_state: Arc::new(RwLock::new(SwitchLiveState::new(&fsm))),
             bmc_injection: Arc::new(InjectionStore::new()),
+            bmc_mock_wrapper: None,
             _bmc_mock: None,
             bmc_dhcp_info: None,
             fsm,
@@ -184,6 +188,7 @@ impl SwitchActor {
             config,
             live_state: Arc::new(RwLock::new(SwitchLiveState::new(&fsm))),
             bmc_injection: Arc::new(InjectionStore::new()),
+            bmc_mock_wrapper: None,
             _bmc_mock: None,
             bmc_dhcp_info: None,
             fsm,
@@ -380,18 +385,11 @@ impl SwitchActor {
             .await?)
     }
 
-    async fn setup_bmc(
-        &mut self,
-        mailbox: &ActorMailbox<SwitchMessage>,
-    ) -> Result<(), MachineStateError> {
-        let dhcp_info = self
-            .bmc_dhcp_info
-            .as_ref()
-            .ok_or(MachineStateError::NoBmcDhcpInfo)?;
+    fn build_bmc_mock(&self, mailbox: &ActorMailbox<SwitchMessage>) -> BmcMockWrapper {
         let machine_info = MachineInfo::Host(self.host_info.clone());
         let bmc_mock = BmcMockWrapper::new(
             &machine_info,
-            self.app_context.clone(),
+            ConsoleSimulators::from(&self.app_context.app_config),
             Arc::new(SwitchCallbacks {
                 state: self.live_state.clone(),
                 mailbox: mailbox.clone(),
@@ -408,15 +406,29 @@ impl SwitchActor {
                 .account_service_state
                 .change_factory_default_password(password);
         }
+        bmc_mock
+    }
 
-        let bmc_handle = {
-            self.app_context
-                .bmc_registry
-                .write()
-                .await
-                .insert(dhcp_info.ip_address.to_string(), bmc_mock.router().clone());
-            bmc_mock.start().await?.map(Arc::new)
+    async fn setup_bmc(
+        &mut self,
+        mailbox: &ActorMailbox<SwitchMessage>,
+    ) -> Result<(), MachineStateError> {
+        let ip_address = self
+            .bmc_dhcp_info
+            .as_ref()
+            .ok_or(MachineStateError::NoBmcDhcpInfo)?
+            .ip_address;
+        let bmc_mock = match &mut self.bmc_mock_wrapper {
+            Some(bmc_mock) => bmc_mock,
+            None => {
+                let bmc_mock = self.build_bmc_mock(mailbox);
+                self.bmc_mock_wrapper.insert(bmc_mock)
+            }
         };
+        bmc_mock
+            .register(&self.app_context.bmc_registry, ip_address)
+            .await;
+        let bmc_handle = bmc_mock.start().await?.map(Arc::new);
 
         if let Some(ssh_host_key) = bmc_handle
             .as_ref()
@@ -428,7 +440,7 @@ impl SwitchActor {
 
         {
             let mut state = self.live_state.write().unwrap();
-            state.bmc_ip = Some(dhcp_info.ip_address);
+            state.bmc_ip = Some(ip_address);
             state.ipmi_port = bmc_handle.as_ref().and_then(|handle| handle.ipmi_port());
             state.ssh_endpoint_port = bmc_handle
                 .as_ref()


### PR DESCRIPTION
Under sustained Redfish load with glibc malloc, machine-a-tron's resident memory grew until the pod was OOM-killed, resetting all BMC credentials. tikv-jemallocator becomes the global allocator, and SetupBmc retries reuse the device's BMC mock, evicting a stale key only while it still points at that device. Redfish behavior is unchanged.

## Related issues
Closes #5965

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Unit tests for machine-a-tron, axum-utils, and bmc-mock passed, excluding one needing the ipmi_sim binary. On a simulated 250-rack site (17,750 BMCs) resident memory peaked at 14.6 GB with no restarts over 24 hours, where the glibc build had reached its 48 GB limit.

## Additional Notes
jemalloc purging is allocation-driven, so an idle process shrinks slowly.
