### PR TITLE
Fully switch to pinned driver versions

### DIFF
--- a/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.postinst.chroot
+++ b/pxe/mkosi.profiles/scout-oss-aarch64/mkosi.postinst.chroot
@@ -12,7 +12,7 @@ echo "$PKG_VERSION" >/etc/scout-image-version
 # NVIDIA DRIVERS & DCGM
 # ============================================================================
 # We install these in postinst to avoid double-triggering the DKMS build
-NV_PACKAGES="cuda-drivers-580=580.126.16-1ubuntu1 datacenter-gpu-manager-4-cuda13 datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary-cuda13 libnvidia-cfg1-580=580.126.16-1ubuntu1 libnvidia-common-580=580.126.16-1ubuntu1 libnvidia-compute-580=580.126.16-1ubuntu1 libnvidia-decode-580=580.126.16-1ubuntu1 libnvidia-encode-580=580.126.16-1ubuntu1 libnvidia-extra-580=580.126.16-1ubuntu1 libnvidia-fbc1-580=580.126.16-1ubuntu1 libnvidia-gl-580=580.126.16-1ubuntu1 libnvidia-gpucomp-580=580.126.16-1ubuntu1 nvidia-compute-utils-580=580.126.16-1ubuntu1 nvidia-dkms-580-open=580.126.16-1ubuntu1 nvidia-driver-580-open=580.126.16-1ubuntu1 nvidia-fabricmanager=580.126.16-1 nvidia-firmware-580=580.126.16-1ubuntu1 nvidia-kernel-common-580=580.126.16-1ubuntu1 nvidia-kernel-source-580-open=580.126.16-1ubuntu1 nvidia-modprobe=580.126.16-1ubuntu1 nvidia-persistenced=580.126.16-1ubuntu1 nvidia-utils-580=580.126.16-1ubuntu1 xserver-xorg-video-nvidia-580=580.126.16-1ubuntu1 libxnvctrl0=580.126.16-1ubuntu1 nvidia-settings=580.126.16-1ubuntu1 nvidia-imex=580.126.16-1 mft"
+NV_PACKAGES="nvidia-open=615.71.09-1ubuntu1 datacenter-gpu-manager-4-cuda13 datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary-cuda13 libnvidia-cfg1=615.71.09-1ubuntu1 libnvidia-compute=615.71.09-1ubuntu1 libnvidia-decode=615.71.09-1ubuntu1 libnvidia-encode=615.71.09-1ubuntu1 libnvidia-fbc1=615.71.09-1ubuntu1 libnvidia-gl=615.71.09-1ubuntu1 libnvidia-gpucomp=615.71.09-1ubuntu1 nvidia-dkms-open=615.71.09-1ubuntu1 nvidia-driver-open=615.71.09-1ubuntu1 nvidia-fabricmanager=615.71.09-1ubuntu1 nvidia-firmware=615.71.09-1ubuntu1 nvidia-kernel-common=615.71.09-1ubuntu1 nvidia-kernel-source-open=615.71.09-1ubuntu1 nvidia-modprobe=615.71.09-1ubuntu1 nvidia-persistenced=615.71.09-1ubuntu1 xserver-xorg-video-nvidia=615.71.09-1ubuntu1 libxnvctrl0=615.71.09-1ubuntu1 nvidia-settings=615.71.09-1ubuntu1 nvidia-imex=615.71.09-1ubuntu1 mft"
 APT_SANDBOX_OPTS="-o APT::Sandbox::User=root"
 export DEBIAN_FRONTEND=noninteractive
 
@@ -20,9 +20,9 @@ apt-get ${APT_SANDBOX_OPTS} update
 
 # Debug: Check what NVIDIA driver packages are actually available
 echo "=== Checking NVIDIA repository status ==="
-apt-cache policy cuda-drivers-580 || echo "cuda-drivers-580 not found"
-echo "=== Available cuda-drivers versions ==="
-apt-cache search cuda-drivers | head -20
+apt-cache policy nvidia-open || echo "nvidia-open not found"
+echo "=== Available nvidia-open versions ==="
+apt-cache search nvidia-open | head -20
 echo "=== Available nvidia-driver versions ==="
 apt-cache search nvidia-driver | grep "^nvidia-driver" | head -20
 
@@ -125,9 +125,8 @@ do
 done
 
 # Check the nvidia driver versions are consistent
-NV_PKGS="cuda-drivers-580 libnvidia-common-580 libnvidia-compute-580 nvidia-compute-utils-580
-         nvidia-dkms-580-open nvidia-driver-580-open nvidia-fabricmanager nvidia-firmware-580
-         nvidia-kernel-common-580 nvidia-kernel-source-580-open nvidia-persistenced"
+NV_PKGS="nvidia-open libnvidia-compute nvidia-dkms-open nvidia-driver-open nvidia-fabricmanager
+         nvidia-firmware nvidia-kernel-common nvidia-kernel-source-open nvidia-persistenced"
 if [ $(dpkg -l ${NV_PKGS} | grep '^ii' | awk '{print $3}' | cut -d. -f1-2 | sort -u | wc -l) -ne 1 ]
 then
   echo "ERROR: Mismatched nvidia package versions, dcgmi may not run"

--- a/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.postinst.chroot
+++ b/pxe/mkosi.profiles/scout-oss-x86_64/mkosi.postinst.chroot
@@ -12,7 +12,7 @@ echo "$PKG_VERSION" >/etc/scout-image-version
 # NVIDIA DRIVERS & DCGM
 # ============================================================================
 # We install these in postinst to avoid double-triggering the DKMS build
