### PR TITLE
fix(flow): resolve BMC MAC addresses case-insensitively

### DIFF
--- a/rest-api/api/pkg/api/handler/tray_test.go
+++ b/rest-api/api/pkg/api/handler/tray_test.go
@@ -198,6 +198,8 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 		flowv1.ComponentType_COMPONENT_TYPE_COMPUTE, "rack-id-1",
 	)
 
+	mockComponent.Bmcs = []*flowv1.BMCInfo{{MacAddress: "d8:ab:cd:ef:00:01"}}
+
 	tracer := oteltrace.NewNoopTracerProvider().Tracer("test")
 	ctx := context.Background()
 
@@ -222,6 +224,15 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 			mockComponent:  mockComponent,
 			expectedStatus: http.StatusOK,
 			wantErr:        false,
+		},
+		{
+			name:           "success - get tray by response MAC",
+			reqOrg:         org,
+			user:           providerUser,
+			trayID:         model.NewAPITray(mockComponent).BMCs[0].MacAddress,
+			queryParams:    map[string]string{"siteId": site.ID.String()},
+			mockComponent:  mockComponent,
+			expectedStatus: http.StatusOK,
 		},
 		{
 			name:   "failure - Flow not enabled on site",
@@ -331,6 +342,8 @@ func TestGetTrayHandler_Handle(t *testing.T) {
 			assert.Equal(t, trayID, apiTray.ID)
 			assert.Equal(t, "Compute", apiTray.Type)
 			assert.Equal(t, "NVIDIA", apiTray.Manufacturer)
+			require.Len(t, apiTray.BMCs, 1)
+			assert.Equal(t, "d8:ab:cd:ef:00:01", apiTray.BMCs[0].MacAddress)
 		})
 	}
 }

--- a/rest-api/flow/internal/db/migrations/20260912010000_bmc_mac_lookup.down.sql
+++ b/rest-api/flow/internal/db/migrations/20260912010000_bmc_mac_lookup.down.sql
@@ -1,0 +1,4 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+DROP INDEX bmc_mac_address_lower_idx;

--- a/rest-api/flow/internal/db/migrations/20260912010000_bmc_mac_lookup.up.sql
+++ b/rest-api/flow/internal/db/migrations/20260912010000_bmc_mac_lookup.up.sql
@@ -1,0 +1,5 @@
+-- SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+-- SPDX-License-Identifier: Apache-2.0
+
+-- Support case-insensitive lookups without rewriting existing BMC identities.
+CREATE INDEX bmc_mac_address_lower_idx ON bmc (lower(mac_address));

--- a/rest-api/flow/internal/db/migrations/bmc_mac_lookup_test.go
+++ b/rest-api/flow/internal/db/migrations/bmc_mac_lookup_test.go
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: Copyright (c) 2026 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// SPDX-License-Identifier: Apache-2.0
+
+package migrations_test
+
+import (
+	"context"
+	_ "embed"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"github.com/uptrace/bun"
+
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/eventrule/store/storetest"
+)
+
+//go:embed 20260912010000_bmc_mac_lookup.up.sql
+var bmcMACLookupUp string
+
+//go:embed 20260912010000_bmc_mac_lookup.down.sql
+var bmcMACLookupDown string
+
+func TestBMCMACLookupMigration(t *testing.T) {
+	ctx := context.Background()
+	session := storetest.NewPostgresTestSession(t)
+	_, err := session.DB.ExecContext(ctx, bmcMACLookupDown)
+	require.NoError(t, err)
+
+	owner := uuid.New()
+	_, err = session.DB.ExecContext(ctx, "INSERT INTO component (id, type) VALUES (?, 'Compute')", owner)
+	require.NoError(t, err)
+	_, err = session.DB.ExecContext(ctx, "INSERT INTO bmc (mac_address, type, component_id) VALUES ('D8:AB:CD:EF:00:01', 'Host', ?), ('d8:ab:cd:ef:00:01', 'Host', ?)", owner, owner)
+	require.NoError(t, err)
+
+	_, err = session.DB.ExecContext(ctx, bmcMACLookupUp)
+	require.NoError(t, err, "index must accept predecessor records, including case variants")
+	_, err = session.DB.ExecContext(ctx, "INSERT INTO bmc (mac_address, type, component_id) VALUES ('D8:Ab:Cd:Ef:00:01', 'Host', ?)", owner)
+	require.NoError(t, err, "predecessor writers must remain compatible")
+
+	var plan string
+	err = session.DB.RunInTx(ctx, nil, func(ctx context.Context, tx bun.Tx) error {
+		_, err := tx.ExecContext(ctx, "SET LOCAL enable_seqscan = off")
+		if err != nil {
+			return err
+		}
+		return tx.NewRaw("EXPLAIN (FORMAT JSON) SELECT component_id FROM bmc WHERE lower(mac_address) = lower(?)", "d8:ab:cd:ef:00:01").Scan(ctx, &plan)
+	})
+	require.NoError(t, err)
+	require.Contains(t, plan, "bmc_mac_address_lower_idx")
+
+	_, err = session.DB.ExecContext(ctx, bmcMACLookupDown)
+	require.NoError(t, err)
+	var macs []string
+	err = session.DB.NewRaw("SELECT mac_address FROM bmc ORDER BY mac_address").Scan(ctx, &macs)
+	require.NoError(t, err)
+	require.ElementsMatch(t, []string{"D8:AB:CD:EF:00:01", "d8:ab:cd:ef:00:01", "D8:Ab:Cd:Ef:00:01"}, macs, "upgrade and rollback must preserve persisted identities")
+}

