### PR TITLE
fix(flow): source compute firmware from component inventory

### DIFF
--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync.go
@@ -6,6 +6,7 @@ package inventorysync
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/rs/zerolog/log"
 	"github.com/uptrace/bun"
@@ -136,68 +137,147 @@ func persistComponentOperationStatuses(
 	}
 }
 
-// applyInventoryToComponents extracts firmware_version and power_state from
-// GetComponentInventoryResponse and direct-writes them to the matching
-// components. It does not emit drift: correlation and drift are keyed on BMC
-// MAC (handled by each type's linked-RPC sync), and serial number is no longer
-// compared. componentsByID maps the component_id echoed back in each
-// ComponentResult to the DB component. Shared by the switch and power-shelf
-// syncs; the machine sync uses pre-fetched MachineDetail directly instead of
-// going through GetComponentInventory.
+// applyInventoryToComponents projects every runtime field used by switch and
+// power-shelf synchronization.
 func applyInventoryToComponents(
 	ctx context.Context,
 	pool *cdb.Session,
 	resp *corev1.GetComponentInventoryResponse,
 	componentsByID map[string]*model.Component,
 ) {
+	firmwareUpdates := make([]model.Component, 0, len(resp.GetEntries()))
+	powerStateUpdates := make([]model.Component, 0, len(resp.GetEntries()))
 	for _, entry := range resp.GetEntries() {
-		result := entry.GetResult()
-		if result == nil {
-			continue
-		}
-		comp, ok := componentsByID[result.GetComponentId()]
+		comp, report, ok := successfulInventoryEntry(entry, componentsByID)
 		if !ok {
 			continue
 		}
-		if result.GetStatus() != corev1.ComponentManagerStatusCode_COMPONENT_MANAGER_STATUS_CODE_SUCCESS {
-			log.Warn().Msgf("Component %s: inventory status %s: %s", result.GetComponentId(), result.GetStatus(), result.GetError())
-			continue
+
+		if version := bmcFirmwareVersion(report); version != "" && comp.FirmwareVersion != version {
+			comp.FirmwareVersion = version
+			firmwareUpdates = append(firmwareUpdates, *comp)
 		}
 
-		report := entry.GetReport()
-		if report == nil {
-			continue
-		}
-
-		needsUpdate := false
-
-		// Extract firmware_version from the "BMC image" inventory entry
-		for _, svc := range report.GetService() {
-			for _, inv := range svc.GetInventories() {
-				if inv.GetDescription() == "BMC image" {
-					if v := inv.GetVersion(); v != "" && comp.FirmwareVersion != v {
-						comp.FirmwareVersion = v
-						needsUpdate = true
-					}
-				}
-			}
-		}
-
-		// Extract power_state from first ComputerSystem entry
 		if systems := report.GetSystems(); len(systems) > 0 {
 			ps := computerSystemPowerStateToNICo(systems[0].GetPowerState())
 			if comp.PowerState == nil || *comp.PowerState != ps {
 				comp.PowerState = &ps
-				needsUpdate = true
-			}
-		}
-
-		if needsUpdate {
-			if err := comp.Patch(ctx, pool.DB); err != nil {
-				log.Error().Msgf("Component %s: unable to write inventory fields: %v", result.GetComponentId(), err)
+				powerStateUpdates = append(powerStateUpdates, *comp)
 			}
 		}
 	}
+
+	if len(firmwareUpdates) == 0 && len(powerStateUpdates) == 0 {
+		return
+	}
+	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		for i := range firmwareUpdates {
+			if err := firmwareUpdates[i].SetFirmwareVersionByComponentID(ctx, tx); err != nil {
+				return fmt.Errorf("set firmware version: %w", err)
+			}
+		}
+		for i := range powerStateUpdates {
+			if err := powerStateUpdates[i].SetPowerStateByComponentID(ctx, tx); err != nil {
+				return fmt.Errorf("set power state: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		log.Error().Msgf("Unable to persist component inventory fields: %v", err)
+	}
+}
+
+// applyFirmwareInventoryToComponents projects only firmware_version. Compute
+// power state remains owned by GetPowerStates rather than the exploration
+// report returned by GetComponentInventory. Use a targeted column update so a
+// stale component snapshot cannot overwrite fields owned by another job.
+func applyFirmwareInventoryToComponents(
+	ctx context.Context,
+	pool *cdb.Session,
+	resp *corev1.GetComponentInventoryResponse,
+	componentsByID map[string]*model.Component,
+) {
+	toUpdate := make([]model.Component, 0, len(resp.GetEntries()))
+	for _, entry := range resp.GetEntries() {
+		comp, report, ok := successfulInventoryEntry(entry, componentsByID)
+		if !ok {
+			continue
+		}
+		if version := bmcFirmwareVersion(report); version != "" && comp.FirmwareVersion != version {
+			comp.FirmwareVersion = version
+			toUpdate = append(toUpdate, *comp)
+		}
+	}
+
+	if len(toUpdate) == 0 {
+		return
+	}
+	if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
+		for i := range toUpdate {
+			if err := toUpdate[i].SetFirmwareVersionByComponentID(ctx, tx); err != nil {
+				return fmt.Errorf("set firmware version: %w", err)
+			}
+		}
+		return nil
+	}); err != nil {
+		log.Error().Msgf("Unable to persist component firmware versions: %v", err)
+	}
+}
+
+// successfulInventoryEntry validates an inventory entry and resolves the
+// component_id echoed by Core to its Flow component.
+func successfulInventoryEntry(
+	entry *corev1.ComponentInventoryEntry,
+	componentsByID map[string]*model.Component,
+) (*model.Component, *corev1.EndpointExplorationReport, bool) {
+	result := entry.GetResult()
+	if result == nil {
+		return nil, nil, false
+	}
+	comp, ok := componentsByID[result.GetComponentId()]
+	if !ok {
+		return nil, nil, false
+	}
+	if result.GetStatus() != corev1.ComponentManagerStatusCode_COMPONENT_MANAGER_STATUS_CODE_SUCCESS {
+		log.Warn().Msgf("Component %s: inventory status %s: %s", result.GetComponentId(), result.GetStatus(), result.GetError())
+		return nil, nil, false
+	}
+	if entry.GetReport() == nil {
+		return nil, nil, false
+	}
+	return comp, entry.GetReport(), true
+}
+
+// bmcFirmwareVersion resolves BMC firmware for compute, switch, and power-shelf
+// inventory. Precedence is Core's canonical "bmc" version, then the exact raw
+// inventory ID "BMC", then the legacy "BMC image" description. Retaining the
+// description match as a fallback lets an exact ID later in the report win
+// regardless of inventory ordering. Within each raw fallback tier, the first
+// nonblank match wins.
+func bmcFirmwareVersion(report *corev1.EndpointExplorationReport) string {
+	if report == nil {
+		return ""
+	}
+	if version := strings.TrimSpace(report.GetFirmwareVersions()["bmc"]); version != "" {
+		return version
+	}
+
+	descriptionFallback := ""
+	for _, svc := range report.GetService() {
+		for _, inv := range svc.GetInventories() {
+			version := strings.TrimSpace(inv.GetVersion())
+			if version == "" {
+				continue
+			}
+			if inv.GetId() == "BMC" {
+				return version
+			}
+			if descriptionFallback == "" && inv.GetDescription() == "BMC image" {
+				descriptionFallback = version
+			}
+		}
+	}
+	return descriptionFallback
 }
 
 func computerSystemPowerStateToNICo(

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/actual_sync_machine.go
@@ -42,11 +42,11 @@ func filterHostMachineDetails(machineDetails []nicoapi.MachineDetail) []nicoapi.
 // syncMachines: sync machine components against NICo
 // ---------------------------------------------------------------------------
 //
-// NICo API calls (3 round-trips):
+// NICo API calls (4 round-trips):
 //   - GetMachines (FindMachineIds + FindMachinesByIds): BMC-MAC linking,
-//     firmware_version and controller_state direct-write, plus
-//     missing_in_expected detection
+//     controller_state direct-write, plus missing_in_expected detection
 //   - GetPowerStates: power_state direct-write
+//   - GetComponentInventory: firmware_version direct-write
 //   - GetMachinePositionInfo: position validation fields for drift comparison
 //
 // Flow:
@@ -56,8 +56,9 @@ func filterHostMachineDetails(machineDetails []nicoapi.MachineDetail) []nicoapi.
 //  3. Link by BMC MAC (from step 2 data) → direct-write external_id
 //  4. Reconcile associated DPU BMC children by MAC from the same snapshot
 //  5. NICo GetPowerStates: direct-write power_state
-//  6. Direct-write firmware_version (from step 2 data)
-//  7. NICo GetMachinePositionInfo: compare validation fields, return drifts
+//  6. NICo GetComponentInventory: direct-write firmware_version
+//  7. Direct-write controller status (from step 2 data)
+//  8. NICo GetMachinePositionInfo: compare validation fields, return drifts
 //
 // Correlation/identity key: BMC MAC address (serial number is not used).
 // Validation fields (compared for drift): slot_id, tray_index, host_id
@@ -80,8 +81,8 @@ func syncMachines(
 	// compute components. The empty expected set still needs an authoritative
 	// Core query so discovered hosts become missing_in_expected drift, while an
 	// RPC failure remains distinguishable from a successful empty inventory.
-	// This is also the single source for BMC-MAC linking, firmware_version,
-	// controller_state, and missing_in_expected detection — a failure here means
+	// This is also the single source for BMC-MAC linking, controller_state, and
+	// missing_in_expected detection — a failure here means
 	// we can't trust this cycle, so preserve prior state rather than writing a
 	// partial view.
 	allMachineDetails, err := nicoClient.GetMachines(ctx)
@@ -142,13 +143,36 @@ func syncMachines(
 	// Step 5: Direct-write power_state (requires separate NICo API)
 	syncPowerStates(ctx, pool, nicoClient, machineIDs, componentsByExternalID)
 
-	// Step 6: Direct-write firmware_version (from pre-fetched details, no extra API call)
-	syncFirmwareVersions(ctx, pool, detailByID, componentsByExternalID)
+	// Step 6: Direct-write firmware_version from the same component inventory
+	// contract used by switch and power-shelf synchronization. Inventory is
+	// best-effort: a failed call preserves the previously stored version without
+	// making the independently computed drift snapshot partial.
+	componentMachineIDs := make([]*corev1.MachineId, 0, len(machineIDs))
+	inventoryComponents := make(map[string]*model.Component, len(machineIDs))
+	for _, machineID := range machineIDs {
+		if _, matched := detailByID[machineID]; !matched {
+			continue
+		}
+		componentMachineIDs = append(componentMachineIDs, &corev1.MachineId{Id: machineID})
+		inventoryComponents[machineID] = componentsByExternalID[machineID]
+	}
+	if len(componentMachineIDs) > 0 {
+		invResp, err := nicoClient.GetComponentInventory(ctx, &corev1.GetComponentInventoryRequest{
+			Target: &corev1.GetComponentInventoryRequest_MachineIds{
+				MachineIds: &corev1.MachineIdList{MachineIds: componentMachineIDs},
+			},
+		})
+		if err != nil {
+			log.Error().Msgf("Unable to retrieve compute inventory from NICo: %v", err)
+		} else {
+			applyFirmwareInventoryToComponents(ctx, pool, invResp, inventoryComponents)
+		}
+	}
 
-	// Step 6b: Direct-write derived ComponentOperationStatus (from pre-fetched detail.State).
+	// Step 7: Direct-write derived ComponentOperationStatus (from pre-fetched detail.State).
 	syncMachineStatuses(ctx, pool, detailByID, componentsByExternalID)
 
-	// Step 7: Fetch positions and build drift records (requires separate NICo API)
+	// Step 8: Fetch positions and build drift records (requires separate NICo API)
 	machinePositions, err := nicoClient.GetMachinePositionInfo(ctx, machineIDs)
 	if err != nil {
 		log.Error().Msgf("Unable to retrieve machine positions from NICo: %v", err)
@@ -323,7 +347,7 @@ func syncMachineIDs(
 		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			for _, cur := range toUpdate {
 				if err := cur.Patch(ctx, tx); err != nil {
-					return fmt.Errorf("Unable to update machine ID: %w", err)
+					return fmt.Errorf("unable to update machine ID: %w", err)
 				}
 			}
 			return nil
@@ -365,43 +389,12 @@ func syncPowerStates(
 		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
 			for _, cur := range toUpdate {
 				if err := cur.SetPowerStateByComponentID(ctx, tx); err != nil {
-					return fmt.Errorf("Unable to update power state: %w", err)
+					return fmt.Errorf("unable to update power state: %w", err)
 				}
 			}
 			return nil
 		}); err != nil {
 			log.Error().Msgf("Unable to update components with power state: %v", err)
-		}
-	}
-}
-
-// syncFirmwareVersions direct-writes firmware_version from NICo machine details to component table.
-func syncFirmwareVersions(
-	ctx context.Context,
-	pool *cdb.Session,
-	detailByID map[string]nicoapi.MachineDetail,
-	componentsByExternalID map[string]*model.Component,
-) {
-	var toUpdate []model.Component
-	for machineID, detail := range detailByID {
-		if comp, ok := componentsByExternalID[machineID]; ok {
-			if detail.FirmwareVersion != "" && comp.FirmwareVersion != detail.FirmwareVersion {
-				comp.FirmwareVersion = detail.FirmwareVersion
-				toUpdate = append(toUpdate, *comp)
-			}
-		}
-	}
-
-	if len(toUpdate) > 0 {
-		if err := pool.RunInTx(ctx, func(ctx context.Context, tx bun.Tx) error {
-			for _, cur := range toUpdate {
-				if err := cur.SetFirmwareVersionByComponentID(ctx, tx); err != nil {
-					return fmt.Errorf("unable to update firmware version: %w", err)
-				}
-			}
-			return nil
-		}); err != nil {
-			log.Error().Msgf("Unable to update components with firmware version: %v", err)
 		}
 	}
 }

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/expected_mirror_component.go
@@ -28,9 +28,9 @@ import (
 // (ExpectedComponentLabel* constants).
 //
 // firmware_version is intentionally absent: that column on Flow's component
-// table is owned by the runtime sync (see syncFirmwareVersions in
-// inventory.go), which reads what the BMC is actually running. Mirroring an
-// "expected" version here would clobber the runtime value every cycle.
+// table is owned by the runtime component-inventory sync, which reads what the
+// BMC is actually running. Mirroring an "expected" version here would clobber
+// the runtime value every cycle.
 const (
 	labelComponentManufacturer = "manufacturer"
 	labelComponentModel        = "model"
@@ -897,9 +897,7 @@ func planBMCReconciliation(component *model.Component, spec expectedBMCSpec) (op
 	// any stale host rows. ComponentID stays the same so downstream FKs
 	// keep resolving.
 	ops.insert = &want
-	for i := range hosts {
-		ops.deletes = append(ops.deletes, hosts[i])
-	}
+	ops.deletes = append(ops.deletes, hosts...)
 	return ops
 }
 

--- a/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
+++ b/rest-api/flow/internal/scheduler/jobs/inventorysync/inventory_test.go
@@ -5,6 +5,7 @@ package inventorysync
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"testing"
@@ -12,12 +13,14 @@ import (
 	"github.com/google/uuid"
 	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/nicoapi"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 	corev1 "github.com/NVIDIA/infra-controller/rest-api/proto/core/gen/v1"
 )
 
@@ -28,6 +31,25 @@ func createTestBMC(ctx context.Context, t *testing.T, pool *cdb.Session, compone
 	bmc := model.BMC{MacAddress: mac, ComponentID: componentID, Type: "Host"}
 	_, err := pool.DB.NewInsert().Model(&bmc).Exec(ctx)
 	assert.Nil(t, err)
+}
+
+type firmwareInventoryClient struct {
+	nicoapi.Client
+	response *corev1.GetComponentInventoryResponse
+	err      error
+	request  *corev1.GetComponentInventoryRequest
+	before   func()
+}
+
+func (c *firmwareInventoryClient) GetComponentInventory(
+	_ context.Context,
+	req *corev1.GetComponentInventoryRequest,
+) (*corev1.GetComponentInventoryResponse, error) {
+	c.request = req
+	if c.before != nil {
+		c.before()
+	}
+	return c.response, c.err
 }
 
 // TestInventory is the main test for the inventory package
@@ -96,7 +118,7 @@ func TestInventory(t *testing.T) {
 	for rows.Next() {
 		var serial string
 		var state *nicoapi.PowerState
-		rows.Scan(&serial, &state)
+		require.NoError(t, rows.Scan(&serial, &state))
 
 		switch serial {
 		case "serial2":
@@ -112,63 +134,305 @@ func TestInventory(t *testing.T) {
 	assert.Equal(t, 2, found)
 }
 
-// TestSyncFirmwareVersion verifies that syncMachines direct-writes firmware_version
-// from NICo machine details to the component table.
+// TestSyncFirmwareVersion verifies that syncMachines sources compute firmware
+// from component inventory while preserving the prior value when that
+// best-effort inventory is unavailable.
 func TestSyncFirmwareVersion(t *testing.T) {
-	ctx := context.Background()
-
 	if os.Getenv("DB_PORT") == "" {
 		log.Warn().Msgf("Not running unit test due to no DB environment specified")
 		t.SkipNow()
 	}
 
+	testCases := []struct {
+		name                 string
+		canonicalVersion     string
+		inventoryID          string
+		inventoryDescription string
+		inventoryVersion     string
+		inventoryStatus      corev1.ComponentManagerStatusCode
+		inventoryErr         error
+		omitReport           bool
+		concurrentLeakUpdate bool
+		expectedVersion      string
+	}{
+		{
+			name:                 "canonical component inventory replaces the predecessor machine field",
+			canonicalVersion:     "3.0.0",
+			inventoryDescription: "BMC image",
+			inventoryVersion:     "raw-version-must-not-win",
+			expectedVersion:      "3.0.0",
+		},
+		{
+			name:                 "exact BMC inventory ID is the raw fallback",
+			inventoryID:          "BMC",
+			inventoryDescription: "Vendor BMC Firmware",
+			inventoryVersion:     "3.1.0",
+			expectedVersion:      "3.1.0",
+		},
+		{
+			name:                 "legacy BMC image description remains a fallback",
+			inventoryDescription: "BMC image",
+			inventoryVersion:     "3.2.0",
+			expectedVersion:      "3.2.0",
+		},
+		{
+			name:            "empty BMC inventory preserves the stored version",
+			expectedVersion: "1.0.0",
+		},
+		{
+			name:            "missing report preserves the stored version",
+			omitReport:      true,
+			expectedVersion: "1.0.0",
+		},
+		{
+			name:             "failed component result preserves the stored version",
+			inventoryVersion: "3.0.0",
+			inventoryStatus:  corev1.ComponentManagerStatusCode_COMPONENT_MANAGER_STATUS_CODE_UNAVAILABLE,
+			expectedVersion:  "1.0.0",
+		},
+		{
+			name:            "inventory RPC failure preserves the stored version",
+			inventoryErr:    errors.New("inventory unavailable"),
+			expectedVersion: "1.0.0",
+		},
+		{
+			name:                 "firmware update preserves a concurrent leak status update",
+			canonicalVersion:     "4.0.0",
+			concurrentLeakUpdate: true,
+			expectedVersion:      "4.0.0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+			dbConf, err := cdb.ConfigFromEnv()
+			require.NoError(t, err)
+			pool, err := utils.UnitTestDB(ctx, t, dbConf)
+			require.NoError(t, err)
+
+			const machineID = "fw-id"
+			const bmcMAC = "aa:bb:cc:dd:ff:01"
+			mockClient := nicoapi.NewMockClient()
+			mockClient.AddMachine(nicoapi.MachineDetail{
+				MachineID:       machineID,
+				BmcMac:          bmcMAC,
+				FirmwareVersion: "2.0.0",
+				MachineType:     corev1.MachineType_HOST.String(),
+			})
+			mockClient.AddPowerState(machineID, nicoapi.PowerStateOn)
+
+			componentID := machineID
+			inventoryID := tc.inventoryID
+			description := tc.inventoryDescription
+			version := tc.inventoryVersion
+			report := &corev1.EndpointExplorationReport{
+				FirmwareVersions: map[string]string{"bmc": tc.canonicalVersion},
+				Systems:          []*corev1.ComputerSystem{{PowerState: corev1.ComputerSystemPowerState_Off}},
+				Service: []*corev1.Service{{
+					Inventories: []*corev1.Inventory{{
+						Id:          inventoryID,
+						Description: &description,
+						Version:     &version,
+					}},
+				}},
+			}
+			if tc.omitReport {
+				report = nil
+			}
+			response := &corev1.GetComponentInventoryResponse{
+				Entries: []*corev1.ComponentInventoryEntry{{
+					Result: &corev1.ComponentResult{
+						ComponentId: &componentID,
+						Status:      tc.inventoryStatus,
+					},
+					Report: report,
+				}},
+			}
+			client := &firmwareInventoryClient{
+				Client:   mockClient,
+				response: response,
+				err:      tc.inventoryErr,
+			}
+
+			rack := model.Rack{
+				Name:         "test-rack-fw",
+				Manufacturer: "TestMfg",
+				SerialNumber: "rack-serial-fw",
+			}
+			require.NoError(t, rack.Create(ctx, pool.DB))
+
+			component := model.Component{
+				SerialNumber:    "fw-serial",
+				Manufacturer:    "TestMfg",
+				RackID:          rack.ID,
+				FirmwareVersion: "1.0.0",
+				LeakStatus:      types.LeakStatusNotDetected,
+			}
+			require.NoError(t, component.Create(ctx, pool.DB))
+			createTestBMC(ctx, t, pool, component.ID, bmcMAC)
+			if tc.concurrentLeakUpdate {
+				client.before = func() {
+					_, updateErr := pool.DB.NewUpdate().
+						Model(&model.Component{}).
+						Set("leak_status = ?", types.LeakStatusDetected).
+						Where("id = ?", component.ID).
+						Exec(ctx)
+					require.NoError(t, updateErr)
+				}
+			}
+
+			// expectedSyncEnabled=false: actual-sync only. See TestInventory for
+			// why the mirror must stay off when the mock has no expected machines.
+			runInventoryOne(ctx, pool, client, false)
+
+			var updated model.Component
+			err = pool.DB.NewSelect().Model(&updated).Where("id = ?", component.ID).Scan(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, tc.expectedVersion, updated.FirmwareVersion)
+			require.NotNil(t, updated.PowerState)
+			assert.Equal(t, nicoapi.PowerStateOn, *updated.PowerState)
+			if tc.concurrentLeakUpdate {
+				assert.Equal(t, types.LeakStatusDetected, updated.LeakStatus)
+			}
+
+			require.NotNil(t, client.request)
+			requestedIDs := client.request.GetMachineIds().GetMachineIds()
+			require.Len(t, requestedIDs, 1)
+			assert.Equal(t, machineID, requestedIDs[0].GetId())
+		})
+	}
+}
+
+func TestBMCFirmwareVersionExactIDWinsOverEarlierDescription(t *testing.T) {
+	description := "BMC image"
+	descriptionVersion := "description-version"
+	exactIDVersion := "exact-id-version"
+	report := &corev1.EndpointExplorationReport{
+		Service: []*corev1.Service{{
+			Inventories: []*corev1.Inventory{
+				{Id: "other", Description: &description, Version: &descriptionVersion},
+				{Id: "BMC", Version: &exactIDVersion},
+			},
+		}},
+	}
+
+	assert.Equal(t, exactIDVersion, bmcFirmwareVersion(report))
+}
+
+// TestApplyInventoryToComponentsPreservesConcurrentFields verifies that the
+// shared switch and power-shelf projection updates only its owned columns.
+func TestApplyInventoryToComponentsPreservesConcurrentFields(t *testing.T) {
+	if os.Getenv("DB_PORT") == "" {
+		log.Warn().Msgf("Not running unit test due to no DB environment specified")
+		t.SkipNow()
+	}
+
+	ctx := context.Background()
 	dbConf, err := cdb.ConfigFromEnv()
-	assert.Nil(t, err)
+	require.NoError(t, err)
 	pool, err := utils.UnitTestDB(ctx, t, dbConf)
-	assert.Nil(t, err)
-
-	grpcMock := nicoapi.NewMockClient()
-
-	// Link both components to their Core machines by BMC MAC (matched against
-	// the machine's BmcMac).
-	mac1 := "aa:bb:cc:dd:ff:01"
-	mac2 := "aa:bb:cc:dd:ff:02"
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id1", BmcMac: mac1, FirmwareVersion: "2.0.0", MachineType: corev1.MachineType_HOST.String()})
-	grpcMock.AddMachine(nicoapi.MachineDetail{MachineID: "fw-id2", BmcMac: mac2, FirmwareVersion: "3.1.0", MachineType: corev1.MachineType_HOST.String()})
-	grpcMock.AddPowerState("fw-id1", nicoapi.PowerStateOn)
+	require.NoError(t, err)
 
 	rack := model.Rack{
-		Name:         "test-rack-fw",
+		Name:         "test-rack-shared-inventory",
 		Manufacturer: "TestMfg",
-		SerialNumber: "rack-serial-fw",
+		SerialNumber: "rack-serial-shared-inventory",
 	}
-	err = rack.Create(ctx, pool.DB)
-	assert.Nil(t, err)
+	require.NoError(t, rack.Create(ctx, pool.DB))
 
-	c1 := model.Component{SerialNumber: "fw-serial-1", Manufacturer: "TestMfg", RackID: rack.ID, FirmwareVersion: "1.0.0"}
-	err = c1.Create(ctx, pool.DB)
-	assert.Nil(t, err)
-	createTestBMC(ctx, t, pool, c1.ID, mac1)
+	componentID := "shared-inventory-id"
+	component := model.Component{
+		SerialNumber:    "shared-inventory-serial",
+		Manufacturer:    "TestMfg",
+		RackID:          rack.ID,
+		ComponentID:     &componentID,
+		FirmwareVersion: "1.0.0",
+		LeakStatus:      types.LeakStatusNotDetected,
+	}
+	require.NoError(t, component.Create(ctx, pool.DB))
 
-	c2 := model.Component{SerialNumber: "fw-serial-2", Manufacturer: "TestMfg", RackID: rack.ID, FirmwareVersion: "1.0.0"}
-	err = c2.Create(ctx, pool.DB)
-	assert.Nil(t, err)
-	createTestBMC(ctx, t, pool, c2.ID, mac2)
+	var stale model.Component
+	require.NoError(t, pool.DB.NewSelect().Model(&stale).Where("id = ?", component.ID).Scan(ctx))
+	_, err = pool.DB.NewUpdate().
+		Model(&model.Component{}).
+		Set("leak_status = ?", types.LeakStatusDetected).
+		Where("id = ?", component.ID).
+		Exec(ctx)
+	require.NoError(t, err)
 
-	// expectedSyncEnabled=false: actual-sync only. See TestInventory for why
-	// the mirror must stay off here (empty expected-mock would soft-delete
-	// the components this test relies on).
-	runInventoryOne(ctx, pool, grpcMock, false)
+	firmwareVersion := "2.0.0"
+	responseID := componentID
+	response := &corev1.GetComponentInventoryResponse{
+		Entries: []*corev1.ComponentInventoryEntry{{
+			Result: &corev1.ComponentResult{
+				ComponentId: &responseID,
+				Status:      corev1.ComponentManagerStatusCode_COMPONENT_MANAGER_STATUS_CODE_SUCCESS,
+			},
+			Report: &corev1.EndpointExplorationReport{
+				FirmwareVersions: map[string]string{"bmc": firmwareVersion},
+				Systems:          []*corev1.ComputerSystem{{PowerState: corev1.ComputerSystemPowerState_On}},
+			},
+		}},
+	}
 
-	var updated1 model.Component
-	err = pool.DB.NewSelect().Model(&updated1).Where("id = ?", c1.ID).Scan(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, "2.0.0", updated1.FirmwareVersion)
+	applyInventoryToComponents(ctx, pool, response, map[string]*model.Component{componentID: &stale})
 
-	var updated2 model.Component
-	err = pool.DB.NewSelect().Model(&updated2).Where("id = ?", c2.ID).Scan(ctx)
-	assert.Nil(t, err)
-	assert.Equal(t, "3.1.0", updated2.FirmwareVersion)
+	var updated model.Component
+	require.NoError(t, pool.DB.NewSelect().Model(&updated).Where("id = ?", component.ID).Scan(ctx))
+	assert.Equal(t, firmwareVersion, updated.FirmwareVersion)
+	require.NotNil(t, updated.PowerState)
+	assert.Equal(t, nicoapi.PowerStateOn, *updated.PowerState)
+	assert.Equal(t, types.LeakStatusDetected, updated.LeakStatus)
+}
+
+// TestSyncFirmwareSkipsUnmatchedMachineID verifies that a stale external ID
+// absent from the current GetMachines snapshot is not sent to component
+// inventory and cannot update a component marked missing in actual inventory.
+func TestSyncFirmwareSkipsUnmatchedMachineID(t *testing.T) {
+	if os.Getenv("DB_PORT") == "" {
+		log.Warn().Msgf("Not running unit test due to no DB environment specified")
+		t.SkipNow()
+	}
+
+	ctx := context.Background()
+	dbConf, err := cdb.ConfigFromEnv()
+	require.NoError(t, err)
+	pool, err := utils.UnitTestDB(ctx, t, dbConf)
+	require.NoError(t, err)
+
+	mockClient := nicoapi.NewMockClient()
+	client := &firmwareInventoryClient{
+		Client: mockClient,
+		response: &corev1.GetComponentInventoryResponse{
+			Entries: []*corev1.ComponentInventoryEntry{},
+		},
+	}
+
+	rack := model.Rack{
+		Name:         "test-rack-stale-fw",
+		Manufacturer: "TestMfg",
+		SerialNumber: "rack-serial-stale-fw",
+	}
+	require.NoError(t, rack.Create(ctx, pool.DB))
+
+	staleMachineID := "stale-machine-id"
+	component := model.Component{
+		SerialNumber:    "stale-fw-serial",
+		Manufacturer:    "TestMfg",
+		RackID:          rack.ID,
+		ComponentID:     &staleMachineID,
+		FirmwareVersion: "1.0.0",
+	}
+	require.NoError(t, component.Create(ctx, pool.DB))
+	createTestBMC(ctx, t, pool, component.ID, "aa:bb:cc:dd:ff:02")
+
+	runInventoryOne(ctx, pool, client, false)
+
+	assert.Nil(t, client.request, "component inventory must not be called for unmatched machine IDs")
+	var updated model.Component
+	require.NoError(t, pool.DB.NewSelect().Model(&updated).Where("id = ?", component.ID).Scan(ctx))
+	assert.Equal(t, "1.0.0", updated.FirmwareVersion)
 }
 
 // TestSyncMachineIDs_DpuBmcNotLinked verifies that a compute component owning


### PR DESCRIPTION
Flow actual inventory synchronization currently treats compute firmware differently from NVSwitch and power-shelf firmware. Compute reads the denormalized `Machine.bmc_info.firmware_version`, while the other component types use the unified `GetComponentInventory` response.

This change queries `GetComponentInventory` for matched compute machine IDs and reuses the existing BMC inventory projection. `GetMachines` remains authoritative for identity, DPU association, controller state, and missing-in-expected detection. Missing or failed component inventory preserves the stored firmware version, and compute power state remains owned by `GetPowerStates`.

## Related issues

Closes #6037

## Type of Change

- [ ] **Add** - New feature or capability
- [x] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 

## Additional Notes

The compute inventory projection intentionally ignores `report.systems[].power_state`; the existing `GetPowerStates` path remains the source of truth for compute power state. Component inventory persistence uses targeted, transactional firmware and power-state column updates so concurrently owned fields are preserved for every component type.

BMC firmware resolution prefers `report.firmware_versions["bmc"]`, falls back to raw inventory ID `BMC`, and retains the legacy `BMC image` description fallback. Component inventory is requested only for host machine IDs confirmed by the current `GetMachines` snapshot.
