### PR TITLE
chore: update rest-api default cpu request limits

### DIFF
--- a/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
+++ b/helm/rest/nico-rest/charts/nico-rest-api/values.yaml
@@ -26,7 +26,7 @@ resources:
     cpu: "100m"
   limits:
     memory: "512Mi"
-    cpu: "500m"
+    cpu: "1000m"
 
 secrets:
   temporalEncryptionKey: temporal-encryption-key


### PR DESCRIPTION
Increase the default nico-rest-api CPU limit from 500m to 1000m.

Under sustained concurrent inventory traffic, the existing 500m default caused nico-rest-api to remain CPU-throttled at its configured limit. Because inventory read requests are synchronously proxied through nico-rest-api without caching, this limit became a throughput ceiling for the entire read path, producing high latency despite all requests eventually succeeding.

Benchmarking at a fixed target of 300 requests per second produced the following results:

CPU limit | Throughput | p50 latency | p99 latency | CPU utilization
  ----------|------------|-------------|-------------|----------------
  500m      | 113.8 req/s| 10.90s      | 15.49s      | 100%
  1000m     | 172.5 req/s| 7.84s       | 10.63s      | 51%
  2000m     | 175.3 req/s| 7.49s       | 10.37s      | 18%

Raising the limit to 1000m increased throughput by approximately 52% and reduced p99 latency by approximately 31%. No errors occurred at any tested limit, confirming that the issue was CPU throttling and queueing rather than request correctness or memory pressure. Memory remained within the existing 512Mi limit throughout testing.

Increasing the limit further to 2000m improved throughput by only 1.6%, indicating that another component becomes the bottleneck around 170–175 requests per second. Therefore, 1000m is the best-supported default: it removes the demonstrated CPU ceiling without allocating additional CPU that did not provide a meaningful improvement.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

