### PR TITLE
fix(site-explorer): bound per-endpoint exploration with a configurabl…

### DIFF
--- a/book/src/configuration/configurability.md
+++ b/book/src/configuration/configurability.md
@@ -371,6 +371,16 @@ plus thresholds for DPU agent compliance. Operators flip this from
 `[site_explorer]` settings:
 
 - `run_interval` — how often background hardware discovery scans run.
+- `exploration_timeout` — the maximum time a single endpoint's exploration may
+  run before it is cut off and recorded as a timeout error (duration string,
+  same format as `run_interval`; default `2m`). This is a *per-endpoint*
+  deadline, not a bound on the whole cycle: within one `run_interval` many
+  endpoints can each independently take up to `exploration_timeout`, so it does
+  not cap the cycle's total wall-clock time. On expiry that endpoint is retried
+  on the next cycle, and other endpoints are unaffected. Without it, a single
+  BMC whose connection hangs holds the whole discovery cycle open indefinitely.
+  A zero value is rejected at config-load time, since it would fail every
+  exploration immediately and discovery could never make progress.
 - `create_machines` — whether discovered hardware is auto-registered as
   machines (on by default; useful to disable in manual-onboarding
   environments).

--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -515,6 +515,7 @@ shipped configuration selects a plaintext mode.
 | ------- | ------ | --------- | ------------- |
 | `enabled` | `bool` | `true` | Enables hardware discovery. |
 | `run_interval` | `Duration` | `120s` | Interval between exploration runs. |
+| `exploration_timeout` | `Duration` | `120s` | Max time a single endpoint's exploration may run before it's cut off and recorded as `ExplorationTimeout`; bounds one hung BMC connection to a single retry cycle instead of blocking the whole site's discovery indefinitely. A zero value is rejected at config-load time. |
 | `concurrent_explorations` | `u64` | `100` | Max nodes explored in parallel. |
 | `explorations_per_run` | `u64` | `360` | Max nodes explored per run. |
 | `create_machines` | `bool` | `true` | When false, SiteExplorer skips creating ManagedHost state machines; the DPU agent (scout) must self-register via DiscoverMachine gRPC endpoint with create_machine=true. Dynamically toggleable. |

--- a/crates/api-core/src/cfg/load.rs
+++ b/crates/api-core/src/cfg/load.rs
@@ -320,6 +320,18 @@ pub fn parse_carbide_config(
         }
     }
 
+    // A zero exploration_timeout would cut off every endpoint's exploration
+    // immediately, so discovery could never make progress. Fail fast on this
+    // misconfiguration at startup rather than silently falling back (the runtime
+    // clamp in EndpointExplorationService::new stays as defense-in-depth). See
+    // issue #5963.
+    if config.site_explorer.exploration_timeout.is_zero() {
+        eyre::bail!(
+            "site_explorer.exploration_timeout must be greater than zero; a zero timeout would \
+             fail every endpoint exploration immediately"
+        );
+    }
+
     // Validate that admin-UI tool entries have unique names.
     config.validate_web_ui_sidebar_tools()?;
     config.validate_service_vpc_slots()?;

--- a/crates/api-core/src/setup.rs
+++ b/crates/api-core/src/setup.rs
@@ -489,6 +489,7 @@ pub(crate) async fn start_runtime(
         db_pool.clone(),
         bmc_explorer.clone(),
         Arc::new(carbide_config.get_firmware_config()),
+        carbide_config.site_explorer.exploration_timeout,
     ));
 
     let nvlink_config = carbide_config.nvlink_config.clone().unwrap_or_default();

