### PR TITLE
docs: fix dead links to renamed and moved pages

### DIFF
--- a/docs/manuals/cargo-via-docker-macos.md
+++ b/docs/manuals/cargo-via-docker-macos.md
@@ -12,7 +12,7 @@ This guide describes what is in place for running Cargo (build, test, check) via
 | **Makefile task: `build-cargo-docker-image-minimal`** | `Makefile.toml` | Build the minimal image (Rust + protoc only). Quick (~2–5 min). Required once for workspace builds (e.g. `nico-rpc` needs `protoc`). |
 | **Makefile task: `cargo-docker`** | `Makefile.toml` | Run Cargo inside the repo’s full build container (`nico-build-x86_64`). Requires building that image first. |
 | **Makefile task: `build-cargo-docker-image`** | `Makefile.toml` | Build the full Linux build image from `dev/docker/Dockerfile.build-container-x86_64`. Slow on Apple Silicon (45+ min). |
-| **This guide** | `docs/development/cargo-via-docker-macos.md` | How to use the above and when to choose which option. |
+| **This guide** | `docs/manuals/cargo-via-docker-macos.md` | How to use the above and when to choose which option. |
 | **Minimal Dockerfile** | `dev/docker/Dockerfile.cargo-docker-minimal` | Rust 1.97 + `protobuf-compiler` + `libprotobuf-dev` (well-known types). Used for `nico-build-minimal`. |
 | **Full build Dockerfile** | `dev/docker/Dockerfile.build-container-x86_64` | Defines the full build image (Rust 1.97, PostgreSQL, protobuf, TSS, etc.). |
 

--- a/docs/manuals/networking/ip_resource_pools.md
+++ b/docs/manuals/networking/ip_resource_pools.md
@@ -100,7 +100,7 @@ lo-ip pool size = H × D
 
 For example, 100 hosts with 2 DPUs each require 200 addresses.
 
-`docs/manuals/networking_requirements.md` states the combined IPv4 prefix requirement as `(expected number of servers + expected number of DPUs) × 2 + 2`. The `lo-ip` pool supplies the per-DPU loopback portion of that allocation. The remainder of the formula covers admin and other infrastructure addresses.
+`docs/getting-started/prerequisites/network.md` states the combined IPv4 prefix requirement as `(expected number of servers + expected number of DPUs) × 2 + 2`. The `lo-ip` pool supplies the per-DPU loopback portion of that allocation. The remainder of the formula covers admin and other infrastructure addresses.
 
 ### `vpc-dpu-lo`
 
@@ -112,7 +112,7 @@ vpc-dpu-lo pool size (worst case) = number of VPCs × total number of DPUs
 
 In practice, consumption is typically lower because tenant workloads are not spread uniformly across the entire fleet. Plan for the worst case unless site-specific workload data supports a smaller estimate.
 
-`docs/manuals/networking_requirements.md` notes that a separate IPv4 prefix is required for these addresses, with a total allocation of `expected number of DPUs × 2` at minimum. Size the `vpc-dpu-lo` pool within that allocation, leaving headroom for VPC growth.
+`docs/getting-started/prerequisites/network.md` notes that a separate IPv4 prefix is required for these addresses, with a total allocation of `expected number of DPUs × 2` at minimum. Size the `vpc-dpu-lo` pool within that allocation, leaving headroom for VPC growth.
 
 ### Headroom recommendation
 
@@ -183,6 +183,6 @@ If the original pool was prefix-based, the grow file may also provide additional
 
 - `docs/manuals/vpc/vni_resource_pools.md` — companion page covering VNI and VLAN ID resource pools
 - `docs/manuals/vpc/vpc_network_virtualization.md` — end-to-end VPC network virtualization overview that ties VNI pools, IP pools, and routing profiles together
-- `docs/manuals/networking_requirements.md` — site-level networking requirements including IPv4 prefix sizing formulas
+- `docs/getting-started/prerequisites/network.md` — site-level networking requirements including IPv4 prefix sizing formulas
 - `docs/manuals/vpc/vpc_routing_profiles.md` — VPC routing profile configuration, which governs the VPC overlay network configuration and therefore drives `vpc-dpu-lo` consumption
 

--- a/docs/manuals/vpc/vni_resource_pools.md
+++ b/docs/manuals/vpc/vni_resource_pools.md
@@ -10,7 +10,7 @@ configure the API server's resource pools correctly.
 
 - `docs/manuals/vpc/vpc_routing_profiles.md` — how the `internal` flag on a routing profile
   determines which VNI pool is used
-- `docs/manuals/networking_requirements.md` — site-wide networking prerequisites, including
+- `docs/getting-started/prerequisites/network.md` — site-wide networking prerequisites, including
   general VNI and ASN allocation guidance
 - `docs/manuals/networking/ip_resource_pools.md` — IP resource pool configuration
 - `docs/manuals/vpc/vpc_network_virtualization.md` — end-to-end VPC network virtualization
@@ -151,7 +151,7 @@ Use the following approach to determine the required pool size for each pool.
    route-targets, so the network team must configure import and export policies that reference the
    same ranges you define in the pool.
 
-The `docs/manuals/networking_requirements.md` document states the general rule: one VNI is
+The `docs/getting-started/prerequisites/network.md` page states the general rule: one VNI is
 required per expected VPC. The pools defined here are the mechanism that enforces and tracks that
 allocation.
 


### PR DESCRIPTION
## Description

fix dead links to renamed and moved pages`docs/manuals/networking_requirements.md` no longer exists; its content lives at `docs/getting-started/prerequisites/network.md`. Point the five references in `ip_resource_pools.md` and `vni_resource_pools.md` at the current page. `docs/manuals/cargo-via-docker-macos.md` named its own location as

`docs/development/cargo-via-docker-macos.md`, a path it moved away from.

Correct the self-reference.

No content changes beyond the paths.

## Related issues
Refs #6027

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [x] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes


