### PR TITLE
fix(health): normalize Prometheus metric label names

### DIFF
--- a/crates/health/src/metrics.rs
+++ b/crates/health/src/metrics.rs
@@ -16,7 +16,7 @@
  */
 
 use std::borrow::Cow;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use std::hash::Hash;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -478,6 +478,7 @@ pub struct GaugeMetrics {
     metric_name_prefix: String,
     metric_help: String,
     static_labels: Vec<proto::LabelPair>,
+    static_label_names: HashSet<String>,
     desc: Desc,
 }
 
@@ -490,20 +491,27 @@ impl GaugeMetrics {
         static_labels: Vec<(impl Into<String>, impl Into<String>)>,
     ) -> Result<Self, prometheus::Error> {
         let desc = Desc::new(id.clone(), id, Vec::new(), HashMap::new())?;
+        let mut static_label_names = HashSet::with_capacity(static_labels.len());
+        let static_labels = static_labels
+            .into_iter()
+            .map(|(name, value)| {
+                let name = name.into();
+                static_label_names.insert(name.clone());
+
+                let mut label = LabelPair::new();
+                label.set_name(name);
+                label.set_value(value.into());
+                label
+            })
+            .collect();
+
         let metrics = Self {
             gauges: Arc::new(DashMap::new()),
             current_generation: Arc::new(AtomicU64::new(0)),
             metric_name_prefix: metric_name_prefix.into(),
             metric_help: metric_help.into(),
-            static_labels: static_labels
-                .into_iter()
-                .map(|(name, value)| {
-                    let mut label = LabelPair::new();
-                    label.set_name(name.into());
-                    label.set_value(value.into());
-                    label
-                })
-                .collect(),
+            static_labels,
+            static_label_names,
             desc,
         };
 
@@ -513,6 +521,10 @@ impl GaugeMetrics {
 
     pub fn begin_update(&self) {
         self.current_generation.fetch_add(1, Ordering::Release);
+    }
+
+    pub(crate) fn has_static_label(&self, name: &str) -> bool {
+        self.static_label_names.contains(name)
     }
 
     pub fn record(&self, reading: GaugeReading) {

--- a/crates/health/src/sink/prometheus.rs
+++ b/crates/health/src/sink/prometheus.rs
@@ -125,19 +125,19 @@ impl PrometheusSink {
     /// Normalizes effective dynamic labels before they enter the registry.
     fn normalize_label_names(
         context: &EventContext,
+        stream_metrics: &GaugeMetrics,
         metric: &str,
         labels: &mut [(Cow<'static, str>, String)],
     ) -> Result<(), HealthError> {
-        let mut label_names = Self::stream_static_labels(context)
-            .into_iter()
-            .map(|(name, _)| name.into_owned())
-            .collect::<HashSet<_>>();
+        let mut label_names = HashSet::with_capacity(labels.len());
 
         for (name, _) in labels {
             let original_name = name.clone();
             let normalized_name = Self::normalize_label_name(original_name.clone());
 
-            if !label_names.insert(normalized_name.to_string()) {
+            if stream_metrics.has_static_label(&normalized_name)
+                || !label_names.insert(normalized_name.clone())
+            {
                 tracing::warn!(
                     endpoint_key = context.endpoint_key(),
                     collector = context.collector_type,
@@ -298,7 +298,12 @@ impl DataSink for PrometheusSink {
                             .map(|(name, value)| (Cow::Owned(name.clone()), value.clone())),
                     );
 
-                    Self::normalize_label_names(context, &sample.name, &mut labels)?;
+                    Self::normalize_label_names(
+                        context,
+                        &stream_metrics,
+                        &sample.name,
+                        &mut labels,
+                    )?;
 
                     stream_metrics.record(
                         GaugeReading::new(

--- a/crates/health/src/sink/prometheus.rs
+++ b/crates/health/src/sink/prometheus.rs
@@ -16,6 +16,7 @@
  */
 
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::sync::Arc;
 
 use dashmap::DashMap;
@@ -24,6 +25,12 @@ use super::{CollectorEvent, DataSink, EventContext, MetricSample};
 use crate::HealthError;
 use crate::metrics::{CollectorRegistry, GaugeMetrics, GaugeReading, MetricsManager};
 
+/// Publishes metric samples to the Prometheus telemetry registry.
+///
+/// In dynamic label names, characters other than ASCII letters, digits, and
+/// `_` become `_`; an initial ASCII digit gains an `_` prefix, and an empty
+/// name becomes `_`. A sample is rejected when normalization collides with
+/// another dynamic label or a label supplied by the sink.
 pub struct PrometheusSink {
     collector_registry: Arc<CollectorRegistry>,
     stream_metrics: DashMap<String, DashMap<&'static str, Arc<GaugeMetrics>>>,
@@ -77,6 +84,78 @@ impl PrometheusSink {
         key.push_str(KEY_SEPARATOR);
         key.push_str(&sample.unit);
         key
+    }
+
+    fn is_valid_label_name(name: &str) -> bool {
+        let mut characters = name.chars();
+
+        characters
+            .next()
+            .is_some_and(|character| character.is_ascii_alphabetic() || character == '_')
+            && characters.all(|character| character.is_ascii_alphanumeric() || character == '_')
+    }
+
+    /// Converts sink-neutral attribute names to Prometheus label names.
+    fn normalize_label_name(name: Cow<'static, str>) -> Cow<'static, str> {
+        if Self::is_valid_label_name(&name) {
+            return name;
+        }
+
+        let mut normalized = String::with_capacity(name.len().saturating_add(1));
+
+        if name.is_empty() {
+            normalized.push('_');
+        }
+
+        for (index, character) in name.chars().enumerate() {
+            if index == 0 && character.is_ascii_digit() {
+                normalized.push('_');
+            }
+
+            normalized.push(if character.is_ascii_alphanumeric() || character == '_' {
+                character
+            } else {
+                '_'
+            });
+        }
+
+        Cow::Owned(normalized)
+    }
+
+    /// Normalizes effective dynamic labels before they enter the registry.
+    fn normalize_label_names(
+        context: &EventContext,
+        metric: &str,
+        labels: &mut [(Cow<'static, str>, String)],
+    ) -> Result<(), HealthError> {
+        let mut label_names = Self::stream_static_labels(context)
+            .into_iter()
+            .map(|(name, _)| name.into_owned())
+            .collect::<HashSet<_>>();
+
+        for (name, _) in labels {
+            let original_name = name.clone();
+            let normalized_name = Self::normalize_label_name(original_name.clone());
+
+            if !label_names.insert(normalized_name.to_string()) {
+                tracing::warn!(
+                    endpoint_key = context.endpoint_key(),
+                    collector = context.collector_type,
+                    metric,
+                    label = original_name.as_ref(),
+                    normalized_label = normalized_name.as_ref(),
+                    "Prometheus metric has conflicting label names"
+                );
+
+                return Err(HealthError::GenericError(format!(
+                    "prometheus label {original_name:?} conflicts after normalization as {normalized_name:?}"
+                )));
+            }
+
+            *name = normalized_name;
+        }
+
+        Ok(())
     }
 
     fn stream_static_labels(context: &EventContext) -> Vec<(Cow<'static, str>, String)> {
@@ -211,11 +290,16 @@ impl DataSink for PrometheusSink {
             CollectorEvent::Metric(sample) => match self.get_or_create_stream_metrics(context) {
                 Ok(stream_metrics) => {
                     let mut labels = sample.labels.clone();
-                    for (name, value) in context.labels() {
-                        if labels.iter().all(|(existing, _)| existing.as_ref() != name) {
-                            labels.push((Cow::Owned(name.clone()), value.clone()));
-                        }
-                    }
+
+                    labels.extend(
+                        context
+                            .labels()
+                            .iter()
+                            .map(|(name, value)| (Cow::Owned(name.clone()), value.clone())),
+                    );
+
+                    Self::normalize_label_names(context, &sample.name, &mut labels)?;
+
                     stream_metrics.record(
                         GaugeReading::new(
                             Self::metric_reading_key(sample),
@@ -430,5 +514,112 @@ mod tests {
                 .iter()
                 .all(|(label, _)| label.as_ref() != "power_shelf_id")
         );
+    }
+
+    #[test]
+    fn prometheus_sink_normalizes_dynamic_label_names() {
+        let metrics_manager =
+            Arc::new(MetricsManager::new("test").expect("metrics manager should initialize"));
+
+        let sink = PrometheusSink::new(metrics_manager.clone(), "test_sink")
+            .expect("Prometheus sink should initialize");
+
+        let context = EventContext {
+            endpoint_key: "11:22:33:44:55:66".to_string(),
+            addr: BmcAddr {
+                ip: "10.0.1.1".parse().expect("test IP address should parse"),
+                port: Some(443),
+                mac: MacAddress::from_str("11:22:33:44:55:66")
+                    .expect("test MAC address should parse"),
+            },
+            collector_type: "nvue_gnmi_events",
+            labels: [("site".to_string(), "test".to_string())].into(),
+            metadata: None,
+            rack_id: None,
+        };
+
+        sink.handle_event(
+            &context,
+            &CollectorEvent::Metric(Box::new(MetricSample {
+                key: "event:42".to_string(),
+                name: "nvue_gnmi_events".to_string(),
+                metric_type: "on_change_row".to_string(),
+                unit: "severity".to_string(),
+                value: 1.0,
+                labels: vec![
+                    (Cow::Borrowed("type-id"), "link".to_string()),
+                    (Cow::Borrowed("event-id"), "42".to_string()),
+                    (
+                        Cow::Borrowed("time-created"),
+                        "2026-09-10T14:42:19Z".to_string(),
+                    ),
+                ],
+                context: None,
+            })),
+        );
+
+        let exposition = metrics_manager
+            .export_telemetry()
+            .expect("telemetry should export");
+
+        assert!(exposition.contains("type_id=\"link\""));
+        assert!(exposition.contains("event_id=\"42\""));
+        assert!(exposition.contains("time_created=\"2026-09-10T14:42:19Z\""));
+        assert!(!exposition.contains("type-id="));
+        assert!(!exposition.contains("event-id="));
+        assert!(!exposition.contains("time-created="));
+
+        let collision_cases = [
+            ("normalized dynamic labels", vec!["type-id", "type_id"]),
+            (
+                "duplicate valid dynamic labels",
+                vec!["event_id", "event_id"],
+            ),
+            ("digit-prefixed normalization", vec!["9port", "_9port"]),
+            ("empty-name normalization", vec!["", "_"]),
+            ("normalized static label", vec!["endpoint-ip"]),
+            ("valid static label", vec!["endpoint_ip"]),
+            ("exact sample and context label", vec!["site"]),
+        ];
+
+        for (scenario, names) in collision_cases {
+            let sample = CollectorEvent::Metric(Box::new(MetricSample {
+                key: scenario.to_string(),
+                name: "nvue_gnmi_events".to_string(),
+                metric_type: "on_change_row".to_string(),
+                unit: "severity".to_string(),
+                value: 1.0,
+                labels: names
+                    .into_iter()
+                    .map(|name| (Cow::Owned(name.to_string()), "collision".to_string()))
+                    .collect(),
+                context: None,
+            }));
+
+            assert!(
+                sink.try_handle_event(&context, &sample).is_err(),
+                "{scenario}"
+            );
+        }
+
+        let exposition = metrics_manager
+            .export_telemetry()
+            .expect("telemetry should remain exportable");
+
+        assert!(!exposition.contains("\"collision\""));
+    }
+
+    #[test]
+    fn prometheus_label_name_normalization_cases() {
+        let cases = [
+            ("type-id", "type_id"),
+            ("9port", "_9port"),
+            ("", "_"),
+            ("valid_name", "valid_name"),
+        ];
+
+        for (input, expected) in cases {
+            assert_eq!(PrometheusSink::normalize_label_name(input.into()), expected);
+        }
     }
 }


### PR DESCRIPTION
Normalize dynamic metric label names before recording Prometheus samples. This prevents gNMI fields such as `type-id`, `event-id`, and `time-created` from producing invalid Prometheus exposition.

Unsupported characters become underscores, and names beginning with a digit receive an underscore prefix. Samples with label-name collisions are rejected from Prometheus.

## Related Issues

Bug 6763002

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)