### PR TITLE
fix(vpc-prefix): check VNI allocations before allowing prefix reuse

### DIFF
--- a/crates/api-core/src/cfg/README.md
+++ b/crates/api-core/src/cfg/README.md
@@ -816,9 +816,11 @@ An overlapping `VpcPrefix` pair is eligible only when all of these conditions
 are true:
 
 - The requested and existing CIDRs are identical, the existing `VpcPrefix` is
-  not deleted, and the `VpcPrefix` records belong to different VPCs and tenant
-  organizations.
-- Both VPCs use FNN and have assigned, distinct status VNIs.
+  not deleted, and the `VpcPrefix` records belong to different VPCs. The VPCs
+  may belong to the same tenant and share one tenant-managed `SitePrefix`.
+- Both VPCs use FNN and have distinct `status.vni` values. Each VPC owns exactly
+  one VNI allocation across the internal and external pools, matching
+  `status.vni`. A retained previous allocation makes the VPC ineligible.
 - Each `VpcPrefix` is linked to a tenant-managed, `DatacenterOnly` `SitePrefix`
   owned by its VPC tenant and containing the `VpcPrefix` CIDR. The requested
   `SitePrefix` must be `Ready`; the existing `SitePrefix` may be `Ready` or
@@ -826,11 +828,21 @@ are true:
 - Site-wide `vpc_isolation_behavior` is `"mutual_isolation"`.
 - `site_global_vpc_vni` and `common_internal_route_target` are unset, and
   `additional_route_target_imports` is empty, so they cannot bridge the VPCs.
+- The deprecated site-wide `anycast_site_prefixes` list is empty.
 - Each resolved FNN profile, after applying its VPC overrides, has
   `tenant_prefix_overlap_eligible = true` and `internal = true`; has no import
   or export route targets; disables default-route leakage, tenant-host-route
   leakage, and tenant leak communities; and has no accepted underlay leaks or
   allowed anycast prefixes.