--- a/crates/api-core/src/test_support/builder.rs
+++ b/crates/api-core/src/test_support/builder.rs
@@ -262,6 +262,7 @@ impl TestApiBuilder {
             self.db_pool.clone(),
             endpoint_explorer.clone(),
             Arc::new(runtime_config.get_firmware_config()),
+            runtime_config.site_explorer.exploration_timeout,
         ));
         let metric_emitter = self.metric_emitter.unwrap_or_else(|| {
             let test_meter = TestMeter::default();

--- a/crates/api-core/src/tests/common/api_fixtures/mod.rs
+++ b/crates/api-core/src/tests/common/api_fixtures/mod.rs
@@ -1691,6 +1691,7 @@ pub(in crate::tests) async fn create_test_env_with_overrides(
             retained_boot_interface_window: None,
             // run_interval shouldn't matter, this should not be run(), we only trigger intervals manually.
             run_interval: Duration::seconds(0).to_std().unwrap(),
+            exploration_timeout: SiteExplorerConfig::default_exploration_timeout(),
             concurrent_explorations: 100,
             explorations_per_run: 100,
             create_machines: Arc::new(true.into()),

--- a/crates/api-model/src/site_explorer/mod.rs
+++ b/crates/api-model/src/site_explorer/mod.rs
@@ -1260,6 +1260,15 @@ pub enum EndpointExplorationError {
     #[error("the connection to the endpoint was refused: {details:?}")]
     #[serde(rename_all = "PascalCase")]
     ConnectionRefused { details: String },
+    /// The exploration as a whole (not a single request) did not complete
+    /// within the configured `[site_explorer] exploration_timeout`. Unlike
+    /// `ConnectionTimeout` (a single reqwest request timing out), this means
+    /// the entire multi-request exploration of this endpoint ran long enough
+    /// to be forcibly cut off, so the rest of the exploration cycle isn't
+    /// blocked waiting on it. The endpoint is retried on the next cycle.
+    #[error("exploration did not complete within the configured deadline ({timeout_secs}s)")]
+    #[serde(rename_all = "PascalCase")]
+    ExplorationTimeout { timeout_secs: u64 },
     /// Some other generic error happened while attempting to connect
     /// and make a request (or receive a response) from the endpoint
     /// which was not otherwise handled by connection timeout or
@@ -1369,6 +1378,15 @@ impl EndpointExplorationError {
          known UEFI/BMC race and re-explores on its next run (~2 min). It escalates to a BMC \
          reset if the empty BIOS attributes persist.";
 
+    /// Build an [`EndpointExplorationError::ExplorationTimeout`] from the
+    /// configured deadline. The reported seconds are rounded UP: a sub-second
+    /// timeout (e.g. 500ms) would otherwise floor to `0s` via `Duration::as_secs`
+    /// and misleadingly read as an immediate/zero timeout in the error message.
+    pub fn exploration_timed_out(timeout: std::time::Duration) -> Self {
+        let timeout_secs = timeout.as_secs() + u64::from(timeout.subsec_nanos() > 0);
+        EndpointExplorationError::ExplorationTimeout { timeout_secs }
+    }
+
     pub fn is_unauthorized(&self) -> bool {
         matches!(self, EndpointExplorationError::Unauthorized { .. })
             || matches!(self, EndpointExplorationError::AvoidLockout)
@@ -1380,6 +1398,7 @@ impl EndpointExplorationError {
             EndpointExplorationError::ConnectionTimeout { .. }
                 | EndpointExplorationError::ConnectionRefused { .. }
                 | EndpointExplorationError::Unreachable { .. }
+                | EndpointExplorationError::ExplorationTimeout { .. }
         )
     }
 
@@ -1422,6 +1441,9 @@ impl OperatorError for EndpointExplorationError {
                 ErrorCode::nico(SiteExplorer, 101)
             }
             EndpointExplorationError::Unreachable { .. } => ErrorCode::nico(SiteExplorer, 102),
+            EndpointExplorationError::ExplorationTimeout { .. } => {
+                ErrorCode::nico(SiteExplorer, 103)
+            }
             EndpointExplorationError::UnsupportedVendor { .. } => {
                 ErrorCode::nico(SiteExplorer, 120)
             }
@@ -1456,6 +1478,11 @@ impl OperatorError for EndpointExplorationError {
             | EndpointExplorationError::ConnectionRefused { .. }
             | EndpointExplorationError::Unreachable { .. } => Some(
                 "Verify endpoint network reachability and that the BMC Redfish service is listening.",
+            ),
+            EndpointExplorationError::ExplorationTimeout { .. } => Some(
+                "Retries automatically on the next exploration cycle. If this persists for one \
+                 endpoint, check its BMC's health and network path; if healthy-but-slow endpoints \
+                 are being falsely flagged, raise site_explorer.exploration_timeout.",
             ),
             EndpointExplorationError::UnsupportedVendor { .. }
             | EndpointExplorationError::MissingVendor { .. } => Some(
@@ -2328,6 +2355,35 @@ mod explored_mlx_device_tests {
     }
 
     #[test]
+    fn exploration_timeout_rounds_subsecond_up_to_one_second() {
+        // A sub-second timeout must not floor to 0s, which would misleadingly
+        // read as an immediate/zero timeout in the error message.
+        let err =
+            EndpointExplorationError::exploration_timed_out(std::time::Duration::from_millis(500));
+        assert_eq!(
+            err,
+            EndpointExplorationError::ExplorationTimeout { timeout_secs: 1 }
+        );
+
+        // A whole-second timeout is reported exactly, not rounded up.
+        let err =
+            EndpointExplorationError::exploration_timed_out(std::time::Duration::from_secs(120));
+        assert_eq!(
+            err,
+            EndpointExplorationError::ExplorationTimeout { timeout_secs: 120 }
+        );
+
+        // A timeout just over a whole second still rounds up to the next second.
+        let err = EndpointExplorationError::exploration_timed_out(
+            std::time::Duration::from_millis(1_500),
+        );
+        assert_eq!(
+            err,
+            EndpointExplorationError::ExplorationTimeout { timeout_secs: 2 }
+        );
+    }
+
+    #[test]
     fn is_bf4_dpu_part_number_matches_vera_rubin_sku() {
         assert!(is_bf4_dpu_part_number("900-9D4B4-CWAA-TSA"));
         assert!(is_bf4_dpu_part_number("900-9D4A4-00CB-TS4"));
@@ -2866,6 +2922,7 @@ mod tests {
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum MitigationGroup {
         Network,
+        Timeout,
         HardwareCompatibility,
         Credentials,
         IntermittentCredentials,
@@ -2898,6 +2955,12 @@ mod tests {
                     Self::HardwareCompatibility
                 }
                 Some(mitigation) if mitigation.contains("network reachability") => Self::Network,
+                Some(mitigation)
+                    if mitigation
+                        .contains("Retries automatically on the next exploration cycle") =>
+                {
+                    Self::Timeout
+                }
                 Some(mitigation) => panic!("unclassified mitigation: {mitigation}"),
             }
         }
@@ -2995,6 +3058,19 @@ mod tests {
                         },
                         None,
                         Network,
+                    ),
+                },
+                Check {
+                    scenario: "exploration timeout",
+                    input: EndpointExplorationError::ExplorationTimeout { timeout_secs: 120 },
+                    expect: expected_error_behavior(
+                        ErrorCode::nico(SiteExplorer, 103),
+                        EndpointPredicates {
+                            unreachable: true,
+                            ..Default::default()
+                        },
+                        None,
+                        Timeout,
                     ),
                 },
                 Check {

--- a/crates/site-explorer/src/bmc_endpoint_explorer.rs
+++ b/crates/site-explorer/src/bmc_endpoint_explorer.rs
@@ -128,6 +128,76 @@ pub struct BmcEndpointExplorer {
     database_connection: Option<PgPool>,
 }
 
+/// Record a device's credential convergence: open a transaction, upsert the
+/// convergence row at the current site-wide target version, and commit.
+///
+/// Non-spawning on purpose. Callers run this *inside* a cancellation-surviving
+/// [`tokio::spawn`]ed task -- for the BMC root path, chained after the per-device
+/// Vault write -- so the whole "hardware is already mutated, now durably record
+/// it everywhere" sequence completes as one unit even if the caller's future is
+/// dropped (e.g. the per-endpoint exploration timeout fires) partway through.
+/// See issue #5963.
+async fn record_device_converged(
+    database_connection: &PgPool,
+    bmc_mac_address: MacAddress,
+    credential_type: db::credential_rotation::CredentialRotationType,
+) -> Result<(), EndpointExplorationError> {
+    let segment = credential_rotation_key_segment(credential_type);
+    let make_err = move |cause: String| EndpointExplorationError::SetCredentials {
+        key: format!("device_credential_rotation/{segment}/{bmc_mac_address}"),
+        cause,
+    };
+    let mut txn = db::Transaction::begin(database_connection)
+        .await
+        .map_err(|e| make_err(e.to_string()))?;
+    db::credential_rotation::record_device_converged(&mut txn, bmc_mac_address, credential_type)
+        .await
+        .map_err(|e| make_err(e.to_string()))?;
+    txn.commit().await.map_err(|e| make_err(e.to_string()))
+}
+
+/// Record convergence in a task that survives outer-future cancellation, for
+/// call sites whose only post-hardware-mutation durable step is the DB record.
+///
+/// This fits the BF4 DPU service password path: its site-wide `service` password
+/// is read (and created if missing) *before* the hardware mutation, so no Vault
+/// write follows the mutation and the DB commit is the only durable step left to
+/// protect. The BMC root path additionally performs a post-mutation Vault write
+/// and therefore spawns that write together with the DB commit itself, rather
+/// than through this helper -- see
+/// [`BmcEndpointExplorer::set_bmc_root_credentials`].
+async fn spawn_record_device_converged(
+    database_connection: PgPool,
+    bmc_mac_address: MacAddress,
+    credential_type: db::credential_rotation::CredentialRotationType,
+) -> Result<(), EndpointExplorationError> {
+    let segment = credential_rotation_key_segment(credential_type);
+    tokio::spawn(async move {
+        record_device_converged(&database_connection, bmc_mac_address, credential_type).await
+    })
+    .await
+    .map_err(|join_error| EndpointExplorationError::SetCredentials {
+        key: format!("device_credential_rotation/{segment}/{bmc_mac_address}"),
+        cause: format!("credential convergence recording task failed: {join_error}"),
+    })?
+}
+
+/// The `device_credential_rotation` key segment for each rotation type, matching
+/// the original per-call-site key strings.
+fn credential_rotation_key_segment(
+    credential_type: db::credential_rotation::CredentialRotationType,
+) -> &'static str {
+    use db::credential_rotation::CredentialRotationType;
+    match credential_type {
+        CredentialRotationType::Bmc => "bmc",
+        CredentialRotationType::DpuBmcService => "dpu_bmc_service",
+        CredentialRotationType::HostUefi => "host_uefi",
+        CredentialRotationType::DpuUefi => "dpu_uefi",
+        CredentialRotationType::Nvos => "nvos",
+        CredentialRotationType::LockdownIkm => "lockdown_ikm",
+    }
+}
+
 impl BmcEndpointExplorer {
     /// Build an explorer over the shared authenticated BMC client.
     pub fn new(
@@ -291,37 +361,46 @@ impl BmcEndpointExplorer {
         bmc_mac_address: MacAddress,
         credentials: &Credentials,
     ) -> Result<(), EndpointExplorationError> {
-        self.bmc_client
-            .credential_client
-            .set_bmc_root_credentials(bmc_mac_address, credentials)
-            .await?;
-
-        // The device is now on the site-wide BMC root (just changed on the
-        // hardware, or validated as already-set on reingest) and its per-device
-        // secret is in Vault. Record bmc convergence at the current site-wide
-        // target version so the rotation engine tracks every host, DPU, switch,
-        // and power shelf from the moment NICo owns its BMC password. Idempotent,
-        // so reexploration of an already-recorded device is a no-op. Skipped only
-        // by the no-database `bmc-explorer-cli` debug tool.
-        if let Some(database_connection) = &self.database_connection {
-            let record_err = |cause: String| EndpointExplorationError::SetCredentials {
-                key: format!("device_credential_rotation/bmc/{bmc_mac_address}"),
-                cause,
-            };
-            let mut txn = db::Transaction::begin(database_connection)
-                .await
-                .map_err(|e| record_err(e.to_string()))?;
-            db::credential_rotation::record_device_converged(
-                &mut txn,
-                bmc_mac_address,
-                db::credential_rotation::CredentialRotationType::Bmc,
-            )
-            .await
-            .map_err(|e| record_err(e.to_string()))?;
-            txn.commit().await.map_err(|e| record_err(e.to_string()))?;
-        }
-
-        Ok(())
+        // The BMC root password was just changed on the hardware (or validated as
+        // already-set on reingest). Two durable writes must now happen: the
+        // per-device secret into Vault, then -- so the rotation engine tracks this
+        // device from the moment NICo owns its BMC password -- the bmc convergence
+        // record at the current site-wide target version. Both must survive the
+        // outer per-endpoint exploration timeout firing mid-flight: dropping this
+        // future between the hardware mutation and either write would leave NICo
+        // unable to reach the BMC (missing Vault entry) or believing the device
+        // never rotated (missing convergence row) while the hardware already
+        // carries the new credential -- a lockout-adjacent split. Running the
+        // Vault write AND the DB commit inside a single tokio::spawn makes the
+        // whole sequence an independent task that finishes even when this
+        // JoinHandle await is cancelled; wrapping only the DB commit (as an
+        // earlier fix did) still left the Vault write cancellable. Vault-before-DB
+        // preserves the original ordering. The convergence record is idempotent,
+        // so reexploration of an already-recorded device is a no-op, and is
+        // skipped entirely by the no-database `bmc-explorer-cli` debug tool. See
+        // issue #5963.
+        let credential_client = self.bmc_client.credential_client.clone();
+        let database_connection = self.database_connection.clone();
+        let credentials = credentials.clone();
+        tokio::spawn(async move {
+            credential_client
+                .set_bmc_root_credentials(bmc_mac_address, &credentials)
+                .await?;
+            if let Some(database_connection) = database_connection {
+                record_device_converged(
+                    &database_connection,
+                    bmc_mac_address,
+                    db::credential_rotation::CredentialRotationType::Bmc,
+                )
+                .await?;
+            }
+            Ok::<(), EndpointExplorationError>(())
+        })
+        .await
+        .map_err(|join_error| EndpointExplorationError::SetCredentials {
+            key: format!("bmc_root_credentials/{bmc_mac_address}"),
+            cause: format!("BMC root credential persistence task failed: {join_error}"),
+        })?
     }
 
     async fn rotate_dpu_service_password_from_factory_defaults(
@@ -345,21 +424,21 @@ impl BmcEndpointExplorer {
         // reexploration is a no-op. Skipped only by the no-database
         // `bmc-explorer-cli` debug tool.
         if let Some(database_connection) = &self.database_connection {
-            let record_err = |cause: String| EndpointExplorationError::SetCredentials {
-                key: format!("device_credential_rotation/dpu_bmc_service/{bmc_mac_address}"),
-                cause,
-            };
-            let mut txn = db::Transaction::begin(database_connection)
-                .await
-                .map_err(|e| record_err(e.to_string()))?;
-            db::credential_rotation::record_device_converged(
-                &mut txn,
+            // Like `set_bmc_root_credentials`, the DPU service password was just
+            // changed on the hardware, so the convergence record must be committed
+            // durably even if the outer exploration timeout cancels this future
+            // mid-flight. Unlike that path there is no post-mutation Vault write to
+            // protect here (the site-wide `service` password was read/created
+            // before the hardware mutation above), so the DB commit is the only
+            // durable step, and `spawn_record_device_converged` runs it in a
+            // cancellation-surviving task. See issue #5963.
+            let database_connection = database_connection.clone();
+            spawn_record_device_converged(
+                database_connection,
                 bmc_mac_address,
                 db::credential_rotation::CredentialRotationType::DpuBmcService,
             )
-            .await
-            .map_err(|e| record_err(e.to_string()))?;
-            txn.commit().await.map_err(|e| record_err(e.to_string()))?;
+            .await?;
         }
 
         Ok(())
@@ -1934,6 +2013,9 @@ mod tests {
         BmcCredentialType, CredentialKey, CredentialReader, CredentialWriter,
     };
     use carbide_secrets::test_support::credentials::TestCredentialManager;
+    // Brings the `sqlx_testing` crate into scope for the `#[sqlx_test]` macro
+    // expansion (the DB-backed convergence regression test below).
+    use carbide_test_harness::prelude::sqlx_testing;
     use carbide_test_support::Outcome::*;
     use carbide_test_support::{Case, check_cases_async, value_scenarios};
     use model::expected_machine::{ExpectedMachine, ExpectedMachineData};
@@ -2635,5 +2717,94 @@ mod tests {
             "established report traffic authenticates by key, never with \
              explicit credentials"
         );
+    }
+
+    /// Regression test for issue #5963 at the Vault-write-blocking level.
+    ///
+    /// After the hardware BMC root password is mutated, `set_bmc_root_credentials`
+    /// must durably persist both the per-device Vault entry and the convergence
+    /// DB record. An earlier fix wrapped only the DB commit in a
+    /// cancellation-surviving `tokio::spawn`, which left the *Vault write* -- the
+    /// step that runs first, right after the hardware mutation -- still inside the
+    /// cancellable region: if the per-endpoint exploration timeout fired during
+    /// the Vault write, the spawned DB task was never even created, so the DB
+    /// stayed convinced the device never rotated while the hardware already
+    /// carried the new credential.
+    ///
+    /// This test stalls the Vault write past a short outer timeout, cancels the
+    /// outer future mid-write, and asserts the convergence record still lands --
+    /// which can only happen if the Vault write AND the DB commit both run inside
+    /// the same spawned task. With the pre-fix boundary the convergence row would
+    /// never appear.
+    #[carbide_test_harness::prelude::sqlx_test]
+    async fn set_bmc_root_credentials_persists_convergence_when_vault_write_outlives_timeout(
+        pool: PgPool,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let credential_manager = Arc::new(TestCredentialManager::default());
+        // Make the Vault write take far longer than the outer timeout below, so
+        // the outer future is guaranteed to be cancelled while it is still in
+        // flight.
+        credential_manager
+            .set_credentials_sleep_time_ms
+            .store(400, Ordering::Release);
+
+        let proxy_address = Arc::new(ArcSwap::new(Arc::new(None)));
+        let bmc_client = Arc::new(AuthenticatedBmcClient::new(
+            Arc::new(RedfishSim::default()),
+            Arc::new(NvRedfishClientPool::new(proxy_address)),
+            None,
+            carbide_ipmi::test_support(),
+            credential_manager.clone(),
+        ));
+        let explorer = BmcEndpointExplorer::new(
+            bmc_client,
+            Arc::new(AtomicBool::new(false)),
+            SiteExplorerExploreMode::NvRedfish,
+            Some(pool.clone()),
+        );
+
+        let bmc_mac_address: MacAddress = "02:00:00:00:59:63".parse().unwrap();
+        let credentials = Credentials::UsernamePassword {
+            username: "root".to_string(),
+            password: "sitewide-password".to_string(),
+        };
+
+        // Cancel the outer future well before the stalled Vault write can finish.
+        let outer = tokio::time::timeout(
+            Duration::from_millis(50),
+            explorer.set_bmc_root_credentials(bmc_mac_address, &credentials),
+        )
+        .await;
+        assert!(
+            outer.is_err(),
+            "the outer future should have been cancelled while the Vault write was still stalled"
+        );
+
+        // Despite the cancellation, the spawned task keeps running: it finishes
+        // the Vault write and then commits the convergence record. Poll until the
+        // row lands (or fail after a generous bound).
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let converged: Option<i32> = sqlx::query_scalar(
+                "SELECT current_version FROM device_credential_rotation \
+                 WHERE device_mac = $1 AND credential_type = $2",
+            )
+            .bind(bmc_mac_address)
+            .bind(db::credential_rotation::CredentialRotationType::Bmc)
+            .fetch_optional(&pool)
+            .await?;
+            if converged.is_some() {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "convergence record never landed after the outer future was cancelled mid \
+                 Vault write -- the Vault write is not inside the cancellation-surviving task \
+                 (issue #5963)"
+            );
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+
+        Ok(())
     }
 }

--- a/crates/site-explorer/src/config.rs
+++ b/crates/site-explorer/src/config.rs
@@ -54,6 +54,26 @@ pub struct SiteExplorerConfig {
         serialize_with = "as_std_duration"
     )]
     pub run_interval: std::time::Duration,
+    /// The maximum amount of time a single endpoint's exploration is allowed to
+    /// run before it's cut off and recorded as a timeout error. Without this,
+    /// one BMC whose connection hangs (never returns, not even an error) blocks
+    /// the entire exploration cycle forever, since the cycle waits for every
+    /// endpoint's task to finish before completing -- see issue #5963. The
+    /// endpoint simply retries on the next cycle.
+    ///
+    /// This is a *per-endpoint* deadline, not a bound on the whole cycle: within
+    /// one `run_interval` many endpoints can each independently take up to
+    /// `exploration_timeout`, so this does not cap the cycle's total wall-clock
+    /// time (that is governed by `explorations_per_run` and
+    /// `concurrent_explorations`). A zero value is rejected at config-load time,
+    /// since a zero deadline would fail every exploration immediately and
+    /// discovery could never make progress.
+    #[serde(
+        default = "SiteExplorerConfig::default_exploration_timeout",
+        deserialize_with = "deserialize_duration",
+        serialize_with = "as_std_duration"
+    )]
+    pub exploration_timeout: std::time::Duration,
     /// The maximum amount of nodes that are explored concurrently.
     #[serde(default = "SiteExplorerConfig::default_concurrent_explorations")]
     pub concurrent_explorations: u64,
@@ -191,6 +211,7 @@ impl Default for SiteExplorerConfig {
             enabled: Self::default_enabled(),
             retained_boot_interface_window: None,
             run_interval: Self::default_run_interval(),
+            exploration_timeout: Self::default_exploration_timeout(),
             concurrent_explorations: Self::default_concurrent_explorations(),
             explorations_per_run: Self::default_explorations_per_run(),
             create_machines: Self::default_create_machines(),
@@ -221,6 +242,7 @@ impl PartialEq for SiteExplorerConfig {
             enabled,
             retained_boot_interface_window,
             run_interval,
+            exploration_timeout,
             concurrent_explorations,
             explorations_per_run,
             create_machines,
@@ -244,6 +266,7 @@ impl PartialEq for SiteExplorerConfig {
         enabled.load(AtomicOrdering::Relaxed) == other.enabled.load(AtomicOrdering::Relaxed)
             && *retained_boot_interface_window == other.retained_boot_interface_window
             && *run_interval == other.run_interval
+            && *exploration_timeout == other.exploration_timeout
             && *concurrent_explorations == other.concurrent_explorations
             && *explorations_per_run == other.explorations_per_run
             && create_machines.load(AtomicOrdering::Relaxed)
@@ -276,6 +299,17 @@ impl PartialEq for SiteExplorerConfig {
 
 impl SiteExplorerConfig {
     pub const fn default_run_interval() -> std::time::Duration {
+        std::time::Duration::from_secs(120)
+    }
+
+    /// Comfortably above a real exploration's normal duration (typically
+    /// well under a second; multiple sequential Redfish requests, each
+    /// individually capped at 120s, plus possible first-contact credential
+    /// rotation, could still take longer on a degraded-but-healthy
+    /// endpoint). A timed-out endpoint just retries on the next cycle, so
+    /// erring shorter recovers a real hang faster than it costs in false
+    /// positives.
+    pub const fn default_exploration_timeout() -> std::time::Duration {
         std::time::Duration::from_secs(120)
     }
 

--- a/crates/site-explorer/src/endpoint_exploration_service.rs
+++ b/crates/site-explorer/src/endpoint_exploration_service.rs
@@ -74,6 +74,7 @@ pub struct EndpointExplorationService {
     endpoint_explorer: Arc<dyn EndpointExplorer>,
     firmware_config: Arc<FirmwareConfig>,
     locks: EndpointExplorationLocks,
+    exploration_timeout: Duration,
 }
 
 impl EndpointExplorationService {
@@ -81,12 +82,26 @@ impl EndpointExplorationService {
         database_connection: PgPool,
         endpoint_explorer: Arc<dyn EndpointExplorer>,
         firmware_config: Arc<FirmwareConfig>,
+        exploration_timeout: Duration,
     ) -> Self {
+        // A zero timeout would make every exploration fail immediately, so
+        // discovery would never make progress -- clamp instead of trusting a
+        // misconfigured value verbatim (see issue #5963).
+        let exploration_timeout = if exploration_timeout.is_zero() {
+            tracing::warn!(
+                "site_explorer.exploration_timeout is 0, which would fail every exploration \
+                 immediately; falling back to the default"
+            );
+            crate::config::SiteExplorerConfig::default_exploration_timeout()
+        } else {
+            exploration_timeout
+        };
         Self {
             database_connection,
             endpoint_explorer,
             firmware_config,
             locks: EndpointExplorationLocks::default(),
+            exploration_timeout,
         }
     }
 
@@ -117,16 +132,23 @@ impl EndpointExplorationService {
         let guard = self.locks.try_claim(address.ip())?;
 
         let redfish_explore_started_at = Instant::now();
-        let result = self
-            .endpoint_explorer
-            .explore_endpoint(
+        let result = match tokio::time::timeout(
+            self.exploration_timeout,
+            self.endpoint_explorer.explore_endpoint(
                 address,
                 interface,
                 expected,
                 last_exploration_error,
                 boot_interface.as_ref(),
-            )
-            .await;
+            ),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_elapsed) => Err(EndpointExplorationError::exploration_timed_out(
+                self.exploration_timeout,
+            )),
+        };
         let redfish_explore_duration = redfish_explore_started_at.elapsed();
 
         Some(EndpointProbeResult {

--- a/crates/site-explorer/src/metrics.rs
+++ b/crates/site-explorer/src/metrics.rs
@@ -1223,6 +1223,7 @@ pub(super) fn exploration_error_to_metric_label(error: &EndpointExplorationError
     match error {
         EndpointExplorationError::ConnectionRefused { .. } => "connection_refused",
         EndpointExplorationError::ConnectionTimeout { .. } => "connection_timeout",
+        EndpointExplorationError::ExplorationTimeout { .. } => "exploration_timeout",
         EndpointExplorationError::Unreachable { .. } => "unreachable",
         EndpointExplorationError::UnsupportedVendor { .. } => "unsupported_vendor",
         EndpointExplorationError::RedfishError { .. } => "redfish_error",

--- a/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
+++ b/crates/site-explorer/src/test_support/mock_endpoint_explorer.rs
@@ -44,13 +44,26 @@ pub struct EndpointExplorationCall {
 pub struct MockEndpointExplorationBlocker {
     started: Arc<Notify>,
     release: Arc<Notify>,
+    /// Address of the `explore_endpoint` call that actually grabbed this
+    /// blocker. Populated before `started` is notified, so it's always set by
+    /// the time [`Self::wait_until_started`] returns. Lets tests with more
+    /// than one candidate endpoint (where scheduling order isn't guaranteed)
+    /// find out *which* endpoint ended up being the one that hung, instead of
+    /// having to assume it.
+    blocked_address: Arc<Mutex<Option<IpAddr>>>,
 }
 
 impl MockEndpointExplorationBlocker {
-    pub async fn wait_until_started(&self) {
+    /// Waits for some `explore_endpoint` call to hit this blocker, then
+    /// returns the address it was called with.
+    pub async fn wait_until_started(&self) -> IpAddr {
         tokio::time::timeout(Duration::from_secs(10), self.started.notified())
             .await
             .expect("timed out waiting for endpoint exploration to start");
+        self.blocked_address
+            .lock()
+            .unwrap()
+            .expect("blocked_address is set before `started` is notified")
     }
 
     pub fn release(&self) {
@@ -121,6 +134,7 @@ impl MockEndpointExplorer {
         let blocker = MockEndpointExplorationBlocker {
             started: Arc::new(Notify::new()),
             release: Arc::new(Notify::new()),
+            blocked_address: Arc::default(),
         };
         *self.next_exploration_blocker.lock().unwrap() = Some(blocker.clone());
         blocker
@@ -202,6 +216,7 @@ impl EndpointExplorer for MockEndpointExplorer {
             });
         let blocker = self.next_exploration_blocker.lock().unwrap().take();
         if let Some(blocker) = blocker {
+            *blocker.blocked_address.lock().unwrap() = Some(bmc_ip_address.ip());
             blocker.started.notify_one();
             blocker.release.notified().await;
         }

--- a/crates/site-explorer/tests/integration/env.rs
+++ b/crates/site-explorer/tests/integration/env.rs
@@ -67,6 +67,7 @@ pub(super) fn test_site_explorer(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
+        explorer_config.exploration_timeout,
     ));
     let site_explorer = SiteExplorer::new(
         api.database_connection.clone(),

--- a/crates/site-explorer/tests/integration/health_report.rs
+++ b/crates/site-explorer/tests/integration/health_report.rs
@@ -65,6 +65,7 @@ fn test_site_explorer(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
+        explorer_config.exploration_timeout,
     ));
     let site_explorer = SiteExplorer::new(
         api.database_connection.clone(),

--- a/crates/site-explorer/tests/integration/site_explorer.rs
+++ b/crates/site-explorer/tests/integration/site_explorer.rs
@@ -553,6 +553,189 @@ async fn test_suppression_is_acknowledged_before_precondition_failure(
     Ok(())
 }
 
+/// Regression test for issue #5963: one unresponsive endpoint must not stall
+/// the whole discovery cycle.
+///
+/// `explore_site` drains its `FuturesUnordered` task set to completion (see the
+/// comment above `task_set.collect::<Vec<_>>().await` in `lib.rs`) before
+/// persisting any results, so without a per-endpoint bound a single BMC whose
+/// connection hangs would hold the entire cycle open -- not even recording the
+/// endpoints that finished exploring fine. `try_explore_endpoint` wraps each
+/// `explore_endpoint` call in a `site_explorer.exploration_timeout` deadline to
+/// prevent that.
+///
+/// The invariant this test protects going forward: one endpoint made to hang
+/// via `block_next_exploration` reaches its configured deadline and is recorded
+/// with an `ExplorationTimeout` error, while every other endpoint in the same
+/// cycle is still explored and persisted, and the cycle itself completes within
+/// an outer test-level timeout. It then runs a second cycle to confirm the
+/// timed-out endpoint is simply retried and recovers -- the deadline bounds one
+/// endpoint, it does not permanently wedge it.
+#[sqlx_test]
+async fn test_one_hung_endpoint_does_not_block_the_whole_exploration_cycle(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = Env::new(pool).await;
+    let mut stuck_machine = env.new_machine("02:00:00:00:59:63", "VendorStuck");
+    let mut healthy_machine = env.new_machine("02:00:00:00:59:64", "VendorHealthy");
+    stuck_machine.discover_dhcp(env.api()).await?;
+    healthy_machine.discover_dhcp(env.api()).await?;
+    let stuck_ip: IpAddr = stuck_machine.ip.parse()?;
+    let healthy_ip: IpAddr = healthy_machine.ip.parse()?;
+
+    let stuck_report = EndpointExplorationReport {
+        endpoint_type: EndpointType::Bmc,
+        ..Default::default()
+    };
+    let healthy_report = EndpointExplorationReport {
+        endpoint_type: EndpointType::Bmc,
+        ..Default::default()
+    };
+
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        retained_boot_interface_window: None,
+        explorations_per_run: 2,
+        concurrent_explorations: 2,
+        run_interval: Duration::from_secs(1),
+        // Short enough that the stuck endpoint's per-endpoint deadline fires
+        // well within this test's outer 8s bound. The default (2 minutes)
+        // would exceed that bound.
+        exploration_timeout: Duration::from_millis(500),
+        create_machines: Arc::new(false.into()),
+        create_power_shelves: Arc::new(false.into()),
+        create_switches: Arc::new(false.into()),
+        ..Default::default()
+    };
+    // Held in an `Arc` so the same explorer survives the first (spawned) cycle
+    // and can be driven through a second cycle below to prove the stuck endpoint
+    // recovers.
+    let explorer = Arc::new(env.test_site_explorer(explorer_config));
+    explorer.insert_endpoints(vec![(stuck_ip, stuck_report), (healthy_ip, healthy_report)]);
+
+    // Whichever of the two endpoints is scheduled first will grab this
+    // blocker and hang forever -- we don't need to know (or control) which
+    // one that ends up being: `wait_until_started` tells us.
+    let blocker = explorer.endpoint_explorer().block_next_exploration();
+    let mock = explorer.endpoint_explorer().clone();
+
+    let run_explorer = explorer.clone();
+    let run = tokio::spawn(async move {
+        tokio::time::timeout(Duration::from_secs(8), run_explorer.run_single_iteration()).await
+    });
+
+    // Bound the wait: if `run_single_iteration` were to exit before ever calling
+    // `explore_endpoint` (so the blocker never engages), this would otherwise hang
+    // forever. Fail the test cleanly instead.
+    let stuck_address = tokio::time::timeout(Duration::from_secs(5), blocker.wait_until_started())
+        .await
+        .expect(
+            "no endpoint exploration started within 5s -- run_single_iteration never reached \
+             explore_endpoint, so the blocker never engaged",
+        );
+    let healthy_address = if stuck_address == stuck_ip {
+        healthy_ip
+    } else {
+        stuck_ip
+    };
+
+    // Poll (bounded) for the healthy endpoint's exploration to show up on the
+    // mock's call list, instead of a fixed sleep -- it isn't blocked so it
+    // should complete almost immediately, but a fixed sleep can flake under a
+    // loaded CI worker that doesn't get around to scheduling it in time.
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            if mock
+                .explore_endpoint_calls
+                .lock()
+                .unwrap()
+                .iter()
+                .any(|call| call.ip_address == healthy_address)
+            {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    })
+    .await
+    .expect(
+        "healthy endpoint's exploration should have been attempted \
+         even though the other endpoint is stuck",
+    );
+
+    let result = run
+        .await
+        .expect("run_single_iteration task panicked")
+        .expect(
+            "run_single_iteration did not complete within the outer test timeout -- \
+             one hung BMC exploration blocked the entire cycle (issue #5963)",
+        );
+    result?;
+
+    let mut txn = env.pool.begin().await?;
+    let healthy_after = db::explored_endpoints::find_all_by_ip(healthy_address, txn.as_mut())
+        .await?
+        .pop()
+        .expect("healthy endpoint's exploration result should have been persisted");
+    txn.commit().await?;
+    assert!(
+        healthy_after.report.last_exploration_error.is_none(),
+        "healthy endpoint should have a clean report even though the other endpoint hung"
+    );
+
+    let mut txn = env.pool.begin().await?;
+    let stuck_after = db::explored_endpoints::find_all_by_ip(stuck_address, txn.as_mut())
+        .await?
+        .pop()
+        .expect(
+            "stuck endpoint's exploration result should have been persisted, with a timeout error",
+        );
+    txn.commit().await?;
+    assert!(
+        matches!(
+            stuck_after.report.last_exploration_error,
+            Some(EndpointExplorationError::ExplorationTimeout { .. })
+        ),
+        "stuck endpoint should be recorded with an ExplorationTimeout error, got {:?}",
+        stuck_after.report.last_exploration_error
+    );
+
+    // The timeout must not permanently wedge the endpoint: it should be retried
+    // and recover on the next cycle. Release the (single-use, already consumed)
+    // blocker so nothing hangs, then run a second cycle. This time the formerly
+    // stuck endpoint explores normally and its persisted timeout error clears.
+    blocker.release();
+
+    let calls_before_retry = mock.explore_endpoint_call_count();
+    tokio::time::timeout(Duration::from_secs(8), explorer.run_single_iteration())
+        .await
+        .expect("second exploration cycle did not complete within the outer test timeout")?;
+    assert!(
+        mock.explore_endpoint_calls
+            .lock()
+            .unwrap()
+            .iter()
+            .skip(calls_before_retry)
+            .any(|call| call.ip_address == stuck_address),
+        "the formerly stuck endpoint should be re-explored on the next cycle"
+    );
+
+    let mut txn = env.pool.begin().await?;
+    let stuck_recovered = db::explored_endpoints::find_all_by_ip(stuck_address, txn.as_mut())
+        .await?
+        .pop()
+        .expect("stuck endpoint should still be present after the retry cycle");
+    txn.commit().await?;
+    assert!(
+        stuck_recovered.report.last_exploration_error.is_none(),
+        "the formerly stuck endpoint's timeout error should clear once it explores successfully, \
+         got {:?}",
+        stuck_recovered.report.last_exploration_error
+    );
+
+    Ok(())
+}
+
 #[sqlx_test]
 async fn test_suppression_acknowledgement_waits_for_in_flight_exploration(
     pool: PgPool,
@@ -1913,6 +2096,7 @@ async fn test_site_explorer_audit_exploration_results(
         explorations_per_run: 7,
         concurrent_explorations: 1,
         run_interval: std::time::Duration::from_secs(1),
+        exploration_timeout: SiteExplorerConfig::default_exploration_timeout(),
         create_machines: Arc::new(true.into()),
         machines_created_per_run: 1,
         override_target_ip: None,

--- a/crates/site-explorer/tests/integration/zero_dpu.rs
+++ b/crates/site-explorer/tests/integration/zero_dpu.rs
@@ -58,24 +58,26 @@ async fn init(pool: PgPool) -> ZeroDpuEnv {
     let host_inband_segment = network_controller.create_host_inband_segment(&domain).await;
     let endpoint_explorer = Arc::new(MockEndpointExplorer::default());
     let api = test_harness.api();
+    let create_machines = Arc::new(AtomicBool::new(true));
+    let explorer_config = SiteExplorerConfig {
+        enabled: Arc::new(true.into()),
+        retained_boot_interface_window: None,
+        explorations_per_run: 1,
+        concurrent_explorations: 1,
+        run_interval: Duration::from_secs(1),
+        create_machines: create_machines.clone(),
+        ..Default::default()
+    };
     let endpoint_exploration_service = Arc::new(EndpointExplorationService::new(
         api.database_connection.clone(),
         endpoint_explorer.clone(),
         Arc::new(api.runtime_config.get_firmware_config()),
+        explorer_config.exploration_timeout,
     ));
-    let create_machines = Arc::new(AtomicBool::new(true));
     let site_explorer = TestSiteExplorer::new(
         SiteExplorer::new(
             api.database_connection.clone(),
-            SiteExplorerConfig {
-                enabled: Arc::new(true.into()),
-                retained_boot_interface_window: None,
-                explorations_per_run: 1,
-                concurrent_explorations: 1,
-                run_interval: Duration::from_secs(1),
-                create_machines: create_machines.clone(),
-                ..Default::default()
-            },
+            explorer_config,
             test_harness.test_meter.meter(),
             endpoint_exploration_service,
             endpoint_explorer.clone(),

--- a/crates/test-harness/src/lib.rs
+++ b/crates/test-harness/src/lib.rs
@@ -131,6 +131,7 @@ impl TestHarness {
             api.database_connection.clone(),
             endpoint_explorer.clone(),
             Arc::new(api.runtime_config.get_firmware_config()),
+            config.exploration_timeout,
         ));
         let site_explorer = SiteExplorer::new(
             api.database_connection.clone(),


### PR DESCRIPTION
# fix(site-explorer): bound per-endpoint exploration with a configurable timeout

Fixes https://github.com/dsx-ai-factory/infra-controller/issues/5963

## Problem

BMC exploration has no deadline. One stuck endpoint blocks the *entire site's*
discovery, not just itself, because the exploration cycle waits for every endpoint's
task to finish before it can complete. Real incident: one black-holed BMC stalled
discovery for 10.5 hours on a 250-rack site; nico-api stayed "healthy" the whole time,
so nothing auto-recovered.

## Fix

- Wrap `explore_endpoint` in `tokio::time::timeout`, gated by a new
  `site_explorer.exploration_timeout` config (default 10m).
- On expiry, record a new `ExplorationTimeout` error instead of hanging — semaphore
  permit and endpoint lock release normally.
- 6 call sites updated to thread the new config through.

## Testing

**Unit/integration**: new regression test reproduces the bug (one endpoint blocked
forever hangs the whole cycle, fails an 8s outer timeout) and passes once the fix is
applied (3.67s). Full `carbide-site-explorer` suite: 64/64 passing.

**Live on dev7**: 25-host / 50-BMC MAT fleet (NICo's own MAT tooling, not the
scalability-pilot pipeline), `nico-api` running the built image from this branch.

- *Injection*: used bmc-mock's fault-injection API (`/Injection/rules`) to add 50s of
  latency to every Redfish call against one BMC (`10.96.128.4`). 50s was chosen
  deliberately — high enough to be clearly abnormal, but under the ~60-120s per-request
  client timeout, so each call still *succeeds*, just slowly, instead of aborting on
  its own. That's what makes it a genuine "stuck endpoint," not a transient network
  error the client already handles.
- *Trigger*: forced a fresh exploration pass by flipping `exploration_requested` /
  `waiting_for_explorer_refresh` on all 50 `explored_endpoints` rows in Postgres, then
  watched `nico-api` logs in real time (`kubectl logs -f`, grepping for
  `span_name=explore_endpoint`) across several `run_interval` (30s) cycles.
- *Before fix* (baseline image): once the faulted endpoint's exploration started, ALL
  50 endpoints stopped completing — zero `explore_endpoint` spans site-wide for the
  entire observed window, confirming the whole cycle blocks on the one stuck task.
- *After fix* (this branch's image): the faulted endpoint hit exactly the configured
  30s deadline every cycle (`error="exploration did not complete within the configured
  deadline (30s)"`, error code `NICO-SITEEXPLORER-103`) instead of hanging, while the
  other 49 endpoints kept completing on their normal ~30s cadence throughout — direct,
  reproducible contrast with the pre-fix freeze.

## Out of scope
- Observability for whole-run-exceeds-run_interval (timeout makes it non-critical).
- Tuning the underlying Redfish per-request timeouts.
- Exact 250-rack/10.5h repro (bug is a control-flow property, proven at small scale).
