### PR TITLE
fix(pxe/ci): Pin ARM Scout to the last passing kernel

### DIFF
--- a/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-loader-aarch64/mkosi.conf
@@ -26,7 +26,11 @@ Packages=
          isc-dhcp-client
          iproute2
          kmod
-         linux-nvidia-64k-hwe-24.04
+         # Keep the boot kernel in sync with scout-oss-aarch64's driver modules.
+         linux-image-6.17.0-1032-nvidia-64k=6.17.0-1032.32
+         linux-headers-6.17.0-1032-nvidia-64k=6.17.0-1032.32
+         linux-modules-nvidia-fs-6.17.0-1032-nvidia-64k=6.17.0-1032.32
+         linux-firmware
          net-tools
          netbase
          procps

--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.conf
@@ -50,7 +50,12 @@ Packages=
      libudev-dev
      libuser
      libuser1
-     linux-nvidia-64k-hwe-24.04
+     # Keep in sync with scout-loader-aarch64: NVIDIA 580.126.16 builds against
+     # this ABI, but fails against the 7.0 kernel selected by the HWE metapackage.
+     linux-image-6.17.0-1032-nvidia-64k=6.17.0-1032.32
+     linux-headers-6.17.0-1032-nvidia-64k=6.17.0-1032.32
+     linux-modules-nvidia-fs-6.17.0-1032-nvidia-64k=6.17.0-1032.32
+     linux-firmware
      locales
      lshw
      memtester


### PR DESCRIPTION
Core CI on `main` fails because Ubuntu’s ARM HWE metapackage now selects kernel `7.0.0-1019-nvidia-64k`, against which NVIDIA driver `580.126.16` fails to compile. This PR pins Scout and its loader to the last passing kernel, `6.17.0-1032-nvidia-64k`, retaining matching headers, NVIDIA filesystem modules, and firmware.

## Related issues
[First failing Core CI build](https://github.com/dsx-ai-factory/infra-controller/actions/runs/34623412865/job/103345695573)

## Type of Change
- [x] **Fix** - Bug fixes

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [x] Manual testing performed

Compiled and installed NVIDIA driver `580.126.16` against the pinned kernel in an ARM Ubuntu container, verified module version and kernel metadata, checked both configurations with the pinned mkosi parser, and passed all 12 existing boot-output contract tests. Full CI and physical hardware validation remain outstanding.

## Additional Notes
- Keep Scout and loader kernel versions aligned because the loader retains its kernel when entering Scout through a soft reboot.
- Follow up by upgrading Scout’s NVIDIA packages, including Fabric Manager and IMEX, to `580.178.04`. DKMS compilation against `7.0.0-1019-nvidia-64k` passed in an ARM Ubuntu container; validate full image builds and GPU/NVLink operation on hardware before removing the recovery kernel pin. Until then, kernel updates require an explicit pin change.