### PR TITLE
fix(health): reconnect unsynchronized gNMI streams

### DIFF
--- a/crates/health/example/config.example.toml
+++ b/crates/health/example/config.example.toml
@@ -485,6 +485,10 @@ platform_environment_status_enabled = true
 # platform_general_enabled is true)
 gnmi_port = 9339
 sample_interval = "5m"
+# Applied independently to connection establishment, opening the Subscribe RPC,
+# and initial synchronization. One attempt may take nearly three times this
+# duration before reconnect backoff. Updates before sync_response=true do not
+# extend the synchronization timeout.
 request_timeout = "30s"
 # Keep strict TLS certificate and hostname verification by default. Set true only
 # for lab/self-signed NVOS gNMI endpoints where that dangerous bypass is required.

--- a/crates/health/src/collectors/nvue/gnmi/client.rs
+++ b/crates/health/src/collectors/nvue/gnmi/client.rs
@@ -35,6 +35,9 @@ use crate::config::{
     NvueGnmiSubscriptionMode,
 };
 
+const GNMI_HTTP2_KEEPALIVE_INTERVAL: Duration = Duration::from_secs(300);
+const GNMI_HTTP2_KEEPALIVE_TIMEOUT: Duration = Duration::from_secs(30);
+
 pub(super) fn nvue_subscribe_paths(paths_config: &NvueGnmiPaths) -> Vec<Path> {
     let mut paths = Vec::with_capacity(5);
 
@@ -166,7 +169,7 @@ pub(super) struct GnmiClientConfig {
     /// Optional password sent as gNMI `password` metadata.
     pub password: Option<String>,
 
-    /// Timeout applied to gNMI connection and RPC operations.
+    /// Timeout applied independently to connection establishment and RPC opening.
     pub request_timeout: Duration,
 
     /// Whether legacy non-mTLS connections accept invalid switch certificates.
@@ -246,7 +249,12 @@ impl GnmiClient {
         )
         .await?
         .connect_timeout(self.request_timeout)
-        .timeout(self.request_timeout);
+        .timeout(self.request_timeout)
+        // Periodic HTTP/2 PINGs make transport loss observable when a peer
+        // stops acknowledging frames without closing the Subscribe stream.
+        .http2_keep_alive_interval(GNMI_HTTP2_KEEPALIVE_INTERVAL)
+        .keep_alive_timeout(GNMI_HTTP2_KEEPALIVE_TIMEOUT)
+        .keep_alive_while_idle(true);
 
         let channel = endpoint.connect().await.map_err(|e| {
             HealthError::GnmiError(format!(

--- a/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
+++ b/crates/health/src/collectors/nvue/gnmi/sample_processor.rs
@@ -1600,6 +1600,7 @@ mod tests {
         super::super::subscriber::GnmiStreamMetrics {
             connection_state: IntGauge::new("test_conn_state", "test").unwrap(),
             connected: IntGauge::new("test_connected", "test").unwrap(),
+            synchronized: IntGauge::new("test_synchronized", "test").unwrap(),
             reconnections_total: Counter::new("test_reconn", "test").unwrap(),
             server_initiated_closures_total: Counter::new("test_closures", "test").unwrap(),
             connection_established_timestamp: Gauge::new("test_conn_ts", "test").unwrap(),

--- a/crates/health/src/collectors/nvue/gnmi/subscriber.rs
+++ b/crates/health/src/collectors/nvue/gnmi/subscriber.rs
@@ -16,6 +16,7 @@
  */
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::sync::atomic::{AtomicU64, Ordering as AtomicOrdering};
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
@@ -23,6 +24,7 @@ use std::time::Duration;
 use carbide_uuid::rack::RackId;
 use prometheus::{Counter, Gauge, Histogram, HistogramOpts, IntGauge, Opts};
 use tokio::sync::OnceCell;
+use tokio_stream::{Stream, StreamExt};
 use tokio_util::sync::CancellationToken;
 
 use super::client::{
@@ -57,6 +59,9 @@ pub(crate) struct GnmiStreamMetrics {
     pub(crate) connection_state: IntGauge,
     /// binary "is this stream live right now?" -- guard-managed, mirrors SSE's `connected` gauge
     pub(crate) connected: IntGauge,
+
+    /// Binary readiness signal set after the current stream completes initial synchronization.
+    pub(crate) synchronized: IntGauge,
     pub(crate) reconnections_total: Counter,
     pub(crate) server_initiated_closures_total: Counter,
     pub(crate) connection_established_timestamp: Gauge,
@@ -91,6 +96,16 @@ impl GnmiStreamMetrics {
             .const_labels(const_labels.clone()),
         )?;
         registry.register(Box::new(connected.clone()))?;
+
+        let synchronized = IntGauge::with_opts(
+            Opts::new(
+                format!("{prefix}_nvue_gnmi{stream_name}_stream_synchronized"),
+                "1 after the current stream receives sync_response=true, 0 otherwise",
+            )
+            .const_labels(const_labels.clone()),
+        )?;
+
+        registry.register(Box::new(synchronized.clone()))?;
 
         let reconnections_total = Counter::with_opts(
             Opts::new(
@@ -168,6 +183,7 @@ impl GnmiStreamMetrics {
         Ok(Self {
             connection_state,
             connected,
+            synchronized,
             reconnections_total,
             server_initiated_closures_total,
             connection_established_timestamp,
@@ -237,6 +253,108 @@ struct GnmiCredentialCache {
 struct GnmiUsernamePassword {
     username: Option<String>,
     password: Option<String>,
+}
+
+/// Processes responses until `sync_response=true` completes initial synchronization.
+///
+/// The timeout covers the complete synchronization period; updates received
+/// before synchronization are processed without extending it. EOF records a
+/// clean server closure, while a timeout or error records a stream failure and
+/// refreshes rejected credentials. Every non-ready exit returns `None` so the
+/// caller can apply reconnect backoff. A returned guard keeps the synchronization
+/// gauge set until that stream ends.
+async fn await_stream_synchronization<S, F>(
+    cancel_token: &CancellationToken,
+    responses: &mut S,
+    client_provider: &GnmiClientProvider,
+    credential_generation: u64,
+    stream_metrics: &GnmiStreamMetrics,
+    mut process_response: F,
+) -> Option<StreamingConnectionGuard>
+where
+    S: Stream<Item = Result<proto::SubscribeResponse, tonic::Status>> + Unpin,
+    F: FnMut(&proto::SubscribeResponse) -> Result<(), tonic::Status>,
+{
+    let receive_until_synchronized = async {
+        loop {
+            let Some(response) = responses.next().await else {
+                return Ok(false);
+            };
+
+            let response = response?;
+
+            match response.response.as_ref() {
+                Some(proto::subscribe_response::Response::SyncResponse(true)) => {
+                    return Ok(true);
+                }
+                Some(proto::subscribe_response::Response::SyncResponse(false)) => continue,
+                #[allow(deprecated, reason = "accept the legacy in-band gNMI error response")]
+                Some(proto::subscribe_response::Response::Error(error)) => {
+                    let code = i32::try_from(error.code)
+                        .map(tonic::Code::from_i32)
+                        .unwrap_or(tonic::Code::Unknown);
+
+                    return Err(tonic::Status::new(code, error.message.clone()));
+                }
+                _ => process_response(&response)?,
+            }
+        }
+    };
+
+    let result = cancel_token
+        .run_until_cancelled(tokio::time::timeout(
+            client_provider.request_timeout,
+            receive_until_synchronized,
+        ))
+        .await;
+
+    let result = match result {
+        None => {
+            stream_metrics.connection_state.set(SHUTDOWN);
+
+            tracing::info!(
+                switch_id = %client_provider.switch_id,
+                rack_id = client_provider.rack_id.as_ref().map(tracing::field::display),
+                "gNMI stream synchronization cancelled"
+            );
+
+            return None;
+        }
+        Some(Ok(result)) => result,
+        Some(Err(_)) => Err(tonic::Status::deadline_exceeded(format!(
+            "gNMI stream did not synchronize within {:?}",
+            client_provider.request_timeout
+        ))),
+    };
+
+    match result {
+        Ok(true) => Some(StreamingConnectionGuard::inc(
+            stream_metrics.synchronized.clone(),
+        )),
+        Ok(false) => {
+            stream_metrics.connection_state.set(IDLE);
+            stream_metrics.server_initiated_closures_total.inc();
+            None
+        }
+        Err(error) => {
+            stream_metrics.connection_state.set(TRANSIENT_FAILURE);
+            stream_metrics.stream_errors_total.inc();
+            stream_metrics.reconnections_total.inc();
+
+            client_provider
+                .refresh_status_auth_if_needed(&error, credential_generation)
+                .await;
+
+            tracing::warn!(
+                error = ?error,
+                switch_id = %client_provider.switch_id,
+                rack_id = client_provider.rack_id.as_ref().map(tracing::field::display),
+                "gNMI stream failed before synchronization; backing off"
+            );
+
+            None
+        }
+    }
 }
 
 impl GnmiClientProvider {
@@ -727,7 +845,7 @@ async fn gnmi_extended_task(cancel_token: CancellationToken, mut state: Extended
                     "extended gNMI stream connection failed; backing off"
                 );
             }
-            Ok((mut stream, credential_generation)) => {
+            Ok((mut stream, credential_generation)) => 'connected: {
                 state.stream_metrics.connection_state.set(READY);
                 state
                     .stream_metrics
@@ -737,12 +855,32 @@ async fn gnmi_extended_task(cancel_token: CancellationToken, mut state: Extended
                 let _connection_guard =
                     StreamingConnectionGuard::inc(state.stream_metrics.connected.clone());
 
+                let Some(_synchronization_guard) = await_stream_synchronization(
+                    &cancel_token,
+                    &mut stream,
+                    &state.client_provider,
+                    credential_generation,
+                    &state.stream_metrics,
+                    |response| {
+                        state
+                            .processor
+                            .process_subscribe_response(response, &state.stream_metrics)
+                            .map(|_| ())
+                    },
+                )
+                .await
+                else {
+                    break 'connected;
+                };
+
                 tracing::info!(
                     switch_id = %state.processor.switch_id,
                     subscription = %state.processor.subscription_name,
                     rack_id = state.client_provider.rack_id.as_ref().map(tracing::field::display),
                     "extended gNMI stream connected"
                 );
+
+                backoff.reset();
 
                 if consume_extended_stream(
                     &cancel_token,
@@ -854,6 +992,37 @@ async fn gnmi_sample_task(
     stream_metrics: GnmiStreamMetrics,
     sample_processor: GnmiSampleProcessor,
 ) {
+    run_gnmi_sample_task(
+        &cancel_token,
+        &config,
+        &stream_metrics,
+        &sample_processor,
+        || {
+            subscribe_sample_with_cached_credentials(
+                &config.client_provider,
+                &config.paths,
+                config.sample_interval_nanos,
+            )
+        },
+    )
+    .await;
+}
+
+/// Runs the SAMPLE reconnect loop with an injectable stream opener.
+///
+/// Production uses the cached-credential subscriber; tests inject streams to
+/// exercise timeout and retry behavior without a network server.
+async fn run_gnmi_sample_task<S, F, Fut>(
+    cancel_token: &CancellationToken,
+    config: &GnmiStreamConfig,
+    stream_metrics: &GnmiStreamMetrics,
+    sample_processor: &GnmiSampleProcessor,
+    mut subscribe: F,
+) where
+    S: Stream<Item = Result<proto::SubscribeResponse, tonic::Status>> + Send + Unpin,
+    F: FnMut() -> Fut + Send,
+    Fut: Future<Output = Result<(S, u64), GnmiStreamOpenError>> + Send,
+{
     let mut backoff = ExponentialBackoff::new(&BackoffConfig {
         initial: Duration::from_secs(2),
         max: Duration::from_secs(60),
@@ -862,14 +1031,7 @@ async fn gnmi_sample_task(
     loop {
         stream_metrics.connection_state.set(CONNECTING);
 
-        let Some(stream) = cancel_token
-            .run_until_cancelled(subscribe_sample_with_cached_credentials(
-                &config.client_provider,
-                &config.paths,
-                config.sample_interval_nanos,
-            ))
-            .await
-        else {
+        let Some(stream) = cancel_token.run_until_cancelled(subscribe()).await else {
             stream_metrics.connection_state.set(SHUTDOWN);
             return;
         };
@@ -891,12 +1053,31 @@ async fn gnmi_sample_task(
                     "nvue_gnmi SAMPLE: connection failed, backing off"
                 );
             }
-            Ok((mut stream, credential_generation)) => {
+            Ok((mut stream, credential_generation)) => 'connected: {
                 stream_metrics.connection_state.set(READY);
                 stream_metrics
                     .connection_established_timestamp
                     .set(now_unix_secs());
-                let _conn_guard = StreamingConnectionGuard::inc(stream_metrics.connected.clone());
+
+                let _connection_guard =
+                    StreamingConnectionGuard::inc(stream_metrics.connected.clone());
+
+                let Some(_synchronization_guard) = await_stream_synchronization(
+                    cancel_token,
+                    &mut stream,
+                    &config.client_provider,
+                    credential_generation,
+                    stream_metrics,
+                    |response| {
+                        sample_processor.process_subscribe_response(response, stream_metrics);
+                        Ok(())
+                    },
+                )
+                .await
+                else {
+                    break 'connected;
+                };
+
                 backoff.reset();
                 tracing::info!(
                     switch_id = %sample_processor.switch_id,
@@ -905,7 +1086,7 @@ async fn gnmi_sample_task(
                 );
 
                 loop {
-                    let Some(msg) = cancel_token.run_until_cancelled(stream.message()).await else {
+                    let Some(msg) = cancel_token.run_until_cancelled(stream.next()).await else {
                         stream_metrics.connection_state.set(SHUTDOWN);
                         tracing::info!(
                             switch_id = %sample_processor.switch_id,
@@ -916,10 +1097,10 @@ async fn gnmi_sample_task(
                     };
 
                     match msg {
-                        Ok(Some(resp)) => {
-                            sample_processor.process_subscribe_response(&resp, &stream_metrics);
+                        Some(Ok(resp)) => {
+                            sample_processor.process_subscribe_response(&resp, stream_metrics);
                         }
-                        Ok(None) => {
+                        None => {
                             stream_metrics.connection_state.set(IDLE);
                             stream_metrics.server_initiated_closures_total.inc();
                             tracing::info!(
@@ -930,7 +1111,7 @@ async fn gnmi_sample_task(
                             backoff.reset();
                             break;
                         }
-                        Err(e) => {
+                        Some(Err(e)) => {
                             stream_metrics.connection_state.set(TRANSIENT_FAILURE);
                             stream_metrics.stream_errors_total.inc();
                             stream_metrics.reconnections_total.inc();
@@ -1007,12 +1188,31 @@ async fn gnmi_on_change_task(
                     "nvue_gnmi ON_CHANGE: connection failed, backing off"
                 );
             }
-            Ok((mut stream, credential_generation)) => {
+            Ok((mut stream, credential_generation)) => 'connected: {
                 stream_metrics.connection_state.set(READY);
                 stream_metrics
                     .connection_established_timestamp
                     .set(now_unix_secs());
-                let _conn_guard = StreamingConnectionGuard::inc(stream_metrics.connected.clone());
+
+                let _connection_guard =
+                    StreamingConnectionGuard::inc(stream_metrics.connected.clone());
+
+                let Some(_synchronization_guard) = await_stream_synchronization(
+                    &cancel_token,
+                    &mut stream,
+                    &client_provider,
+                    credential_generation,
+                    &stream_metrics,
+                    |response| {
+                        on_change_processor.process_subscribe_response(response, &stream_metrics);
+                        Ok(())
+                    },
+                )
+                .await
+                else {
+                    break 'connected;
+                };
+
                 backoff.reset();
                 tracing::info!(
                     switch_id = %on_change_processor.switch_id,
@@ -1083,7 +1283,9 @@ async fn gnmi_on_change_task(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::VecDeque;
     use std::net::{IpAddr, Ipv4Addr};
+    use std::pin::Pin;
     use std::sync::Mutex as StdMutex;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
@@ -1237,6 +1439,257 @@ mod tests {
             ("switch_id".to_string(), "test-switch".to_string()),
             ("switch_ip".to_string(), "10.0.0.1".to_string()),
         ])
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn initial_stream_without_sync_times_out() {
+        let mut responses = tokio_stream::pending();
+        let metrics = test_gnmi_stream_metrics();
+
+        let client_provider = test_client_provider(RecordingProvider::responding_with(
+            ProviderResponse::Pending,
+        ));
+
+        let result = await_stream_synchronization(
+            &CancellationToken::new(),
+            &mut responses,
+            &client_provider,
+            0,
+            &metrics,
+            |_| Ok(()),
+        )
+        .await;
+
+        assert!(result.is_none());
+        assert_eq!(metrics.connection_state.get(), TRANSIENT_FAILURE);
+        assert_eq!(metrics.connected.get(), 0);
+        assert_eq!(metrics.synchronized.get(), 0);
+        assert_eq!(metrics.stream_errors_total.get(), 1.0);
+        assert_eq!(metrics.reconnections_total.get(), 1.0);
+    }
+
+    #[tokio::test]
+    async fn initial_stream_eof_is_recorded_as_server_closure() {
+        let mut responses = tokio_stream::empty();
+        let metrics = test_gnmi_stream_metrics();
+
+        let client_provider = test_client_provider(RecordingProvider::responding_with(
+            ProviderResponse::Pending,
+        ));
+
+        let result = await_stream_synchronization(
+            &CancellationToken::new(),
+            &mut responses,
+            &client_provider,
+            0,
+            &metrics,
+            |_| Ok(()),
+        )
+        .await;
+
+        assert!(result.is_none());
+        assert_eq!(metrics.connection_state.get(), IDLE);
+        assert_eq!(metrics.connected.get(), 0);
+        assert_eq!(metrics.synchronized.get(), 0);
+        assert_eq!(metrics.server_initiated_closures_total.get(), 1.0);
+        assert_eq!(metrics.stream_errors_total.get(), 0.0);
+        assert_eq!(metrics.reconnections_total.get(), 0.0);
+    }
+
+    #[tokio::test]
+    #[allow(deprecated, reason = "exercise legacy in-band gNMI error handling")]
+    async fn initial_stream_auth_status_refreshes_credentials() {
+        let provider = RecordingProvider::new(BmcCredentials::UsernamePassword {
+            username: "nvos-admin".to_string(),
+            password: Some("nvos-secret".to_string()),
+        });
+
+        let client_provider = test_client_provider(provider.clone());
+
+        let (_client, credential_generation) =
+            client_provider.new_client().await.expect("client builds");
+
+        let mut responses = tokio_stream::once(Ok(proto::SubscribeResponse {
+            response: Some(proto::subscribe_response::Response::Error(proto::Error {
+                code: tonic::Code::Unauthenticated as u32,
+                message: "expired gNMI credentials".to_string(),
+                ..Default::default()
+            })),
+            ..Default::default()
+        }));
+
+        let metrics = test_gnmi_stream_metrics();
+
+        let result = await_stream_synchronization(
+            &CancellationToken::new(),
+            &mut responses,
+            &client_provider,
+            credential_generation,
+            &metrics,
+            |_| Ok(()),
+        )
+        .await;
+
+        assert!(result.is_none());
+        assert_eq!(metrics.connection_state.get(), TRANSIENT_FAILURE);
+        assert_eq!(metrics.connected.get(), 0);
+        assert_eq!(metrics.synchronized.get(), 0);
+        assert_eq!(metrics.stream_errors_total.get(), 1.0);
+        assert_eq!(metrics.reconnections_total.get(), 1.0);
+        assert_eq!(provider.calls.load(Ordering::SeqCst), 2);
+    }
+
+    #[tokio::test]
+    async fn initial_stream_processes_updates_until_true_sync() {
+        let mut responses = tokio_stream::iter([
+            Ok(proto::SubscribeResponse {
+                response: Some(proto::subscribe_response::Response::Update(
+                    proto::Notification::default(),
+                )),
+                ..Default::default()
+            }),
+            Ok(proto::SubscribeResponse {
+                response: Some(proto::subscribe_response::Response::SyncResponse(false)),
+                ..Default::default()
+            }),
+            Ok(proto::SubscribeResponse {
+                response: Some(proto::subscribe_response::Response::SyncResponse(true)),
+                ..Default::default()
+            }),
+        ]);
+
+        let metrics = test_gnmi_stream_metrics();
+
+        let client_provider = test_client_provider(RecordingProvider::responding_with(
+            ProviderResponse::Pending,
+        ));
+
+        let mut processed_updates = 0;
+
+        let result = await_stream_synchronization(
+            &CancellationToken::new(),
+            &mut responses,
+            &client_provider,
+            0,
+            &metrics,
+            |_| {
+                processed_updates += 1;
+                Ok(())
+            },
+        )
+        .await;
+
+        assert!(result.is_some());
+        assert_eq!(processed_updates, 1);
+        assert_eq!(metrics.synchronized.get(), 1);
+    }
+
+    #[tokio::test]
+    async fn initial_stream_cancellation_sets_shutdown() {
+        let cancel_token = CancellationToken::new();
+        cancel_token.cancel();
+
+        let mut responses = tokio_stream::pending();
+        let metrics = test_gnmi_stream_metrics();
+
+        let client_provider = test_client_provider(RecordingProvider::responding_with(
+            ProviderResponse::Pending,
+        ));
+
+        let result = await_stream_synchronization(
+            &cancel_token,
+            &mut responses,
+            &client_provider,
+            0,
+            &metrics,
+            |_| Ok(()),
+        )
+        .await;
+
+        assert!(result.is_none());
+        assert_eq!(metrics.connection_state.get(), SHUTDOWN);
+        assert_eq!(metrics.synchronized.get(), 0);
+        assert_eq!(metrics.stream_errors_total.get(), 0.0);
+        assert_eq!(metrics.reconnections_total.get(), 0.0);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn sample_task_retries_when_initial_stream_does_not_synchronize() {
+        type TestStream =
+            Pin<Box<dyn Stream<Item = Result<proto::SubscribeResponse, tonic::Status>> + Send>>;
+
+        let cancel_token = CancellationToken::new();
+
+        let client_provider = test_client_provider(RecordingProvider::responding_with(
+            ProviderResponse::Pending,
+        ));
+
+        let config = GnmiStreamConfig {
+            client_provider,
+            paths: Vec::new(),
+            sample_interval_nanos: 1,
+        };
+
+        let metrics = test_gnmi_stream_metrics();
+
+        let processor = GnmiSampleProcessor {
+            data_sink: None,
+            event_context: EventContext {
+                endpoint_key: "test-endpoint".to_string(),
+                addr: test_addr(),
+                collector_type: NVUE_GNMI_SAMPLE_STREAM_ID,
+                metadata: None,
+                rack_id: None,
+                labels: Default::default(),
+            },
+            switch_id: "switch-1".to_string(),
+        };
+
+        let synchronized = proto::SubscribeResponse {
+            response: Some(proto::subscribe_response::Response::SyncResponse(true)),
+            ..Default::default()
+        };
+
+        let stalled: TestStream = Box::pin(tokio_stream::pending());
+
+        let synchronized: TestStream =
+            Box::pin(tokio_stream::once(Ok(synchronized)).chain(tokio_stream::pending()));
+
+        let mut streams = VecDeque::from([stalled, synchronized]);
+        let (attempt_tx, mut attempt_rx) = tokio::sync::mpsc::unbounded_channel();
+
+        let run = run_gnmi_sample_task(&cancel_token, &config, &metrics, &processor, || {
+            attempt_tx.send(()).expect("attempt receiver remains open");
+            std::future::ready(Ok((
+                streams.pop_front().expect("test stream is available"),
+                0,
+            )))
+        });
+
+        let observe = async {
+            attempt_rx.recv().await.expect("first subscription attempt");
+
+            tokio::task::yield_now().await;
+            assert_eq!(metrics.connection_state.get(), READY);
+            assert_eq!(metrics.connected.get(), 1);
+            assert_eq!(metrics.synchronized.get(), 0);
+
+            attempt_rx.recv().await.expect("retry subscription attempt");
+
+            tokio::task::yield_now().await;
+            assert_eq!(metrics.connection_state.get(), READY);
+            assert_eq!(metrics.connected.get(), 1);
+            assert_eq!(metrics.synchronized.get(), 1);
+            assert_eq!(metrics.reconnections_total.get(), 1.0);
+
+            cancel_token.cancel();
+        };
+
+        tokio::join!(run, observe);
+
+        assert_eq!(metrics.connection_state.get(), SHUTDOWN);
+        assert_eq!(metrics.connected.get(), 0);
+        assert_eq!(metrics.synchronized.get(), 0);
     }
 
     #[test]

--- a/crates/health/src/config.rs
+++ b/crates/health/src/config.rs
@@ -1846,7 +1846,12 @@ pub struct NvueGnmiConfig {
     #[serde(with = "humantime_serde")]
     pub sample_interval: Duration,
 
-    /// Timeout for gRPC connection attempts.
+    /// Timeout applied independently to connection establishment, opening the
+    /// Subscribe RPC, and initial stream synchronization.
+    ///
+    /// One attempt may take nearly three times this duration before reconnect
+    /// backoff. Updates before `sync_response=true` do not extend the
+    /// synchronization timeout.
     #[serde(with = "humantime_serde")]
     pub request_timeout: Duration,
 


### PR DESCRIPTION
Detect gNMI subscriptions that open but do not complete initial protocol synchronization. If a stream does not deliver `sync_response=true` within `request_timeout`, the collector marks the attempt failed and reconnects through the existing backoff.

Updates received before synchronization are processed. Authentication failures refresh credentials, EOF is recorded as a server closure, and HTTP/2 keepalive detects peers that stop acknowledging PING frames. Existing connection metrics retain their transport semantics; the new `stream_synchronized` metrics report synchronization state. The behavior applies to SAMPLE, ON_CHANGE, and additional subscriptions.

## Related Issues

Fixes #6065

## Type of Change

- [ ] **Add** - New feature or capability
- [ ] **Change** - Changes in existing functionality
- [x] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes

- [ ] **This PR contains breaking changes**

## Testing

- [x] Unit tests added/updated
- [ ] Integration tests added/updated
- [x] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)