+
+The FNN renderer falls back to `anycast_site_prefixes` when the profile's
+`allowed_anycast_prefixes` is empty. The [chart's default configuration](../../../../helm/charts/nico-api/files/carbide-api-config.toml)
+sets `anycast_site_prefixes = ["0.0.0.0/0"]`; a site using that default must
+override it with `[]` to meet the overlap requirements.
+
+For an overlapping prefix, `CreateVpcPrefix` locks the participating VPCs
+until its transaction ends. Concurrent VNI changes or VPC deletion must wait,
+including for a VPC owned by another tenant.
 
 The gRPC `CreateNetworkSegment` and `AttachNetworkSegmentToVpc` handlers reject
 any direct prefix that overlaps a `VpcPrefix`, regardless of the site gate. The

--- a/crates/api-core/src/handlers/tenant_prefix_overlap.rs
+++ b/crates/api-core/src/handlers/tenant_prefix_overlap.rs
@@ -96,8 +96,9 @@ fn site_prefix_is_eligible(
 ///
 /// The pair eligibility checks ownership, FNN isolation, distinct VNIs,
 /// `SitePrefix` state, and each VPC's resolved routing profile. Callers still
-/// need `db::tenant_prefix_overlap::lock_checks` and must reject every
-/// ineligible overlap.
+/// need `db::tenant_prefix_overlap::lock_checks`, must verify each VPC owns
+/// exactly one allocation matching its VNI, and must reject every ineligible
+/// overlap.
 pub(super) fn pair_is_eligible(
     runtime_config: &crate::cfg::file::CarbideConfig,
     candidate: VpcPrefixParticipant<'_>,
@@ -109,10 +110,11 @@ pub(super) fn pair_is_eligible(
             VpcIsolationBehaviorType::MutualIsolation
         )
         || runtime_config.site_global_vpc_vni.is_some()
+        // The renderer falls back to this list when profile anycast is empty.
+        || !runtime_config.anycast_site_prefixes.is_empty()
         || existing.is_deleted
         || candidate.prefix != existing.prefix
         || candidate.vpc.id == existing.vpc.id
-        || candidate.vpc.config.tenant_organization_id == existing.vpc.config.tenant_organization_id
         || candidate.vpc.config.network_virtualization_type != VpcVirtualizationType::Fnn
         || existing.vpc.config.network_virtualization_type != VpcVirtualizationType::Fnn
         || !site_prefix_is_eligible(
@@ -173,6 +175,7 @@ mod tests {
         SiteGateDisabled,
         OpenIsolation,
         SiteGlobalVpcVni,
+        LegacyAnycastSitePrefixes,
         CommonInternalRouteTarget,
         AdditionalRouteTargetImport,
         NestedPrefix,
@@ -299,6 +302,11 @@ mod tests {
                     expect: false,
                 },
                 Check {
+                    scenario: "site uses deprecated anycast prefixes",
+                    input: Variation::LegacyAnycastSitePrefixes,
+                    expect: false,
+                },
+                Check {
                     scenario: "site uses a common internal route target",
                     input: Variation::CommonInternalRouteTarget,
                     expect: false,
@@ -319,9 +327,9 @@ mod tests {
                     expect: false,
                 },
                 Check {
-                    scenario: "prefixes belong to the same tenant",
+                    scenario: "distinct VPCs share one tenant SitePrefix",
                     input: Variation::SameTenant,
-                    expect: false,
+                    expect: true,
                 },
                 Check {
                     scenario: "existing VPC does not use FNN",
@@ -396,6 +404,9 @@ mod tests {
                         config.vpc_isolation_behavior = VpcIsolationBehaviorType::Open;
                     }
                     Variation::SiteGlobalVpcVni => config.site_global_vpc_vni = Some(5_000),
+                    Variation::LegacyAnycastSitePrefixes => {
+                        config.anycast_site_prefixes = vec!["10.0.0.0/16".parse().unwrap()];
+                    }
                     Variation::CommonInternalRouteTarget => {
                         config.fnn.as_mut().unwrap().common_internal_route_target =
                             Some(crate::cfg::file::RouteTargetConfig { asn: 1, vni: 2 });
@@ -410,8 +421,7 @@ mod tests {
                     Variation::SameVpc => existing_vpc.id = candidate_vpc.id,
                     Variation::SameTenant => {
                         existing_vpc.config.tenant_organization_id = "tenant-a".to_string();
-                        existing_site_prefix.config.tenant_organization_id =
-                            Some("tenant-a".parse().unwrap());
+                        existing_site_prefix = candidate_site_prefix.clone();
                     }
                     Variation::ExistingNotFnn => {
                         existing_vpc.config.network_virtualization_type =

--- a/crates/api-core/src/handlers/vpc_prefix.rs
+++ b/crates/api-core/src/handlers/vpc_prefix.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashMap;
 
+use ::db::resource_pool::ResourcePoolDatabaseError;
 use ::db::{ObjectColumnFilter, vpc_prefix as db};
 use ::rpc::forge as rpc;
 use ::rpc::forge::PrefixMatchType;
@@ -25,6 +26,7 @@ use carbide_uuid::vpc::VpcId;
 use ipnetwork::IpNetwork;
 use model::network_prefix::NetworkPrefix;
 use model::network_segment::NetworkSegmentType;
+use model::resource_pool::{OwnerType, ResourcePoolError};
 use model::site_prefix::{
     SitePrefix, SitePrefixAuthority, SitePrefixLifecycleState, SitePrefixRoutingScope,
 };
@@ -34,7 +36,6 @@ use sqlx::PgConnection;
 use tonic::{Request, Response, Status};
 
 use crate::api::{Api, log_request_data};
-use crate::cfg::file::CarbideConfig;
 use crate::{CarbideError, CarbideResult};
 
 fn validate_site_prefix_attachment(
@@ -89,13 +90,14 @@ fn validate_site_prefix_attachment(
 }
 
 /// `validate_vpc_prefix_overlaps` rejects `candidate` unless every existing
-/// overlap passes `pair_is_eligible`.
+/// overlap passes `pair_is_eligible` and every participating VPC owns exactly
+/// one allocation matching its VNI.
 ///
 /// The caller acquires the overlap lock before reading the candidate `Vpc` and
 /// any selected `SitePrefix`, so a waiting create sees every competing prefix
 /// that committed first.
 async fn validate_vpc_prefix_overlaps(
-    runtime_config: &CarbideConfig,
+    api: &Api,
     txn: &mut PgConnection,
     candidate: &vpc_prefix::NewVpcPrefix,
     candidate_vpc: &Vpc,
@@ -113,9 +115,12 @@ async fn validate_vpc_prefix_overlaps(
         .iter()
         .map(|prefix| prefix.vpc_id)
         .collect::<Vec<_>>();
-    let vpcs = ::db::vpc::find_by(
+    // VNI changes take this parent lock before updating status or allocations.
+    // Allocation row locks alone cannot prevent a second allocation appearing.
+    let vpcs = ::db::vpc::find_by_with_lock(
         &mut *txn,
         ObjectColumnFilter::List(::db::vpc::IdColumn, &vpc_ids),
+        ::db::vpc::VpcRowLock::Mutation,
     )
     .await?
     .into_iter()
@@ -145,7 +150,7 @@ async fn validate_vpc_prefix_overlaps(
             return Err(super::tenant_prefix_overlap::overlap_error());
         };
         if !super::tenant_prefix_overlap::pair_is_eligible(
-            runtime_config,
+            &api.runtime_config,
             super::tenant_prefix_overlap::VpcPrefixParticipant {
                 prefix: candidate.config.prefix,
                 is_deleted: false,
@@ -163,6 +168,49 @@ async fn validate_vpc_prefix_overlaps(
         }
     }
 
+    for vpc in std::iter::once(candidate_vpc).chain(vpcs.values()) {
+        validate_overlap_vni(api, txn, vpc).await?;
+    }
+
+    Ok(())
+}
+
+/// A retained VNI may still carry routes from a previous profile. Overlap
+/// admission requires one owned allocation, not just a matching active VNI.
+/// The caller holds the VPC mutation lock until the prefix write completes.
+async fn validate_overlap_vni(api: &Api, txn: &mut PgConnection, vpc: &Vpc) -> CarbideResult<()> {
+    let owner_id = vpc.id.to_string();
+    let mut allocation = None;
+    for pool in [
+        &api.common_pools.ethernet.pool_vpc_vni,
+        &api.common_pools.ethernet.pool_external_vpc_vni,
+    ] {
+        let owned = ::db::resource_pool::find_owned_allocation(pool, txn, OwnerType::Vpc, &owner_id)
+            .await
+            .map_err(|error| {
+                let invalid_allocation = match &error {
+                    ResourcePoolDatabaseError::ResourcePool(ResourcePoolError::Parse { .. }) => true,
+                    ResourcePoolDatabaseError::Database(error) => {
+                        matches!(error.as_ref(), ::db::DatabaseError::FailedPrecondition(_))
+                    }
+                    _ => false,
+                };
+                if invalid_allocation {
+                    tracing::warn!(vpc_id = %vpc.id, %error, "invalid VNI allocation for prefix overlap");
+                    super::tenant_prefix_overlap::overlap_error()
+                } else {
+                    error.into()
+                }
+            })?;
+        if let Some(owned) = owned
+            && allocation.replace(owned).is_some()
+        {
+            return Err(super::tenant_prefix_overlap::overlap_error());
+        }
+    }
+    if allocation.is_none() || allocation != vpc.status.vni {
+        return Err(super::tenant_prefix_overlap::overlap_error());
+    }
     Ok(())
 }
 
@@ -319,7 +367,7 @@ pub(crate) async fn create(
 
     let conflicting_vpc_prefixes = db::probe(new_prefix.config.prefix, &mut txn).await?;
     validate_vpc_prefix_overlaps(
-        &api.runtime_config,
+        api,
         &mut txn,
         &new_prefix,
         vpc,

--- a/crates/api-core/src/tests/vpc_prefix.rs
+++ b/crates/api-core/src/tests/vpc_prefix.rs
@@ -31,6 +31,7 @@ use model::network_prefix::NewNetworkPrefix;
 use model::network_segment::{
     NetworkSegmentControllerState, NetworkSegmentType, NewNetworkSegment,
 };
+use model::resource_pool::OwnerType;
 use model::site_prefix::{
     NewTenantManagedSitePrefix, RetireTenantManagedSitePrefix, SitePrefixAuthority,
     SitePrefixLifecycleState, SitePrefixRoutingScope,
@@ -528,6 +529,8 @@ async fn eligible_exact_overlap_reaches_legacy_database_exclusion(
     create_overlap_tenant(&env, tenant_b).await?;
     let vpc_a = create_fnn_vpc_for_tenant(&env, tenant_a, "overlap VPC A", Some("OVERLAP")).await;
     let vpc_b = create_fnn_vpc_for_tenant(&env, tenant_b, "overlap VPC B", Some("OVERLAP")).await;
+    let same_tenant_vpc =
+        create_fnn_vpc_for_tenant(&env, tenant_a, "same tenant VPC", Some("OVERLAP")).await;
     let root_a = seed_tenant_managed_site_prefix(
         &env,
         tenant_a,
@@ -551,24 +554,329 @@ async fn eligible_exact_overlap_reaches_legacy_database_exclusion(
             "10.100.1.0/24",
         )))
         .await?;
-    let error = env
-        .api
+    for (scenario, vpc_id, site_prefix_id) in [
+        ("different tenants", vpc_b, root_b),
+        ("same tenant and SitePrefix", same_tenant_vpc, root_a),
+    ] {
+        let prefix_id = VpcPrefixId::new();
+        let error = env
+            .api
+            .create_vpc_prefix(Request::new(site_prefix_child_request(
+                prefix_id,
+                vpc_id,
+                Some(site_prefix_id),
+                "10.100.1.0/24",
+            )))
+            .await
+            .expect_err("the legacy database exclusion should still block exact reuse");
+
+        assert_eq!(error.code(), tonic::Code::InvalidArgument, "{scenario}");
+        assert!(
+            error
+                .message()
+                .contains("overlaps an existing or deleting VPC prefix"),
+            "{scenario}: the pair check should accept the pair before persistence: {error}"
+        );
+        assert_eq!(
+            stored_vpc_prefix_count(&env, prefix_id).await,
+            0,
+            "{scenario}"
+        );
+    }
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn exact_overlap_requires_one_matching_vni_allocation_per_vpc(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    enum AllocationChange {
+        MissingCandidate,
+        MismatchedCandidate,
+        RetainedExisting,
+        DuplicateExisting,
+    }
+    struct TestCase {
+        scenario: &'static str,
+        change: AllocationChange,
+        prefix: &'static str,
+        candidate_vpc: VpcId,
+        existing_vpc: VpcId,
+    }
+
+    let env = create_test_env_with_overrides(pool, tenant_prefix_overlap_overrides(true)).await;
+    let candidate_tenant = "overlap-allocation-candidate";
+    let existing_tenant = "overlap-allocation-existing";
+    // Eight VPCs plus duplicate and replacement allocations need ten VNIs.
+    // The shared fixture provides four; keep each case independent of releases.
+    let mut txn = env.pool.begin().await?;
+    db::resource_pool::populate(
+        &env.common_pools.ethernet.pool_vpc_vni,
+        &mut txn,
+        (20_005..=20_010).collect(),
+        true,
+    )
+    .await?;
+    txn.commit().await?;
+    create_overlap_tenant(&env, candidate_tenant).await?;
+    create_overlap_tenant(&env, existing_tenant).await?;
+    let candidate_root = seed_tenant_managed_site_prefix(
+        &env,
+        candidate_tenant,
+        "10.106.0.0/16",
+        SitePrefixLifecycleState::Ready,
+    )
+    .await;
+    let existing_root = seed_tenant_managed_site_prefix(
+        &env,
+        existing_tenant,
+        "10.106.0.0/16",
+        SitePrefixLifecycleState::Ready,
+    )
+    .await;
+
+    // Create every VPC before releasing any allocation. Otherwise a later
+    // fixture could allocate a freed VNI still recorded in another VPC's status.
+    let mut cases = Vec::new();
+    for (scenario, change, prefix) in [
+        (
+            "existing VPC has duplicate owned allocations",
+            AllocationChange::DuplicateExisting,
+            "10.106.4.0/24",
+        ),
+        (
+            "candidate allocation differs from status",
+            AllocationChange::MismatchedCandidate,
+            "10.106.2.0/24",
+        ),
+        (
+            "existing VPC retains a second allocation",
+            AllocationChange::RetainedExisting,
+            "10.106.3.0/24",
+        ),
+        (
+            "candidate allocation is missing",
+            AllocationChange::MissingCandidate,
+            "10.106.1.0/24",
+        ),
+    ] {
+        let candidate_vpc =
+            create_fnn_vpc_for_tenant(&env, candidate_tenant, scenario, Some("OVERLAP")).await;
+        let existing_vpc =
+            create_fnn_vpc_for_tenant(&env, existing_tenant, scenario, Some("OVERLAP")).await;
+        cases.push(TestCase {
+            scenario,
+            change,
+            prefix,
+            candidate_vpc,
+            existing_vpc,
+        });
+    }
+    for TestCase {
+        scenario,
+        change,
+        prefix,
+        candidate_vpc,
+        existing_vpc,
+    } in cases
+    {
+        env.api
+            .create_vpc_prefix(Request::new(site_prefix_child_request(
+                VpcPrefixId::new(),
+                existing_vpc,
+                Some(existing_root),
+                prefix,
+            )))
+            .await?;
+
+        let mut txn = env.pool.begin().await?;
+        let internal_pool = &env.common_pools.ethernet.pool_vpc_vni;
+        match change {
+            AllocationChange::MissingCandidate | AllocationChange::MismatchedCandidate => {
+                let active_vni = db::resource_pool::find_owned_allocation(
+                    internal_pool,
+                    &mut txn,
+                    OwnerType::Vpc,
+                    &candidate_vpc.to_string(),
+                )
+                .await?
+                .expect("candidate VPC owns its active VNI");
+                if matches!(change, AllocationChange::MismatchedCandidate) {
+                    // Allocate before releasing so the replacement cannot be
+                    // the VNI still recorded in `status.vni`.
+                    db::resource_pool::allocate(
+                        internal_pool,
+                        &mut txn,
+                        OwnerType::Vpc,
+                        &candidate_vpc.to_string(),
+                        None,
+                    )
+                    .await?;
+                }
+                db::resource_pool::release(internal_pool, &mut txn, active_vni).await?;
+            }
+            AllocationChange::RetainedExisting | AllocationChange::DuplicateExisting => {
+                let extra_pool = match change {
+                    AllocationChange::RetainedExisting => {
+                        &env.common_pools.ethernet.pool_external_vpc_vni
+                    }
+                    _ => internal_pool,
+                };
+                db::resource_pool::allocate(
+                    extra_pool,
+                    &mut txn,
+                    OwnerType::Vpc,
+                    &existing_vpc.to_string(),
+                    None,
+                )
+                .await?;
+            }
+        }
+        txn.commit().await?;
+
+        let prefix_id = VpcPrefixId::new();
+        let error = env
+            .api
+            .create_vpc_prefix(Request::new(site_prefix_child_request(
+                prefix_id,
+                candidate_vpc,
+                Some(candidate_root),
+                prefix,
+            )))
+            .await
+            .expect_err(scenario);
+        assert_eq!(error.code(), tonic::Code::InvalidArgument, "{scenario}");
+        assert_eq!(
+            error.message(),
+            "the requested prefix overlaps address space that is not eligible for reuse",
+            "{scenario}"
+        );
+        assert_eq!(
+            stored_vpc_prefix_count(&env, prefix_id).await,
+            0,
+            "{scenario}"
+        );
+    }
+    Ok(())
+}
+
+#[crate::sqlx_test]
+async fn exact_overlap_waits_for_existing_vpc_allocation_cleanup(
+    pool: PgPool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = create_test_env_with_overrides(pool, tenant_prefix_overlap_overrides(true)).await;
+    let tenant = "overlap-allocation-cleanup";
+    create_overlap_tenant(&env, tenant).await?;
+    let candidate_vpc =
+        create_fnn_vpc_for_tenant(&env, tenant, "candidate VPC", Some("OVERLAP")).await;
+    let existing_vpc =
+        create_fnn_vpc_for_tenant(&env, tenant, "existing VPC", Some("OVERLAP")).await;
+    let root = seed_tenant_managed_site_prefix(
+        &env,
+        tenant,
+        "10.107.0.0/16",
+        SitePrefixLifecycleState::Ready,
+    )
+    .await;
+    env.api
         .create_vpc_prefix(Request::new(site_prefix_child_request(
             VpcPrefixId::new(),
-            vpc_b,
-            Some(root_b),
-            "10.100.1.0/24",
+            existing_vpc,
+            Some(root),
+            "10.107.1.0/24",
         )))
-        .await
-        .expect_err("the legacy database exclusion should still block exact reuse");
+        .await?;
 
+    let mut txn = env.pool.begin().await?;
+    let retained_vni = db::resource_pool::allocate(
+        &env.common_pools.ethernet.pool_external_vpc_vni,
+        &mut txn,
+        OwnerType::Vpc,
+        &existing_vpc.to_string(),
+        None,
+    )
+    .await?;
+    txn.commit().await?;
+    let routing_state = env
+        .api
+        .get_vpc_routing_state(Request::new(rpc::forge::VpcRoutingStateRequest {
+            id: Some(existing_vpc),
+        }))
+        .await?
+        .into_inner();
+    let active_vni = routing_state.active_vni;
+
+    // Hold the allocation row so cleanup pauses after locking its VPC.
+    // The overlapping create must wait for that VPC, not skip to its allocations.
+    let mut allocation_lock = env.pool.begin().await?;
+    let blocker_pid: i32 = sqlx::query_scalar("SELECT pg_backend_pid()")
+        .fetch_one(allocation_lock.as_mut())
+        .await?;
+    assert_eq!(
+        db::resource_pool::find_owned_allocation(
+            &env.common_pools.ethernet.pool_vpc_vni,
+            allocation_lock.as_mut(),
+            OwnerType::Vpc,
+            &existing_vpc.to_string(),
+        )
+        .await?,
+        Some(i32::try_from(active_vni)?)
+    );
+    let cleanup =
+        env.api
+            .release_vpc_inactive_vni(Request::new(rpc::forge::VpcReleaseInactiveVniRequest {
+                id: Some(existing_vpc),
+                if_version_match: Some(routing_state.version),
+                expected_inactive_vni: Some(u32::try_from(retained_vni)?),
+            }));
+    tokio::pin!(cleanup);
+    let cleanup_pid = tokio::select! {
+        result = &mut cleanup => panic!("cleanup passed a locked allocation: {result:?}"),
+        pid = wait_for_blocked_query(&env.pool, blocker_pid, "resource_pool") => pid,
+    };
+
+    let prefix_id = VpcPrefixId::new();
+    let create = env
+        .api
+        .create_vpc_prefix(Request::new(site_prefix_child_request(
+            prefix_id,
+            candidate_vpc,
+            Some(root),
+            "10.107.1.0/24",
+        )));
+    tokio::pin!(create);
+    tokio::select! {
+        result = &mut cleanup => panic!("cleanup passed a locked allocation: {result:?}"),
+        result = &mut create => panic!("create passed the existing VPC lock: {result:?}"),
+        _ = wait_for_blocked_query(&env.pool, cleanup_pid, "vpcs") => {}
+    }
+    allocation_lock.commit().await?;
+    let (cleanup, create) = tokio::time::timeout(Duration::from_secs(30), async {
+        tokio::join!(cleanup, create)
+    })
+    .await?;
+    assert_eq!(
+        cleanup?.into_inner().released_inactive_vni,
+        u32::try_from(retained_vni)?
+    );
+    let error = create.expect_err("the legacy database exclusion still prevents persistence");
     assert_eq!(error.code(), tonic::Code::InvalidArgument);
     assert!(
         error
             .message()
             .contains("overlaps an existing or deleting VPC prefix"),
-        "the pair check should accept the pair before persistence: {error}"
+        "the create should see the completed allocation cleanup: {error}"
     );
+    assert_eq!(stored_vpc_prefix_count(&env, prefix_id).await, 0);
+    let after_cleanup = env
+        .api
+        .get_vpc_routing_state(Request::new(rpc::forge::VpcRoutingStateRequest {
+            id: Some(existing_vpc),
+        }))
+        .await?
+        .into_inner();
+    assert_eq!(after_cleanup.active_vni, active_vni);
+    assert_eq!(after_cleanup.retained_allocation, None);
     Ok(())
 }
 


### PR DESCRIPTION
Tenant-managed SitePrefixes are intended to let isolated VPCs reuse an address range, including two VPCs belonging to one tenant. The overlap check incorrectly rejects that same-tenant case. This PR allows it when both VPCs use the same tenant-managed SitePrefix and satisfy the isolation checks; reuse within one VPC remains prohibited.

Prefix creation also needs to account for routing-profile transitions. A VPC can still own its previous VNI while DPUs remove old routes. Require each VPC to own exactly one VNI allocation matching `status.vni`, and lock the participating VPC records before checking their allocations. These locks last through the prefix-creation transaction, so concurrent VNI changes or deletion may wait, including for another tenant's VPC. Non-overlapping creation is unchanged.

Reject reuse when the deprecated `anycast_site_prefixes` list is nonempty: the FNN renderer still uses it when the profile's `allowed_anycast_prefixes` is empty. The chart defaults to `["0.0.0.0/0"]`, so a site using that default must override it with `[]` to qualify. The overlap feature remains disabled by default, and the existing database exclusion still prevents overlapping prefixes from being stored. This PR prepares the admission checks; it does not enable overlapping address space.

## Related issues

This supports https://github.com/dsx-ai-factory/infra-controller/issues/5113

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

Coverage:

- Policy tests cover same-tenant reuse and the deprecated anycast fallback. Database-backed tests cover missing, mismatched, and multiple VNI allocations, plus prefix creation waiting for concurrent inactive-VNI cleanup.
- Related overlap, allocation-reader, and routing-state tests pass, along with full workspace lint and documentation checks.

## Review Findings

<details>
<summary>Model Findings Overview</summary>

All four local reviewers covered the same stable patch. The adopted corrections passed final scope review, tests, and lint.

| Reviewer | Received | Adopted | Declined |
| --- | ---: | ---: | ---: |
| Codex self-review | 0 | 0 | 0 |
| CodeRabbit CLI | 0 | 0 | 0 |
| Claude CLI | 12 | 3 | 9 |
| common-nits-reviewer | 0 | 0 | 0 |
| Total | 12 | 3 | 9 |

</details>

<details>
<summary>Model Findings Details</summary>

### Codex self-review

No findings.

### CodeRabbit CLI

No findings.

### Claude CLI

1. **Adopted:** Correct the configuration reference's eligibility rules and explain the chart's anycast default.
2. **Declined:** The claimed fixture-range collision does not occur; the shared range excludes its upper bound.
3. **Adopted:** Add two local test VNIs and exercise peak allocation demand before release-only cases, removing dependence on case order.
4. **Declined:** A shared allocation classifier would combine different lifecycle contracts; the private admission check needs no broader refactor.
5. **Declined:** Keep the existing anonymous overlap error rather than add candidate-specific diagnostics.
6. **Adopted:** Document participating VPC locks and their effect on concurrent changes, including another tenant's VPC.
7. **Declined:** Rewriting `Option::replace` would lengthen equivalent logic without fixing a defect.
8. **Declined:** Present `status.vni` does not prove an allocation exists; retain the explicit missing-allocation check.
9. **Declined:** The private validator's name, parameter, and contract already identify its purpose.
10. **Declined:** Keep the rule with its one production caller; no second caller requires an extraction.
11. **Declined:** The typed error match and existing privacy contract explain the classification; query failures still propagate.
12. **Declined:** Test-summary comments would repeat descriptive test names; the non-obvious setup and locking reasons are already documented.

### common-nits-reviewer

No findings.

</details>

Closes #5113
