### PR TITLE
fix(health): refresh collectors when machine NVLink domain changes

### DIFF
--- a/crates/health/src/discovery/cleanup.rs
+++ b/crates/health/src/discovery/cleanup.rs
@@ -28,6 +28,7 @@ use crate::endpoint::BmcEndpoint;
 #[derive(Clone, Copy)]
 enum CollectorStopReason {
     EndpointRemoved,
+    MachineDomainChanged,
     PowerShelfIdChanged,
     SwitchEndpointNoLongerEligible,
     SwitchDomainChanged,
@@ -37,6 +38,7 @@ impl std::fmt::Display for CollectorStopReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(match self {
             Self::EndpointRemoved => "endpoint removed",
+            Self::MachineDomainChanged => "machine NVLink domain changed",
             Self::PowerShelfIdChanged => "PowerShelf ID changed",
             Self::SwitchEndpointNoLongerEligible => "switch endpoint is no longer eligible",
             Self::SwitchDomainChanged => "switch NVLink domain changed",
@@ -104,6 +106,58 @@ pub(super) async fn stop_stale_switch_collectors(
 
     // CollectorRemoved unregisters the old Prometheus label set. Wait for that
     // cleanup before replacement collectors register the new domain UUID.
+    join_all(stale_collectors.into_iter().map(Collector::stop)).await;
+}
+
+/// Restarts machine collectors when discovery reports a different NVLink domain.
+///
+/// Collectors retain the endpoint metadata captured at startup, while the
+/// endpoint key remains unchanged when the domain changes. For duplicate keys,
+/// only the first endpoint is considered to match collector spawn precedence.
+/// Its machine domain establishes a baseline; a later change removes affected
+/// collectors and waits for shutdown before discovery respawns them. An endpoint
+/// returning after an absent pass establishes a new baseline without a restart.
+pub(super) async fn stop_stale_machine_collectors(
+    ctx: &mut DiscoveryLoopContext,
+    endpoints: &[Arc<BmcEndpoint>],
+) {
+    let mut active_endpoint_keys = HashSet::with_capacity(endpoints.len());
+    let mut changed_endpoints = HashSet::new();
+
+    for endpoint in endpoints {
+        let key: Cow<'static, str> = Cow::Owned(endpoint.key());
+
+        if !active_endpoint_keys.insert(key.clone()) {
+            continue;
+        }
+
+        let Some(crate::endpoint::EndpointMetadata::Machine(machine)) = endpoint.metadata.as_ref()
+        else {
+            continue;
+        };
+
+        if ctx
+            .collectors
+            .observe_machine_domain(&key, machine.nvlink_domain_uuid)
+        {
+            changed_endpoints.insert(key.clone());
+        }
+    }
+
+    ctx.collectors.retain_machine_domains(&active_endpoint_keys);
+
+    let stale_collectors = CollectorKind::ALL
+        .into_iter()
+        .flat_map(|kind| {
+            take_collectors_for_keys(
+                ctx,
+                kind,
+                &changed_endpoints,
+                CollectorStopReason::MachineDomainChanged,
+            )
+        })
+        .collect::<Vec<_>>();
+
     join_all(stale_collectors.into_iter().map(Collector::stop)).await;
 }
 
@@ -275,7 +329,6 @@ pub(super) fn stop_ineligible_nmxc_collectors(
 
 #[cfg(test)]
 mod tests {
-
     use std::str::FromStr;
     use std::sync::Arc;
 
@@ -285,7 +338,10 @@ mod tests {
     use crate::collectors::Collector;
     use crate::config::Config;
     use crate::endpoint::test_support::{mac, test_endpoint};
-    use crate::endpoint::{EndpointMetadata, PowerShelfData, SwitchData, SwitchEndpointRole};
+    use crate::endpoint::{
+        EndpointMetadata, MachineData, PowerShelfData, SharedSystemUuid, SwitchData,
+        SwitchEndpointRole,
+    };
     use crate::limiter::{NoopLimiter, RateLimiter};
     use crate::metrics::MetricsManager;
 
@@ -391,6 +447,90 @@ mod tests {
         );
         stop_stale_switch_collectors(&mut ctx, &[endpoint]).await;
         assert!(ctx.collectors.contains(CollectorKind::NvueRest, &key));
+    }
+
+    #[tokio::test]
+    async fn machine_domain_change_restarts_collectors_for_same_endpoint_key() {
+        let mut ctx = context("machine_domain_change_restarts_collectors");
+        let initial_domain = carbide_uuid::nvlink::NvLinkDomainId::new();
+        let mut endpoint = test_endpoint(mac("00:11:22:33:44:55"));
+
+        endpoint.metadata = Some(EndpointMetadata::Machine(MachineData {
+            machine_id: None,
+            machine_serial: None,
+            system_uuid: SharedSystemUuid::default(),
+            slot_number: None,
+            tray_index: None,
+            nvlink_domain_uuid: Some(initial_domain),
+            driver_version: None,
+        }));
+
+        let key = endpoint.key();
+        let mut endpoint = Arc::new(endpoint);
+
+        ctx.collectors.insert(
+            CollectorKind::Sensor,
+            Cow::Owned(key.clone()),
+            noop_collector(),
+        );
+
+        stop_stale_machine_collectors(&mut ctx, std::slice::from_ref(&endpoint)).await;
+
+        assert!(ctx.collectors.contains(CollectorKind::Sensor, &key));
+
+        let expected_domain = carbide_uuid::nvlink::NvLinkDomainId::new();
+
+        let Some(EndpointMetadata::Machine(machine)) =
+            Arc::make_mut(&mut endpoint).metadata.as_mut()
+        else {
+            panic!("test endpoint should contain machine metadata");
+        };
+
+        machine.nvlink_domain_uuid = Some(expected_domain);
+
+        stop_stale_machine_collectors(&mut ctx, std::slice::from_ref(&endpoint)).await;
+
+        assert!(!ctx.collectors.contains(CollectorKind::Sensor, &key));
+    }
+
+    #[tokio::test]
+    async fn non_machine_first_duplicate_owns_machine_domain_precedence() {
+        let mut ctx = context("non_machine_first_duplicate");
+        let first = Arc::new(test_endpoint(mac("00:11:22:33:44:55")));
+        let mut duplicate = first.as_ref().clone();
+
+        duplicate.metadata = Some(EndpointMetadata::Machine(MachineData {
+            machine_id: None,
+            machine_serial: None,
+            system_uuid: SharedSystemUuid::default(),
+            slot_number: None,
+            tray_index: None,
+            nvlink_domain_uuid: None,
+            driver_version: None,
+        }));
+
+        let key = first.key();
+        let mut duplicate = Arc::new(duplicate);
+
+        stop_stale_machine_collectors(&mut ctx, &[first.clone(), duplicate.clone()]).await;
+
+        ctx.collectors.insert(
+            CollectorKind::Sensor,
+            Cow::Owned(key.clone()),
+            noop_collector(),
+        );
+
+        let Some(EndpointMetadata::Machine(machine)) =
+            Arc::make_mut(&mut duplicate).metadata.as_mut()
+        else {
+            panic!("test duplicate should contain machine metadata");
+        };
+
+        machine.nvlink_domain_uuid = Some(carbide_uuid::nvlink::NvLinkDomainId::new());
+
+        stop_stale_machine_collectors(&mut ctx, &[first, duplicate]).await;
+
+        assert!(ctx.collectors.contains(CollectorKind::Sensor, &key));
     }
 
     #[tokio::test]

--- a/crates/health/src/discovery/context.rs
+++ b/crates/health/src/discovery/context.rs
@@ -94,12 +94,32 @@ pub(super) struct CollectorState {
     gpu_inventory: HashMap<Cow<'static, str>, Collector>,
     reachability: HashMap<Cow<'static, str>, Collector>,
     inventories: HashMap<Cow<'static, str>, SharedInventory<BmcClient>>,
+    machine_domain_uuids: HashMap<Cow<'static, str>, Option<NvLinkDomainId>>,
     switch_domain_uuids: HashMap<Cow<'static, str>, Option<NvLinkDomainId>>,
     power_shelf_ids: HashMap<Cow<'static, str>, Option<PowerShelfId>>,
     pub(super) reachability_specs: HashMap<Cow<'static, str>, ReachabilitySpec>,
 }
 
 impl CollectorState {
+    /// Stores the first value as a baseline and reports subsequent changes.
+    fn observe_value<T: PartialEq>(
+        values: &mut HashMap<Cow<'static, str>, Option<T>>,
+        key: &str,
+        value: Option<T>,
+    ) -> bool {
+        match values.get_mut(key) {
+            Some(previous) if previous != &value => {
+                *previous = value;
+                true
+            }
+            Some(_) => false,
+            None => {
+                values.insert(Cow::Owned(key.to_string()), value);
+                false
+            }
+        }
+    }
+
     fn new() -> Self {
         Self {
             discovery: HashMap::new(),
@@ -116,6 +136,7 @@ impl CollectorState {
             gpu_inventory: HashMap::new(),
             reachability: HashMap::new(),
             inventories: HashMap::new(),
+            machine_domain_uuids: HashMap::new(),
             switch_domain_uuids: HashMap::new(),
             power_shelf_ids: HashMap::new(),
             reachability_specs: HashMap::new(),
@@ -176,6 +197,25 @@ impl CollectorState {
         self.inventories.remove(key);
     }
 
+    /// Records the latest machine domain and reports whether it changed.
+    ///
+    /// The first observation establishes a baseline without forcing a restart.
+    /// Later transitions between absent and present values, or between two UUIDs,
+    /// require a restart because running collectors retain their startup metadata.
+    pub(super) fn observe_machine_domain(
+        &mut self,
+        key: &str,
+        domain_uuid: Option<NvLinkDomainId>,
+    ) -> bool {
+        Self::observe_value(&mut self.machine_domain_uuids, key, domain_uuid)
+    }
+
+    /// Removes baselines for machines absent from the discovery pass.
+    pub(super) fn retain_machine_domains(&mut self, active_endpoints: &HashSet<Cow<'static, str>>) {
+        self.machine_domain_uuids
+            .retain(|key, _| active_endpoints.contains(key));
+    }
+
     /// Records the latest switch domain and reports whether it changed.
     ///
     /// The first observation establishes a baseline without forcing a restart.
@@ -186,18 +226,7 @@ impl CollectorState {
         key: &str,
         domain_uuid: Option<NvLinkDomainId>,
     ) -> bool {
-        match self.switch_domain_uuids.get_mut(key) {
-            Some(previous) if *previous != domain_uuid => {
-                *previous = domain_uuid;
-                true
-            }
-            Some(_) => false,
-            None => {
-                self.switch_domain_uuids
-                    .insert(Cow::Owned(key.to_string()), domain_uuid);
-                false
-            }
-        }
+        Self::observe_value(&mut self.switch_domain_uuids, key, domain_uuid)
     }
 
     pub(super) fn retain_switch_domains(
@@ -217,18 +246,7 @@ impl CollectorState {
         key: &str,
         power_shelf_id: Option<PowerShelfId>,
     ) -> bool {
-        match self.power_shelf_ids.get_mut(key) {
-            Some(previous) if *previous != power_shelf_id => {
-                *previous = power_shelf_id;
-                true
-            }
-            Some(_) => false,
-            None => {
-                self.power_shelf_ids
-                    .insert(Cow::Owned(key.to_string()), power_shelf_id);
-                false
-            }
-        }
+        Self::observe_value(&mut self.power_shelf_ids, key, power_shelf_id)
     }
 
     /// Removes saved PowerShelf IDs for endpoints absent from the discovery pass.

--- a/crates/health/src/discovery/iteration.rs
+++ b/crates/health/src/discovery/iteration.rs
@@ -24,7 +24,7 @@ use futures::{StreamExt, stream};
 
 use super::DiscoveryIterationStats;
 use super::cleanup::{
-    stop_ineligible_nmxc_collectors, stop_removed_bmc_collectors,
+    stop_ineligible_nmxc_collectors, stop_removed_bmc_collectors, stop_stale_machine_collectors,
     stop_stale_power_shelf_collectors, stop_stale_switch_collectors,
 };
 use super::context::{CollectorKind, DiscoveryLoopContext};
@@ -122,9 +122,10 @@ pub async fn run_discovery_iteration(
     // prune before respawn so downgraded auto-mode endpoints get replaced
     ctx.collectors.prune_finished_logs();
 
-    // A domain change keeps the same endpoint key and collector type. Complete
+    // Metadata changes keep the same endpoint key and collector type. Complete
     // old collector cleanup before respawn so a late CollectorRemoved cannot
     // unregister the replacement's metrics.
+    stop_stale_machine_collectors(ctx, &sharded_endpoints).await;
     stop_stale_switch_collectors(ctx, &sharded_endpoints).await;
     stop_stale_power_shelf_collectors(ctx, &sharded_endpoints).await;
 


### PR DESCRIPTION
Restart machine collectors when endpoint discovery reports a different NVLink domain UUID for the same endpoint key. The restart updates the domain metadata emitted by logs and metrics.

## Related Issues

Bug 6755800

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)