### PR TITLE
fix(rest-api): Redact Site Agent OTP in logs

### DIFF
--- a/rest-api/common/pkg/util/encryption.go
+++ b/rest-api/common/pkg/util/encryption.go
@@ -8,10 +8,35 @@ import (
 	"crypto/cipher"
 	"crypto/rand"
 	"crypto/sha256"
+	"fmt"
 	"io"
 
 	"github.com/rs/zerolog/log"
 )
+
+const (
+	// secretLogPrefixLen is how much of a secret a diagnostic log may carry. The
+	// shortest secret this covers is a Site registration OTP, 20 random bytes in
+	// base64, so four characters tell two of them apart and leave the remaining
+	// 136 bits out of the logs.
+	secretLogPrefixLen = 4
+
+	// redactedMarker stands in for the withheld remainder. It repeats the text of
+	// grpcproxy.RedactedPlaceholder rather than importing it, because a test in
+	// that package already imports this one.
+	redactedMarker = "[REDACTED]"
+)
+
+// RedactSecret renders a secret for a diagnostic log: a short identifying
+// prefix, a marker for the withheld remainder, and the length. That is enough
+// to tell which value a failure was about, and never enough to reuse it. A
+// secret no longer than the prefix keeps none of its characters.
+func RedactSecret(secret string) string {
+	if len(secret) <= secretLogPrefixLen {
+		return fmt.Sprintf("%s len=%d", redactedMarker, len(secret))
+	}
+	return fmt.Sprintf("%s%s len=%d", secret[:secretLogPrefixLen], redactedMarker, len(secret))
+}
 
 // CreateHash takes a string and returns SHA 256 digest in a byte array
 func CreateHash(key string) []byte {

--- a/rest-api/common/pkg/util/encryption.go
+++ b/rest-api/common/pkg/util/encryption.go
@@ -15,11 +15,18 @@ import (
 )
 
 const (
-	// secretLogPrefixLen is how much of a secret a diagnostic log may carry. The
-	// shortest secret this covers is a Site registration OTP, 20 random bytes in
-	// base64, so four characters tell two of them apart and leave the remaining
-	// 136 bits out of the logs.
-	secretLogPrefixLen = 4
+	// SecretLogPrefixLen is how much of an opaque secret a diagnostic log may
+	// carry. The shortest one this covers is a Site registration OTP, 20 random
+	// bytes in base64, so four characters tell two of them apart and leave the
+	// remaining 136 bits out of the logs.
+	SecretLogPrefixLen = 4
+
+	// CertLogPrefixLen is how much of a PEM a diagnostic log may carry. Its
+	// `-----BEGIN CERTIFICATE-----` line takes the first 28 characters, so a
+	// prefix has to clear that before it reaches anything that tells two
+	// certificates apart. This leaves 36 characters of the encoded body, and a
+	// certificate is public in any case.
+	CertLogPrefixLen = 64
 
 	// redactedMarker stands in for the withheld remainder. It repeats the text of
 	// grpcproxy.RedactedPlaceholder rather than importing it, because a test in
@@ -27,15 +34,17 @@ const (
 	redactedMarker = "[REDACTED]"
 )
 
-// RedactSecret renders a secret for a diagnostic log: a short identifying
-// prefix, a marker for the withheld remainder, and the length. That is enough
-// to tell which value a failure was about, and never enough to reuse it. A
-// secret no longer than the prefix keeps none of its characters.
-func RedactSecret(secret string) string {
-	if len(secret) <= secretLogPrefixLen {
+// RedactSecret renders a secret for a diagnostic log: up to prefixLen leading
+// characters, a marker for the withheld remainder, and the length. That is
+// enough to tell which value a failure was about, and never enough to reuse it.
+// Pass SecretLogPrefixLen for an opaque secret or CertLogPrefixLen for a PEM. A
+// secret no longer than prefixLen keeps none of its characters, so asking for
+// more than the value holds yields nothing rather than all of it.
+func RedactSecret(secret string, prefixLen int) string {
+	if prefixLen < 0 || len(secret) <= prefixLen {
 		return fmt.Sprintf("%s len=%d", redactedMarker, len(secret))
 	}
-	return fmt.Sprintf("%s%s len=%d", secret[:secretLogPrefixLen], redactedMarker, len(secret))
+	return fmt.Sprintf("%s%s len=%d", secret[:prefixLen], redactedMarker, len(secret))
 }
 
 // CreateHash takes a string and returns SHA 256 digest in a byte array

--- a/rest-api/common/pkg/util/encryption_test.go
+++ b/rest-api/common/pkg/util/encryption_test.go
@@ -6,6 +6,7 @@ package util
 import (
 	"bytes"
 	"crypto/sha256"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,30 +62,56 @@ func TestEncryptAndDecryptWithWrongPassphrase(t *testing.T) {
 }
 
 func TestRedactSecret(t *testing.T) {
+	// pemBody stands in for the base64 of a certificate, where the prefix has to
+	// reach past the BEGIN line to carry anything identifying.
+	pemBody := strings.Repeat("A", 100)
+
 	tcs := []struct {
-		descr  string
-		secret string
-		want   string
+		descr     string
+		secret    string
+		prefixLen int
+		want      string
 	}{
 		{
-			descr:  "registration OTP keeps an identifying prefix",
-			secret: "8Nn5Qk0mVQqHqk2hXwfXQz1Yk5A=",
-			want:   "8Nn5[REDACTED] len=28",
+			descr:     "registration OTP keeps an identifying prefix",
+			secret:    "8Nn5Qk0mVQqHqk2hXwfXQz1Yk5A=",
+			prefixLen: SecretLogPrefixLen,
+			want:      "8Nn5[REDACTED] len=28",
 		},
 		{
-			descr:  "value no longer than the prefix keeps nothing",
-			secret: "8Nn5",
-			want:   "[REDACTED] len=4",
+			descr:     "certificate keeps its BEGIN line and part of the body",
+			secret:    "-----BEGIN CERTIFICATE-----\n" + pemBody,
+			prefixLen: CertLogPrefixLen,
+			want:      "-----BEGIN CERTIFICATE-----\n" + strings.Repeat("A", 36) + "[REDACTED] len=128",
 		},
 		{
-			descr:  "absent secret reports its length",
-			secret: "",
-			want:   "[REDACTED] len=0",
+			descr:     "value no longer than the prefix keeps nothing",
+			secret:    "8Nn5",
+			prefixLen: SecretLogPrefixLen,
+			want:      "[REDACTED] len=4",
+		},
+		{
+			descr:     "certificate prefix on a short value keeps nothing",
+			secret:    "8Nn5Qk0mVQqHqk2hXwfXQz1Yk5A=",
+			prefixLen: CertLogPrefixLen,
+			want:      "[REDACTED] len=28",
+		},
+		{
+			descr:     "negative prefix keeps nothing",
+			secret:    "8Nn5Qk0mVQqHqk2hXwfXQz1Yk5A=",
+			prefixLen: -1,
+			want:      "[REDACTED] len=28",
+		},
+		{
+			descr:     "absent secret reports its length",
+			secret:    "",
+			prefixLen: SecretLogPrefixLen,
+			want:      "[REDACTED] len=0",
 		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.descr, func(t *testing.T) {
-			assert.Equal(t, tc.want, RedactSecret(tc.secret))
+			assert.Equal(t, tc.want, RedactSecret(tc.secret, tc.prefixLen))
 		})
 	}
 }

--- a/rest-api/common/pkg/util/encryption_test.go
+++ b/rest-api/common/pkg/util/encryption_test.go
@@ -7,6 +7,8 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateHash(t *testing.T) {
@@ -56,4 +58,33 @@ func TestEncryptAndDecryptWithWrongPassphrase(t *testing.T) {
 
 	// Attempt to decrypt with wrong passphrase (should cause a panic)
 	DecryptData(encryptedData, wrongPassphrase)
+}
+
+func TestRedactSecret(t *testing.T) {
+	tcs := []struct {
+		descr  string
+		secret string
+		want   string
+	}{
+		{
+			descr:  "registration OTP keeps an identifying prefix",
+			secret: "8Nn5Qk0mVQqHqk2hXwfXQz1Yk5A=",
+			want:   "8Nn5[REDACTED] len=28",
+		},
+		{
+			descr:  "value no longer than the prefix keeps nothing",
+			secret: "8Nn5",
+			want:   "[REDACTED] len=4",
+		},
+		{
+			descr:  "absent secret reports its length",
+			secret: "",
+			want:   "[REDACTED] len=0",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.descr, func(t *testing.T) {
+			assert.Equal(t, tc.want, RedactSecret(tc.secret))
+		})
+	}
 }

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/activity.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/activity.go
@@ -36,7 +36,7 @@ func (o *OTPHandler) ReceiveAndSaveOTP(ctx context.Context, base64EncodedEncrypt
 	// Base64 decode the OTP
 	encryptedOtpBytes, err := base64.StdEncoding.DecodeString(base64EncodedEncryptedOtp)
 	if err != nil {
-		logger.Error().Err(err).Str("OTP", cutils.RedactSecret(base64EncodedEncryptedOtp)).
+		logger.Error().Err(err).Str("OTP", cutils.RedactSecret(base64EncodedEncryptedOtp, cutils.SecretLogPrefixLen)).
 			Msg("Failed to decode Base64 OTP")
 		return temporal.NewNonRetryableApplicationError(err.Error(), "ErrBase64DecodeOTP", err)
 	}

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/activity.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/activity.go
@@ -10,7 +10,7 @@ import (
 	"encoding/pem"
 	"errors"
 
-	cloudutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	cutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/rs/zerolog/log"
 	"go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/temporal"
@@ -36,7 +36,8 @@ func (o *OTPHandler) ReceiveAndSaveOTP(ctx context.Context, base64EncodedEncrypt
 	// Base64 decode the OTP
 	encryptedOtpBytes, err := base64.StdEncoding.DecodeString(base64EncodedEncryptedOtp)
 	if err != nil {
-		logger.Error().Err(err).Str("OTP", base64EncodedEncryptedOtp).Msg("Failed to decode Base64 OTP")
+		logger.Error().Err(err).Str("OTP", cutils.RedactSecret(base64EncodedEncryptedOtp)).
+			Msg("Failed to decode Base64 OTP")
 		return temporal.NewNonRetryableApplicationError(err.Error(), "ErrBase64DecodeOTP", err)
 	}
 
@@ -60,7 +61,7 @@ func (o *OTPHandler) ReceiveAndSaveOTP(ctx context.Context, base64EncodedEncrypt
 	}
 
 	// Decrypt the new OTP using the siteID
-	decryptedOtp := cloudutils.DecryptData(encryptedOtpBytes, ManagerAccess.Conf.EB.Temporal.ClusterID)
+	decryptedOtp := cutils.DecryptData(encryptedOtpBytes, ManagerAccess.Conf.EB.Temporal.ClusterID)
 
 	// Update the OTP in the bootstrap-info secret without base64 encoding
 	bootstrapInfoSecret.Data["otp"] = []byte(decryptedOtp)

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/activity_test.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/activity_test.go
@@ -23,7 +23,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 
-	cloudutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
+	cutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	Manager "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/managerapi"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/conftypes"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/elektratypes"
@@ -167,7 +167,7 @@ func TestOTPHandler_ReceiveAndSaveOTP(t *testing.T) {
 	_, err = client.CoreV1().Secrets("default").Create(context.TODO(), mockTemporalSecret, metav1.CreateOptions{})
 
 	// Test with a valid OTP
-	encryptedOtp := cloudutils.EncryptData([]byte(mockOtp), ManagerAccess.Conf.EB.Temporal.ClusterID)
+	encryptedOtp := cutils.EncryptData([]byte(mockOtp), ManagerAccess.Conf.EB.Temporal.ClusterID)
 	encryptedOtpB64 := base64.StdEncoding.EncodeToString(encryptedOtp)
 
 	wrun := &tmocks.WorkflowRun{}

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/rs/zerolog/log"
 
+	cutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	computils "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/utils"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/conftypes"
 	bootstraptypes "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/managertypes/bootstrap"
@@ -95,7 +96,11 @@ func newBootstrapConfig(dir string) error {
 	if bCfg.CACert == "" || bCfg.CredsURL == "" || bCfg.OTP == "" || bCfg.UUID == "" {
 		return ErrInvalidBootstrapSecret
 	}
-	log.Info().Msgf("Bootstrap: Read %v %v %v %v", bCfg.UUID, bCfg.OTP, bCfg.CredsURL, bCfg.CACert)
+	// The OTP stays out of this line. It is a live credential from the moment the
+	// secret is read until the handshake consumes it, and every Site Agent start
+	// reaches this point whether or not the handshake follows.
+	log.Info().Msgf("Bootstrap: Read Site: %v, OTP, credentials URL: %v, CA certificate: %v",
+		bCfg.UUID, bCfg.CredsURL, cutils.RedactSecret(bCfg.CACert))
 
 	return nil
 }
@@ -251,7 +256,7 @@ func (bs *BoostrapAPI) GetState() []string {
 	strs = append(strs, fmt.Sprintln("Creds Download Attempted: ", bt.State.DownloadAttempted.Load()))
 	strs = append(strs, fmt.Sprintln("Creds Download Succeeded: ", bt.State.DownloadSucceeded.Load()))
 	strs = append(strs, fmt.Sprintln("URL: ", bt.Config.CredsURL))
-	strs = append(strs, fmt.Sprintln("OTP: ", bt.Config.OTP))
+	strs = append(strs, fmt.Sprintln("OTP: ", cutils.RedactSecret(bt.Config.OTP)))
 	strs = append(strs, fmt.Sprintln("UUID: ", bt.Config.UUID))
 
 	return strs
@@ -302,7 +307,10 @@ func (bs *BoostrapAPI) DownloadAndStoreCreds(otpOverride []byte) error {
 	credsResponse, err := bs.downloadCredentials(ctx)
 	if err != nil {
 		span.SetStatus(codes.Error, err.Error())
-		log.Info().Msgf("Bootstrap: Download Credentials Response %v", err.Error())
+		// A stale OTP is the usual cause, so the prefix identifies which one the
+		// Site sent.
+		log.Error().Err(err).Msgf("Bootstrap: Download Credentials failed for Site %v from %v with OTP %v",
+			bCfg.UUID, bCfg.CredsURL, cutils.RedactSecret(bCfg.OTP))
 		return err
 	}
 	err = bs.storeCredentials(ctx, credsResponse)
@@ -419,7 +427,6 @@ func (bs *BoostrapAPI) downloadCredentials(ctx context.Context) (*bootstraptypes
 		log.Error().Msgf("Bootstrap: req %v", err.Error())
 		return nil, err
 	}
-	log.Info().Msgf("Bootstrap: body %v", string(m))
 	ctx, span := otel.Tracer("elektra-site-agent").Start(ctx, "Bootstrap-client")
 	span.SetAttributes(attribute.String("url", bCfg.CredsURL))
 	defer span.End()
@@ -481,7 +488,8 @@ func (bs *BoostrapAPI) downloadCredentials(ctx context.Context) (*bootstraptypes
 	block, _ := pem.Decode([]byte(credsResponse.CACertificate))
 	if block == nil {
 		log.Error().Msgf("Bootstrap: failed to decode certificate PEM")
-		return nil, fmt.Errorf("failed to decode certificate PEM CACertificate %v", credsResponse.CACertificate)
+		return nil, fmt.Errorf("failed to decode certificate PEM CACertificate %v",
+			cutils.RedactSecret(credsResponse.CACertificate))
 	}
 
 	_, err = x509.ParseCertificate(block.Bytes)

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap.go
@@ -96,11 +96,12 @@ func newBootstrapConfig(dir string) error {
 	if bCfg.CACert == "" || bCfg.CredsURL == "" || bCfg.OTP == "" || bCfg.UUID == "" {
 		return ErrInvalidBootstrapSecret
 	}
-	// The OTP stays out of this line. It is a live credential from the moment the
-	// secret is read until the handshake consumes it, and every Site Agent start
-	// reaches this point whether or not the handshake follows.
+	// The OTP is named to report that it was read, with no value of any kind. It
+	// is a live credential from the moment the secret is read until the handshake
+	// consumes it, and every Site Agent start reaches this point whether or not a
+	// handshake follows.
 	log.Info().Msgf("Bootstrap: Read Site: %v, OTP, credentials URL: %v, CA certificate: %v",
-		bCfg.UUID, bCfg.CredsURL, cutils.RedactSecret(bCfg.CACert))
+		bCfg.UUID, bCfg.CredsURL, cutils.RedactSecret(bCfg.CACert, cutils.CertLogPrefixLen))
 
 	return nil
 }
@@ -256,7 +257,7 @@ func (bs *BoostrapAPI) GetState() []string {
 	strs = append(strs, fmt.Sprintln("Creds Download Attempted: ", bt.State.DownloadAttempted.Load()))
 	strs = append(strs, fmt.Sprintln("Creds Download Succeeded: ", bt.State.DownloadSucceeded.Load()))
 	strs = append(strs, fmt.Sprintln("URL: ", bt.Config.CredsURL))
-	strs = append(strs, fmt.Sprintln("OTP: ", cutils.RedactSecret(bt.Config.OTP)))
+	strs = append(strs, fmt.Sprintln("OTP: ", cutils.RedactSecret(bt.Config.OTP, cutils.SecretLogPrefixLen)))
 	strs = append(strs, fmt.Sprintln("UUID: ", bt.Config.UUID))
 
 	return strs
@@ -310,7 +311,7 @@ func (bs *BoostrapAPI) DownloadAndStoreCreds(otpOverride []byte) error {
 		// A stale OTP is the usual cause, so the prefix identifies which one the
 		// Site sent.
 		log.Error().Err(err).Msgf("Bootstrap: Download Credentials failed for Site %v from %v with OTP %v",
-			bCfg.UUID, bCfg.CredsURL, cutils.RedactSecret(bCfg.OTP))
+			bCfg.UUID, bCfg.CredsURL, cutils.RedactSecret(bCfg.OTP, cutils.SecretLogPrefixLen))
 		return err
 	}
 	err = bs.storeCredentials(ctx, credsResponse)
@@ -489,7 +490,7 @@ func (bs *BoostrapAPI) downloadCredentials(ctx context.Context) (*bootstraptypes
 	if block == nil {
 		log.Error().Msgf("Bootstrap: failed to decode certificate PEM")
 		return nil, fmt.Errorf("failed to decode certificate PEM CACertificate %v",
-			cutils.RedactSecret(credsResponse.CACertificate))
+			cutils.RedactSecret(credsResponse.CACertificate, cutils.CertLogPrefixLen))
 	}
 
 	_, err = x509.ParseCertificate(block.Bytes)

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap_test.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/rs/zerolog"
@@ -30,8 +31,11 @@ func TestNewBootstrapConfig(t *testing.T) {
 	const (
 		siteID   = "d2f4b0c6-6f1e-4a0e-9f5a-0b6a6f4c1e77"
 		credsURL = "https://sitemgr.nico-system.svc/v1/sitecreds"
-		caCert   = "-----BEGIN CERTIFICATE-----\nc2l0ZS1jYQ==\n-----END CERTIFICATE-----"
 	)
+	// A real Site Manager CA runs past a thousand characters, so the body has to
+	// outrun the logged prefix for the assertions below to mean anything.
+	caCert := "-----BEGIN CERTIFICATE-----\n" + strings.Repeat("c2l0ZS1jYQ", 100) +
+		"\n-----END CERTIFICATE-----"
 
 	dir := t.TempDir()
 	for name, contents := range map[string]string{

--- a/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap_test.go
+++ b/rest-api/site-agent/pkg/components/managers/bootstrap/bootstrap_test.go
@@ -1,0 +1,71 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrap
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	Manager "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/managerapi"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/elektratypes"
+	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/managertypes"
+	bootstraptypes "github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/managertypes/bootstrap"
+)
+
+// testOTP matches what Site Manager issues: 20 random bytes in URL-safe base64.
+const testOTP = "8Nn5Qk0mVQqHqk2hXwfXQz1Yk5A="
+
+// TestNewBootstrapConfig guards the startup record every Site Agent
+// initialization emits, which has to identify the Site and the secret it read
+// without carrying the OTP that is still live at that point.
+func TestNewBootstrapConfig(t *testing.T) {
+	const (
+		siteID   = "d2f4b0c6-6f1e-4a0e-9f5a-0b6a6f4c1e77"
+		credsURL = "https://sitemgr.nico-system.svc/v1/sitecreds"
+		caCert   = "-----BEGIN CERTIFICATE-----\nc2l0ZS1jYQ==\n-----END CERTIFICATE-----"
+	)
+
+	dir := t.TempDir()
+	for name, contents := range map[string]string{
+		bootstraptypes.TagUUID:     siteID,
+		bootstraptypes.TagOTP:      testOTP,
+		bootstraptypes.TagCredsURL: credsURL,
+		bootstraptypes.TagCACert:   caCert,
+	} {
+		require.NoError(t, os.WriteFile(filepath.Join(dir, name), []byte(contents), 0600))
+	}
+
+	ManagerAccess = &Manager.ManagerAccess{
+		Data: &Manager.ManagerData{
+			EB: &elektratypes.Elektra{
+				Managers: &managertypes.Managers{
+					Bootstrap: bootstraptypes.NewBootstrapInstance(),
+				},
+			},
+		},
+	}
+
+	var logged bytes.Buffer
+	restore := log.Logger
+	log.Logger = zerolog.New(&logged)
+	t.Cleanup(func() { log.Logger = restore })
+
+	err := newBootstrapConfig(dir + string(os.PathSeparator))
+	require.NoError(t, err)
+
+	bCfg := ManagerAccess.Data.EB.Managers.Bootstrap.Config
+	assert.Equal(t, testOTP, bCfg.OTP)
+
+	assert.NotContains(t, logged.String(), testOTP)
+	assert.NotContains(t, logged.String(), caCert)
+	assert.Contains(t, logged.String(), siteID)
+	assert.Contains(t, logged.String(), credsURL)
+}

--- a/rest-api/site-agent/pkg/components/testing.go
+++ b/rest-api/site-agent/pkg/components/testing.go
@@ -360,8 +360,8 @@ func simulateMountedSecretFile(t *testing.T, secretFilePath string) error {
 
 	log.Info().Msg("Successfully read bootstrap secret from file:")
 	log.Info().Msgf("UUID: %v", bCfg.UUID)
-	log.Info().Msgf("OTP: %v", cutils.RedactSecret(bCfg.OTP))
-	log.Info().Msgf("CACert: %v", cutils.RedactSecret(bCfg.CACert))
+	log.Info().Msgf("OTP: %v", cutils.RedactSecret(bCfg.OTP, cutils.SecretLogPrefixLen))
+	log.Info().Msgf("CACert: %v", cutils.RedactSecret(bCfg.CACert, cutils.CertLogPrefixLen))
 	log.Info().Msgf("CredsURL: %v", bCfg.CredsURL)
 
 	err = os.WriteFile(filepath.Join(secretDir, bootstraptypes.TagUUID), []byte(bCfg.UUID), 0644)

--- a/rest-api/site-agent/pkg/components/testing.go
+++ b/rest-api/site-agent/pkg/components/testing.go
@@ -24,6 +24,7 @@ import (
 
 	"gopkg.in/yaml.v2"
 
+	cutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/components/managers/coregrpc"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/conftypes"
 	"github.com/NVIDIA/infra-controller/rest-api/site-agent/pkg/datatypes/elektratypes"
@@ -344,7 +345,7 @@ func simulateMountedSecretFile(t *testing.T, secretFilePath string) error {
 		return err
 	}
 
-	log.Info().Msgf("Read bootstrap secret file: %s", string(cfgFile))
+	log.Info().Msgf("Read bootstrap secret file: %v bytes", len(cfgFile))
 
 	err = yaml.Unmarshal(cfgFile, result)
 	if err != nil {
@@ -359,8 +360,8 @@ func simulateMountedSecretFile(t *testing.T, secretFilePath string) error {
 
 	log.Info().Msg("Successfully read bootstrap secret from file:")
 	log.Info().Msgf("UUID: %v", bCfg.UUID)
-	log.Info().Msgf("OTP: %v", bCfg.OTP)
-	log.Info().Msgf("CACert: %v", bCfg.CACert)
+	log.Info().Msgf("OTP: %v", cutils.RedactSecret(bCfg.OTP))
+	log.Info().Msgf("CACert: %v", cutils.RedactSecret(bCfg.CACert))
 	log.Info().Msgf("CredsURL: %v", bCfg.CredsURL)
 
 	err = os.WriteFile(filepath.Join(secretDir, bootstraptypes.TagUUID), []byte(bCfg.UUID), 0644)

--- a/rest-api/site-manager/pkg/sitemgr/credshandlers.go
+++ b/rest-api/site-manager/pkg/sitemgr/credshandlers.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"time"
 
+	cutils "github.com/NVIDIA/infra-controller/rest-api/common/pkg/util"
 	crdsv1 "github.com/NVIDIA/infra-controller/rest-api/site-manager/pkg/crds/v1"
 	"github.com/NVIDIA/infra-controller/rest-api/site-manager/pkg/types"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +37,10 @@ func (h *credsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	siteObj, err := h.manager.crdClient.ForgeV1().Sites(h.manager.namespace).Get(r.Context(), objName, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("Site Creds Req: %+v  %v", req, err)
+		// This line and the rejections below report the OTP that arrived rather
+		// than the request, which carries it in full and stays usable until a
+		// handshake consumes it.
+		log.Errorf("Site Creds Req: site %s, OTP %s  %v", req.SiteUUID, cutils.RedactSecret(req.OTP), err)
 		var errStr string
 		if k8serr.IsNotFound(err) {
 			errStr = fmt.Sprintf("site %s not found", req.SiteUUID)
@@ -48,26 +52,26 @@ func (h *credsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if siteObj.Status.BootstrapState != crdsv1.SiteAwaitHandshake {
-		log.Infof("Creds request with used OTP: %+v", req)
+		log.Infof("Creds request with used OTP: site %s, OTP %s", req.SiteUUID, cutils.RedactSecret(req.OTP))
 		http.Error(w, "OTP already used", http.StatusInternalServerError)
 		return
 	}
 
 	if req.OTP != siteObj.Status.OTP.Passcode {
-		log.Infof("Bad OTP received: %+v", req)
+		log.Infof("Bad OTP received: site %s, OTP %s", req.SiteUUID, cutils.RedactSecret(req.OTP))
 		http.Error(w, "Bad OTP", http.StatusInternalServerError)
 		return
 	}
 
 	expiry, err := parseExpiry(&siteObj.Status.OTP)
 	if err != nil {
-		log.Errorf("Error parsing expiry: %v +%v", err, siteObj.Status.OTP)
+		log.Errorf("Error parsing expiry: %v +%v", err, siteObj.Status.OTP.Timestamp)
 		http.Error(w, "check logs", http.StatusInternalServerError)
 		return
 	}
 
 	if time.Now().After(*expiry) {
-		log.Infof("Expired OTP received: %+v", req)
+		log.Infof("Expired OTP received: site %s, OTP %s", req.SiteUUID, cutils.RedactSecret(req.OTP))
 		http.Error(w, "OTP expired", http.StatusInternalServerError)
 		return
 	}

--- a/rest-api/site-manager/pkg/sitemgr/credshandlers.go
+++ b/rest-api/site-manager/pkg/sitemgr/credshandlers.go
@@ -40,7 +40,8 @@ func (h *credsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// This line and the rejections below report the OTP that arrived rather
 		// than the request, which carries it in full and stays usable until a
 		// handshake consumes it.
-		log.Errorf("Site Creds Req: site %s, OTP %s  %v", req.SiteUUID, cutils.RedactSecret(req.OTP), err)
+		log.Errorf("Site Creds Req: site %s, OTP %s  %v", req.SiteUUID,
+			cutils.RedactSecret(req.OTP, cutils.SecretLogPrefixLen), err)
 		var errStr string
 		if k8serr.IsNotFound(err) {
 			errStr = fmt.Sprintf("site %s not found", req.SiteUUID)
@@ -52,13 +53,15 @@ func (h *credsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if siteObj.Status.BootstrapState != crdsv1.SiteAwaitHandshake {
-		log.Infof("Creds request with used OTP: site %s, OTP %s", req.SiteUUID, cutils.RedactSecret(req.OTP))
+		log.Infof("Creds request with used OTP: site %s, OTP %s", req.SiteUUID,
+			cutils.RedactSecret(req.OTP, cutils.SecretLogPrefixLen))
 		http.Error(w, "OTP already used", http.StatusInternalServerError)
 		return
 	}
 
 	if req.OTP != siteObj.Status.OTP.Passcode {
-		log.Infof("Bad OTP received: site %s, OTP %s", req.SiteUUID, cutils.RedactSecret(req.OTP))
+		log.Infof("Bad OTP received: site %s, OTP %s", req.SiteUUID,
+			cutils.RedactSecret(req.OTP, cutils.SecretLogPrefixLen))
 		http.Error(w, "Bad OTP", http.StatusInternalServerError)
 		return
 	}
@@ -71,7 +74,8 @@ func (h *credsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if time.Now().After(*expiry) {
-		log.Infof("Expired OTP received: site %s, OTP %s", req.SiteUUID, cutils.RedactSecret(req.OTP))
+		log.Infof("Expired OTP received: site %s, OTP %s", req.SiteUUID,
+			cutils.RedactSecret(req.OTP, cutils.SecretLogPrefixLen))
 		http.Error(w, "OTP expired", http.StatusInternalServerError)
 		return
 	}


### PR DESCRIPTION
Currently every Site Agent start logs the bootstrap secret it just read at INFO, OTP and CA certificate included, and `downloadCredentials` logs the serialized request body carrying the same OTP. A registration OTP stays live until Site Manager consumes it, so on a fresh bootstrap the log holds a usable credential before the handshake spends it, which is what QA reported against `v2.2.0-rc.2`.

This PR adds `RedactSecret` to `common/pkg/util`, which renders a secret as a four character prefix plus its length (`8Nn5[REDACTED] len=28`), and uses it on the paths that have to say which OTP was involved. The startup record now names the Site and credentials URL with no OTP at all, the download failure reports a redacted one at ERROR, and Site Manager logs the redacted OTP rather than the whole request on each rejected handshake.

## Related issues
Internal

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Unit tests added/updated

## Additional Notes
* Logs retained from before this change still hold OTPs, so any Site whose registration token was printed and not yet consumed should have it re-issued after this merges
* The credentials download failure moved from INFO to ERROR and the Site Agent `/status` output now prints a redacted OTP, so anything keyed on either needs a look