--- a/rest-api/flow/internal/db/model/bmc.go
+++ b/rest-api/flow/internal/db/model/bmc.go
@@ -5,6 +5,8 @@ package model
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	"github.com/google/uuid"
@@ -81,24 +83,38 @@ func (bd *BMC) InvalidType() bool {
 	return !devicetypes.IsValidBMCTypeString(bd.Type)
 }
 
-// GetComponentByBMCMAC retrieves a component by its BMC MAC address.
+// ErrAmbiguousBMCMAC indicates that case variants of a BMC MAC belong to different components.
+var ErrAmbiguousBMCMAC = errors.New("BMC MAC address matches multiple components")
+
+// GetComponentByBMCMAC retrieves a unique component by its case-insensitive BMC MAC address.
 // Returns the component with all its associated BMCs (needed for powershelf manager queries).
 func GetComponentByBMCMAC(
 	ctx context.Context,
 	idb bun.IDB,
 	macAddress string,
 ) (*Component, error) {
-	var bmc BMC
+	// Select components rather than BMC rows so duplicate spellings owned by
+	// the same component do not make the component identity ambiguous.
+	matchingBMCs := idb.NewSelect().Model((*BMC)(nil)).Column("component_id").
+		Where("lower(b.mac_address) = lower(?)", macAddress)
+	var components []Component
 	err := idb.NewSelect().
-		Model(&bmc).
-		Where("b.mac_address = ?", macAddress).
-		Relation("Component").
-		Relation("Component.BMCs").
-		Relation("Component.Rack").
+		Model(&components).
+		Where("c.id IN (?)", matchingBMCs).
+		Relation("BMCs").
+		Relation("Rack").
+		Limit(2).
 		Scan(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	return bmc.Component, nil
+	switch len(components) {
+	case 0:
+		return nil, sql.ErrNoRows
+	case 1:
+		return &components[0], nil
+	default:
+		return nil, ErrAmbiguousBMCMAC
+	}
 }

--- a/rest-api/flow/internal/inventory/store/postgres.go
+++ b/rest-api/flow/internal/inventory/store/postgres.go
@@ -5,6 +5,7 @@ package store
 
 import (
 	"context"
+	stderrors "errors"
 	"fmt"
 
 	"github.com/google/uuid"
@@ -429,6 +430,9 @@ func (s *PostgresStore) GetComponentByBMCMAC(
 	}
 
 	c, err := model.GetComponentByBMCMAC(ctx, s.pg.DB, macAddress)
+	if stderrors.Is(err, model.ErrAmbiguousBMCMAC) {
+		return nil, status.Errorf(codes.FailedPrecondition, "component with BMC MAC %q is ambiguous", macAddress)
+	}
 	if err != nil {
 		return nil, s.checkDBGetError(err, fmt.Sprintf("component with BMC MAC %s", macAddress))
 	}

--- a/rest-api/flow/internal/inventory/store/postgres_test.go
+++ b/rest-api/flow/internal/inventory/store/postgres_test.go
@@ -6,6 +6,7 @@ package store
 import (
 	"context"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -15,8 +16,10 @@ import (
 
 	cdb "github.com/NVIDIA/infra-controller/rest-api/db/pkg/db"
 	commonutils "github.com/NVIDIA/infra-controller/rest-api/flow/internal/common/utils"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/converter/protobuf"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/model"
 	dbquery "github.com/NVIDIA/infra-controller/rest-api/flow/internal/db/query"
+	"github.com/NVIDIA/infra-controller/rest-api/flow/internal/inventory/resolver"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/common/devicetypes"
 	"github.com/NVIDIA/infra-controller/rest-api/flow/pkg/types"
 )
@@ -123,4 +126,96 @@ func TestPostgresStore_GetRackByID(t *testing.T) {
 
 func stringPtr(value string) *string {
 	return &value
+}
+
+func TestPostgresStore_GetComponentByBMCMAC(t *testing.T) {
+	if os.Getenv("DB_PORT") == "" {
+		t.Skip("Skipping integration test: no DB environment specified")
+	}
+	ctx := context.Background()
+	tests := []struct {
+		name          string
+		componentType devicetypes.ComponentType
+		bmcType       devicetypes.BMCType
+		storedMAC     string
+		duplicate     string
+		otherOwner    bool
+		missing       bool
+		wantCode      codes.Code
+	}{
+		{name: "uppercase Host", componentType: devicetypes.ComponentTypeCompute, bmcType: devicetypes.BMCTypeHost, storedMAC: "D8:AB:CD:EF:00:01"},
+		{name: "lowercase DPU", componentType: devicetypes.ComponentTypeCompute, bmcType: devicetypes.BMCTypeDPU, storedMAC: "d8:ab:cd:ef:00:02"},
+		{name: "mixed case NVSwitch", componentType: devicetypes.ComponentTypeNVSwitch, bmcType: devicetypes.BMCTypeHost, storedMAC: "D8:ab:Cd:eF:00:03"},
+		{name: "uppercase PowerShelf", componentType: devicetypes.ComponentTypePowerShelf, bmcType: devicetypes.BMCTypeHost, storedMAC: "D8:AB:CD:EF:00:04"},
+		{name: "case variants with same owner", componentType: devicetypes.ComponentTypeCompute, bmcType: devicetypes.BMCTypeHost, storedMAC: "D8:AB:CD:EF:00:05", duplicate: "d8:ab:cd:ef:00:05"},
+		{name: "case variants with different owners", componentType: devicetypes.ComponentTypeCompute, bmcType: devicetypes.BMCTypeHost, storedMAC: "D8:AB:CD:EF:00:06", duplicate: "d8:ab:cd:ef:00:06", otherOwner: true, wantCode: codes.FailedPrecondition},
+		{name: "unknown MAC", componentType: devicetypes.ComponentTypeCompute, bmcType: devicetypes.BMCTypeHost, storedMAC: "D8:AB:CD:EF:00:07", missing: true, wantCode: codes.NotFound},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			dbConf, err := cdb.ConfigFromEnv()
+			require.NoError(t, err)
+			pool, err := commonutils.UnitTestDB(ctx, t, dbConf)
+			require.NoError(t, err)
+			t.Cleanup(pool.Close)
+			store := NewPostgres(pool)
+			rack := model.Rack{Name: "MAC lookup rack", ExternalID: stringPtr("rack-mac")}
+			require.NoError(t, rack.Create(ctx, pool.DB))
+			owner := model.Component{Name: tc.name, Type: devicetypes.ComponentTypeToString(tc.componentType), RackID: rack.ID, ComponentID: stringPtr("component-mac")}
+			require.NoError(t, owner.Create(ctx, pool.DB))
+			bmcs := []model.BMC{
+				{MacAddress: tc.storedMAC, Type: devicetypes.BMCTypeToString(tc.bmcType), ComponentID: owner.ID},
+				{MacAddress: "00:11:22:33:44:55", Type: devicetypes.BMCTypeToString(tc.bmcType), ComponentID: owner.ID},
+			}
+			if tc.duplicate != "" {
+				duplicateOwner := owner.ID
+				if tc.otherOwner {
+					other := model.Component{Name: "other owner", Type: owner.Type, RackID: rack.ID}
+					require.NoError(t, other.Create(ctx, pool.DB))
+					duplicateOwner = other.ID
+				}
+				bmcs = append(bmcs, model.BMC{MacAddress: tc.duplicate, Type: bmcs[0].Type, ComponentID: duplicateOwner})
+			}
+			_, err = pool.DB.NewInsert().Model(&bmcs).Exec(ctx)
+			require.NoError(t, err)
+
+			// Use the serialized response MAC, not a separately normalized test input.
+			byID, err := store.GetComponentByID(ctx, owner.ID)
+			require.NoError(t, err)
+			wire := protobuf.ComponentTo(byID)
+			var responseMAC string
+			for _, controller := range wire.GetBmcs() {
+				if strings.EqualFold(controller.GetMacAddress(), tc.storedMAC) {
+					responseMAC = controller.GetMacAddress()
+				}
+			}
+			require.Equal(t, strings.ToLower(tc.storedMAC), responseMAC)
+			if tc.missing {
+				responseMAC = "ff:ff:ff:ff:ff:ff"
+			}
+			got, err := store.GetComponentByBMCMAC(ctx, strings.ToUpper(responseMAC))
+			require.Equal(t, tc.wantCode, status.Code(err))
+			resolved, resolveErr := resolver.ResolveComponentIdentifier(ctx, store, responseMAC, tc.componentType)
+			require.Equal(t, tc.wantCode, status.Code(resolveErr))
+			if tc.wantCode != codes.OK {
+				assert.Nil(t, got)
+				assert.Nil(t, resolved)
+				return
+			}
+			require.NotNil(t, got)
+			require.NotNil(t, resolved)
+			assert.Equal(t, owner.ID, got.Info.ID)
+			assert.Equal(t, owner.ID, resolved.Info.ID)
+			assert.Equal(t, "component-mac", resolved.ComponentID)
+			assert.Equal(t, rack.ID, resolved.RackID)
+			assert.Equal(t, "rack-mac", resolved.RackExternalID)
+			assert.Equal(t, tc.componentType, resolved.Type)
+			assert.Len(t, resolved.BmcsByType[tc.bmcType], len(bmcs), "lookup must retain companion controllers")
+			var persisted []model.BMC
+			err = pool.DB.NewSelect().Model(&persisted).Order("mac_address").Scan(ctx)
+			require.NoError(t, err)
+			assert.Len(t, persisted, len(bmcs))
+			assert.Contains(t, persisted, bmcs[0], "lookup must not rewrite persisted identities")
+		})
+	}
 }


### PR DESCRIPTION
Flow serializes BMC MAC addresses in lowercase but previously looked them up with case-sensitive SQL equality. A Host MAC returned by REST could therefore produce 404 when copied into a GET request if its persisted value contained uppercase digits.

Make the shared database lookup case-insensitive and add a non-unique `lower(mac_address)` expression index. This fixes existing records without rewriting or deleting user data. If case variants belong to different components, the lookup returns `FailedPrecondition` instead of selecting an arbitrary device.

This PR is the first stage of the rollout described in [the issue plan](https://github.com/dsx-ai-factory/infra-controller/issues/6059#issuecomment-5658150972). Follow-up changes will enforce case-insensitive uniqueness and then canonicalize writes and historical values.

## Related issues

Closes #6059

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [ ] Unit tests added/updated
- [x] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)
 

## Additional Notes

The non-unique index is intentional for this compatibility stage. This PR does not normalize stored values, delete duplicates, or enforce case-insensitive uniqueness. A later migration will create a unique `lower(mac_address)` index and fail atomically if operators need to reconcile conflicting historical records.

No API schema or generated client changes are required.
