### PR TITLE
fix(nvue-client): recognize applied and saved revisions

### DIFF
--- a/crates/nvue-client/src/types/revision.rs
+++ b/crates/nvue-client/src/types/revision.rs
@@ -32,13 +32,17 @@ pub struct RevisionData {
 }
 
 impl RevisionData {
+    /// Classify the revision state for the apply polling loop.
+    ///
+    /// NVUE reports both `applied` and `applied_and_saved` for completed
+    /// revisions; error issues take precedence over either success state.
     pub(crate) fn apply_status(&self) -> RevisionApplyStatus {
         let error_issues = self.error_issue_summaries();
         if !error_issues.is_empty() {
             return RevisionApplyStatus::Failed(error_issues);
         }
 
-        if self.state.as_deref() == Some("applied") {
+        if matches!(self.state.as_deref(), Some("applied" | "applied_and_saved")) {
             return RevisionApplyStatus::Applied;
         }
 
@@ -195,6 +199,12 @@ mod tests {
             Case {
                 name: "applied revision without issues succeeds",
                 revision: revision(Some("applied"), None, vec![]),
+                expected_status: RevisionApplyStatus::Applied,
+                expected_progress: None,
+            },
+            Case {
+                name: "applied and saved revision without issues succeeds",
+                revision: revision(Some("applied_and_saved"), None, vec![]),
                 expected_status: RevisionApplyStatus::Applied,
                 expected_progress: None,
             },


### PR DESCRIPTION
NVUE can report `applied_and_saved` after successfully applying and saving a revision. Core's NVUE client recognizes only `applied`, so it classifies this completed revision as pending and eventually reports an apply timeout.

We also hit this during NICo testing: the NVUE endpoint reported `applied_and_saved`, while the client continued treating the revision as pending.

Accept `applied_and_saved` alongside `applied`, and add a regression case to the existing revision-status test table. Error issues retain precedence over successful states, and unknown or missing states remain pending.

This makes `apply_status` idempotent

## Official NVUE references

- NVIDIA's [NVUE API walkthrough for Cumulus Linux 5.16](https://docs.nvidia.com/networking-ethernet-software/cumulus-linux-516/System-Configuration/NVIDIA-User-Experience-NVUE/NVUE-API/#make-a-configuration-change) shows revision responses with `pending`, `apply`, and `applied`.
- The official [NVUE `nv config revision` reference](https://docs.nvidia.com/networking-ethernet-software/nvue-reference/Config-Commands/#nv-config-revision) explicitly shows `applied_and_saved` in the revision **State** column. The same reference documents automatic saving after apply in Cumulus Linux 5.9 and later.
- The published [Cumulus Linux 5.16 OpenAPI schema](https://api-prod.nvidia.com/openapi-browser/openapi%205.16.0.json) defines revision `state` as a nullable string (`x-defs.schema-revision-revision-config.properties.state`), without an enum. The API walkthrough's examples therefore do not enumerate every possible revision state.

## Related issues

Related to https://github.com/dsx-ai-factory/nv-rms/issues/20, which identifies the same classification gap in Core. This change covers `infra-controller`'s client; the separate RMS implementation still requires its own fix.

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

The new `applied_and_saved` case failed against the original condition (`Pending` instead of `Applied`) and passes with this change. All 16 crate tests pass, including the existing error, unknown-state, and missing-state cases.

Validation:

```bash
REPO_ROOT="$PWD" cargo test --frozen -p nvue-client
REPO_ROOT="$PWD" cargo clippy --frozen -p nvue-client --all-targets -- -D warnings
cargo +nightly-2026-06-16 fmt -p nvue-client -- --check
```