-NV_PACKAGES="cuda-drivers-580=580.126.16-1ubuntu1 datacenter-gpu-manager-4-cuda13 datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary-cuda13 libnvidia-cfg1-580=580.126.16-1ubuntu1 libnvidia-common-580=580.126.16-1ubuntu1 libnvidia-compute-580=580.126.16-1ubuntu1 libnvidia-decode-580=580.126.16-1ubuntu1 libnvidia-encode-580=580.126.16-1ubuntu1 libnvidia-extra-580=580.126.16-1ubuntu1 libnvidia-fbc1-580=580.126.16-1ubuntu1 libnvidia-gl-580=580.126.16-1ubuntu1 libnvidia-gpucomp-580=580.126.16-1ubuntu1 nvidia-compute-utils-580=580.126.16-1ubuntu1 nvidia-dkms-580-open=580.126.16-1ubuntu1 nvidia-driver-580-open=580.126.16-1ubuntu1 nvidia-fabricmanager=580.126.16-1 nvidia-firmware-580=580.126.16-1ubuntu1 nvidia-kernel-common-580=580.126.16-1ubuntu1 nvidia-kernel-source-580-open=580.126.16-1ubuntu1 nvidia-modprobe=580.126.16-1ubuntu1 nvidia-persistenced=580.126.16-1ubuntu1 nvidia-utils-580=580.126.16-1ubuntu1 xserver-xorg-video-nvidia-580=580.126.16-1ubuntu1 libxnvctrl0=580.126.16-1ubuntu1 nvidia-settings=580.126.16-1ubuntu1 nvidia-imex=580.126.16-1 mft"
+NV_PACKAGES="nvidia-open=615.71.09-1ubuntu1 datacenter-gpu-manager-4-cuda13 datacenter-gpu-manager-4-core datacenter-gpu-manager-4-proprietary-cuda13 libnvidia-cfg1=615.71.09-1ubuntu1 libnvidia-compute=615.71.09-1ubuntu1 libnvidia-decode=615.71.09-1ubuntu1 libnvidia-encode=615.71.09-1ubuntu1 libnvidia-fbc1=615.71.09-1ubuntu1 libnvidia-gl=615.71.09-1ubuntu1 libnvidia-gpucomp=615.71.09-1ubuntu1 nvidia-dkms-open=615.71.09-1ubuntu1 nvidia-driver-open=615.71.09-1ubuntu1 nvidia-fabricmanager=615.71.09-1ubuntu1 nvidia-firmware=615.71.09-1ubuntu1 nvidia-kernel-common=615.71.09-1ubuntu1 nvidia-kernel-source-open=615.71.09-1ubuntu1 nvidia-modprobe=615.71.09-1ubuntu1 nvidia-persistenced=615.71.09-1ubuntu1 xserver-xorg-video-nvidia=615.71.09-1ubuntu1 libxnvctrl0=615.71.09-1ubuntu1 nvidia-settings=615.71.09-1ubuntu1 nvidia-imex=615.71.09-1ubuntu1 mft"
 APT_SANDBOX_OPTS="-o APT::Sandbox::User=root"
 export DEBIAN_FRONTEND=noninteractive
 
@@ -20,9 +20,9 @@ apt-get ${APT_SANDBOX_OPTS} update
 
 # Debug: Check what NVIDIA driver packages are actually available
 echo "=== Checking NVIDIA repository status ==="
-apt-cache policy cuda-drivers-580 || echo "cuda-drivers-580 not found"
-echo "=== Available cuda-drivers versions ==="
-apt-cache search cuda-drivers | head -20
+apt-cache policy nvidia-open || echo "nvidia-open not found"
+echo "=== Available nvidia-open versions ==="
+apt-cache search nvidia-open | head -20
 echo "=== Available nvidia-driver versions ==="
 apt-cache search nvidia-driver | grep "^nvidia-driver" | head -20
 
@@ -125,9 +125,8 @@ do
 done
 
 # Check the nvidia driver versions are consistent
-NV_PKGS="cuda-drivers-580 libnvidia-common-580 libnvidia-compute-580 nvidia-compute-utils-580
-         nvidia-dkms-580-open nvidia-driver-580-open nvidia-fabricmanager nvidia-firmware-580
-         nvidia-kernel-common-580 nvidia-kernel-source-580-open nvidia-persistenced"
+NV_PKGS="nvidia-open libnvidia-compute nvidia-dkms-open nvidia-driver-open nvidia-fabricmanager
+         nvidia-firmware nvidia-kernel-common nvidia-kernel-source-open nvidia-persistenced"
 if [ $(dpkg -l ${NV_PKGS} | grep '^ii' | awk '{print $3}' | cut -d. -f1-2 | sort -u | wc -l) -ne 1 ]
 then
   echo "ERROR: Mismatched nvidia package versions, dcgmi may not run"


### PR DESCRIPTION
Fully switch to using nvidia-driver-pinning-615 to lock the driver versions, rather than listing explicit versions.

## Related issues

## Type of Change
- [ ] **Add** - New feature or capability
- [X] **Change** - Changes in existing functionality
- [ ] **Fix** - Bug fixes
- [ ] **Remove** - Removed features or deprecated functionality
- [ ] **Internal** - Internal changes (refactoring, tests, docs, etc.)

## Breaking Changes
- [ ] **This PR contains breaking changes**

## Testing
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [X] Manual testing performed
- [ ] No testing required (docs, internal refactor, etc.)

## Additional Notes

