### PR TITLE
chore(rest-api): Switch Machine inventory to adaptive mode

### DIFF
--- a/rest-api/api/pkg/api/model/machine.go
+++ b/rest-api/api/pkg/api/model/machine.go
@@ -646,7 +646,6 @@ func NewAPIMachine(dbm *cdbm.Machine, dbmcs []cdbm.MachineCapability, dbmis []cd
 
 	// Only Provider Admin can see the metadata
 	if dbm.Metadata != nil && includeMetadata && isProviderOrPrivilegedTenant {
-
 		apim.Metadata = &APIMachineMetadata{}
 
 		// Get the Machine json body

--- a/rest-api/site-agent/pkg/components/config/config_manager.go
+++ b/rest-api/site-agent/pkg/components/config/config_manager.go
@@ -365,19 +365,11 @@ func validateInventorySchedule(schedule string) error {
 	return nil
 }
 
-// inventoryCarbidePageSize mirrors InventoryCarbidePageSize (hardcoded to 100 in every
-// managers/*/cron.go; importing one here would cycle back to this config package). Keep in
-// sync if that value ever changes.
-const inventoryCarbidePageSize = 100
-
-// validateInventoryCloudPageSize rejects a page size Temporal or machine pagination can't
-// handle. Must be >=1 and <=MaxInventoryCloudPageSize (2MB Temporal blob ceiling, see
-// conftypes.go). Must also divide 100 evenly: CollectAndPublishMachineInventory
-// (site-workflow/pkg/activity/machine.go) chunks each 100-item Core page into Cloud pages
-// independently rather than buffering across Core pages, so a non-divisor desyncs its
-// TotalPages/CurrentPage reconciliation. Unreachable before this value became configurable
-// (the old hardcoded 25 always divided 100 cleanly); a real fix means buffering the machine
-// publisher like the instance one already does.
+// validateInventoryCloudPageSize rejects a page size Temporal cannot carry. Must be >=1 and
+// <=MaxInventoryCloudPageSize (2MB Temporal blob ceiling, see conftypes.go). The page size no
+// longer has to divide the Core fetch page evenly: every inventory now publishes through the
+// shared collector, which buffers items across Core pages instead of chunking each one on its
+// own, so a page size like 30 no longer desyncs the paging totals.
 func validateInventoryCloudPageSize(pageSize int) error {
 	if pageSize < 1 {
 		return fmt.Errorf("INVENTORY_CLOUD_PAGE_SIZE %d must be at least 1", pageSize)
@@ -385,9 +377,7 @@ func validateInventoryCloudPageSize(pageSize int) error {
 	if pageSize > conftypes.MaxInventoryCloudPageSize {
 		return fmt.Errorf("INVENTORY_CLOUD_PAGE_SIZE %d exceeds the %d maximum", pageSize, conftypes.MaxInventoryCloudPageSize)
 	}
-	if inventoryCarbidePageSize%pageSize != 0 {
-		return fmt.Errorf("INVENTORY_CLOUD_PAGE_SIZE %d must evenly divide %d (the Core/site fetch page size) -- a non-divisor breaks machine-inventory pagination totals across Core page boundaries", pageSize, inventoryCarbidePageSize)
-	}
+
 	return nil
 }
 

--- a/rest-api/site-agent/pkg/components/config/inventory_page_size_test.go
+++ b/rest-api/site-agent/pkg/components/config/inventory_page_size_test.go
@@ -19,16 +19,11 @@ func TestValidateInventoryCloudPageSize(t *testing.T) {
 		{"100 is the maximum valid value", 100, false},
 		{"101 rejected (just over max)", 101, true},
 		{"far over max rejected", 100000, true},
-		// Non-divisors of 100 break machine-inventory pagination totals across Core page
-		// boundaries (see the function doc comment) -- rejected even though they're within
-		// [1, 100].
-		{"40 rejected (does not divide 100)", 40, true},
-		{"30 rejected (does not divide 100)", 30, true},
-		{"33 rejected (does not divide 100)", 33, true},
-		{"99 rejected (does not divide 100)", 99, true},
-		{"20 accepted (divides 100)", 20, false},
-		{"10 accepted (divides 100)", 10, false},
-		{"4 accepted (divides 100)", 4, false},
+		// Every inventory publishes through the shared collector, which buffers items across
+		// Core pages, so a page size that does not divide the Core fetch page is accepted.
+		{"30 accepted (does not divide 100)", 30, false},
+		{"99 accepted (does not divide 100)", 99, false},
+		{"20 accepted", 20, false},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {

--- a/rest-api/site-agent/pkg/components/managers/machine/publisher.go
+++ b/rest-api/site-agent/pkg/components/managers/machine/publisher.go
@@ -19,14 +19,14 @@ func (api *API) RegisterPublisher() error {
 	ManagerAccess.Data.EB.Log.Info().Msg("Machine: Successfully registered CollectAndPublishMachineInventory workflow")
 
 	// Register CollectAndPublishMachineInventory activity
-	machineInventoryManager := swa.NewManageMachineInventory(
-		uuid.MustParse(ManagerAccess.Conf.EB.Temporal.ClusterID),
-		ManagerAccess.Data.EB.Managers.CoreGrpc.Client,
-		ManagerAccess.Data.EB.Managers.Workflow.Temporal.Publisher,
-		ManagerAccess.Conf.EB.Temporal.TemporalPublishQueue,
-		InventoryCarbidePageSize,
-		ManagerAccess.Conf.EB.Temporal.InventoryCloudPageSize,
-	)
+	machineInventoryManager := swa.NewManageMachineInventory(swa.ManageInventoryConfig{
+		SiteID:                uuid.MustParse(ManagerAccess.Conf.EB.Temporal.ClusterID),
+		CoreGrpcAtomicClient:  ManagerAccess.Data.EB.Managers.CoreGrpc.Client,
+		TemporalPublishClient: ManagerAccess.Data.EB.Managers.Workflow.Temporal.Publisher,
+		TemporalPublishQueue:  ManagerAccess.Conf.EB.Temporal.TemporalPublishQueue,
+		SitePageSize:          InventoryCarbidePageSize,
+		CloudPageSize:         ManagerAccess.Conf.EB.Temporal.InventoryCloudPageSize,
+	})
 
 	ManagerAccess.Data.EB.Managers.Workflow.Temporal.Worker.RegisterActivity(machineInventoryManager.CollectAndPublishMachineInventory)
 	ManagerAccess.Data.EB.Log.Info().Msg("Machine: Successfully registered CollectAndPublishMachineInventory activity")

--- a/rest-api/site-agent/pkg/conftypes/conftypes.go
+++ b/rest-api/site-agent/pkg/conftypes/conftypes.go
@@ -51,9 +51,11 @@ const (
 	// DefaultInventoryCloudPageSize is the fallback page size when
 	// INVENTORY_CLOUD_PAGE_SIZE is unset. Matches the historical hardcoded value.
 	DefaultInventoryCloudPageSize = 25
-	// MaxInventoryCloudPageSize caps the configurable page size. Each page is a Temporal
-	// history blob (2MB hard limit); at ~10-15KB per real Machine proto, 100 stays under
-	// 1.5MB with margin. Larger risks intermittent BlobSizeLimitError on fat nodes.
+	// MaxInventoryCloudPageSize caps the configurable page size. Do not read it as a size that
+	// fits Temporal's 2MB blob limit: a real Machine has measured at 49KB after pruning and
+	// 156KB before it, so 100 of them exceeds the limit either way. Staying under it is the
+	// publish ladder's job, which shrinks a page until it measures small enough, and this bound
+	// only keeps the starting page size somewhere sensible.
 	MaxInventoryCloudPageSize = 100
 )
 

--- a/rest-api/site-workflow/pkg/activity/inventory.go
+++ b/rest-api/site-workflow/pkg/activity/inventory.go
@@ -249,7 +249,7 @@ type inventoryCollector[K any, R any, P any] struct {
 	pagesPublished   int
 	itemsPublished   int
 	// itemsMissing counts IDs that FindIDs reported but FindByIDs did not return, which is what
-	// a delete landing between the two calls looks like.
+	// a delete arriving between the two calls looks like.
 	itemsMissing int
 	// pending holds items fetched but not yet published. It never exceeds one page, because the
 	// tail stays here until the caller flushes it.

--- a/rest-api/site-workflow/pkg/activity/machine.go
+++ b/rest-api/site-workflow/pkg/activity/machine.go
@@ -277,22 +277,24 @@ func machineFindByIDs(ctx context.Context, grpcClient *cClient.CoreGrpcClient, i
 	return machines, nil
 }
 
-// maxPublishedMachineEvents bounds the event history a published Machine carries. Cloud reads the
-// events only to date the current state, but a Machine arrives with its whole history, which is
-// the largest thing in the message. Twenty keeps recent history worth reading without carrying
-// hundreds of entries per Machine.
+// maxPublishedMachineEvents bounds the event history a published Machine carries. The REST layer
+// reads the events only to date the current state, but a Machine arrives with its whole history,
+// which is the largest thing in the message. Twenty keeps recent history worth reading without
+// carrying hundreds of entries per Machine.
 const maxPublishedMachineEvents = 20
 
-// pruneMachineForPublish drops what Cloud does not read from a Machine before it is published.
+// pruneMachineForPublish drops what the REST layer does not read from a Machine before it is
+// published.
 //
 // Core fills both the fields under status and config and their deprecated twins on the Machine
-// itself, which the proto marks for removal once rest-api reads the new ones. Cloud already reads
-// status and config, so the twins are an exact duplicate of about a quarter of every Machine, and
-// Cloud persists the whole message as jsonb so they cost storage as well as Temporal payload.
+// itself, which the proto marks for removal once rest-api reads the new ones. The REST layer
+// already reads status and config, so the twins are an exact duplicate of about a quarter of every
+// Machine, and it persists the whole message as jsonb, so they cost storage as well as Temporal
+// payload.
 //
-// Events are the larger cost. A Machine arrives with its full state history, and Cloud uses it to
-// date one lifecycle transition, so only the events matching the current state_version are worth
-// sending.
+// Events are the larger cost. A Machine arrives with its full state history, and the REST layer
+// uses it to date one lifecycle transition, so only the events around the current state_version
+// are worth sending.
 //
 //nolint:staticcheck // Clearing the deprecated fields is the point, so SA1019 has nothing to warn about here.
 func pruneMachineForPublish(machine *corev1.Machine) {
@@ -338,8 +340,8 @@ func pruneMachineForPublish(machine *corev1.Machine) {
 
 // recentMachineEvents keeps the tail of a Machine's event history. Core reports events oldest
 // first, so the tail is the newest, and the event recording the current state version is normally
-// the last one. Cloud needs that event to date the current state, so it is carried explicitly
-// when it falls outside the tail rather than relying on the reported order.
+// the last one. The REST layer needs that event to date the current state, so it is carried
+// explicitly when it falls outside the tail rather than relying on the reported order.
 func recentMachineEvents(events []*corev1.MachineEvent, stateVersion string) []*corev1.MachineEvent {
 	if len(events) <= maxPublishedMachineEvents {
 		return events

--- a/rest-api/site-workflow/pkg/activity/machine.go
+++ b/rest-api/site-workflow/pkg/activity/machine.go
@@ -327,7 +327,8 @@ func pruneMachineForPublish(machine *corev1.Machine) {
 	machine.NvlinkInfo = nil
 	machine.NvlinkStatusObservation = nil
 	machine.SpxStatusObservation = nil
-	machine.LastScoutObservedVersion = nil
+	// LastScoutObservedVersion stays. NewAPIMachine still falls back to it when status does not
+	// carry one, and at 26 bytes clearing it would trade a response field for nothing.
 
 	// Superseded by config.
 	machine.MaintenanceReference = nil

--- a/rest-api/site-workflow/pkg/activity/machine.go
+++ b/rest-api/site-workflow/pkg/activity/machine.go
@@ -6,13 +6,10 @@ package activity
 import (
 	"context"
 	"errors"
-	"fmt"
+	"slices"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
-	"go.temporal.io/sdk/client"
-	tClient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
@@ -230,184 +227,165 @@ func NewManageMachine(coreGrpcAtomicClient *cClient.CoreGrpcAtomicClient) Manage
 
 // ManageMachineInventory is an activity wrapper for Machine inventory collection and publishing
 type ManageMachineInventory struct {
-	siteID                uuid.UUID
-	coreGrpcAtomicClient  *cClient.CoreGrpcAtomicClient
-	temporalPublishClient tClient.Client
-	temporalPublishQueue  string
-	sitePageSize          int
-	cloudPageSize         int
+	config ManageInventoryConfig
 }
 
 // CollectAndPublishMachineInventory is an activity to collect Machine inventory and publish to Temporal queue
 func (mmi *ManageMachineInventory) CollectAndPublishMachineInventory(ctx context.Context) error {
 	logger := log.With().Str("Activity", "CollectAndPublishMachineInventory").Logger()
-
 	logger.Info().Msg("Starting activity")
-
-	// Define workflow options
-	workflowOptions := tClient.StartWorkflowOptions{
-		ID:        "update-machine-inventory-" + mmi.siteID.String(),
-		TaskQueue: mmi.temporalPublishQueue,
+	inventoryImpl := manageInventoryImpl[*corev1.MachineId, *corev1.Machine, *corev1.MachineInventory]{
+		itemType:               "Machine",
+		config:                 mmi.config,
+		internalFindIDs:        machineFindIDs,
+		internalFindByIDs:      machineFindByIDs,
+		internalPagedInventory: machinePagedInventory,
 	}
+	return inventoryImpl.CollectAndPublishInventory(ctx, &logger)
+}
 
-	// Call Core gRPC endpoint to get available Machine IDs
-	grpcClient := mmi.coreGrpcAtomicClient.GetClient()
-	if grpcClient == nil {
-		return cClient.ErrCoreGrpcClientNotConnected
+// NewManageMachineInventory returns a ManageInventory implementation for Machine activity
+func NewManageMachineInventory(config ManageInventoryConfig) ManageMachineInventory {
+	return ManageMachineInventory{
+		config: config,
 	}
+}
+
+func machineFindIDs(ctx context.Context, grpcClient *cClient.CoreGrpcClient) ([]*corev1.MachineId, error) {
 	grpcServiceClient := grpcClient.GrpcServiceClient()
-
 	machineIDList, err := grpcServiceClient.FindMachineIds(ctx, &corev1.MachineSearchConfig{})
 	if err != nil {
-		logger.Warn().Err(err).Msg("Failed to retrieve available Machine IDs using Core gRPC API")
-
-		// Error encountered before we've published anything, report inventory collection error to Cloud
-		inventory := &corev1.MachineInventory{
-			Timestamp: &timestamppb.Timestamp{
-				Seconds: time.Now().Unix(),
-			},
-			InventoryStatus: corev1.InventoryStatus_INVENTORY_STATUS_FAILED,
-			StatusMsg:       err.Error(),
-		}
-
-		_, serr := mmi.temporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, "UpdateMachineInventory", mmi.siteID, inventory)
-		if serr != nil {
-			logger.Error().Err(serr).Msg("Failed to publish Machine inventory error to Cloud")
-			return serr
-		}
-		return err
+		return nil, err
 	}
-
-	// Paginate IDs and collect Machine inventory
-	totalSiteCount := len(machineIDList.MachineIds)
-	totalSitePages := len(machineIDList.MachineIds) / mmi.sitePageSize
-	if totalSiteCount%mmi.sitePageSize > 0 {
-		totalSitePages++
-	}
-
-	allMachineIDs := []*corev1.MachineId{}
-	allMachineIDs = append(allMachineIDs, machineIDList.MachineIds...)
-
-	if totalSitePages == 0 {
-		inventoryPage := getPagedMachineInventory([]*corev1.Machine{}, allMachineIDs, totalSiteCount, 1, mmi.cloudPageSize, corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "No Machines reported by SIte Controller")
-
-		_, serr := mmi.temporalPublishClient.ExecuteWorkflow(context.Background(), workflowOptions, "UpdateMachineInventory", mmi.siteID, inventoryPage)
-		if serr != nil {
-			logger.Error().Err(serr).Msg("Failed to publish Machine inventory to Cloud")
-			return serr
-		}
-	}
-
-	// Iterate through all pages and publish Machine inventory
-	effectiveCloudPage := 1
-	for sitePage := 1; sitePage <= totalSitePages; sitePage++ {
-		pagedMachineIDs := getPagedMachineIDs(machineIDList.MachineIds, sitePage, mmi.sitePageSize)
-
-		// Call Core gRPC endpoint to get Machines for the paged IDs
-		pagedMachines, serr := grpcServiceClient.FindMachinesByIds(ctx, &corev1.MachinesByIdsRequest{
-			MachineIds: pagedMachineIDs,
-		})
-		if serr != nil {
-			logger.Warn().Err(serr).Int("Site Page", sitePage).Msg("Failed to retrieve Machines using Core gRPC API")
-			return serr
-		}
-
-		totalCloudCount := len(pagedMachines.Machines)
-		totalCloudPages := len(pagedMachines.Machines) / mmi.cloudPageSize
-		if totalCloudCount%mmi.cloudPageSize > 0 {
-			totalCloudPages++
-		}
-
-		// Publish machine inventory to Cloud in separate chunks
-		for cloudPage := 1; cloudPage <= totalCloudPages; cloudPage++ {
-			startIndex := (cloudPage - 1) * mmi.cloudPageSize
-			endIndex := startIndex + mmi.cloudPageSize
-			if endIndex > totalCloudCount {
-				endIndex = totalCloudCount
-			}
-
-			pagedWorkflowOptions := client.StartWorkflowOptions{
-				ID:        fmt.Sprintf("%v-%v", workflowOptions.ID, effectiveCloudPage),
-				TaskQueue: workflowOptions.TaskQueue,
-			}
-
-			// Create an inventory page with the subset of Machines
-			inventoryPage := getPagedMachineInventory(pagedMachines.Machines[startIndex:endIndex], allMachineIDs, totalSiteCount, effectiveCloudPage, mmi.cloudPageSize, corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS, "Successfully retrieved Machines from Site Controller")
-
-			logger.Info().Msgf("Publishing Machine inventory page %d to Cloud", effectiveCloudPage)
-
-			_, serr = mmi.temporalPublishClient.ExecuteWorkflow(context.Background(), pagedWorkflowOptions, "UpdateMachineInventory", mmi.siteID, inventoryPage)
-			if serr != nil {
-				logger.Error().Err(serr).Int("Cloud Page", effectiveCloudPage).Msg("Failed to publish Machine inventory to Cloud")
-				return serr
-			}
-
-			effectiveCloudPage++
-		}
-	}
-
-	return nil
+	return machineIDList.GetMachineIds(), nil
 }
 
-// getPagedMachineIDs returns a slice of Machine IDs for a given page
-func getPagedMachineIDs(machineIDs []*corev1.MachineId, page int, pageSize int) []*corev1.MachineId {
-	totalCount := len(machineIDs)
-	startIndex := (page - 1) * pageSize
-	endIndex := startIndex + pageSize
-	if endIndex > totalCount {
-		endIndex = totalCount
+func machineFindByIDs(ctx context.Context, grpcClient *cClient.CoreGrpcClient, ids []*corev1.MachineId) ([]*corev1.Machine, error) {
+	grpcServiceClient := grpcClient.GrpcServiceClient()
+	machineList, err := grpcServiceClient.FindMachinesByIds(ctx, &corev1.MachinesByIdsRequest{
+		MachineIds: ids,
+	})
+	if err != nil {
+		return nil, err
 	}
 
-	return machineIDs[startIndex:endIndex]
+	machines := machineList.GetMachines()
+	for _, machine := range machines {
+		pruneMachineForPublish(machine)
+	}
+
+	return machines, nil
 }
 
-// getPagedMachineInventory returns a subset of MachineInventory for a given page
-func getPagedMachineInventory(pagedMachines []*corev1.Machine, machineIDs []*corev1.MachineId, totalCount int, page int, pageSize int, status corev1.InventoryStatus, statusMessage string) *corev1.MachineInventory {
-	totalPages := (totalCount / pageSize)
-	if totalCount%pageSize > 0 {
-		totalPages++
+// maxPublishedMachineEvents bounds the event history a published Machine carries. Cloud reads the
+// events only to date the current state, but a Machine arrives with its whole history, which is
+// the largest thing in the message. Twenty keeps recent history worth reading without carrying
+// hundreds of entries per Machine.
+const maxPublishedMachineEvents = 20
+
+// pruneMachineForPublish drops what Cloud does not read from a Machine before it is published.
+//
+// Core fills both the fields under status and config and their deprecated twins on the Machine
+// itself, which the proto marks for removal once rest-api reads the new ones. Cloud already reads
+// status and config, so the twins are an exact duplicate of about a quarter of every Machine, and
+// Cloud persists the whole message as jsonb so they cost storage as well as Temporal payload.
+//
+// Events are the larger cost. A Machine arrives with its full state history, and Cloud uses it to
+// date one lifecycle transition, so only the events matching the current state_version are worth
+// sending.
+//
+//nolint:staticcheck // Clearing the deprecated fields is the point, so SA1019 has nothing to warn about here.
+func pruneMachineForPublish(machine *corev1.Machine) {
+	if machine == nil {
+		return
+	}
+
+	machine.Events = recentMachineEvents(machine.GetEvents(), machine.GetStateVersion())
+
+	// Superseded by status.
+	machine.Interfaces = nil
+	machine.DiscoveryInfo = nil
+	machine.LastRebootTime = nil
+	machine.LastObservationTime = nil
+	machine.AssociatedHostMachineId = nil
+	machine.LastRebootRequestedTime = nil
+	machine.LastRebootRequestedMode = nil
+	machine.DpuAgentVersion = nil
+	machine.AssociatedDpuMachineIds = nil
+	machine.Health = nil
+	machine.HealthSources = nil
+	machine.FailureDetails = nil
+	machine.IbStatus = nil
+	machine.InstanceNetworkRestrictions = nil
+	machine.Capabilities = nil
+	machine.HwSkuStatus = nil
+	machine.QuarantineState = nil
+	machine.HwSkuDeviceType = nil
+	machine.UpdateComplete = false
+	machine.NvlinkInfo = nil
+	machine.NvlinkStatusObservation = nil
+	machine.SpxStatusObservation = nil
+	machine.LastScoutObservedVersion = nil
+
+	// Superseded by config.
+	machine.MaintenanceReference = nil
+	machine.MaintenanceStartTime = nil
+	machine.FirmwareAutoupdate = nil
+	machine.InstanceTypeId = nil
+	machine.HwSku = nil
+	machine.Dpf = nil
+}
+
+// recentMachineEvents keeps the tail of a Machine's event history. Core reports events oldest
+// first, so the tail is the newest, and the event recording the current state version is normally
+// the last one. Cloud needs that event to date the current state, so it is carried explicitly
+// when it falls outside the tail rather than relying on the reported order.
+func recentMachineEvents(events []*corev1.MachineEvent, stateVersion string) []*corev1.MachineEvent {
+	if len(events) <= maxPublishedMachineEvents {
+		return events
+	}
+
+	recent := events[len(events)-maxPublishedMachineEvents:]
+	if stateVersion == "" || slices.ContainsFunc(recent, func(event *corev1.MachineEvent) bool {
+		return event.GetVersion() == stateVersion
+	}) {
+		return recent
+	}
+
+	for _, event := range events[:len(events)-maxPublishedMachineEvents] {
+		if event.GetVersion() == stateVersion {
+			return append([]*corev1.MachineEvent{event}, recent...)
+		}
+	}
+
+	return recent
+}
+
+func machinePagedInventory(allItemIDs []*corev1.MachineId, pagedItems []*corev1.Machine, input *pagedInventoryInput) *corev1.MachineInventory {
+	itemIDs := []string{}
+	for _, id := range allItemIDs {
+		itemIDs = append(itemIDs, id.GetId())
 	}
 
 	pagedMachineInfo := []*corev1.MachineInfo{}
-	for _, machine := range pagedMachines {
+	for _, machine := range pagedItems {
 		pagedMachineInfo = append(pagedMachineInfo, &corev1.MachineInfo{
 			Machine: machine,
 		})
 	}
 
-	itemIDs := []string{}
-	for _, machineID := range machineIDs {
-		itemIDs = append(itemIDs, machineID.Id)
-	}
-
-	// Create an inventory page with the subset of Machines
-	inventoryPage := &corev1.MachineInventory{
+	machineInventory := &corev1.MachineInventory{
 		Machines: pagedMachineInfo,
 		Timestamp: &timestamppb.Timestamp{
 			Seconds: time.Now().Unix(),
 		},
-		InventoryStatus: status,
-		StatusMsg:       statusMessage,
-		InventoryPage: &corev1.InventoryPage{
-			TotalPages:  int32(totalPages),
-			CurrentPage: int32(page),
-			PageSize:    int32(pageSize),
-			TotalItems:  int32(totalCount),
-			ItemIds:     itemIDs,
-		},
+		InventoryStatus: input.status,
+		StatusMsg:       input.statusMessage,
+		InventoryPage:   input.buildPage(),
+	}
+	if machineInventory.InventoryPage != nil {
+		machineInventory.InventoryPage.ItemIds = itemIDs
 	}
 
-	return inventoryPage
-}
-
-// NewManageMachineInventory returns a new ManageMachineInventory activity
-func NewManageMachineInventory(siteID uuid.UUID, coreGrpcAtomicClient *cClient.CoreGrpcAtomicClient, temporalPublishClient tClient.Client, temporalPublishQueue string, sitePageSize int, cloudPageSize int) ManageMachineInventory {
-	return ManageMachineInventory{
-		siteID:                siteID,
-		coreGrpcAtomicClient:  coreGrpcAtomicClient,
-		temporalPublishClient: temporalPublishClient,
-		temporalPublishQueue:  temporalPublishQueue,
-		sitePageSize:          sitePageSize,
-		cloudPageSize:         cloudPageSize,
-	}
+	return machineInventory
 }

--- a/rest-api/site-workflow/pkg/activity/machine_test.go
+++ b/rest-api/site-workflow/pkg/activity/machine_test.go
@@ -6,6 +6,7 @@ package activity
 import (
 	"context"
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/google/uuid"
@@ -15,6 +16,7 @@ import (
 	tmocks "go.temporal.io/sdk/mocks"
 	"go.temporal.io/sdk/temporal"
 	"google.golang.org/grpc"
+	"google.golang.org/protobuf/proto"
 
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 	cClient "github.com/NVIDIA/infra-controller/rest-api/site-workflow/pkg/grpc/client"
@@ -167,200 +169,77 @@ func TestManageMachine_DeleteMachineHealthReportOnSite(t *testing.T) {
 	assert.Error(t, err)
 }
 
-func Test_getPagedInventory(t *testing.T) {
-	// Generate inventories
-	pageSize := 25
+//nolint:staticcheck // Asserting the deprecated fields were cleared means reading them.
+func Test_pruneMachineForPublish(t *testing.T) {
+	events := func(versions ...string) []*corev1.MachineEvent {
+		out := []*corev1.MachineEvent{}
+		for _, v := range versions {
+			out = append(out, &corev1.MachineEvent{Version: v, Event: "state change"})
+		}
 
-	inventory1Machines := []*corev1.Machine{}
-	inventory1MachineIDs := []*corev1.MachineId{}
-	for i := 0; i < 95; i++ {
-		inventory1Machines = append(inventory1Machines, &corev1.Machine{
-			Id: &corev1.MachineId{
-				Id: uuid.NewString(),
-			},
-			State: "Ready",
-		})
-		inventory1MachineIDs = append(inventory1MachineIDs, inventory1Machines[i].Id)
+		return out
 	}
 
-	inventory2Machines := []*corev1.Machine{}
-	inventory2MachineIDs := []*corev1.MachineId{}
-	for i := 0; i < pageSize-5; i++ {
-		inventory2Machines = append(inventory2Machines, &corev1.Machine{
-			Id: &corev1.MachineId{
-				Id: uuid.NewString(),
-			},
-			State: "Ready",
-		})
-		inventory2MachineIDs = append(inventory2MachineIDs, inventory2Machines[i].Id)
-	}
+	t.Run("clears the deprecated twins and keeps status and config", func(t *testing.T) {
+		machine := &corev1.Machine{
+			Id:             &corev1.MachineId{Id: "machine-1"},
+			Health:         &corev1.HealthReport{Source: "deprecated"},
+			Capabilities:   &corev1.MachineCapabilitiesSet{},
+			UpdateComplete: true,
+			HwSku:          proto.String("deprecated-sku"),
+			Status:         &corev1.MachineStatus{Health: &corev1.HealthReport{Source: "status"}},
+			Config:         &corev1.MachineConfig{},
+		}
 
-	type args struct {
-		pagedMachines   []*corev1.Machine
-		pagedMachineIDs []*corev1.MachineId
-		totalCount      int
-		page            int
-		pageSize        int
-		status          corev1.InventoryStatus
-		statusMessage   string
-	}
-	tests := []struct {
-		name             string
-		args             args
-		wantMachineCount int
-		wantTotalPages   int
-		wantCurrentPage  int
-		wantTotalItems   int
-		wantItemIDCount  int
-	}{
-		{
-			name: "test generating first page for empty inventory",
-			args: args{
-				pagedMachines:   nil,
-				pagedMachineIDs: nil,
-				totalCount:      0,
-				page:            1,
-				pageSize:        pageSize,
-				status:          corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
-				statusMessage:   "No Machines reported by SIte Controller",
-			},
-			wantMachineCount: 0,
-			wantTotalPages:   0,
-			wantCurrentPage:  1,
-			wantTotalItems:   0,
-			wantItemIDCount:  0,
-		},
-		{
-			name: "test generating first page for normal inventory",
-			args: args{
-				pagedMachines:   inventory1Machines[:pageSize],
-				pagedMachineIDs: inventory1MachineIDs[:pageSize],
-				totalCount:      95,
-				page:            1,
-				pageSize:        pageSize,
-				status:          corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
-				statusMessage:   "Successfully retrieved Machines from Site Controller",
-			},
-			wantMachineCount: pageSize,
-			wantTotalPages:   4,
-			wantCurrentPage:  1,
-			wantTotalItems:   95,
-			wantItemIDCount:  pageSize,
-		},
-		{
-			name: "test generating last page for inventory sized less than page size",
-			args: args{
-				pagedMachines:   inventory2Machines,
-				pagedMachineIDs: inventory2MachineIDs,
-				totalCount:      pageSize - 5,
-				page:            1,
-				pageSize:        pageSize,
-				status:          corev1.InventoryStatus_INVENTORY_STATUS_SUCCESS,
-				statusMessage:   "Successfully retrieved Machines from Site Controller",
-			},
-			wantMachineCount: pageSize - 5,
-			wantTotalPages:   1,
-			wantCurrentPage:  1,
-			wantTotalItems:   pageSize - 5,
-			wantItemIDCount:  pageSize - 5,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getPagedMachineInventory(tt.args.pagedMachines, tt.args.pagedMachineIDs, tt.args.totalCount, tt.args.page, tt.args.pageSize, tt.args.status, tt.args.statusMessage)
-			assert.Equal(t, tt.wantMachineCount, len(got.Machines))
-			assert.Equal(t, tt.wantCurrentPage, int(got.InventoryPage.CurrentPage))
-			assert.Equal(t, tt.wantTotalPages, int(got.InventoryPage.TotalPages))
-			assert.Equal(t, tt.wantTotalItems, int(got.InventoryPage.TotalItems))
-			assert.Equal(t, tt.wantItemIDCount, len(got.InventoryPage.ItemIds))
+		pruneMachineForPublish(machine)
 
-			assert.Equal(t, tt.args.status, got.InventoryStatus)
-			assert.Equal(t, tt.args.statusMessage, got.StatusMsg)
-		})
-	}
-}
+		assert.Nil(t, machine.Health)
+		assert.Nil(t, machine.Capabilities)
+		assert.Nil(t, machine.HwSku)
+		assert.False(t, machine.UpdateComplete)
+		// The replacements Cloud actually reads have to survive.
+		assert.Equal(t, "status", machine.GetStatus().GetHealth().GetSource())
+		assert.NotNil(t, machine.GetConfig())
+		assert.Equal(t, "machine-1", machine.GetId().GetId())
+	})
 
-func Test_getPagedMachineIDs(t *testing.T) {
-	type args struct {
-		machineIDs []*corev1.MachineId
-		page       int
-		pageSize   int
-	}
-	tests := []struct {
-		name               string
-		args               args
-		wantMachineIDCount int
-	}{
-		{
-			name: "test getting first page for empty machine IDs",
-			args: args{
-				machineIDs: nil,
-				page:       1,
-				pageSize:   25,
-			},
-			wantMachineIDCount: 0,
-		},
-		{
-			name: "test getting first page for normal machine IDs",
-			args: args{
-				machineIDs: []*corev1.MachineId{
-					{Id: "machine-1"},
-					{Id: "machine-2"},
-					{Id: "machine-3"},
-					{Id: "machine-4"},
-					{Id: "machine-5"},
-					{Id: "machine-6"},
-					{Id: "machine-7"},
-					{Id: "machine-8"},
-					{Id: "machine-9"},
-					{Id: "machine-10"},
-				},
-				page:     1,
-				pageSize: 5,
-			},
-			wantMachineIDCount: 5,
-		},
-		{
-			name: "test getting last page for machine IDs",
-			args: args{
-				machineIDs: []*corev1.MachineId{
-					{Id: "machine-1"},
-					{Id: "machine-2"},
-					{Id: "machine-3"},
-					{Id: "machine-4"},
-					{Id: "machine-5"},
-					{Id: "machine-6"},
-					{Id: "machine-7"},
-					{Id: "machine-8"},
-					{Id: "machine-9"},
-					{Id: "machine-10"},
-				},
-				page:     2,
-				pageSize: 5,
-			},
-			wantMachineIDCount: 5,
-		},
-		{
-			name: "test getting last page for machine IDs with less than page size",
-			args: args{
-				machineIDs: []*corev1.MachineId{
-					{Id: "machine-1"},
-					{Id: "machine-2"},
-					{Id: "machine-3"},
-					{Id: "machine-4"},
-				},
-				page:     1,
-				pageSize: 5,
-			},
-			wantMachineIDCount: 4,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := getPagedMachineIDs(tt.args.machineIDs, tt.args.page, tt.args.pageSize)
-			assert.Equal(t, tt.wantMachineIDCount, len(got))
-		})
-	}
+	t.Run("keeps a short history whole", func(t *testing.T) {
+		machine := &corev1.Machine{StateVersion: "V58", Events: events("V56", "V57", "V58")}
+
+		pruneMachineForPublish(machine)
+
+		assert.Len(t, machine.Events, 3)
+	})
+
+	t.Run("keeps the newest events when the history is longer than the bound", func(t *testing.T) {
+		versions := make([]string, 0, 30)
+		for i := range 30 {
+			versions = append(versions, fmt.Sprintf("V%d", i))
+		}
+		machine := &corev1.Machine{StateVersion: "V29", Events: events(versions...)}
+
+		pruneMachineForPublish(machine)
+
+		assert.Len(t, machine.Events, maxPublishedMachineEvents)
+		// Core reports oldest first, so the tail has to be the newest entries.
+		assert.Equal(t, "V10", machine.Events[0].GetVersion())
+		assert.Equal(t, "V29", machine.Events[maxPublishedMachineEvents-1].GetVersion())
+	})
+
+	t.Run("carries the current state version when it falls outside the newest events", func(t *testing.T) {
+		// Cloud dates the current state from this event, so dropping it would silently empty a
+		// response field. Nothing guarantees Core orders the matching event last.
+		versions := []string{"V0"}
+		for i := 1; i < 30; i++ {
+			versions = append(versions, fmt.Sprintf("V%d", i))
+		}
+		machine := &corev1.Machine{StateVersion: "V0", Events: events(versions...)}
+
+		pruneMachineForPublish(machine)
+
+		assert.Len(t, machine.Events, maxPublishedMachineEvents+1)
+		assert.Equal(t, "V0", machine.Events[0].GetVersion())
+	})
 }
 
 func TestManageMachineInventory_CollectAndPublishMachineInventory(t *testing.T) {
@@ -424,12 +303,14 @@ func TestManageMachineInventory_CollectAndPublishMachineInventory(t *testing.T) 
 			tc.AssertNumberOfCalls(t, "ExecuteWorkflow", 0)
 
 			mmi := &ManageMachineInventory{
-				siteID:                tt.fields.siteID,
-				coreGrpcAtomicClient:  tt.fields.coreGrpcAtomicClient,
-				temporalPublishClient: tc,
-				temporalPublishQueue:  tt.fields.temporalPublishQueue,
-				sitePageSize:          tt.fields.sitePageSize,
-				cloudPageSize:         tt.fields.cloudPageSize,
+				config: ManageInventoryConfig{
+					SiteID:                tt.fields.siteID,
+					CoreGrpcAtomicClient:  tt.fields.coreGrpcAtomicClient,
+					TemporalPublishClient: tc,
+					TemporalPublishQueue:  tt.fields.temporalPublishQueue,
+					SitePageSize:          tt.fields.sitePageSize,
+					CloudPageSize:         tt.fields.cloudPageSize,
+				},
 			}
 
 			ctx := context.Background()

--- a/rest-api/site-workflow/pkg/activity/machine_test.go
+++ b/rest-api/site-workflow/pkg/activity/machine_test.go
@@ -197,7 +197,7 @@ func Test_pruneMachineForPublish(t *testing.T) {
 		assert.Nil(t, machine.Capabilities)
 		assert.Nil(t, machine.HwSku)
 		assert.False(t, machine.UpdateComplete)
-		// The replacements Cloud actually reads have to survive.
+		// The replacements the REST layer actually reads have to survive.
 		assert.Equal(t, "status", machine.GetStatus().GetHealth().GetSource())
 		assert.NotNil(t, machine.GetConfig())
 		assert.Equal(t, "machine-1", machine.GetId().GetId())
@@ -227,8 +227,8 @@ func Test_pruneMachineForPublish(t *testing.T) {
 	})
 
 	t.Run("carries the current state version when it falls outside the newest events", func(t *testing.T) {
-		// Cloud dates the current state from this event, so dropping it would silently empty a
-		// response field. Nothing guarantees Core orders the matching event last.
+		// The REST layer dates the current state from this event, so dropping it would silently
+		// empty a response field. Nothing guarantees Core orders the matching event last.
 		versions := []string{"V0"}
 		for i := 1; i < 30; i++ {
 			versions = append(versions, fmt.Sprintf("V%d", i))

--- a/rest-api/site-workflow/pkg/activity/machine_test.go
+++ b/rest-api/site-workflow/pkg/activity/machine_test.go
@@ -179,67 +179,80 @@ func Test_pruneMachineForPublish(t *testing.T) {
 
 		return out
 	}
-
-	t.Run("clears the deprecated twins and keeps status and config", func(t *testing.T) {
-		machine := &corev1.Machine{
-			Id:             &corev1.MachineId{Id: "machine-1"},
-			Health:         &corev1.HealthReport{Source: "deprecated"},
-			Capabilities:   &corev1.MachineCapabilitiesSet{},
-			UpdateComplete: true,
-			HwSku:          proto.String("deprecated-sku"),
-			Status:         &corev1.MachineStatus{Health: &corev1.HealthReport{Source: "status"}},
-			Config:         &corev1.MachineConfig{},
+	numberedVersions := func(n int) []string {
+		out := make([]string, 0, n)
+		for i := range n {
+			out = append(out, fmt.Sprintf("V%d", i))
 		}
 
-		pruneMachineForPublish(machine)
+		return out
+	}
 
-		assert.Nil(t, machine.Health)
-		assert.Nil(t, machine.Capabilities)
-		assert.Nil(t, machine.HwSku)
-		assert.False(t, machine.UpdateComplete)
-		// The replacements the REST layer actually reads have to survive.
-		assert.Equal(t, "status", machine.GetStatus().GetHealth().GetSource())
-		assert.NotNil(t, machine.GetConfig())
-		assert.Equal(t, "machine-1", machine.GetId().GetId())
-	})
+	// Each case asserts a different property of the pruned Machine, so the check travels with the
+	// input rather than a shared assertion block trying to cover all of them.
+	tests := []struct {
+		name    string
+		machine *corev1.Machine
+		check   func(*testing.T, *corev1.Machine)
+	}{
+		{
+			name: "clears the deprecated twins and keeps status and config",
+			machine: &corev1.Machine{
+				Id:             &corev1.MachineId{Id: "machine-1"},
+				Health:         &corev1.HealthReport{Source: "deprecated"},
+				Capabilities:   &corev1.MachineCapabilitiesSet{},
+				UpdateComplete: true,
+				HwSku:          proto.String("deprecated-sku"),
+				Status:         &corev1.MachineStatus{Health: &corev1.HealthReport{Source: "status"}},
+				Config:         &corev1.MachineConfig{},
+			},
+			check: func(t *testing.T, machine *corev1.Machine) {
+				assert.Nil(t, machine.Health)
+				assert.Nil(t, machine.Capabilities)
+				assert.Nil(t, machine.HwSku)
+				assert.False(t, machine.UpdateComplete)
+				// The replacements the REST layer actually reads have to survive.
+				assert.Equal(t, "status", machine.GetStatus().GetHealth().GetSource())
+				assert.NotNil(t, machine.GetConfig())
+				assert.Equal(t, "machine-1", machine.GetId().GetId())
+			},
+		},
+		{
+			name:    "keeps a short history whole",
+			machine: &corev1.Machine{StateVersion: "V58", Events: events("V56", "V57", "V58")},
+			check: func(t *testing.T, machine *corev1.Machine) {
+				assert.Len(t, machine.Events, 3)
+			},
+		},
+		{
+			name:    "keeps the newest events when the history is longer than the bound",
+			machine: &corev1.Machine{StateVersion: "V29", Events: events(numberedVersions(30)...)},
+			check: func(t *testing.T, machine *corev1.Machine) {
+				assert.Len(t, machine.Events, maxPublishedMachineEvents)
+				// Core reports oldest first, so the tail has to be the newest entries.
+				assert.Equal(t, "V10", machine.Events[0].GetVersion())
+				assert.Equal(t, "V29", machine.Events[maxPublishedMachineEvents-1].GetVersion())
+			},
+		},
+		{
+			// The REST layer dates the current state from this event, so dropping it would
+			// silently empty a response field. Nothing guarantees Core orders the matching event
+			// last.
+			name:    "carries the current state version when it falls outside the newest events",
+			machine: &corev1.Machine{StateVersion: "V0", Events: events(numberedVersions(30)...)},
+			check: func(t *testing.T, machine *corev1.Machine) {
+				assert.Len(t, machine.Events, maxPublishedMachineEvents+1)
+				assert.Equal(t, "V0", machine.Events[0].GetVersion())
+			},
+		},
+	}
 
-	t.Run("keeps a short history whole", func(t *testing.T) {
-		machine := &corev1.Machine{StateVersion: "V58", Events: events("V56", "V57", "V58")}
-
-		pruneMachineForPublish(machine)
-
-		assert.Len(t, machine.Events, 3)
-	})
-
-	t.Run("keeps the newest events when the history is longer than the bound", func(t *testing.T) {
-		versions := make([]string, 0, 30)
-		for i := range 30 {
-			versions = append(versions, fmt.Sprintf("V%d", i))
-		}
-		machine := &corev1.Machine{StateVersion: "V29", Events: events(versions...)}
-
-		pruneMachineForPublish(machine)
-
-		assert.Len(t, machine.Events, maxPublishedMachineEvents)
-		// Core reports oldest first, so the tail has to be the newest entries.
-		assert.Equal(t, "V10", machine.Events[0].GetVersion())
-		assert.Equal(t, "V29", machine.Events[maxPublishedMachineEvents-1].GetVersion())
-	})
-
-	t.Run("carries the current state version when it falls outside the newest events", func(t *testing.T) {
-		// The REST layer dates the current state from this event, so dropping it would silently
-		// empty a response field. Nothing guarantees Core orders the matching event last.
-		versions := []string{"V0"}
-		for i := 1; i < 30; i++ {
-			versions = append(versions, fmt.Sprintf("V%d", i))
-		}
-		machine := &corev1.Machine{StateVersion: "V0", Events: events(versions...)}
-
-		pruneMachineForPublish(machine)
-
-		assert.Len(t, machine.Events, maxPublishedMachineEvents+1)
-		assert.Equal(t, "V0", machine.Events[0].GetVersion())
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pruneMachineForPublish(tt.machine)
+			tt.check(t, tt.machine)
+		})
+	}
 }
 
 func TestManageMachineInventory_CollectAndPublishMachineInventory(t *testing.T) {


### PR DESCRIPTION
`CollectAndPublishMachineInventory` publishes on a fixed page size with no payload measurement, unlike the fifteen other inventories that share `CollectAndPublishInventory` and shrink a page until it fits Temporal's blob limit. 

One Site began failing every run with `Blob data size exceeds limit`, because each of its Machines serializes to `159,705` bytes, putting a page of 25 at `3.81 MiB` against the `2 MiB` ceiling. Two thirds of that is data REST layer ignores: `events` carried 250 entries and `71,470` bytes where Cloud reads only the current state, and `42,944` bytes were deprecated twins of fields that moved under `status` and `config`. 

This PR routes Machine inventory through the shared pager and drops both, bringing one Machine to `49,016` bytes and the Site's entire inventory to `1.59 MiB` in a single page.

> [!NOTE]
> The proto marks every deprecated twin for removal "once rest-api uses MachineStatus". REST layer reads are already migrated, so clearing them changes nothing it consumes, and the `reserved` change those TODOs describe is now available on the Core side.

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**
Cloud persists the reported Machine as `jsonb` in `machine.metadata`, so newly reported Machines no longer carry the deprecated fields or the older events there. Nothing reads them today and existing rows are untouched.

## Testing
- [x] Unit tests added/updated

## Additional Notes
* Machine inventory also gains the site-page ladder for the gRPC receive limit, buffered publishing, accurate `TotalPages`, and failure reporting on a detached context, none of which the hand-rolled publisher had
* Page workflow IDs are still derived per page, so a retried attempt collides on the pages it already published. That is unchanged and shared by every inventory, so it needs its own fix. A single Machine past the budget also still fails the run, since the ladder publishes a one-item page anyway